### PR TITLE
World index date parse fix

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/comparisons/fundvalue/retrieval/WorldIndexValueRetriever.java
+++ b/src/main/java/ee/tuleva/onboarding/comparisons/fundvalue/retrieval/WorldIndexValueRetriever.java
@@ -98,12 +98,17 @@ public class WorldIndexValueRetriever implements ComparisonIndexRetriever {
     }
 
     private Optional<LocalDate> parseDate(String date) {
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("d-MMM-yyyy");
         try {
-            return Optional.of(LocalDate.parse(date, formatter));
-        } catch (DateTimeParseException e) {
-            log.warn("Failed to parse date: {}", e.getMessage());
-            return Optional.empty();
+            return Optional.of(LocalDate.parse(date, DateTimeFormatter.ofPattern("d-MMM-yyyy")));
+        }
+        catch (DateTimeParseException ignored) {
+            try {
+                return Optional.of(LocalDate.parse(date, DateTimeFormatter.ofPattern("d-MMMM-yyyy")));
+            }
+            catch (DateTimeParseException e) {
+                log.warn("Failed to parse date: {}", e.getMessage());
+                return Optional.empty();
+            }
         }
     }
 

--- a/src/main/java/ee/tuleva/onboarding/comparisons/fundvalue/retrieval/WorldIndexValueRetriever.java
+++ b/src/main/java/ee/tuleva/onboarding/comparisons/fundvalue/retrieval/WorldIndexValueRetriever.java
@@ -98,7 +98,7 @@ public class WorldIndexValueRetriever implements ComparisonIndexRetriever {
     }
 
     private Optional<LocalDate> parseDate(String date) {
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd-MMM-yyyy");
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("d-MMM-yyyy");
         try {
             return Optional.of(LocalDate.parse(date, formatter));
         } catch (DateTimeParseException e) {

--- a/src/test/groovy/ee/tuleva/onboarding/comparisons/fundvalue/retrieval/WorldIndexValueRetrieverSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/comparisons/fundvalue/retrieval/WorldIndexValueRetrieverSpec.groovy
@@ -37,12 +37,12 @@ class WorldIndexValueRetrieverSpec extends Specification {
         String responseBody = """"Indeks Components ","ISIN","Share","Last price nav","date","expense ratio","",""
 "","","70%","24.1800","","0.25%","",""
 "","","30%","223.8900","","0.20%","",""
-"18-Jul-2018","24.18","223.89","8.1931","0.3617","279.09","",""
+"1-Jul-2018","24.18","223.89","8.1931","0.3617","279.09","",""
 "17-Jul-2018","24.05","224.01","8.1931","0.3617","278.07","",""
 """
         ClientHttpResponse response = createResponse(HttpStatus.OK, responseBody)
         List<FundValue> expectedValues = [
-            new FundValue(WorldIndexValueRetriever.KEY, parse("2018-07-18"), 279.09),
+            new FundValue(WorldIndexValueRetriever.KEY, parse("2018-07-01"), 279.09),
             new FundValue(WorldIndexValueRetriever.KEY, parse("2018-07-17"), 278.07),
         ]
 

--- a/src/test/groovy/ee/tuleva/onboarding/comparisons/fundvalue/retrieval/WorldIndexValueRetrieverSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/comparisons/fundvalue/retrieval/WorldIndexValueRetrieverSpec.groovy
@@ -38,7 +38,7 @@ class WorldIndexValueRetrieverSpec extends Specification {
 "","","70%","24.1800","","0.25%","",""
 "","","30%","223.8900","","0.20%","",""
 "1-Jul-2018","24.18","223.89","8.1931","0.3617","279.09","",""
-"17-Jul-2018","24.05","224.01","8.1931","0.3617","278.07","",""
+"17-July-2018","24.05","224.01","8.1931","0.3617","278.07","",""
 """
         ClientHttpResponse response = createResponse(HttpStatus.OK, responseBody)
         List<FundValue> expectedValues = [


### PR DESCRIPTION
Previously used SimpleDateFormat was more lenient. We have data in mixed format - some with long month names, some with short.