### PR TITLE
Add zero funds with subtractions

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/account/AccountStatementService.java
+++ b/src/main/java/ee/tuleva/onboarding/account/AccountStatementService.java
@@ -7,7 +7,9 @@ import static org.apache.commons.lang3.ObjectUtils.compare;
 import ee.tuleva.onboarding.auth.principal.Person;
 import ee.tuleva.onboarding.epis.EpisService;
 import ee.tuleva.onboarding.epis.account.FundBalanceDto;
+
 import java.util.List;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -24,13 +26,13 @@ public class AccountStatementService {
     List<FundBalanceDto> accountStatement = episService.getAccountStatement(person);
 
     return accountStatement.stream()
-        .filter(fundBalanceDto -> fundBalanceDto.getIsin() != null)
-        .filter(
-            fundBalanceDto ->
-                compare(ZERO, fundBalanceDto.getValue()) != 0
-                    || fundBalanceDto.isActiveContributions())
-        .map(fundBalanceDto -> convertToFundBalance(fundBalanceDto, person))
-        .collect(toList());
+      .filter(fundBalanceDto -> fundBalanceDto.getIsin() != null)
+      .filter(
+        fundBalanceDto ->
+          compare(ZERO, fundBalanceDto.getValue()) != 0
+            || fundBalanceDto.isActiveContributions())
+      .map(fundBalanceDto -> convertToFundBalance(fundBalanceDto, person))
+      .collect(toList());
   }
 
   private FundBalance convertToFundBalance(FundBalanceDto fundBalanceDto, Person person) {

--- a/src/main/java/ee/tuleva/onboarding/account/AccountStatementService.java
+++ b/src/main/java/ee/tuleva/onboarding/account/AccountStatementService.java
@@ -25,13 +25,15 @@ public class AccountStatementService {
 
     return accountStatement.stream()
         .filter(fundBalanceDto -> fundBalanceDto.getIsin() != null)
+        .filter(this::secondPillarNotEmpty)
         .map(fundBalanceDto -> convertToFundBalance(fundBalanceDto, person))
-        .filter(
-            fundBalance ->
-                compare(ZERO, fundBalance.getSubtractions()) == -1
-                    || compare(ZERO, fundBalance.getValue()) != 0
-                    || fundBalance.isActiveContributions())
         .collect(toList());
+  }
+
+  private boolean secondPillarNotEmpty(FundBalanceDto fundBalanceDto) {
+    return compare(ZERO, fundBalanceDto.getValue()) != 0
+        || fundBalanceDto.isActiveContributions()
+        || fundBalanceDto.getPillar() == 3;
   }
 
   private FundBalance convertToFundBalance(FundBalanceDto fundBalanceDto, Person person) {

--- a/src/main/java/ee/tuleva/onboarding/account/AccountStatementService.java
+++ b/src/main/java/ee/tuleva/onboarding/account/AccountStatementService.java
@@ -1,18 +1,17 @@
 package ee.tuleva.onboarding.account;
 
-import static java.math.BigDecimal.ZERO;
-import static java.util.stream.Collectors.toList;
-import static org.apache.commons.lang3.ObjectUtils.compare;
-
 import ee.tuleva.onboarding.auth.principal.Person;
 import ee.tuleva.onboarding.epis.EpisService;
 import ee.tuleva.onboarding.epis.account.FundBalanceDto;
-
-import java.util.List;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+import static java.math.BigDecimal.ZERO;
+import static java.util.stream.Collectors.toList;
+import static org.apache.commons.lang3.ObjectUtils.compare;
 
 @Service
 @Slf4j
@@ -31,7 +30,8 @@ public class AccountStatementService {
       .filter(fundBalance ->
         compare(ZERO, fundBalance.getSubtractions()) == -1
           || compare(ZERO, fundBalance.getValue()) != 0
-          || fundBalance.isActiveContributions())
+          || fundBalance.isActiveContributions()
+      )
       .collect(toList());
   }
 

--- a/src/main/java/ee/tuleva/onboarding/account/AccountStatementService.java
+++ b/src/main/java/ee/tuleva/onboarding/account/AccountStatementService.java
@@ -1,17 +1,16 @@
 package ee.tuleva.onboarding.account;
 
-import ee.tuleva.onboarding.auth.principal.Person;
-import ee.tuleva.onboarding.epis.EpisService;
-import ee.tuleva.onboarding.epis.account.FundBalanceDto;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
-
-import java.util.List;
-
 import static java.math.BigDecimal.ZERO;
 import static java.util.stream.Collectors.toList;
 import static org.apache.commons.lang3.ObjectUtils.compare;
+
+import ee.tuleva.onboarding.auth.principal.Person;
+import ee.tuleva.onboarding.epis.EpisService;
+import ee.tuleva.onboarding.epis.account.FundBalanceDto;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
 
 @Service
 @Slf4j
@@ -25,14 +24,14 @@ public class AccountStatementService {
     List<FundBalanceDto> accountStatement = episService.getAccountStatement(person);
 
     return accountStatement.stream()
-      .filter(fundBalanceDto -> fundBalanceDto.getIsin() != null)
-      .map(fundBalanceDto -> convertToFundBalance(fundBalanceDto, person))
-      .filter(fundBalance ->
-        compare(ZERO, fundBalance.getSubtractions()) == -1
-          || compare(ZERO, fundBalance.getValue()) != 0
-          || fundBalance.isActiveContributions()
-      )
-      .collect(toList());
+        .filter(fundBalanceDto -> fundBalanceDto.getIsin() != null)
+        .map(fundBalanceDto -> convertToFundBalance(fundBalanceDto, person))
+        .filter(
+            fundBalance ->
+                compare(ZERO, fundBalance.getSubtractions()) == -1
+                    || compare(ZERO, fundBalance.getValue()) != 0
+                    || fundBalance.isActiveContributions())
+        .collect(toList());
   }
 
   private FundBalance convertToFundBalance(FundBalanceDto fundBalanceDto, Person person) {

--- a/src/main/java/ee/tuleva/onboarding/account/AccountStatementService.java
+++ b/src/main/java/ee/tuleva/onboarding/account/AccountStatementService.java
@@ -25,12 +25,12 @@ public class AccountStatementService {
 
     return accountStatement.stream()
         .filter(fundBalanceDto -> fundBalanceDto.getIsin() != null)
-        .filter(this::secondPillarNotEmpty)
+        .filter(this::isSecondPillarNotEmpty)
         .map(fundBalanceDto -> convertToFundBalance(fundBalanceDto, person))
         .collect(toList());
   }
 
-  private boolean secondPillarNotEmpty(FundBalanceDto fundBalanceDto) {
+  private boolean isSecondPillarNotEmpty(FundBalanceDto fundBalanceDto) {
     return compare(ZERO, fundBalanceDto.getValue()) != 0
         || fundBalanceDto.isActiveContributions()
         || fundBalanceDto.getPillar() == 3;

--- a/src/main/java/ee/tuleva/onboarding/account/AccountStatementService.java
+++ b/src/main/java/ee/tuleva/onboarding/account/AccountStatementService.java
@@ -27,11 +27,11 @@ public class AccountStatementService {
 
     return accountStatement.stream()
       .filter(fundBalanceDto -> fundBalanceDto.getIsin() != null)
-      .filter(
-        fundBalanceDto ->
-          compare(ZERO, fundBalanceDto.getValue()) != 0
-            || fundBalanceDto.isActiveContributions())
       .map(fundBalanceDto -> convertToFundBalance(fundBalanceDto, person))
+      .filter(fundBalance ->
+        compare(ZERO, fundBalance.getSubtractions()) == -1
+          || compare(ZERO, fundBalance.getValue()) != 0
+          || fundBalance.isActiveContributions())
       .collect(toList());
   }
 

--- a/src/main/java/ee/tuleva/onboarding/account/FundBalanceDtoToFundBalanceConverter.java
+++ b/src/main/java/ee/tuleva/onboarding/account/FundBalanceDtoToFundBalanceConverter.java
@@ -1,20 +1,19 @@
 package ee.tuleva.onboarding.account;
 
+import static java.math.BigDecimal.ZERO;
+
 import ee.tuleva.onboarding.auth.principal.Person;
 import ee.tuleva.onboarding.epis.account.FundBalanceDto;
 import ee.tuleva.onboarding.epis.cashflows.CashFlow;
 import ee.tuleva.onboarding.fund.Fund;
 import ee.tuleva.onboarding.fund.FundRepository;
+import java.math.BigDecimal;
+import java.util.function.Predicate;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Component;
-
-import java.math.BigDecimal;
-import java.util.function.Predicate;
-
-import static java.math.BigDecimal.ZERO;
 
 @Component
 @Slf4j
@@ -29,10 +28,12 @@ public class FundBalanceDtoToFundBalanceConverter
   public FundBalance convert(FundBalanceDto fundBalanceDto, Person person) {
     FundBalance fundBalance = convert(fundBalanceDto);
 
-    BigDecimal contributions = sumAmounts(fundBalance.getIsin(), person, amount -> amount.compareTo(ZERO) > 0);
+    BigDecimal contributions =
+        sumAmounts(fundBalance.getIsin(), person, amount -> amount.compareTo(ZERO) > 0);
     fundBalance.setContributions(contributions);
 
-    BigDecimal subtractions = sumAmounts(fundBalance.getIsin(), person, amount -> amount.compareTo(ZERO) < 0);
+    BigDecimal subtractions =
+        sumAmounts(fundBalance.getIsin(), person, amount -> amount.compareTo(ZERO) < 0);
     fundBalance.setSubtractions(subtractions);
 
     return fundBalance;

--- a/src/main/java/ee/tuleva/onboarding/account/FundBalanceDtoToFundBalanceConverter.java
+++ b/src/main/java/ee/tuleva/onboarding/account/FundBalanceDtoToFundBalanceConverter.java
@@ -1,19 +1,20 @@
 package ee.tuleva.onboarding.account;
 
-import static java.math.BigDecimal.ZERO;
-
 import ee.tuleva.onboarding.auth.principal.Person;
 import ee.tuleva.onboarding.epis.account.FundBalanceDto;
 import ee.tuleva.onboarding.epis.cashflows.CashFlow;
 import ee.tuleva.onboarding.fund.Fund;
 import ee.tuleva.onboarding.fund.FundRepository;
-import java.math.BigDecimal;
-import java.util.function.Predicate;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+import java.util.function.Predicate;
+
+import static java.math.BigDecimal.ZERO;
 
 @Component
 @Slf4j
@@ -27,10 +28,13 @@ public class FundBalanceDtoToFundBalanceConverter
   @NonNull
   public FundBalance convert(FundBalanceDto fundBalanceDto, Person person) {
     FundBalance fundBalance = convert(fundBalanceDto);
-    fundBalance.setContributions(
-        sumAmounts(fundBalance.getIsin(), person, amount -> amount.compareTo(ZERO) > 0));
-    fundBalance.setSubtractions(
-        sumAmounts(fundBalance.getIsin(), person, amount -> amount.compareTo(ZERO) < 0));
+
+    BigDecimal contributions = sumAmounts(fundBalance.getIsin(), person, amount -> amount.compareTo(ZERO) > 0);
+    fundBalance.setContributions(contributions);
+
+    BigDecimal subtractions = sumAmounts(fundBalance.getIsin(), person, amount -> amount.compareTo(ZERO) < 0);
+    fundBalance.setSubtractions(subtractions);
+
     return fundBalance;
   }
 

--- a/src/test/groovy/ee/tuleva/onboarding/account/AccountStatementServiceSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/account/AccountStatementServiceSpec.groovy
@@ -1,6 +1,5 @@
 package ee.tuleva.onboarding.account
 
-import ee.tuleva.onboarding.auth.principal.Person
 import ee.tuleva.onboarding.epis.EpisService
 import ee.tuleva.onboarding.epis.account.FundBalanceDto
 import ee.tuleva.onboarding.fund.Fund
@@ -57,8 +56,12 @@ class AccountStatementServiceSpec extends Specification {
     def activeNonZeroFund = FundBalanceDto.builder().isin("4").value(ONE).activeContributions(true).build()
 
     episService.getAccountStatement(person) >> [nonActiveZeroFund, nonActiveNonZeroFund, activeZeroFund, activeNonZeroFund]
-    fundBalanceConverter.convert(_, person) >> { FundBalanceDto fundBalanceDto, _ ->
-      FundBalance.builder().fund(Fund.builder().isin(fundBalanceDto.isin).build()).build()
+    fundBalanceConverter.convert(_, _) >> { FundBalanceDto fundBalanceDto, _ ->
+      FundBalance.builder()
+        .fund(Fund.builder().isin(fundBalanceDto.isin).build())
+        .value(fundBalanceDto.value)
+        .activeContributions(fundBalanceDto.activeContributions)
+        .build()
     }
 
     when:

--- a/src/test/groovy/ee/tuleva/onboarding/account/AccountStatementServiceSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/account/AccountStatementServiceSpec.groovy
@@ -13,84 +13,84 @@ import static java.math.BigDecimal.ZERO
 
 class AccountStatementServiceSpec extends Specification {
 
-    def episService = Mock(EpisService)
-    def fundBalanceConverter = Mock(FundBalanceDtoToFundBalanceConverter)
+  def episService = Mock(EpisService)
+  def fundBalanceConverter = Mock(FundBalanceDtoToFundBalanceConverter)
 
-    def service = new AccountStatementService(episService, fundBalanceConverter)
+  def service = new AccountStatementService(episService, fundBalanceConverter)
 
-    def "returns an account statement"() {
-        given:
-        def person = samplePerson()
-        def fundBalanceDto = FundBalanceDto.builder().isin("someIsin").build()
-        def fundBalance = activeTuleva2ndPillarFundBalance.first()
+  def "returns an account statement"() {
+    given:
+    def person = samplePerson()
+    def fundBalanceDto = FundBalanceDto.builder().isin("someIsin").build()
+    def fundBalance = activeTuleva2ndPillarFundBalance.first()
 
-        episService.getAccountStatement(person) >> [fundBalanceDto]
-        fundBalanceConverter.convert(fundBalanceDto, person) >> fundBalance
+    episService.getAccountStatement(person) >> [fundBalanceDto]
+    fundBalanceConverter.convert(fundBalanceDto, person) >> fundBalance
 
-        when:
-        List<FundBalance> accountStatement = service.getAccountStatement(person)
+    when:
+    List<FundBalance> accountStatement = service.getAccountStatement(person)
 
-        then:
-        accountStatement == [fundBalance]
+    then:
+    accountStatement == [fundBalance]
+  }
+
+  def "fundBalanceDto with no Isin code are filtered out and will not try to convert"() {
+    given:
+    def person = samplePerson()
+    def fundBalanceDto = FundBalanceDto.builder().isin(null).build()
+    episService.getAccountStatement(person) >> [fundBalanceDto]
+
+    when:
+    List<FundBalance> accountStatement = service.getAccountStatement(person)
+
+    then:
+    accountStatement.isEmpty()
+    0 * fundBalanceConverter.convert(fundBalanceDto, person)
+  }
+
+  def "filters non-active out zero balance funds"() {
+    given:
+    def person = samplePerson()
+    def nonActiveZeroFund = FundBalanceDto.builder().isin("1").value(ZERO).activeContributions(false).build()
+    def nonActiveNonZeroFund = FundBalanceDto.builder().isin("2").value(ONE).activeContributions(false).build()
+    def activeZeroFund = FundBalanceDto.builder().isin("3").value(ZERO).activeContributions(true).build()
+    def activeNonZeroFund = FundBalanceDto.builder().isin("4").value(ONE).activeContributions(true).build()
+
+    episService.getAccountStatement(person) >> [nonActiveZeroFund, nonActiveNonZeroFund, activeZeroFund, activeNonZeroFund]
+    fundBalanceConverter.convert(_, person) >> { FundBalanceDto fundBalanceDto, _ ->
+      FundBalance.builder().fund(Fund.builder().isin(fundBalanceDto.isin).build()).build()
     }
 
-    def "fundBalanceDto with no Isin code are filtered out and will not try to convert"() {
-        given:
-            def person = samplePerson()
-            def fundBalanceDto = FundBalanceDto.builder().isin(null).build()
-            episService.getAccountStatement(person) >> [fundBalanceDto]
+    when:
+    List<FundBalance> accountStatement = service.getAccountStatement(person)
 
-        when:
-            List<FundBalance> accountStatement = service.getAccountStatement(person)
+    then:
+    with(accountStatement.get(0)) {
+      isin == nonActiveNonZeroFund.isin
+    }
+    with(accountStatement.get(1)) {
+      isin == activeZeroFund.isin
+    }
+    with(accountStatement.get(2)) {
+      isin == activeNonZeroFund.isin
+    }
+    accountStatement.size() == 3
+  }
 
-        then:
-            accountStatement.isEmpty()
-            0 * fundBalanceConverter.convert(fundBalanceDto, person)
+  def "handles fundBalanceDto to fundBalance conversion exceptions"() {
+    given:
+    def person = samplePerson()
+    def fundBalanceDto = FundBalanceDto.builder().isin("someIsin").build()
+
+    episService.getAccountStatement(person) >> [fundBalanceDto]
+    fundBalanceConverter.convert(fundBalanceDto, person) >> {
+      throw new IllegalArgumentException()
     }
 
-    def "filters non-active out zero balance funds"() {
-        given:
-        def person = samplePerson()
-        def nonActiveZeroFund = FundBalanceDto.builder().isin("1").value(ZERO).activeContributions(false).build()
-        def nonActiveNonZeroFund = FundBalanceDto.builder().isin("2").value(ONE).activeContributions(false).build()
-        def activeZeroFund = FundBalanceDto.builder().isin("3").value(ZERO).activeContributions(true).build()
-        def activeNonZeroFund = FundBalanceDto.builder().isin("4").value(ONE).activeContributions(true).build()
+    when:
+    service.getAccountStatement(person)
 
-        episService.getAccountStatement(person) >> [nonActiveZeroFund, nonActiveNonZeroFund, activeZeroFund, activeNonZeroFund]
-        fundBalanceConverter.convert(_, person) >> { FundBalanceDto fundBalanceDto, _ ->
-            FundBalance.builder().fund(Fund.builder().isin(fundBalanceDto.isin).build()).build()
-        }
-
-        when:
-        List<FundBalance> accountStatement = service.getAccountStatement(person)
-
-        then:
-        with(accountStatement.get(0)) {
-            isin == nonActiveNonZeroFund.isin
-        }
-        with(accountStatement.get(1)) {
-            isin == activeZeroFund.isin
-        }
-        with(accountStatement.get(2)) {
-            isin == activeNonZeroFund.isin
-        }
-        accountStatement.size() == 3
-    }
-
-    def "handles fundBalanceDto to fundBalance conversion exceptions"() {
-        given:
-        def person = samplePerson()
-        def fundBalanceDto = FundBalanceDto.builder().isin("someIsin").build()
-
-        episService.getAccountStatement(person) >> [fundBalanceDto]
-        fundBalanceConverter.convert(fundBalanceDto, person) >> {
-            throw new IllegalArgumentException()
-        }
-
-        when:
-        service.getAccountStatement(person)
-
-        then:
-        thrown(IllegalStateException)
-    }
+    then:
+    thrown(IllegalStateException)
+  }
 }


### PR DESCRIPTION
This change should allow users who are confused about their fund finance movements to remember that they had non-tuleva funds active in the past.

Solves https://app.asana.com/0/229163390356948/1199360837555677