### PR TITLE
Add empty constructor to MandateFundsTransferExchangeDTO

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/epis/mandate/MandateDto.java
+++ b/src/main/java/ee/tuleva/onboarding/epis/mandate/MandateDto.java
@@ -9,6 +9,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.jetbrains.annotations.Nullable;
 
@@ -30,6 +31,7 @@ public class MandateDto {
   @Nullable private Address address;
 
   @AllArgsConstructor
+  @NoArgsConstructor
   @Getter
   @Setter
   public static class MandateFundsTransferExchangeDTO {


### PR DESCRIPTION
In localhost, without NoArgsConstructor, jaxb cannot instantiate this class without it. Works in production.