### PR TITLE
Remove portrayed non-active funds from account statement

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/account/AccountStatementService.java
+++ b/src/main/java/ee/tuleva/onboarding/account/AccountStatementService.java
@@ -9,7 +9,9 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 
+import static java.math.BigDecimal.ZERO;
 import static java.util.stream.Collectors.toList;
+import static org.apache.commons.lang3.ObjectUtils.compare;
 
 @Service
 @Slf4j
@@ -24,6 +26,9 @@ public class AccountStatementService {
 
         return accountStatement.stream()
             .filter(fundBalanceDto -> fundBalanceDto.getIsin() != null)
+            .filter(fundBalanceDto ->
+                compare(ZERO, fundBalanceDto.getValue()) != 0 || fundBalanceDto.isActiveContributions()
+            )
             .map(fundBalanceDto -> convertToFundBalance(fundBalanceDto, person))
             .collect(toList());
     }

--- a/src/test/groovy/ee/tuleva/onboarding/account/AccountStatementServiceSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/account/AccountStatementServiceSpec.groovy
@@ -1,12 +1,15 @@
 package ee.tuleva.onboarding.account
 
-
+import ee.tuleva.onboarding.auth.principal.Person
 import ee.tuleva.onboarding.epis.EpisService
 import ee.tuleva.onboarding.epis.account.FundBalanceDto
+import ee.tuleva.onboarding.fund.Fund
 import spock.lang.Specification
 
 import static ee.tuleva.onboarding.account.AccountStatementFixture.activeTuleva2ndPillarFundBalance
 import static ee.tuleva.onboarding.auth.PersonFixture.samplePerson
+import static java.math.BigDecimal.ONE
+import static java.math.BigDecimal.ZERO
 
 class AccountStatementServiceSpec extends Specification {
 
@@ -43,6 +46,35 @@ class AccountStatementServiceSpec extends Specification {
         then:
             accountStatement.isEmpty()
             0 * fundBalanceConverter.convert(fundBalanceDto, person)
+    }
+
+    def "filters non-active out zero balance funds"() {
+        given:
+        def person = samplePerson()
+        def nonActiveZeroFund = FundBalanceDto.builder().isin("1").value(ZERO).activeContributions(false).build()
+        def nonActiveNonZeroFund = FundBalanceDto.builder().isin("2").value(ONE).activeContributions(false).build()
+        def activeZeroFund = FundBalanceDto.builder().isin("3").value(ZERO).activeContributions(true).build()
+        def activeNonZeroFund = FundBalanceDto.builder().isin("4").value(ONE).activeContributions(true).build()
+
+        episService.getAccountStatement(person) >> [nonActiveZeroFund, nonActiveNonZeroFund, activeZeroFund, activeNonZeroFund]
+        fundBalanceConverter.convert(_, person) >> { FundBalanceDto fundBalanceDto, _ ->
+            FundBalance.builder().fund(Fund.builder().isin(fundBalanceDto.isin).build()).build()
+        }
+
+        when:
+        List<FundBalance> accountStatement = service.getAccountStatement(person)
+
+        then:
+        with(accountStatement.get(0)) {
+            isin == nonActiveNonZeroFund.isin
+        }
+        with(accountStatement.get(1)) {
+            isin == activeZeroFund.isin
+        }
+        with(accountStatement.get(2)) {
+            isin == activeNonZeroFund.isin
+        }
+        accountStatement.size() == 3
     }
 
     def "handles fundBalanceDto to fundBalance conversion exceptions"() {


### PR DESCRIPTION
Account statement showed all funds that user has had whether they are active or inactive.

Removed non-active funds that have 0 value inside.