### PR TITLE
Hide internal error messages

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/error/converter/ErrorAttributesConverter.java
+++ b/src/main/java/ee/tuleva/onboarding/error/converter/ErrorAttributesConverter.java
@@ -2,7 +2,6 @@ package ee.tuleva.onboarding.error.converter;
 
 import ee.tuleva.onboarding.error.response.ErrorsResponse;
 import java.util.Map;
-import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.stereotype.Component;
@@ -16,8 +15,7 @@ public class ErrorAttributesConverter implements Converter<Map<String, Object>, 
   }
 
   private String code(Map<String, Object> errorAttributes) {
-    String exception = (String) errorAttributes.get("exception");
-    return StringUtils.substringAfterLast(exception, ".");
+    return (String) errorAttributes.get("error");
   }
 
   private String message(Map<String, Object> errorAttributes) {

--- a/src/main/java/ee/tuleva/onboarding/error/response/ErrorsResponse.java
+++ b/src/main/java/ee/tuleva/onboarding/error/response/ErrorsResponse.java
@@ -3,7 +3,11 @@ package ee.tuleva.onboarding.error.response;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 
 @Getter
 @Setter
@@ -16,7 +20,7 @@ public class ErrorsResponse {
 
   public static ErrorsResponse ofSingleError(String code, String message) {
     return new ErrorsResponse(
-        Collections.singletonList(ErrorResponse.builder().code(code).message(message).build()));
+        Collections.singletonList(ErrorResponse.builder().code(code).build()));
   }
 
   public static ErrorsResponse ofSingleError(ErrorResponse error) {

--- a/src/test/groovy/ee/tuleva/onboarding/error/ErrorHandlingControllerSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/error/ErrorHandlingControllerSpec.groovy
@@ -32,41 +32,41 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(ErrorHandlingController)
 @WithMockUser
 @Import([ErrorResponseEntityFactory, InputErrorsConverter, ErrorAttributesConverter,
-    OAuthConfiguration.ResourceServerPathConfiguration, SecurityConfiguration, ConversionDecorator])
+  OAuthConfiguration.ResourceServerPathConfiguration, SecurityConfiguration, ConversionDecorator])
 class ErrorHandlingControllerSpec extends Specification {
 
-    @MockBean
-    CashFlowService cashFlowService
+  @MockBean
+  CashFlowService cashFlowService
 
-    @TestConfiguration
-    static class ErrorAttributesConfiguration {
-        @Bean
-        ErrorAttributes defaultErrorAttributes() {
-            return new DefaultErrorAttributes(true)
-        }
+  @TestConfiguration
+  static class ErrorAttributesConfiguration {
+    @Bean
+    ErrorAttributes defaultErrorAttributes() {
+      return new DefaultErrorAttributes(true)
     }
+  }
 
-    @Autowired
-    MockMvc mvc
+  @Autowired
+  MockMvc mvc
 
-    @MockBean
-    FundRepository fundRepository
+  @MockBean
+  FundRepository fundRepository
 
-    @MockBean
-    AccountStatementService accountStatementService
+  @MockBean
+  AccountStatementService accountStatementService
 
-    def "error handling works"() {
-        expect:
-        mvc.perform(get("/error")
-            .requestAttr(RequestDispatcher.ERROR_EXCEPTION, new RuntimeException())
-            .requestAttr(RequestDispatcher.ERROR_STATUS_CODE, 403)
-            .requestAttr(RequestDispatcher.ERROR_REQUEST_URI, "/asdf")
-            .requestAttr(RequestDispatcher.ERROR_MESSAGE, "oops!"))
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-            .andExpect(jsonPath('$.errors[0].code', is("RuntimeException")))
-            .andExpect(jsonPath('$.errors[0].message', is("oops!")))
-            .andExpect(jsonPath('$.errors[0].path').doesNotExist())
-            .andExpect(jsonPath('$.errors[0].arguments').isEmpty())
-    }
+  def "error handling works"() {
+    expect:
+    mvc.perform(get("/error")
+      .requestAttr(RequestDispatcher.ERROR_EXCEPTION, new RuntimeException())
+      .requestAttr(RequestDispatcher.ERROR_STATUS_CODE, 403)
+      .requestAttr(RequestDispatcher.ERROR_REQUEST_URI, "/asdf")
+      .requestAttr(RequestDispatcher.ERROR_MESSAGE, "oops!"))
+      .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+      .andExpect(jsonPath('$.errors[0].code', is("RuntimeException")))
+      .andExpect(jsonPath('$.errors[0].message', is("oops!")))
+      .andExpect(jsonPath('$.errors[0].path').doesNotExist())
+      .andExpect(jsonPath('$.errors[0].arguments').isEmpty())
+  }
 
 }

--- a/src/test/groovy/ee/tuleva/onboarding/error/ErrorHandlingControllerSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/error/ErrorHandlingControllerSpec.groovy
@@ -63,8 +63,8 @@ class ErrorHandlingControllerSpec extends Specification {
       .requestAttr(RequestDispatcher.ERROR_REQUEST_URI, "/asdf")
       .requestAttr(RequestDispatcher.ERROR_MESSAGE, "oops!"))
       .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-      .andExpect(jsonPath('$.errors[0].code', is("RuntimeException")))
-      .andExpect(jsonPath('$.errors[0].message', is("oops!")))
+      .andExpect(jsonPath('$.errors[0].code', is("Forbidden")))
+      .andExpect(jsonPath('$.errors[0].message').doesNotExist())
       .andExpect(jsonPath('$.errors[0].path').doesNotExist())
       .andExpect(jsonPath('$.errors[0].arguments').isEmpty())
   }

--- a/src/test/groovy/ee/tuleva/onboarding/error/converter/ErrorAttributesConverterSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/error/converter/ErrorAttributesConverterSpec.groovy
@@ -22,8 +22,8 @@ class ErrorAttributesConverterSpec extends Specification {
     def error = errorsResponse.errors.first()
 
     then:
-    error.code == 'SampleException'
-    error.message == 'Error message'
+    error.code == 'Internal Server Error'
+    error.message == null
     error.path == null
     error.arguments == []
   }

--- a/src/test/groovy/ee/tuleva/onboarding/error/converter/ErrorAttributesConverterSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/error/converter/ErrorAttributesConverterSpec.groovy
@@ -9,12 +9,12 @@ class ErrorAttributesConverterSpec extends Specification {
   def "Converts global errors into an ErrorsResponse"() {
     given:
     def errorAttributes = [
-        "timestamp": "2017-04-20T10:37:35Z",
-        "status"   : 500,
-        "error"    : "Internal Server Error",
-        "exception": "ee.tuleva.exception.SampleException",
-        "path"     : "/v1/users",
-        "message"  : "Error message"
+      "timestamp": "2017-04-20T10:37:35Z",
+      "status"   : 500,
+      "error"    : "Internal Server Error",
+      "exception": "ee.tuleva.exception.SampleException",
+      "path"     : "/v1/users",
+      "message"  : "Error message"
     ]
 
     when:


### PR DESCRIPTION
Follow-up to the https://github.com/TulevaEE/epis-service/pull/220 EPIS-service PR. Hides too verbose error messages also from onboarding-service.