### PR TITLE
Move SSL proxy from frontend to backend

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ jobs:
             - v1-build-{{ .Environment.CIRCLE_BRANCH }}-{{ .Environment.CIRCLE_SHA1 }}
       - deploy:
           name: Deploy master to Production
-          command: eb deploy onboarding-service-3 --label ${CIRCLE_SHA1} --timeout 20
+          command: eb deploy onboarding-service  --label ${CIRCLE_SHA1} --timeout 20
 
   notify:
     docker:

--- a/etc/eb/.ebextensions/nginx/conf.d/01_ssl_proxy.conf
+++ b/etc/eb/.ebextensions/nginx/conf.d/01_ssl_proxy.conf
@@ -1,5 +1,3 @@
-set $backend "http://localhost:5000";
-
 map $http_origin $cors_header {
   default "";
   "~^https?:\/\/(pension\.tuleva\.ee|www\.tuleva\.ee|tuleva\.ee|localhost)" "$http_origin";
@@ -35,7 +33,7 @@ server {
     }
 
     location /api/ {
-        proxy_pass  $backend/;
+        proxy_pass http://localhost:5000/;
         proxy_set_header   Connection "";
         proxy_http_version 1.1;
         proxy_set_header        Host            $host;
@@ -45,7 +43,7 @@ server {
     }
 
     location /actuator {
-        proxy_pass  $backend;
+        proxy_pass http://localhost:5000;
         proxy_set_header   Connection "";
         proxy_http_version 1.1;
         proxy_set_header        Host            $host;
@@ -83,7 +81,7 @@ server {
 
     location /idLogin {
         expires -1;
-        proxy_pass $backend;
+        proxy_pass http://localhost:5000;
         proxy_ssl_server_name on;
         proxy_set_header Host onboarding-service.tuleva.ee;
         proxy_set_header X-Real-IP $remote_addr;

--- a/etc/eb/.ebextensions/nginx/conf.d/01_ssl_proxy.conf
+++ b/etc/eb/.ebextensions/nginx/conf.d/01_ssl_proxy.conf
@@ -91,7 +91,6 @@ server {
         proxy_set_header X-Forwarded-Proto https;
         proxy_set_header SSL-CLIENT-VERIFY $ssl_client_verify;
         proxy_set_header SSL-CLIENT-CERT $ssl_client_escaped_cert;
-        proxy_set_header X-Authorization "Bearer 529de078-52ba-4347-bcfa-d88009c20691";
         proxy_cookie_path ~*^/.* /;
     }
 

--- a/etc/eb/.ebextensions/nginx/conf.d/01_ssl_proxy.conf
+++ b/etc/eb/.ebextensions/nginx/conf.d/01_ssl_proxy.conf
@@ -1,0 +1,109 @@
+set $backend "http://localhost:5000";
+
+map $http_origin $cors_header {
+  default "";
+  "~^https?:\/\/(pension\.tuleva\.ee|www\.tuleva\.ee|tuleva\.ee|localhost)" "$http_origin";
+}
+server {
+    listen 443 ssl;
+    server_name pension.tuleva.ee;
+    ssl_certificate /tmp/fullchain.pem;
+    ssl_certificate_key /tmp/privkey.pem;
+    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+    ssl_prefer_server_ciphers on;
+    ssl_dhparam /tmp/dhparam.pem;
+    ssl_ciphers ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:ECDHE-ECDSA-DES-CBC3-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA:!DSS;
+    ssl_ecdh_curve secp384r1;
+    ssl_session_cache off;
+    ssl_session_tickets off;
+    ssl_stapling on;
+    ssl_stapling_verify on;
+    resolver 1.1.1.1 1.0.0.1 valid=300s;
+    resolver_timeout 10s;
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+    add_header X-Frame-Options DENY;
+    add_header X-Content-Type-Options nosniff;
+
+    location / {
+        proxy_pass  http://pension.tuleva.ee.s3-website.eu-central-1.amazonaws.com;
+        proxy_set_header   Connection "";
+        proxy_http_version 1.1;
+        proxy_set_header        Host            "pension.tuleva.ee.s3-website.eu-central-1.amazonaws.com";
+        proxy_set_header        X-Real-IP       $remote_addr;
+        proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header        X-Forwarded-Proto https;
+    }
+
+    location /api/ {
+        proxy_pass  $backend/;
+        proxy_set_header   Connection "";
+        proxy_http_version 1.1;
+        proxy_set_header        Host            $host;
+        proxy_set_header        X-Real-IP       $remote_addr;
+        proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header        X-Forwarded-Proto https;
+    }
+
+    location /actuator {
+        proxy_pass  $backend;
+        proxy_set_header   Connection "";
+        proxy_http_version 1.1;
+        proxy_set_header        Host            $host;
+        proxy_set_header        X-Real-IP       $remote_addr;
+        proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header        X-Forwarded-Proto https;
+    }
+
+    location /idLogin {
+        return 301 https://id.tuleva.ee/$request_uri;
+    }
+}
+server {
+    listen 443 ssl;
+    server_name id.tuleva.ee;
+    ssl_certificate /tmp/fullchain.pem;
+    ssl_certificate_key /tmp/privkey.pem;
+    ssl_client_certificate /tmp/id.crt;
+    ssl_verify_client on;
+    ssl_verify_depth 3;
+    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+    ssl_prefer_server_ciphers on;
+    ssl_dhparam /tmp/dhparam.pem;
+    ssl_ciphers ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:ECDHE-ECDSA-DES-CBC3-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA:!DSS;
+    ssl_ecdh_curve secp384r1;
+    ssl_session_cache off;
+    ssl_session_tickets off;
+    ssl_stapling on;
+    ssl_stapling_verify on;
+    resolver 1.1.1.1 1.0.0.1 valid=300s;
+    resolver_timeout 10s;
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+    add_header X-Frame-Options DENY;
+    add_header X-Content-Type-Options nosniff;
+
+    location /idLogin {
+        expires -1;
+        proxy_pass $backend;
+        proxy_ssl_server_name on;
+        proxy_set_header Host onboarding-service.tuleva.ee;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header SSL-CLIENT-VERIFY $ssl_client_verify;
+        proxy_set_header SSL-CLIENT-CERT $ssl_client_escaped_cert;
+        proxy_set_header X-Authorization "Bearer 529de078-52ba-4347-bcfa-d88009c20691";
+        proxy_cookie_path ~*^/.* /;
+    }
+
+    location / {
+        return 200 '{}';
+        default_type 'application/json; charset=utf-8';
+        add_header 'Access-Control-Allow-Origin' "$cors_header";
+        add_header 'Access-Control-Allow-Methods' 'POST, PUT, GET, OPTIONS, DELETE';
+        add_header 'Access-Control-Max-Age' 3600;
+        add_header 'Access-Control-Allow-Credentials' 'true';
+        add_header 'Access-Control-Allow-Headers' 'x-requested-with, Content-Type, Referer, Authorization, User-Agent, Origin, Accept, Range, DNT, Date';
+        add_header 'P3P' 'CP="ALL IND DSP COR ADM CONo CUR CUSo IVAo IVDo PSA PSD TAI TELo OUR SAMo CNT COM INT NAV ONL PHY PRE PUR UNI"';
+    }
+
+}

--- a/etc/eb/.ebextensions/nginx/conf.d/02_underscores_in_headers.conf
+++ b/etc/eb/.ebextensions/nginx/conf.d/02_underscores_in_headers.conf
@@ -1,0 +1,1 @@
+underscores_in_headers on;

--- a/etc/eb/.ebextensions/nginx/conf.d/elasticbeanstalk/01_redirect.conf
+++ b/etc/eb/.ebextensions/nginx/conf.d/elasticbeanstalk/01_redirect.conf
@@ -1,0 +1,3 @@
+if ($http_x_forwarded_proto = 'http') {
+    return 301 https://$host$request_uri;
+}

--- a/etc/eb/.ebextensions/ssl.config
+++ b/etc/eb/.ebextensions/ssl.config
@@ -1,0 +1,46 @@
+Resources:
+  sslSecurityGroupIngress:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: {"Fn::GetAtt" : ["AWSEBSecurityGroup", "GroupId"]}
+      IpProtocol: tcp
+      ToPort: 443
+      FromPort: 443
+      CidrIp: 0.0.0.0/0
+  AWSEBAutoScalingGroup:
+    Metadata:
+      AWS::CloudFormation::Authentication:
+        S3Auth:
+          type: "s3"
+          buckets: ["tulevasecrets"]
+          roleName:
+            "Fn::GetOptionSetting":
+              Namespace: "aws:asg:launchconfiguration"
+              OptionName: "IamInstanceProfile"
+              DefaultValue: "BeanstalktEC2Role"
+
+files:
+  /tmp/fullchain.pem:
+    mode: "000444"
+    owner: root
+    group: root
+    authentication: "S3Auth"
+    source: https://s3-eu-central-1.amazonaws.com/tulevasecrets/ssl/fullchain.pem
+  /tmp/privkey.pem:
+     mode: "000444"
+     owner: root
+     group: root
+     authentication: "S3Auth"
+     source: https://s3-eu-central-1.amazonaws.com/tulevasecrets/ssl/privkey.pem
+  /tmp/id.crt:
+     mode: "000444"
+     owner: root
+     group: root
+     authentication: "S3Auth"
+     source: https://s3-eu-central-1.amazonaws.com/tulevasecrets/ssl/id.crt
+  /tmp/dhparam.pem:
+     mode: "000444"
+     owner: root
+     group: root
+     authentication: "S3Auth"
+     source: https://s3-eu-central-1.amazonaws.com/tulevasecrets/ssl/dhparam.pem

--- a/etc/eb/.ebextensions/underscores_in_headers.config
+++ b/etc/eb/.ebextensions/underscores_in_headers.config
@@ -1,7 +1,0 @@
-files:
-  /etc/nginx/conf.d/02_underscores_in_headers.conf:
-    mode: "000644"
-    owner: root
-    group: root
-    content: |
-      underscores_in_headers on;

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1-all.zip

--- a/src/main/java/ee/tuleva/onboarding/auth/AuthController.java
+++ b/src/main/java/ee/tuleva/onboarding/auth/AuthController.java
@@ -41,9 +41,6 @@ public class AuthController {
     private final GenericSessionStore genericSessionStore;
     private final IdCardAuthService idCardAuthService;
 
-    @Value("${id-card.secret.token:Bearer ${random.uuid}}")
-    private String idCardSecretToken;
-
     @Value("${frontend.url}")
     private String frontendUrl;
 
@@ -74,12 +71,8 @@ public class AuthController {
     @ResponseBody
     public IdCardLoginResponse idLogin(@RequestHeader(value = "ssl-client-verify") String clientCertificateVerification,
                                        @RequestHeader(value = "ssl-client-cert") String clientCertificate,
-                                       @RequestHeader(value = "x-authorization") String crossAuthorizationToken,
                                        @ApiIgnore HttpServletResponse response,
                                        @ApiIgnore HttpMethod httpMethod) throws IOException {
-        if (!Objects.equals(crossAuthorizationToken, idCardSecretToken)) {
-            throw new UnauthorizedClientException("Invalid X-Authorization");
-        }
         if (!"SUCCESS".equals(clientCertificateVerification)) {
             throw new UnauthorizedClientException("Client certificate not verified");
         }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -163,10 +163,6 @@ digidoc:
   service:
     url: https://digidocservice.sk.ee/
 
-id-card:
-  secret:
-    token: ${ID_CARD_SECRET_HEADER_TOKEN}
-
 mandrill:
   key: ${MANDRILL_KEY}
 

--- a/src/test/groovy/ee/tuleva/onboarding/auth/AuthControllerSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/auth/AuthControllerSpec.groovy
@@ -70,30 +70,10 @@ class AuthControllerSpec extends BaseControllerSpec {
         response.status == HttpStatus.OK.value()
     }
 
-    def "Authenticate: throw exception when X-Authorization header missing"() {
-        when:
-        MockHttpServletResponse response = mockMvc
-                .perform(post("/idLogin")).andReturn().response
-        then:
-        response.status == HttpStatus.BAD_REQUEST.value()
-        0 * idCardAuthService.checkCertificate(_)
-    }
-
-    def "Authenticate: throw exception when invalid X-Authorization header"() {
-        when:
-        MockHttpServletResponse response = mockMvc
-                .perform(post("/idLogin")
-                .header("X-Authorization", "Bearer noob")).andReturn().response
-        then:
-        response.status == HttpStatus.BAD_REQUEST.value()
-        0 * idCardAuthService.checkCertificate(_)
-    }
-
     def "Authenticate: throw exception when no cert sent"() {
         when:
         MockHttpServletResponse response = mockMvc
                 .perform(post("/idLogin")
-                .header("X-Authorization", "Bearer secretz")
                 .header("ssl-client-verify", "NONE")).andReturn().response
         then:
         response.status == HttpStatus.BAD_REQUEST.value()
@@ -104,7 +84,6 @@ class AuthControllerSpec extends BaseControllerSpec {
         when:
         MockHttpServletResponse response = mockMvc
                 .perform(post("/idLogin")
-                .header("X-Authorization", "Bearer secretz")
                 .header("ssl-client-verify", "SUCCESS")
                 .header("ssl-client-cert", "test_cert")).andReturn().response
         then:
@@ -116,7 +95,6 @@ class AuthControllerSpec extends BaseControllerSpec {
         when:
         MockHttpServletResponse response = mockMvc
                 .perform(get("/idLogin")
-                .header("X-Authorization", "Bearer secretz")
                 .header("ssl-client-verify", "SUCCESS")
                 .header("ssl-client-cert", "test_cert")).andReturn().response
         then:

--- a/src/test/groovy/ee/tuleva/onboarding/auth/AuthControllerSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/auth/AuthControllerSpec.groovy
@@ -29,7 +29,6 @@ class AuthControllerSpec extends BaseControllerSpec {
 
     def setup() {
         mockMvc = mockMvc(controller)
-        controller.idCardSecretToken = "Bearer secretz"
     }
 
     def "Authenticate: Initiate mobile id authentication (deprecated)"() {


### PR DESCRIPTION
To serve frontend from a simple S3 bucket without a nginx proxy we need to handle ID card auth on the backend. For that we need to:

- Deploy frontend to a S3 bucket (Done) 
- Move id and pension subdomains from frontend to backend
- Proxy non /api ( and non /actuator) requests to the frontend bucket
- Redirect /idLogin request to id subdomain and make sure /idLogin is only accessible from id subdomain
- Remove cross auth header from /idLogin since it is not needed anymore