### PR TITLE
Smart-ID session fix

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/auth/response/AuthenticateResponse.java
+++ b/src/main/java/ee/tuleva/onboarding/auth/response/AuthenticateResponse.java
@@ -21,6 +21,6 @@ public class AuthenticateResponse {
   }
 
   public static AuthenticateResponse fromSmartIdSession(SmartIdSession smartIdSession) {
-    return builder().challengeCode(smartIdSession.verificationCode).build();
+    return builder().challengeCode(smartIdSession.getVerificationCode()).build();
   }
 }

--- a/src/main/java/ee/tuleva/onboarding/auth/smartid/SmartIdAuthService.java
+++ b/src/main/java/ee/tuleva/onboarding/auth/smartid/SmartIdAuthService.java
@@ -3,13 +3,14 @@ package ee.tuleva.onboarding.auth.smartid;
 import ee.sk.smartid.*;
 import ee.sk.smartid.exception.UserAccountNotFoundException;
 import ee.sk.smartid.exception.UserRefusedException;
+import ee.sk.smartid.rest.SmartIdConnector;
 import ee.sk.smartid.rest.dao.NationalIdentity;
+import ee.sk.smartid.rest.dao.SessionStatus;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.util.Collections;
-import java.util.concurrent.Executor;
 
 @Service
 @RequiredArgsConstructor
@@ -17,67 +18,64 @@ import java.util.concurrent.Executor;
 public class SmartIdAuthService {
     private final SmartIdClient smartIdClient;
     private final SmartIdAuthenticationHashGenerator hashGenerator;
-    private final Executor smartIdExecutor;
     private final AuthenticationResponseValidator authenticationResponseValidator;
+    private final SmartIdConnector connector;
 
     public SmartIdSession startLogin(String nationalIdentityCode) {
-        NationalIdentity nationalIdentity = new NationalIdentity("EE", nationalIdentityCode);
-
         AuthenticationHash authenticationHash = hashGenerator.generateHash();
-
         String verificationCode = authenticationHash.calculateVerificationCode();
+        String sessionId = builder(nationalIdentityCode, authenticationHash).initiateAuthentication();
 
-        SmartIdSession session = new SmartIdSession(verificationCode);
+        return new SmartIdSession(verificationCode, sessionId, nationalIdentityCode, authenticationHash);
+    }
 
-        smartIdExecutor.execute(() -> {
-            try {
-                log.info("Starting authentication");
-                SmartIdAuthenticationResponse authenticationResponse = getSmartIdAuthenticationResponse(nationalIdentity, authenticationHash);
+    public boolean isLoginComplete(SmartIdSession smartIdSession) {
+        try {
+            SessionStatus sessionStatus = connector.getSessionStatus(smartIdSession.getSessionId());
 
-                SmartIdAuthenticationResult authenticationResult = getAuthenticationResult(authenticationResponse);
-                session.setAuthenticationResult(authenticationResult);
-
-            } catch (UserAccountNotFoundException e) {
-                log.info("User account not found", e);
-                session.setErrors(Collections.singletonList("User account not found"));
-            } catch (UserRefusedException e) {
-                log.info("User refused", e);
-                session.setErrors(Collections.singletonList("User refused"));
-            } catch (Exception e) {
-                log.error("Technical error", e);
-                session.setErrors(Collections.singletonList("Smart ID technical error"));
-            } finally {
-                log.info("Authentication ended");
+            if (sessionStatus == null || "RUNNING".equalsIgnoreCase(sessionStatus.getState())) {
+                return false;
             }
 
-        });
-
-        return session;
+            if ("COMPLETE".equalsIgnoreCase(sessionStatus.getState())) {
+                SmartIdAuthenticationResponse authenticationResponse =
+                    builder(smartIdSession.getIdentityCode(), smartIdSession.getAuthenticationHash())
+                        .createSmartIdAuthenticationResponse(sessionStatus);
+                SmartIdAuthenticationResult authenticationResult = getAuthenticationResult(authenticationResponse);
+                smartIdSession.setAuthenticationResult(authenticationResult);
+            }
+        } catch (UserAccountNotFoundException e) {
+            log.info("User account not found", e);
+            smartIdSession.setErrors(Collections.singletonList("User account not found"));
+        } catch (UserRefusedException e) {
+            log.info("User refused", e);
+            smartIdSession.setErrors(Collections.singletonList("User refused"));
+        } catch (Exception e) {
+            log.error("Technical error", e);
+            smartIdSession.setErrors(Collections.singletonList("Smart ID technical error"));
+        } finally {
+            log.info("Authentication ended");
+        }
+        if (!smartIdSession.getErrors().isEmpty()) {
+            throw new IllegalStateException(String.join(",", smartIdSession.getErrors()));
+        }
+        return smartIdSession.isValid();
     }
 
-    SmartIdAuthenticationResponse getSmartIdAuthenticationResponse(NationalIdentity nationalIdentity,
-                                                                   AuthenticationHash authenticationHash) {
+    private AuthenticationRequestBuilder builder(String nationalIdentityCode, AuthenticationHash authenticationHash) {
         return smartIdClient
-                .createAuthentication()
-                .withNationalIdentity(nationalIdentity)
-                .withAuthenticationHash(authenticationHash)
-                .withCertificateLevel("QUALIFIED") // Certificate level can either be "QUALIFIED" or "ADVANCED"
-                .authenticate();
+            .createAuthentication()
+            .withNationalIdentity(new NationalIdentity("EE", nationalIdentityCode))
+            .withAuthenticationHash(authenticationHash)
+            .withCertificateLevel("QUALIFIED"); // Certificate level can either be "QUALIFIED" or "ADVANCED"
     }
 
-    SmartIdAuthenticationResult getAuthenticationResult(SmartIdAuthenticationResponse authenticationResponse) {
+    private SmartIdAuthenticationResult getAuthenticationResult(SmartIdAuthenticationResponse authenticationResponse) {
         SmartIdAuthenticationResult result = authenticationResponseValidator.validate(authenticationResponse);
         log.info("Response is valid {}", result.isValid());
         if (!result.getErrors().isEmpty()) {
             result.getErrors().forEach(log::error);
         }
         return result;
-    }
-
-    public boolean isLoginComplete(SmartIdSession smartIdSession) {
-        if (!smartIdSession.getErrors().isEmpty()) {
-            throw new IllegalStateException(String.join(",", smartIdSession.getErrors()));
-        }
-        return smartIdSession.isValid();
     }
 }

--- a/src/main/java/ee/tuleva/onboarding/auth/smartid/SmartIdSession.java
+++ b/src/main/java/ee/tuleva/onboarding/auth/smartid/SmartIdSession.java
@@ -1,5 +1,6 @@
 package ee.tuleva.onboarding.auth.smartid;
 
+import ee.sk.smartid.AuthenticationHash;
 import ee.sk.smartid.AuthenticationIdentity;
 import ee.sk.smartid.SmartIdAuthenticationResult;
 import lombok.Data;
@@ -17,13 +18,17 @@ public class SmartIdSession implements Serializable {
 
     private static final long serialVersionUID = 6407589354898164171L;
 
-    public final String verificationCode;
-    private boolean valid = false;
-    private List<String> errors = new ArrayList<>();
+    private final String verificationCode;
+    private final String sessionId;
+    private final String identityCode;
+    private final AuthenticationHash authenticationHash;
+    private boolean valid = false; // TODO: remove result from session
     private String givenName;
     private String surName;
-    private String identityCode;
     private String country;
+
+    // TODO: remove errors from session
+    private List<String> errors = new ArrayList<>();
 
     public void setAuthenticationResult(SmartIdAuthenticationResult result) {
         if (result.isValid()) {
@@ -31,7 +36,6 @@ public class SmartIdSession implements Serializable {
             AuthenticationIdentity identity = result.getAuthenticationIdentity();
             givenName = identity.getGivenName();
             surName = identity.getSurName();
-            identityCode = identity.getIdentityCode();
             country = identity.getCountry();
         } else {
             valid = false;

--- a/src/main/java/ee/tuleva/onboarding/config/SmartIdClientConfiguration.java
+++ b/src/main/java/ee/tuleva/onboarding/config/SmartIdClientConfiguration.java
@@ -3,6 +3,7 @@ package ee.tuleva.onboarding.config;
 import ee.sk.smartid.AuthenticationResponseValidator;
 import ee.sk.smartid.SmartIdClient;
 import ee.sk.smartid.exception.TechnicalErrorException;
+import ee.sk.smartid.rest.SmartIdConnector;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -19,8 +20,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.Enumeration;
-import java.util.concurrent.Executor;
-import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 @Configuration
 @RequiredArgsConstructor
@@ -32,12 +32,14 @@ public class SmartIdClientConfiguration {
     @Bean
     @ConfigurationProperties(prefix = "smartid")
     public SmartIdClient smartIdClient() {
-        return new SmartIdClient();
+        SmartIdClient smartIdClient = new SmartIdClient();
+        smartIdClient.setSessionStatusResponseSocketOpenTime(TimeUnit.MILLISECONDS, 1L);
+        return smartIdClient;
     }
 
     @Bean
-    public Executor smartIdExecutor() {
-        return Executors.newFixedThreadPool(100);
+    public SmartIdConnector smartIdConnector() {
+        return smartIdClient().getSmartIdConnector();
     }
 
     @Bean

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -48,7 +48,7 @@ spring:
             user.name: ${spring.security.user.name}
             user.password: ${spring.security.user.password}
   session:
-    store-type: none
+    store-type: jdbc
     jdbc:
       initialize-schema: never
 

--- a/src/test/groovy/ee/tuleva/onboarding/auth/smartid/SmartIdAuthServiceSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/auth/smartid/SmartIdAuthServiceSpec.groovy
@@ -1,6 +1,9 @@
 package ee.tuleva.onboarding.auth.smartid
 
+
 import ee.sk.smartid.*
+import ee.sk.smartid.exception.UserAccountNotFoundException
+import ee.sk.smartid.exception.UserRefusedException
 import ee.sk.smartid.rest.SmartIdConnector
 import ee.sk.smartid.rest.dao.*
 import spock.lang.Specification
@@ -55,6 +58,24 @@ class SmartIdAuthServiceSpec extends Specification {
     def "IsLoginComplete: Login is not complete when result is not valid"() {
         given:
         1 * connector.getSessionStatus(sessionId) >> sessionStatus("COMPLETE", "DOCUMENT_UNUSABLE")
+        when:
+        smartIdAuthService.isLoginComplete(sampleSmartIdSession)
+        then:
+        thrown(IllegalStateException)
+    }
+
+    def "IsLoginComplete: Login is not complete when user account not found"() {
+        given:
+        1 * connector.getSessionStatus(sessionId) >> { throw new UserAccountNotFoundException() }
+        when:
+        smartIdAuthService.isLoginComplete(sampleSmartIdSession)
+        then:
+        thrown(IllegalStateException)
+    }
+
+    def "IsLoginComplete: Login is not complete when user refused authentication"() {
+        given:
+        1 * connector.getSessionStatus(sessionId) >> { throw new UserRefusedException() }
         when:
         smartIdAuthService.isLoginComplete(sampleSmartIdSession)
         then:

--- a/src/test/groovy/ee/tuleva/onboarding/auth/smartid/SmartIdAuthServiceSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/auth/smartid/SmartIdAuthServiceSpec.groovy
@@ -5,6 +5,7 @@ import ee.sk.smartid.rest.SmartIdConnector
 import ee.sk.smartid.rest.dao.*
 import spock.lang.Specification
 
+import static ee.sk.smartid.SmartIdAuthenticationResult.Error.INVALID_END_RESULT
 import static ee.tuleva.onboarding.auth.smartid.SmartIdFixture.*
 
 class SmartIdAuthServiceSpec extends Specification {
@@ -70,6 +71,16 @@ class SmartIdAuthServiceSpec extends Specification {
         isLoginComplete
     }
 
+    def "IsLoginComplete: Error with authentication result"() {
+        given:
+        1 * connector.getSessionStatus(sessionId) >> sessionStatus("COMPLETE", "OK", "signature")
+        1 * validator.validate(_) >> invalidAuthResult()
+        when:
+        smartIdAuthService.isLoginComplete(sampleFinalSmartIdSession)
+        then:
+        thrown(IllegalStateException)
+    }
+
     private SmartIdAuthenticationResult validAuthResult() {
         AuthenticationIdentity identity = new AuthenticationIdentity()
         identity.givenName = givenName
@@ -79,6 +90,18 @@ class SmartIdAuthServiceSpec extends Specification {
         result.valid = true
         result.authenticationIdentity = identity
 
+        return result
+    }
+
+    private SmartIdAuthenticationResult invalidAuthResult() {
+        AuthenticationIdentity identity = new AuthenticationIdentity()
+        identity.givenName = givenName
+        identity.surName = surName
+
+        def result = new SmartIdAuthenticationResult()
+        result.valid = false
+        result.authenticationIdentity = identity
+        result.addError(INVALID_END_RESULT)
         return result
     }
 

--- a/src/test/groovy/ee/tuleva/onboarding/auth/smartid/SmartIdAuthServiceSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/auth/smartid/SmartIdAuthServiceSpec.groovy
@@ -1,86 +1,112 @@
 package ee.tuleva.onboarding.auth.smartid
 
 import ee.sk.smartid.*
-import ee.sk.smartid.exception.TechnicalErrorException
-import ee.sk.smartid.rest.dao.NationalIdentity
+import ee.sk.smartid.rest.SmartIdConnector
+import ee.sk.smartid.rest.dao.*
 import spock.lang.Specification
 
-import java.util.concurrent.Executor
+import static ee.tuleva.onboarding.auth.smartid.SmartIdFixture.*
 
 class SmartIdAuthServiceSpec extends Specification {
 
     SmartIdAuthService smartIdAuthService
-    SmartIdClient smartIdClient = Mock(SmartIdClient)
     SmartIdAuthenticationHashGenerator hashGenerator = Mock(SmartIdAuthenticationHashGenerator)
-    Executor smartIdExecutor = Mock(Executor)
-    AuthenticationHash hash = Mock(AuthenticationHash)
-    AuthenticationResponseValidator validator = new AuthenticationResponseValidator()
+    AuthenticationResponseValidator validator = Mock(AuthenticationResponseValidator)
+    SmartIdConnector connector = Mock(SmartIdConnector)
 
     def setup() {
-        smartIdAuthService = new SmartIdAuthService(smartIdClient, hashGenerator, smartIdExecutor, validator)
+        SmartIdClient smartIdClient = new SmartIdClient()
+        smartIdClient.setSmartIdConnector(connector)
+        smartIdClient.setRelyingPartyUUID("00000000-0000-0000-0000-000000000000")
+        smartIdClient.setRelyingPartyName("Demo")
+
+        smartIdAuthService = new SmartIdAuthService(smartIdClient, hashGenerator, validator, connector)
     }
 
-    def "StartLogin: Start mobile id login generates hash"() {
+    def "StartLogin: Start smart id login generates hash"() {
         given:
-        1 * hash.calculateVerificationCode() >> "12345"
+        AuthenticationHash hash = AuthenticationHash.generateRandomHash()
         1 * hashGenerator.generateHash() >> hash
+        1 * connector.authenticate(_, _) >> authenticationSessionResponse(sessionId)
         when:
-        SmartIdSession smartIdSession = smartIdAuthService.startLogin(SmartIdFixture.identityCode)
+        SmartIdSession session = smartIdAuthService.startLogin(identityCode)
         then:
-        smartIdSession.verificationCode == "12345"
-    }
-
-    def "StartLogin: Start mobile id login with a phone number"() {
-        given:
-        1 * hash.calculateVerificationCode() >> "12345"
-        1 * hashGenerator.generateHash() >> hash
-        when:
-        smartIdAuthService.startLogin(SmartIdFixture.identityCode)
-        then:
-        1 * smartIdExecutor.execute(_)
+        session.verificationCode == hash.calculateVerificationCode()
+        session.sessionId == sessionId
+        session.identityCode == identityCode
+        !session.valid
     }
 
     def "IsLoginComplete: Login is not complete when no result"() {
+        expect:
+        !smartIdAuthService.isLoginComplete(sampleSmartIdSession)
+    }
+
+    def "IsLoginComplete: Login is not complete when still running"() {
+        given:
+        1 * connector.getSessionStatus(sessionId) >> sessionStatus("RUNNING")
         when:
-        boolean isLoginComplete = smartIdAuthService.isLoginComplete(SmartIdFixture.sampleSmartIdSession)
+        boolean isLoginComplete = smartIdAuthService.isLoginComplete(sampleSmartIdSession)
         then:
         !isLoginComplete
     }
 
     def "IsLoginComplete: Login is not complete when result is not valid"() {
+        given:
+        1 * connector.getSessionStatus(sessionId) >> sessionStatus("COMPLETE", "DOCUMENT_UNUSABLE")
         when:
-        smartIdAuthService.isLoginComplete(SmartIdFixture.sampleFinalSmartIdSessionWithErrors)
+        smartIdAuthService.isLoginComplete(sampleSmartIdSession)
         then:
         thrown(IllegalStateException)
     }
 
     def "IsLoginComplete: Fetch state of smart id login"() {
+        given:
+        1 * connector.getSessionStatus(sessionId) >> sessionStatus("COMPLETE", "OK", "signature")
+        1 * validator.validate(_) >> validAuthResult()
         when:
-        boolean isLoginComplete = smartIdAuthService.isLoginComplete(SmartIdFixture.sampleFinalSmartIdSession)
+        boolean isLoginComplete = smartIdAuthService.isLoginComplete(sampleFinalSmartIdSession)
         then:
         isLoginComplete
     }
 
-    def "GetSmartIdAuthenticationResponse: calls authenticate"() {
-        given:
-        NationalIdentity identity = new NationalIdentity("EE", SmartIdFixture.identityCode)
-        AuthenticationRequestBuilder mockBuilder = Mock(AuthenticationRequestBuilder)
-        1 * smartIdClient.createAuthentication() >> mockBuilder
-        1 * mockBuilder.withNationalIdentity(identity) >> mockBuilder
-        1 * mockBuilder.withAuthenticationHash(hash) >> mockBuilder
-        1 * mockBuilder.withCertificateLevel("QUALIFIED") >> mockBuilder
-        when:
-        smartIdAuthService.getSmartIdAuthenticationResponse(identity, hash)
-        then:
-        1 * mockBuilder.authenticate()
+    private SmartIdAuthenticationResult validAuthResult() {
+        AuthenticationIdentity identity = new AuthenticationIdentity()
+        identity.givenName = givenName
+        identity.surName = surName
+
+        def result = new SmartIdAuthenticationResult()
+        result.valid = true
+        result.authenticationIdentity = identity
+
+        return result
     }
 
-    def "GetAuthenticationResult: throws when no cert"() {
-        given:
-        SmartIdAuthenticationResponse response = Mock(SmartIdAuthenticationResponse)
-        when:
-        smartIdAuthService.getAuthenticationResult(response)
-        then:
-        thrown(TechnicalErrorException)
+    private AuthenticationSessionResponse authenticationSessionResponse(String sessionId) {
+        def response = new AuthenticationSessionResponse()
+        response.setSessionID(sessionId)
+        return response
+    }
+
+    private SessionStatus sessionStatus(String state, String endResult = null, String signature = null) {
+        def result = new SessionResult()
+        result.endResult = endResult
+        result.documentNumber = "PNOEE-372123456"
+
+        def sessionSignature = new SessionSignature()
+        sessionSignature.algorithm = "sha256WithRSAEncryption"
+        sessionSignature.value = signature
+
+        def certificate = new SessionCertificate()
+        certificate.certificateLevel = "QUALIFIED"
+        certificate.value = "MIIHhjCCBW6gAwIBAgIQDNYLtVwrKURYStrYApYViTANBgkqhkiG9w0BAQsFADBoMQswCQYDVQQGEwJFRTEiMCAGA1UECgwZQVMgU2VydGlmaXRzZWVyaW1pc2tlc2t1czEXMBUGA1UEYQwOTlRSRUUtMTA3NDcwMTMxHDAaBgNVBAMME1RFU1Qgb2YgRUlELVNLIDIwMTYwHhcNMTYxMjA5MTYyNDU2WhcNMTkxMjA5MTYyNDU2WjCBvzELMAkGA1UEBhMCRUUxIjAgBgNVBAoMGUFTIFNlcnRpZml0c2VlcmltaXNrZXNrdXMxGjAYBgNVBAsMEWRpZ2l0YWwgc2lnbmF0dXJlMS0wKwYDVQQDDCRFTEZSSUlEQSxNQU5JVkFMREUsUE5PRUUtMzExMTExMTExMTExETAPBgNVBAQMCEVMRlJJSURBMRIwEAYDVQQqDAlNQU5JVkFMREUxGjAYBgNVBAUTEVBOT0VFLTMxMTExMTExMTExMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAgcfk+eY6dvVyDDPpJPkoKpQ08pQx5Jpfjgq+G31lRSsx03y4WYWQhILu5R4isI6DGzQ1MK2dEsW9Dl+S39y7mDDqGlviVpxCtgz14H7NG84ew8vd+sBeaYCvEhKS4+FxRWCmg5VCozr3s2Evi/ao3Wj51ThtecVmAY7PoE27Zckr0GJ/0I+JqEQx19POBr/lNkZN1AxBy8O9gvDzdpCa2Vn9qahY9eZnDGScrP2KsR34UlXa5PjEMVPtSB4btPi9VOQuRoZImGchfUyf1A2uyIPhV5aC+Zgl60B65WxZ+/nEsVN4NoSgBUv+HlwuRxJPelQKeA9tPwKroqO9PGc5/ee2C1HLH7loD+SwahSPMOY2e8CQd6pLmRF1a/H+ZPWZBW+U7Ekm3YeNNJToUkuonAQB/JbwBvHkZXwsH4/kMHyMPiws5G3nr/jyqF2595KKghIgjGHR1WhGljQzdgO5LT4uuOhesGDRYeMUanvClWSb/mt0SdS8njziY7WoYPYFFFgjRvIIK5FgOd8d2W88I5pj2/SjcXb6GMqEqI3HkCBGPDSo57nSJZzJD8KjJs/4jvzZnGwCFZ8+jeyh562B01mkFfwFaoFOYfqRG3g5sGdZUdY9Nk3FZ8dgEwylUMSxmaL0R2/mzNVasFWp482eHwlK2rae3v+QtCHGfOKn+vsCAwEAAaOCAdIwggHOMAkGA1UdEwQCMAAwDgYDVR0PAQH/BAQDAgZAMFYGA1UdIARPME0wQAYKKwYBBAHOHwMRAjAyMDAGCCsGAQUFBwIBFiRodHRwczovL3d3dy5zay5lZS9lbi9yZXBvc2l0b3J5L0NQUy8wCQYHBACL7EABATAdBgNVHQ4EFgQUNxW1gjoB4+Qh46Rj3SuULubhtUMwgZkGCCsGAQUFBwEDBIGMMIGJMAgGBgQAjkYBATAVBggrBgEFBQcLAjAJBgcEAIvsSQEBMBMGBgQAjkYBBjAJBgcEAI5GAQYBMFEGBgQAjkYBBTBHMEUWP2h0dHBzOi8vc2suZWUvZW4vcmVwb3NpdG9yeS9jb25kaXRpb25zLWZvci11c2Utb2YtY2VydGlmaWNhdGVzLxMCRU4wHwYDVR0jBBgwFoAUrrDq4Tb4JqulzAtmVf46HQK/ErQwfQYIKwYBBQUHAQEEcTBvMCkGCCsGAQUFBzABhh1odHRwOi8vYWlhLmRlbW8uc2suZWUvZWlkMjAxNjBCBggrBgEFBQcwAoY2aHR0cHM6Ly9zay5lZS91cGxvYWQvZmlsZXMvVEVTVF9vZl9FSUQtU0tfMjAxNi5kZXIuY3J0MA0GCSqGSIb3DQEBCwUAA4ICAQCH+SY8KKgw5UDlVL99ToRWPpcloyfOM64UTnNgEDXDDI5r1CNNA0OlggzoEZfakNQJamHjIT287LV7nXFsB4Q9VzyI3H1J5mzVIZrMUiE68wf25BDuA3Zwpri+f8Me78f3nowO2cJ2AiMJ83vQFKKy1LFOixWguuxioKlda2Jq7B57ty5cN+jZwLO7Vrv4Tryg9QeOaxnFvHvuZaxMnE55of7cLpfyAH/5DKvlXx4cdmh7kNO4F/o2LT7om4Cf+Sq6tFS3cUn4zcQbFKT5lw+7vfewzG6X0qYnHbe7Ts/zhh7IJpHnPF1p23ND0+jHgbcDVTFjV4pN1PhVthYHOMeDW461okw2OA/jfuQetUlDwqT5yCdjrOTMDkjZCjTMhcVPzw+7hSUUnewKiR0smuyZbKpE/ZGZWUA6K0sieGCpHGKJo99zD3zmEWmOmq++D0TmVvEiXVJs8fuNWl+VmXSStkMeNR4noHAL1PFUebXVS0lPpQZzBKgqhMGAgbwvYajZnOlvXVll6QashxFZmOVNy88O67s+a2p1SmQTtqNrlodszqkKsc28nDbbvBUd4PUD5tmVgPe29Zwnm1TxFuhl0gqvVc+qZme8zq6yd3nCKNrY6qron4Xcc1rxCWS7NcyO5JiF+qXgAuDOkSFJaaEnQh83ZJsNneXD/nyBH8kSiQ=="
+
+        def status = new SessionStatus()
+        status.setState(state)
+        status.setResult(result)
+        status.signature = sessionSignature
+        status.cert = certificate
+
+        return status
     }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/auth/smartid/SmartIdFixture.java
+++ b/src/test/groovy/ee/tuleva/onboarding/auth/smartid/SmartIdFixture.java
@@ -1,30 +1,32 @@
 package ee.tuleva.onboarding.auth.smartid;
 
+import ee.sk.smartid.AuthenticationHash;
 import ee.sk.smartid.AuthenticationIdentity;
 import ee.sk.smartid.SmartIdAuthenticationResult;
 
 public class SmartIdFixture {
 
-    public static String identityCode = "10101010005";
-    public static String givenName = "Aadu";
-    public static String surName = "Kadakas";
-    public static SmartIdSession sampleSmartIdSession = new SmartIdSession("12345");
-    public static SmartIdSession sampleFinalSmartIdSession = new SmartIdSession("12345");
-    public static SmartIdSession sampleFinalSmartIdSessionWithErrors = new SmartIdSession("12345");
+    public static final String identityCode = "10101010005";
+    public static final String givenName = "Aadu";
+    public static final String surName = "Kadakas";
+    public static final String sessionId = "sessionId123";
+    private static final String verificationCode = "12345";
+    public static SmartIdSession sampleSmartIdSession = new SmartIdSession(verificationCode, sessionId, identityCode,
+        AuthenticationHash.generateRandomHash());
+    public static SmartIdSession sampleFinalSmartIdSession = new SmartIdSession(verificationCode, sessionId, identityCode,
+        AuthenticationHash.generateRandomHash());
 
     static {
-        SmartIdAuthenticationResult result = new SmartIdAuthenticationResult();
-        result.setValid(true);
         AuthenticationIdentity identity = new AuthenticationIdentity();
         identity.setIdentityCode(identityCode);
         identity.setGivenName(givenName);
         identity.setSurName(surName);
-        result.setAuthenticationIdentity(identity);
-        sampleFinalSmartIdSession.setAuthenticationResult(result);
 
-        SmartIdAuthenticationResult result2 = new SmartIdAuthenticationResult();
-        result2.setValid(false);
-        result2.addError(SmartIdAuthenticationResult.Error.CERTIFICATE_EXPIRED);
-        sampleFinalSmartIdSessionWithErrors.setAuthenticationResult(result2);
+        SmartIdAuthenticationResult result = new SmartIdAuthenticationResult();
+        result.setValid(true);
+        result.setAuthenticationIdentity(identity);
+
+        sampleFinalSmartIdSession.setAuthenticationResult(result);
     }
+
 }


### PR DESCRIPTION
- Removes the async SmartIdExecutor which should not have access to the HTTPSession
- Does 1ms timeout synchronous polling instead (which does not block the thread for long)
- Saves the results to the HTTPSession since the result is fetched synchronously in the same HTTP request handler thread