### PR TITLE
Reduce sensitive data logging

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/account/OnLoginAccountStatementCacheClearer.java
+++ b/src/main/java/ee/tuleva/onboarding/account/OnLoginAccountStatementCacheClearer.java
@@ -19,10 +19,9 @@ public class OnLoginAccountStatementCacheClearer {
   public void onBeforeTokenGrantedEvent(BeforeTokenGrantedEvent event) {
     Person person = event.getPerson();
     log.info(
-        "On BeforeTokenGrantedEvent: timestamp={}, name={} {}",
+        "On BeforeTokenGrantedEvent: timestamp={}, personal code={}",
         event.getTimestamp(),
-        person.getFirstName(),
-        person.getLastName());
+        person.getPersonalCode());
 
     episService.clearCache(person);
   }

--- a/src/main/java/ee/tuleva/onboarding/audit/LoginAuditEventBroadcaster.java
+++ b/src/main/java/ee/tuleva/onboarding/audit/LoginAuditEventBroadcaster.java
@@ -22,10 +22,9 @@ public class LoginAuditEventBroadcaster {
   public void onBeforeTokenGrantedEvent(BeforeTokenGrantedEvent event) {
     Person person = event.getPerson();
     log.info(
-        "Broadcasting login audit event from BeforeTokenGrantedEvent: timestamp={}, name={} {}",
+        "Broadcasting login audit event from BeforeTokenGrantedEvent: timestamp={}, personal code={}",
         event.getTimestamp(),
-        person.getFirstName(),
-        person.getLastName());
+        person.getPersonalCode());
 
     Authentication auth = event.getAuthentication().getUserAuthentication();
 

--- a/src/main/java/ee/tuleva/onboarding/auth/mobileid/MobileIdAuthService.java
+++ b/src/main/java/ee/tuleva/onboarding/auth/mobileid/MobileIdAuthService.java
@@ -2,8 +2,24 @@ package ee.tuleva.onboarding.auth.mobileid;
 
 import static ee.tuleva.onboarding.error.response.ErrorsResponse.ofSingleError;
 
-import ee.sk.mid.*;
-import ee.sk.mid.exception.*;
+import ee.sk.mid.MidAuthentication;
+import ee.sk.mid.MidAuthenticationHashToSign;
+import ee.sk.mid.MidAuthenticationIdentity;
+import ee.sk.mid.MidAuthenticationResponseValidator;
+import ee.sk.mid.MidAuthenticationResult;
+import ee.sk.mid.MidClient;
+import ee.sk.mid.MidDisplayTextFormat;
+import ee.sk.mid.MidLanguage;
+import ee.sk.mid.exception.MidDeliveryException;
+import ee.sk.mid.exception.MidInternalErrorException;
+import ee.sk.mid.exception.MidInvalidUserConfigurationException;
+import ee.sk.mid.exception.MidMissingOrInvalidParameterException;
+import ee.sk.mid.exception.MidNotMidClientException;
+import ee.sk.mid.exception.MidPhoneNotAvailableException;
+import ee.sk.mid.exception.MidSessionNotFoundException;
+import ee.sk.mid.exception.MidSessionTimeoutException;
+import ee.sk.mid.exception.MidUnauthorizedException;
+import ee.sk.mid.exception.MidUserCancellationException;
 import ee.sk.mid.rest.MidConnector;
 import ee.sk.mid.rest.MidSessionStatusPoller;
 import ee.sk.mid.rest.dao.MidSessionStatus;
@@ -35,9 +51,6 @@ public class MobileIdAuthService {
     MidAuthenticationRequest request =
         getBuildMidAuthenticationRequest(phoneNumber, personalCode, authenticationHash);
     MidAuthenticationResponse response = connector.authenticate(request);
-
-    log.info(
-        "Mobile ID authentication with challenge " + verificationCode + " sent to " + phoneNumber);
 
     return new MobileIDSession(
         response.getSessionID(), verificationCode, authenticationHash, request.getPhoneNumber());

--- a/src/main/java/ee/tuleva/onboarding/auth/mobileid/MobileIdTokenGranter.java
+++ b/src/main/java/ee/tuleva/onboarding/auth/mobileid/MobileIdTokenGranter.java
@@ -15,7 +15,13 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.common.OAuth2AccessToken;
 import org.springframework.security.oauth2.common.exceptions.InvalidRequestException;
-import org.springframework.security.oauth2.provider.*;
+import org.springframework.security.oauth2.provider.ClientDetails;
+import org.springframework.security.oauth2.provider.ClientDetailsService;
+import org.springframework.security.oauth2.provider.OAuth2Authentication;
+import org.springframework.security.oauth2.provider.OAuth2Request;
+import org.springframework.security.oauth2.provider.OAuth2RequestFactory;
+import org.springframework.security.oauth2.provider.TokenGranter;
+import org.springframework.security.oauth2.provider.TokenRequest;
 import org.springframework.security.oauth2.provider.token.AbstractTokenGranter;
 import org.springframework.security.oauth2.provider.token.AuthorizationServerTokenServices;
 
@@ -58,7 +64,7 @@ public class MobileIdTokenGranter extends AbstractTokenGranter implements TokenG
     // grant_type validated in AbstractTokenGranter
     final String clientId = client.getClientId();
     if (clientId == null) {
-      log.error("Failed to authenticate client {}", clientId);
+      log.error("Failed to authenticate client");
       throw new InvalidRequestException("Unknown Client ID.");
     }
 

--- a/src/main/java/ee/tuleva/onboarding/comparisons/fundvalue/FundValueIndexingJob.java
+++ b/src/main/java/ee/tuleva/onboarding/comparisons/fundvalue/FundValueIndexingJob.java
@@ -81,7 +81,7 @@ public class FundValueIndexingJob {
         comparisonIndexRetriever.retrieveValuesForRange(startDate, endDate);
     valuesPulled.forEach(
         value -> {
-          if (!fundValueRepository.findExistingValueForFund(value).isPresent())
+          if (fundValueRepository.findExistingValueForFund(value).isEmpty())
             fundValueRepository.save(value);
           else fundValueRepository.update(value);
         });

--- a/src/main/java/ee/tuleva/onboarding/epis/EpisService.java
+++ b/src/main/java/ee/tuleva/onboarding/epis/EpisService.java
@@ -55,8 +55,7 @@ public class EpisService {
   public List<ApplicationDTO> getApplications(Person person) {
     String url = episServiceUrl + "/applications";
 
-    log.info(
-        "Getting applications from {} for {} {}", url, person.getFirstName(), person.getLastName());
+    log.info("Getting applications from {} for {}", url, person.getPersonalCode());
 
     ResponseEntity<ApplicationDTO[]> response =
         userTokenRestTemplate.exchange(url, GET, getHeadersEntity(), ApplicationDTO[].class);
@@ -102,11 +101,7 @@ public class EpisService {
   public UserPreferences getContactDetails(Person person, String token) {
     String url = episServiceUrl + "/contact-details";
 
-    log.info(
-        "Getting contact details from {} for {} {}",
-        url,
-        person.getFirstName(),
-        person.getLastName());
+    log.info("Getting contact details from {} for {}", url, person.getPersonalCode());
 
     ResponseEntity<UserPreferences> response =
         userTokenRestTemplate.exchange(url, GET, getHeadersEntity(token), UserPreferences.class);
@@ -118,11 +113,7 @@ public class EpisService {
   public List<FundBalanceDto> getAccountStatement(Person person) {
     String url = episServiceUrl + "/account-statement";
 
-    log.info(
-        "Getting account statement from {} for {} {}",
-        url,
-        person.getFirstName(),
-        person.getLastName());
+    log.info("Getting account statement from {} for {}", url, person.getPersonalCode());
 
     ResponseEntity<FundBalanceDto[]> response =
         userTokenRestTemplate.exchange(url, GET, getHeadersEntity(), FundBalanceDto[].class);

--- a/src/main/java/ee/tuleva/onboarding/mandate/MandateController.java
+++ b/src/main/java/ee/tuleva/onboarding/mandate/MandateController.java
@@ -1,7 +1,9 @@
 package ee.tuleva.onboarding.mandate;
 
 import static ee.tuleva.onboarding.mandate.MandateController.MANDATES_URI;
-import static org.springframework.web.bind.annotation.RequestMethod.*;
+import static org.springframework.web.bind.annotation.RequestMethod.GET;
+import static org.springframework.web.bind.annotation.RequestMethod.POST;
+import static org.springframework.web.bind.annotation.RequestMethod.PUT;
 
 import com.fasterxml.jackson.annotation.JsonView;
 import ee.tuleva.onboarding.auth.mobileid.MobileIDSession;
@@ -69,7 +71,7 @@ public class MandateController {
       throw new ValidationErrorsException(errors);
     }
 
-    log.info("Creating mandate with {}", createMandateCommand);
+    log.info("Creating mandate");
     return mandateService.save(authenticatedPerson.getUserId(), createMandateCommand);
   }
 

--- a/src/main/java/ee/tuleva/onboarding/mandate/MandateService.java
+++ b/src/main/java/ee/tuleva/onboarding/mandate/MandateService.java
@@ -59,7 +59,7 @@ public class MandateService {
   }
 
   public Mandate save(User user, Mandate mandate) {
-    log.info("Saving mandate {}", mandate);
+    log.info("Saving mandate for user {}", user.getId());
     applicationEventPublisher.publishEvent(new BeforeMandateCreatedEvent(this, user, mandate));
     return mandateRepository.save(mandate);
   }

--- a/src/main/java/ee/tuleva/onboarding/mandate/application/ApplicationService.java
+++ b/src/main/java/ee/tuleva/onboarding/mandate/application/ApplicationService.java
@@ -67,7 +67,7 @@ public class ApplicationService {
 
   private List<TransferApplication> groupTransfers(List<ApplicationDTO> transferApplications) {
     val locale = localeService.getCurrentLocale();
-    log.info("Grouping transfers {}", transferApplications);
+
     return transferApplications.stream()
         .map(
             applicationDto -> {

--- a/src/main/java/ee/tuleva/onboarding/member/email/MemberEmailService.java
+++ b/src/main/java/ee/tuleva/onboarding/member/email/MemberEmailService.java
@@ -18,7 +18,7 @@ public class MemberEmailService {
   private final MemberEmailContentService emailContentService;
 
   public void sendMemberNumber(User user, Locale locale) {
-    log.info("Sending member number email to user: {}", user);
+    log.info("Sending member number email to user: {}", user.getId());
     MandrillMessage message =
         emailService.newMandrillMessage(
             emailService.getRecipients(user),
@@ -29,7 +29,7 @@ public class MemberEmailService {
 
     if (message == null) {
       log.warn(
-          "Failed to create mandrill message, not sending member number email for userId {}, member #",
+          "Failed to create mandrill message, not sending member number email for userId {}, member #{}",
           user.getId(),
           user.getMemberOrThrow().getMemberNumber());
       return;

--- a/src/main/java/ee/tuleva/onboarding/notification/email/EmailService.java
+++ b/src/main/java/ee/tuleva/onboarding/notification/email/EmailService.java
@@ -62,12 +62,7 @@ public class EmailService {
 
   public void send(User user, MandrillMessage message) {
     try {
-      log.info(
-          "Sending email from {} to member {} {} at {}",
-          emailConfiguration.getFrom(),
-          user.getFirstName(),
-          user.getLastName(),
-          user.getEmail());
+      log.info("Sending email from {} to user {}", emailConfiguration.getFrom(), user.getId());
       MandrillMessageStatus[] messageStatusReports = mandrillApi.messages().send(message, false);
 
       log.info("Mandrill API response {}", messageStatusReports[0].getStatus()); // FIXME [0]
@@ -80,7 +75,7 @@ public class EmailService {
 
   public List<Recipient> getRecipients(User user) {
     if (isBlank(user.getEmail())) {
-      log.error("User email is missing: user={}", user);
+      log.error("User email is missing: user={}", user.getId());
     }
 
     List<Recipient> recipients = new ArrayList<>();

--- a/src/main/java/ee/tuleva/onboarding/notification/payment/PaymentController.java
+++ b/src/main/java/ee/tuleva/onboarding/notification/payment/PaymentController.java
@@ -45,7 +45,7 @@ public class PaymentController {
       @ApiIgnore Errors errors)
       throws IOException {
 
-    log.info("Incoming payment: {}", incomingPayment);
+    log.info("Incoming payment");
 
     Payment payment = mapper.readValue(incomingPayment.getJson(), Payment.class);
 

--- a/src/main/java/ee/tuleva/onboarding/user/UserDetailsUpdater.java
+++ b/src/main/java/ee/tuleva/onboarding/user/UserDetailsUpdater.java
@@ -24,18 +24,18 @@ public class UserDetailsUpdater {
   @EventListener
   public void onBeforeTokenGrantedEvent(BeforeTokenGrantedEvent event) {
     Person person = event.getPerson();
-    String firstName = capitalizeFully(person.getFirstName());
-    String lastName = capitalizeFully(person.getLastName());
 
     log.info(
-        "Updating user name: timestamp={}, name={} {}", event.getTimestamp(), firstName, lastName);
+        "Updating user name: timestamp={}, personal code={}",
+        event.getTimestamp(),
+        person.getPersonalCode());
 
     userService
         .findByPersonalCode(person.getPersonalCode())
         .ifPresent(
             user -> {
-              user.setFirstName(firstName);
-              user.setLastName(lastName);
+              user.setFirstName(capitalizeFully(person.getFirstName()));
+              user.setLastName(capitalizeFully(person.getLastName()));
               userService.save(user);
             });
   }

--- a/src/main/java/ee/tuleva/onboarding/user/UserService.java
+++ b/src/main/java/ee/tuleva/onboarding/user/UserService.java
@@ -30,7 +30,7 @@ public class UserService {
   }
 
   public User createNewUser(User user) {
-    log.info("Creating new user {}", user);
+    log.info("Creating new user for personal code {}", user.getPersonalCode());
     return userRepository.save(user);
   }
 
@@ -45,7 +45,7 @@ public class UserService {
                 })
             .orElseThrow(() -> new RuntimeException("User does not exist"));
 
-    log.info("Updating user {}", user);
+    log.info("Updating user with id {}", user.getId());
 
     return save(user);
   }
@@ -63,7 +63,10 @@ public class UserService {
     Member newMember =
         Member.builder().user(user).memberNumber(memberRepository.getNextMemberNumber()).build();
 
-    log.info("Registering user as new member #{}: {}", newMember.getMemberNumber(), user);
+    log.info(
+        "Registering user as new member #{}: user id: {}",
+        newMember.getMemberNumber(),
+        user.getId());
 
     user.setMember(newMember);
 
@@ -76,7 +79,7 @@ public class UserService {
   }
 
   public User save(User user) {
-    log.info("Saving user {}", user);
+    log.info("Saving user with id {}", user.getId());
     return userRepository.save(user);
   }
 }


### PR DESCRIPTION
If someone were to get access to our papertrail environment, they would currently have a very clear picture of all of our members' contact information and full financial situation. This PR aims to log less personal, mandate and financial data since we don't need it for debugging.