### PR TITLE
Fix mobile id signing

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,15 +7,10 @@ indent_size = 2
 trim_trailing_whitespace = true
 
 [*.{gradle,gradle.kts}]
-charset = utf-8
-indent_style = space
 indent_size = 4
 insert_final_newline = true
 max_line_length = 120
 
 [*.{java,groovy}]
-charset = utf-8
-indent_style = space
-indent_size = 2
 insert_final_newline = false
 max_line_length = 100

--- a/src/main/java/ee/tuleva/onboarding/mandate/signature/SignatureFile.java
+++ b/src/main/java/ee/tuleva/onboarding/mandate/signature/SignatureFile.java
@@ -1,5 +1,6 @@
 package ee.tuleva.onboarding.mandate.signature;
 
+import java.io.Serial;
 import java.io.Serializable;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -7,6 +8,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @Getter
 public class SignatureFile implements Serializable {
+
+  @Serial private static final long serialVersionUID = -2405222829412049325L;
 
   private final String name;
   private final String mimeType;

--- a/src/main/java/ee/tuleva/onboarding/mandate/signature/SignatureFile.java
+++ b/src/main/java/ee/tuleva/onboarding/mandate/signature/SignatureFile.java
@@ -1,11 +1,12 @@
 package ee.tuleva.onboarding.mandate.signature;
 
+import java.io.Serializable;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @Getter
-public class SignatureFile {
+public class SignatureFile implements Serializable {
 
   private final String name;
   private final String mimeType;

--- a/src/main/java/ee/tuleva/onboarding/mandate/signature/smartid/SmartIdSignatureSession.java
+++ b/src/main/java/ee/tuleva/onboarding/mandate/signature/smartid/SmartIdSignatureSession.java
@@ -2,6 +2,7 @@ package ee.tuleva.onboarding.mandate.signature.smartid;
 
 import ee.sk.smartid.SignableHash;
 import ee.tuleva.onboarding.mandate.signature.SignatureFile;
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.List;
 import lombok.Data;
@@ -10,7 +11,7 @@ import org.digidoc4j.DataToSign;
 
 @Data
 public class SmartIdSignatureSession implements Serializable {
-  private static final long serialVersionUID = -5454823973379414071L;
+  @Serial private static final long serialVersionUID = -5454823973379414071L;
 
   private final String certificateSessionId;
   private final String personalCode;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -52,7 +52,7 @@ spring:
             user.name: ${spring.security.user.name}
             user.password: ${spring.security.user.password}
   session:
-    store-type: none
+    store-type: jdbc
     jdbc:
       initialize-schema: never
 


### PR DESCRIPTION
Currently our mandate signing with mobile id fails, since session tokens are lost between requests. Since we don't validate the login session before initializing Smart-ID and ID-card signature session, it did not affect users using those flows.