### PR TITLE
Add elastic beanstalk autoscaling rules

### DIFF
--- a/etc/eb/.ebextensions/autoscale.config
+++ b/etc/eb/.ebextensions/autoscale.config
@@ -1,0 +1,6 @@
+Resources:
+  AWSEBAutoScalingGroup:
+    Type: AWS::AutoScaling::AutoScalingGroup
+    Properties:
+      HealthCheckType: ELB
+      HealthCheckGracePeriod: 300


### PR DESCRIPTION
When the application goes down for any reason, AWS will now bring up a healthy replacement so we don't have a lenghty downtime.