### PR TITLE
Unify formatter rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -18,4 +18,4 @@ charset = utf-8
 indent_style = space
 indent_size = 2
 insert_final_newline = false
-max_line_length = 120
+max_line_length = 100


### PR DESCRIPTION
Since we're already using google java style which enforces 100 max line length (via our **spotless** plugin), we should specify the same in .editorconfig.