### PR TITLE
Change polling the Mobile ID session status to non-blocking

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/config/MobileIdConfiguration.java
+++ b/src/main/java/ee/tuleva/onboarding/config/MobileIdConfiguration.java
@@ -32,9 +32,6 @@ public class MobileIdConfiguration {
   @Value("${mobile-id.pollingSleepTimeoutSeconds}")
   private int pollingSleepTimeoutSeconds;
 
-  @Value("${mobile-id.longPollingTimeoutSeconds}")
-  private int longPollingTimeoutSeconds;
-
   @Value("${mobile-id.service.name}")
   private String serviceName;
 
@@ -53,7 +50,6 @@ public class MobileIdConfiguration {
         .withRelyingPartyName(relyingPartyName)
         .withRelyingPartyUUID(relyingPartyUUID)
         .withHostUrl(hostUrl)
-        .withLongPollingTimeoutSeconds(longPollingTimeoutSeconds)
         .withPollingSleepTimeoutSeconds(pollingSleepTimeoutSeconds)
         .build();
   }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -68,7 +68,6 @@ digidoc:
 mobile-id:
   hostUrl: 'https://tsp.demo.sk.ee/mid-api'
   pollingSleepTimeoutSeconds: 2
-  longPollingTimeoutSeconds: 60
   service:
     name: "Testimine"
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -67,7 +67,7 @@ digidoc:
 
 mobile-id:
   hostUrl: 'https://tsp.demo.sk.ee/mid-api'
-  pollingSleepTimeoutSeconds: 2
+  pollingSleepTimeoutSeconds: 1
   service:
     name: "Testimine"
 

--- a/src/test/groovy/ee/tuleva/onboarding/auth/mobileid/MobileIdAuthServiceSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/auth/mobileid/MobileIdAuthServiceSpec.groovy
@@ -79,6 +79,24 @@ class MobileIdAuthServiceSpec extends Specification {
         thrown(MobileIdException)
     }
 
+    def "IsLoginComplete: Mobile ID authentication response is still in RUNNING status"() {
+        given:
+        1 * poller.fetchFinalAuthenticationSessionStatus(_) >> getSampleMidSessionIncomplete()
+        when:
+        boolean isLoginComplete = mobileIdAuthService.isLoginComplete(sampleMobileIdSession)
+        then:
+        isLoginComplete == false
+    }
+
+    def "IsLoginComplete: Mobile ID authentication response has some other response status"() {
+        given:
+        1 * poller.fetchFinalAuthenticationSessionStatus(_) >> getSampleMidSessionOther()
+        when:
+        boolean isLoginComplete = mobileIdAuthService.isLoginComplete(sampleMobileIdSession)
+        then:
+        isLoginComplete == false
+    }
+
     def "IsLoginComplete: User has cancelled login operation"() {
         given:
         1 * poller.fetchFinalAuthenticationSessionStatus(_) >> { throw new MidUserCancellationException() }

--- a/src/test/groovy/ee/tuleva/onboarding/auth/mobileid/MobileIdAuthServiceSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/auth/mobileid/MobileIdAuthServiceSpec.groovy
@@ -6,7 +6,6 @@ import ee.sk.mid.MidClient
 import ee.sk.mid.exception.*
 import ee.sk.mid.rest.MidConnector
 import ee.sk.mid.rest.MidSessionStatusPoller
-import ee.sk.mid.rest.dao.MidSessionStatus
 import ee.sk.mid.rest.dao.response.MidAuthenticationResponse
 import ee.tuleva.onboarding.auth.exception.MobileIdException
 import spock.lang.Specification
@@ -60,7 +59,7 @@ class MobileIdAuthServiceSpec extends Specification {
 
     def "IsLoginComplete: Fetch state of mobile id login"() {
         given:
-        1 * poller.fetchFinalAuthenticationSessionStatus(_) >> new MidSessionStatus()
+        1 * poller.fetchFinalAuthenticationSessionStatus(_) >> getSampleMidSessionComplete()
         1 * client.createMobileIdAuthentication(_, _) >> new MidAuthentication.MobileIdAuthenticationBuilder().withResult("OK").withSignatureValueInBase64("bGVhc3VyZS4=").build()
         1 * validator.validate(_) >> getSampleMidAuthResult(true)
         when:
@@ -71,7 +70,7 @@ class MobileIdAuthServiceSpec extends Specification {
 
     def "IsLoginComplete: Fetch invalid state of mobile id login"() {
         given:
-        1 * poller.fetchFinalAuthenticationSessionStatus(_) >> new MidSessionStatus()
+        1 * poller.fetchFinalAuthenticationSessionStatus(_) >> getSampleMidSessionComplete()
         1 * client.createMobileIdAuthentication(_, _) >> new MidAuthentication.MobileIdAuthenticationBuilder().withResult("OK").withSignatureValueInBase64("bGVhc3VyZS4=").build()
         1 * validator.validate(_) >> getSampleMidAuthResult(false)
         when:
@@ -82,9 +81,7 @@ class MobileIdAuthServiceSpec extends Specification {
 
     def "IsLoginComplete: User has cancelled login operation"() {
         given:
-        1 * poller.fetchFinalAuthenticationSessionStatus(_) >> new MidSessionStatus()
-        1 * client.createMobileIdAuthentication(_, _) >> new MidAuthentication.MobileIdAuthenticationBuilder().withResult("OK").withSignatureValueInBase64("bGVhc3VyZS4=").build()
-        1 * validator.validate(_) >> { throw new MidUserCancellationException() }
+        1 * poller.fetchFinalAuthenticationSessionStatus(_) >> { throw new MidUserCancellationException() }
         when:
         mobileIdAuthService.isLoginComplete(sampleMobileIdSession)
         then:
@@ -93,9 +90,7 @@ class MobileIdAuthServiceSpec extends Specification {
 
     def "IsLoginComplete: User is not a MID client"() {
         given:
-        1 * poller.fetchFinalAuthenticationSessionStatus(_) >> new MidSessionStatus()
-        1 * client.createMobileIdAuthentication(_, _) >> new MidAuthentication.MobileIdAuthenticationBuilder().withResult("OK").withSignatureValueInBase64("bGVhc3VyZS4=").build()
-        1 * validator.validate(_) >> { throw new MidNotMidClientException() }
+        1 * poller.fetchFinalAuthenticationSessionStatus(_) >> { throw new MidNotMidClientException() }
         when:
         mobileIdAuthService.isLoginComplete(sampleMobileIdSession)
         then:
@@ -104,9 +99,7 @@ class MobileIdAuthServiceSpec extends Specification {
 
     def "IsLoginComplete: User did not type in PIN code before session timeout"() {
         given:
-        1 * poller.fetchFinalAuthenticationSessionStatus(_) >> new MidSessionStatus()
-        1 * client.createMobileIdAuthentication(_, _) >> new MidAuthentication.MobileIdAuthenticationBuilder().withResult("OK").withSignatureValueInBase64("bGVhc3VyZS4=").build()
-        1 * validator.validate(_) >> { throw new MidSessionTimeoutException() }
+        1 * poller.fetchFinalAuthenticationSessionStatus(_) >> { throw new MidSessionTimeoutException() }
         when:
         mobileIdAuthService.isLoginComplete(sampleMobileIdSession)
         then:
@@ -115,9 +108,7 @@ class MobileIdAuthServiceSpec extends Specification {
 
     def "IsLoginComplete: Unable to reach phone/SIM card"() {
         given:
-        1 * poller.fetchFinalAuthenticationSessionStatus(_) >> new MidSessionStatus()
-        1 * client.createMobileIdAuthentication(_, _) >> new MidAuthentication.MobileIdAuthenticationBuilder().withResult("OK").withSignatureValueInBase64("bGVhc3VyZS4=").build()
-        1 * validator.validate(_) >> { throw new MidPhoneNotAvailableException() }
+        1 * poller.fetchFinalAuthenticationSessionStatus(_) >> { throw new MidPhoneNotAvailableException() }
         when:
         mobileIdAuthService.isLoginComplete(sampleMobileIdSession)
         then:
@@ -126,9 +117,7 @@ class MobileIdAuthServiceSpec extends Specification {
 
     def "IsLoginComplete: Error communicating with the phone/SIM card"() {
         given:
-        1 * poller.fetchFinalAuthenticationSessionStatus(_) >> new MidSessionStatus()
-        1 * client.createMobileIdAuthentication(_, _) >> new MidAuthentication.MobileIdAuthenticationBuilder().withResult("OK").withSignatureValueInBase64("bGVhc3VyZS4=").build()
-        1 * validator.validate(_) >> { throw new MidDeliveryException() }
+        1 * poller.fetchFinalAuthenticationSessionStatus(_) >> { throw new MidDeliveryException() }
         when:
         mobileIdAuthService.isLoginComplete(sampleMobileIdSession)
         then:
@@ -137,9 +126,7 @@ class MobileIdAuthServiceSpec extends Specification {
 
     def "IsLoginComplete: Mobile-ID configuration invalid"() {
         given:
-        1 * poller.fetchFinalAuthenticationSessionStatus(_) >> new MidSessionStatus()
-        1 * client.createMobileIdAuthentication(_, _) >> new MidAuthentication.MobileIdAuthenticationBuilder().withResult("OK").withSignatureValueInBase64("bGVhc3VyZS4=").build()
-        1 * validator.validate(_) >> { throw new MidInvalidUserConfigurationException() }
+        1 * poller.fetchFinalAuthenticationSessionStatus(_) >> { throw new MidInvalidUserConfigurationException() }
         when:
         mobileIdAuthService.isLoginComplete(sampleMobileIdSession)
         then:
@@ -148,9 +135,7 @@ class MobileIdAuthServiceSpec extends Specification {
 
     def "IsLoginComplete: Integrator-side error with MID integration "() {
         given:
-        1 * poller.fetchFinalAuthenticationSessionStatus(_) >> new MidSessionStatus()
-        1 * client.createMobileIdAuthentication(_, _) >> new MidAuthentication.MobileIdAuthenticationBuilder().withResult("OK").withSignatureValueInBase64("bGVhc3VyZS4=").build()
-        1 * validator.validate(_) >> { throw new MidMissingOrInvalidParameterException("Invalid parameter") }
+        1 * poller.fetchFinalAuthenticationSessionStatus(_) >> { throw new MidMissingOrInvalidParameterException("Invalid parameter") }
         when:
         mobileIdAuthService.isLoginComplete(sampleMobileIdSession)
         then:
@@ -159,9 +144,7 @@ class MobileIdAuthServiceSpec extends Specification {
 
     def "IsLoginComplete: MID service returned internal error"() {
         given:
-        1 * poller.fetchFinalAuthenticationSessionStatus(_) >> new MidSessionStatus()
-        1 * client.createMobileIdAuthentication(_, _) >> new MidAuthentication.MobileIdAuthenticationBuilder().withResult("OK").withSignatureValueInBase64("bGVhc3VyZS4=").build()
-        1 * validator.validate(_) >> { throw new MidInternalErrorException("Internal Error") }
+        1 * poller.fetchFinalAuthenticationSessionStatus(_) >> { throw new MidInternalErrorException("Internal Error") }
         when:
         mobileIdAuthService.isLoginComplete(sampleMobileIdSession)
         then:

--- a/src/test/groovy/ee/tuleva/onboarding/auth/mobileid/MobileIdAuthServiceSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/auth/mobileid/MobileIdAuthServiceSpec.groovy
@@ -88,6 +88,16 @@ class MobileIdAuthServiceSpec extends Specification {
         isLoginComplete == false
     }
 
+    def "IsLoginComplete: Mobile ID sessionStatus is missing"() {
+        given:
+        1 * poller.fetchFinalAuthenticationSessionStatus(_) >> null
+        when:
+        boolean isLoginComplete = mobileIdAuthService.isLoginComplete(sampleMobileIdSession)
+        then:
+        isLoginComplete == false
+    }
+
+
     def "IsLoginComplete: Mobile ID authentication response has some other response status"() {
         given:
         1 * poller.fetchFinalAuthenticationSessionStatus(_) >> getSampleMidSessionOther()

--- a/src/test/groovy/ee/tuleva/onboarding/auth/mobileid/MobileIdFixture.java
+++ b/src/test/groovy/ee/tuleva/onboarding/auth/mobileid/MobileIdFixture.java
@@ -2,6 +2,7 @@ package ee.tuleva.onboarding.auth.mobileid;
 
 import ee.sk.mid.MidAuthenticationIdentity;
 import ee.sk.mid.MidAuthenticationResult;
+import ee.sk.mid.rest.dao.MidSessionStatus;
 
 public class MobileIdFixture {
 
@@ -13,6 +14,12 @@ public class MobileIdFixture {
   public static String sampleSessionId = "12345";
   public static MobileIDSession sampleMobileIdSession =
       new MobileIDSession(sampleSessionId, "challenge", null, samplePhoneNumber);
+
+  public static MidSessionStatus getSampleMidSessionComplete() {
+    MidSessionStatus status = new MidSessionStatus();
+    status.setState("COMPLETE");
+    return status;
+  }
 
   public static MidAuthenticationResult getSampleMidAuthResult(boolean isValid) {
     MidAuthenticationResult sampleAuthResult = new MidAuthenticationResult();

--- a/src/test/groovy/ee/tuleva/onboarding/auth/mobileid/MobileIdFixture.java
+++ b/src/test/groovy/ee/tuleva/onboarding/auth/mobileid/MobileIdFixture.java
@@ -21,6 +21,18 @@ public class MobileIdFixture {
     return status;
   }
 
+  public static MidSessionStatus getSampleMidSessionIncomplete() {
+    MidSessionStatus status = new MidSessionStatus();
+    status.setState("RUNNING");
+    return status;
+  }
+
+  public static MidSessionStatus getSampleMidSessionOther() {
+    MidSessionStatus status = new MidSessionStatus();
+    status.setState("");
+    return status;
+  }
+
   public static MidAuthenticationResult getSampleMidAuthResult(boolean isValid) {
     MidAuthenticationResult sampleAuthResult = new MidAuthenticationResult();
     MidAuthenticationIdentity sampleAuthIdentity = new MidAuthenticationIdentity();


### PR DESCRIPTION
Change polling Mobile ID session status between 1 second intervals instead of blocking with a 60s timeout while verifying user login code.