### PR TITLE
Fix mobile id mandate signing for people with slow connections

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/aml/AmlService.java
+++ b/src/main/java/ee/tuleva/onboarding/aml/AmlService.java
@@ -1,6 +1,13 @@
 package ee.tuleva.onboarding.aml;
 
-import static ee.tuleva.onboarding.aml.AmlCheckType.*;
+import static ee.tuleva.onboarding.aml.AmlCheckType.CONTACT_DETAILS;
+import static ee.tuleva.onboarding.aml.AmlCheckType.DOCUMENT;
+import static ee.tuleva.onboarding.aml.AmlCheckType.OCCUPATION;
+import static ee.tuleva.onboarding.aml.AmlCheckType.PENSION_REGISTRY_NAME;
+import static ee.tuleva.onboarding.aml.AmlCheckType.POLITICALLY_EXPOSED_PERSON;
+import static ee.tuleva.onboarding.aml.AmlCheckType.RESIDENCY_AUTO;
+import static ee.tuleva.onboarding.aml.AmlCheckType.RESIDENCY_MANUAL;
+import static ee.tuleva.onboarding.aml.AmlCheckType.SK_NAME;
 import static java.time.temporal.ChronoUnit.DAYS;
 import static java.util.stream.Collectors.toSet;
 
@@ -100,6 +107,11 @@ public class AmlService {
       @Override
       public String getLastName() {
         return person.getLastName();
+      }
+
+      @Override
+      public String getPhoneNumber() {
+        return person.getPhoneNumber();
       }
     };
   }

--- a/src/main/java/ee/tuleva/onboarding/auth/idcard/IdCardSession.java
+++ b/src/main/java/ee/tuleva/onboarding/auth/idcard/IdCardSession.java
@@ -1,6 +1,7 @@
 package ee.tuleva.onboarding.auth.idcard;
 
 import ee.tuleva.onboarding.auth.principal.Person;
+import java.io.Serial;
 import java.io.Serializable;
 import lombok.Builder;
 import lombok.Data;
@@ -11,10 +12,15 @@ import lombok.RequiredArgsConstructor;
 @Builder
 public class IdCardSession implements Person, Serializable {
 
-  private static final long serialVersionUID = -111852724795571891L;
+  @Serial private static final long serialVersionUID = -111852724795571891L;
 
   public final String firstName;
   public final String lastName;
   public final String personalCode;
   public final IdDocumentType documentType;
+
+  @Override
+  public String getPhoneNumber() {
+    return null;
+  }
 }

--- a/src/main/java/ee/tuleva/onboarding/auth/ocsp/CheckCertificateResponse.java
+++ b/src/main/java/ee/tuleva/onboarding/auth/ocsp/CheckCertificateResponse.java
@@ -1,6 +1,7 @@
 package ee.tuleva.onboarding.auth.ocsp;
 
 import ee.tuleva.onboarding.auth.principal.Person;
+import java.io.Serial;
 import java.io.Serializable;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -11,9 +12,14 @@ import lombok.ToString;
 @ToString
 public class CheckCertificateResponse implements Serializable, Person {
 
-  private static final long serialVersionUID = 333351175769353073L;
+  @Serial private static final long serialVersionUID = 333351175769353073L;
 
   private final String firstName;
   private final String lastName;
   private final String personalCode;
+
+  @Override
+  public String getPhoneNumber() {
+    return null;
+  }
 }

--- a/src/main/java/ee/tuleva/onboarding/auth/principal/AuthenticatedPerson.java
+++ b/src/main/java/ee/tuleva/onboarding/auth/principal/AuthenticatedPerson.java
@@ -1,9 +1,14 @@
 package ee.tuleva.onboarding.auth.principal;
 
 import ee.tuleva.onboarding.user.personalcode.ValidPersonalCode;
+import java.io.Serial;
 import java.io.Serializable;
 import javax.validation.constraints.NotBlank;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Builder
 @Getter
@@ -12,11 +17,15 @@ import lombok.*;
 @NoArgsConstructor
 public class AuthenticatedPerson implements Person, Serializable {
 
+  @Serial private static final long serialVersionUID = 5719823705437190708L;
+
   @ValidPersonalCode private String personalCode;
 
   @NotBlank private String firstName;
 
   @NotBlank private String lastName;
+
+  private String phoneNumber;
 
   private Long userId;
 

--- a/src/main/java/ee/tuleva/onboarding/auth/principal/Person.java
+++ b/src/main/java/ee/tuleva/onboarding/auth/principal/Person.java
@@ -7,4 +7,6 @@ public interface Person {
   String getFirstName();
 
   String getLastName();
+
+  String getPhoneNumber();
 }

--- a/src/main/java/ee/tuleva/onboarding/auth/principal/PrincipalService.java
+++ b/src/main/java/ee/tuleva/onboarding/auth/principal/PrincipalService.java
@@ -32,6 +32,7 @@ public class PrincipalService {
         .firstName(person.getFirstName())
         .lastName(person.getLastName())
         .personalCode(person.getPersonalCode())
+        .phoneNumber(person.getPhoneNumber())
         .userId(user.getId())
         .build();
   }

--- a/src/main/java/ee/tuleva/onboarding/auth/smartid/SmartIdSession.java
+++ b/src/main/java/ee/tuleva/onboarding/auth/smartid/SmartIdSession.java
@@ -3,13 +3,14 @@ package ee.tuleva.onboarding.auth.smartid;
 import ee.sk.smartid.AuthenticationHash;
 import ee.sk.smartid.AuthenticationIdentity;
 import ee.tuleva.onboarding.auth.principal.Person;
+import java.io.Serial;
 import java.io.Serializable;
 import lombok.Data;
 
 @Data
 public class SmartIdSession implements Person, Serializable {
 
-  private static final long serialVersionUID = 6326478770346040900L;
+  @Serial private static final long serialVersionUID = 6326478770346040900L;
 
   private final String verificationCode;
   private final String sessionId;
@@ -23,5 +24,10 @@ public class SmartIdSession implements Person, Serializable {
     firstName = identity.getGivenName();
     lastName = identity.getSurname();
     country = identity.getCountry();
+  }
+
+  @Override
+  public String getPhoneNumber() {
+    return null;
   }
 }

--- a/src/main/java/ee/tuleva/onboarding/mandate/MandateController.java
+++ b/src/main/java/ee/tuleva/onboarding/mandate/MandateController.java
@@ -6,7 +6,6 @@ import static org.springframework.web.bind.annotation.RequestMethod.POST;
 import static org.springframework.web.bind.annotation.RequestMethod.PUT;
 
 import com.fasterxml.jackson.annotation.JsonView;
-import ee.tuleva.onboarding.auth.mobileid.MobileIDSession;
 import ee.tuleva.onboarding.auth.principal.AuthenticatedPerson;
 import ee.tuleva.onboarding.auth.session.GenericSessionStore;
 import ee.tuleva.onboarding.error.ValidationErrorsException;
@@ -81,15 +80,9 @@ public class MandateController {
       @PathVariable("id") Long mandateId,
       @ApiIgnore @AuthenticationPrincipal AuthenticatedPerson authenticatedPerson) {
 
-    Optional<MobileIDSession> session = sessionStore.get(MobileIDSession.class);
-    if (session.isEmpty()) {
-      log.error("Mobile session not found. user_id: {}", authenticatedPerson.getUserId());
-    }
-    MobileIDSession loginSession = session.orElseThrow(IdSessionException::mobileSessionNotFound);
-
     MobileIdSignatureSession signatureSession =
         mandateService.mobileIdSign(
-            mandateId, authenticatedPerson.getUserId(), loginSession.getPhoneNumber());
+            mandateId, authenticatedPerson.getUserId(), authenticatedPerson.getPhoneNumber());
     sessionStore.save(signatureSession);
 
     return new MobileSignatureResponse(signatureSession.getVerificationCode());

--- a/src/main/java/ee/tuleva/onboarding/mandate/signature/mobileid/MobileIdSignatureSession.java
+++ b/src/main/java/ee/tuleva/onboarding/mandate/signature/mobileid/MobileIdSignatureSession.java
@@ -1,5 +1,6 @@
 package ee.tuleva.onboarding.mandate.signature.mobileid;
 
+import java.io.Serial;
 import java.io.Serializable;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,7 +15,7 @@ import org.digidoc4j.DataToSign;
 @Builder
 public class MobileIdSignatureSession implements Serializable {
 
-  private static final long serialVersionUID = -7443368341567864757L;
+  @Serial private static final long serialVersionUID = -7443368341567864757L;
 
   private final String sessionId;
   private final String verificationCode;

--- a/src/test/groovy/ee/tuleva/onboarding/auth/PersonFixture.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/auth/PersonFixture.groovy
@@ -25,6 +25,8 @@ class PersonFixture {
 
         String lastName
 
+        String phoneNumber
+
     }
 
 }

--- a/src/test/groovy/ee/tuleva/onboarding/mandate/MandateControllerSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/mandate/MandateControllerSpec.groovy
@@ -31,7 +31,8 @@ class MandateControllerSpec extends BaseControllerSpec {
   LocaleResolver localeResolver = Mock(LocaleResolver)
 
   MandateController controller =
-    new MandateController(mandateRepository, mandateService, sessionStore, signatureFileArchiver, mandateFileService, localeResolver)
+      new MandateController(mandateRepository, mandateService, sessionStore, signatureFileArchiver, mandateFileService,
+          localeResolver)
 
   MockMvc mvc = mockMvc(controller)
 
@@ -41,20 +42,23 @@ class MandateControllerSpec extends BaseControllerSpec {
     mandateService.save(_ as Long, _ as CreateMandateCommand) >> mandate
     then:
     mvc
-      .perform(post("/v1/mandates")
-        .content(mapper.writeValueAsString(sampleCreateMandateCommand()))
-        .contentType(MediaType.APPLICATION_JSON))
-      .andExpect(status().isOk())
-      .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-      .andExpect(jsonPath('$.futureContributionFundIsin', is(mandate.futureContributionFundIsin.get())))
-      .andExpect(jsonPath('$.pillar', is(mandate.pillar)))
-      .andExpect(jsonPath('$.address.street', is(mandate.address.street)))
-      .andExpect(jsonPath('$.address.districtCode', is(mandate.address.districtCode)))
-      .andExpect(jsonPath('$.address.postalCode', is(mandate.address.postalCode)))
-      .andExpect(jsonPath('$.address.countryCode', is(mandate.address.countryCode)))
-      .andExpect(jsonPath('$.fundTransferExchanges[0].sourceFundIsin', is(mandate.fundTransferExchanges[0].sourceFundIsin)))
-      .andExpect(jsonPath('$.fundTransferExchanges[0].targetFundIsin', is(mandate.fundTransferExchanges[0].targetFundIsin)))
-      .andExpect(jsonPath('$.fundTransferExchanges[0].amount', is(mandate.fundTransferExchanges[0].amount.doubleValue())))
+        .perform(post("/v1/mandates")
+            .content(mapper.writeValueAsString(sampleCreateMandateCommand()))
+            .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath('$.futureContributionFundIsin', is(mandate.futureContributionFundIsin.get())))
+        .andExpect(jsonPath('$.pillar', is(mandate.pillar)))
+        .andExpect(jsonPath('$.address.street', is(mandate.address.street)))
+        .andExpect(jsonPath('$.address.districtCode', is(mandate.address.districtCode)))
+        .andExpect(jsonPath('$.address.postalCode', is(mandate.address.postalCode)))
+        .andExpect(jsonPath('$.address.countryCode', is(mandate.address.countryCode)))
+        .andExpect(
+            jsonPath('$.fundTransferExchanges[0].sourceFundIsin', is(mandate.fundTransferExchanges[0].sourceFundIsin)))
+        .andExpect(
+            jsonPath('$.fundTransferExchanges[0].targetFundIsin', is(mandate.fundTransferExchanges[0].targetFundIsin)))
+        .andExpect(
+            jsonPath('$.fundTransferExchanges[0].amount', is(mandate.fundTransferExchanges[0].amount.doubleValue())))
   }
 
   def "mobile id signature start returns the mobile id challenge code"() {
@@ -64,11 +68,11 @@ class MandateControllerSpec extends BaseControllerSpec {
 
     then:
     mvc
-      .perform(put("/v1/mandates/1/signature/mobileId")
-        .contentType(MediaType.APPLICATION_JSON))
-      .andExpect(status().isOk())
-      .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-      .andExpect(jsonPath('$.challengeCode', is("1234")))
+        .perform(put("/v1/mandates/1/signature/mobileId")
+            .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath('$.challengeCode', is("1234")))
   }
 
   def "mobile id signature start fails when there's no mobile id session"() {
@@ -77,7 +81,7 @@ class MandateControllerSpec extends BaseControllerSpec {
 
     when:
     MvcResult result = mvc.perform(put("/v1/mandates/1/signature/mobileId"))
-      .andReturn()
+        .andReturn()
 
     then:
     IdSessionException exception = result.resolvedException
@@ -94,11 +98,11 @@ class MandateControllerSpec extends BaseControllerSpec {
 
     then:
     mvc
-      .perform(get("/v1/mandates/1/signature/mobileId/status"))
-      .andExpect(status().isOk())
-      .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-      .andExpect(jsonPath('$.statusCode', is("SIGNATURE")))
-      .andExpect(jsonPath('$.challengeCode', is("1234")))
+        .perform(get("/v1/mandates/1/signature/mobileId/status"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath('$.statusCode', is("SIGNATURE")))
+        .andExpect(jsonPath('$.challengeCode', is("1234")))
   }
 
   def "smart id signature start returns null challenge code"() {
@@ -109,11 +113,11 @@ class MandateControllerSpec extends BaseControllerSpec {
 
     then:
     mvc
-      .perform(put("/v1/mandates/1/signature/smartId")
-        .contentType(MediaType.APPLICATION_JSON))
-      .andExpect(status().isOk())
-      .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-      .andExpect(jsonPath('$.challengeCode', is(null)))
+        .perform(put("/v1/mandates/1/signature/smartId")
+            .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath('$.challengeCode', is(null)))
   }
 
   def "get smart id signature status returns the status and challenge code"() {
@@ -126,25 +130,26 @@ class MandateControllerSpec extends BaseControllerSpec {
 
     then:
     mvc
-      .perform(get("/v1/mandates/1/signature/smartId/status"))
-      .andExpect(status().isOk())
-      .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-      .andExpect(jsonPath('$.statusCode', is("SIGNATURE")))
-      .andExpect(jsonPath('$.challengeCode', is("1234")))
+        .perform(get("/v1/mandates/1/signature/smartId/status"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath('$.statusCode', is("SIGNATURE")))
+        .andExpect(jsonPath('$.challengeCode', is("1234")))
   }
 
   def "id card signature start returns the hash to be signed by the client"() {
     when:
-    mandateService.idCardSign(1L, _, "clientCertificate") >> IdCardSignatureSession.builder().hashToSignInHex("asdfg").build()
+    mandateService.idCardSign(1L, _, "clientCertificate") >>
+        IdCardSignatureSession.builder().hashToSignInHex("asdfg").build()
 
     then:
     mvc
-      .perform(put("/v1/mandates/1/signature/idCard")
-        .content(mapper.writeValueAsString(sampleStartIdCardSignCommand("clientCertificate")))
-        .contentType(MediaType.APPLICATION_JSON))
-      .andExpect(status().isOk())
-      .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-      .andExpect(jsonPath('$.hash', is("asdfg")))
+        .perform(put("/v1/mandates/1/signature/idCard")
+            .content(mapper.writeValueAsString(sampleStartIdCardSignCommand("clientCertificate")))
+            .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath('$.hash', is("asdfg")))
   }
 
   def "put ID card signature status returns the status code"() {
@@ -156,24 +161,24 @@ class MandateControllerSpec extends BaseControllerSpec {
 
     then:
     mvc
-      .perform(put("/v1/mandates/1/signature/idCard/status")
-        .content(mapper.writeValueAsString(sampleFinishIdCardSignCommand("signedHash")))
-        .contentType(MediaType.APPLICATION_JSON))
-      .andExpect(status().isOk())
-      .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-      .andExpect(jsonPath('$.statusCode', is("SIGNATURE")))
+        .perform(put("/v1/mandates/1/signature/idCard/status")
+            .content(mapper.writeValueAsString(sampleFinishIdCardSignCommand("signedHash")))
+            .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath('$.statusCode', is("SIGNATURE")))
   }
 
   def "getMandateFile returns mandate file"() {
     when:
     1 * mandateRepository
-      .findByIdAndUserId(sampleMandate().id, _ as Long) >> sampleMandate()
+        .findByIdAndUserId(sampleMandate().id, _ as Long) >> sampleMandate()
 
     then:
     MvcResult result = mvc
-      .perform(get("/v1/mandates/" + sampleMandate().id + "/file"))
-      .andExpect(status().isOk())
-      .andReturn()
+        .perform(get("/v1/mandates/" + sampleMandate().id + "/file"))
+        .andExpect(status().isOk())
+        .andReturn()
 
     result.getResponse().getHeader("Content-Disposition") == "attachment; filename=Tuleva_avaldus.bdoc"
   }
@@ -181,11 +186,11 @@ class MandateControllerSpec extends BaseControllerSpec {
   def "getMandateFile throws exception if mandate is not signed"() {
     given:
     1 * mandateRepository
-      .findByIdAndUserId(sampleMandate().id, _ as Long) >> sampleUnsignedMandate()
+        .findByIdAndUserId(sampleMandate().id, _ as Long) >> sampleUnsignedMandate()
 
     when:
     mvc
-      .perform(get("/v1/mandates/" + sampleMandate().id + "/file"))
+        .perform(get("/v1/mandates/" + sampleMandate().id + "/file"))
 
     then:
     thrown Exception
@@ -201,9 +206,9 @@ class MandateControllerSpec extends BaseControllerSpec {
 
     then:
     MvcResult result = mvc
-      .perform(get("/v1/mandates/" + sampleMandate().id + "/file/preview"))
-      .andExpect(status().isOk())
-      .andReturn()
+        .perform(get("/v1/mandates/" + sampleMandate().id + "/file/preview"))
+        .andExpect(status().isOk())
+        .andReturn()
 
     result.getResponse().getHeader("Content-Disposition") == "attachment; filename=Tuleva_avaldus.zip"
 
@@ -212,12 +217,12 @@ class MandateControllerSpec extends BaseControllerSpec {
   def "getMandateFile returns not found on non existing mandate file"() {
     when:
     1 * mandateRepository
-      .findByIdAndUserId(sampleMandate().id, _ as Long) >> null
+        .findByIdAndUserId(sampleMandate().id, _ as Long) >> null
 
     then:
     mvc
-      .perform(get("/v1/mandates/" + sampleMandate().id + "/file"))
-      .andExpect(status().isNotFound())
+        .perform(get("/v1/mandates/" + sampleMandate().id + "/file"))
+        .andExpect(status().isNotFound())
   }
 
   private Optional<MobileIDSession> dummyMobileIdSessionWithPhone(String phone) {


### PR DESCRIPTION
When simulating a slow 3G connection in Chrome, it's possible to reproduce the "Mobile session not found" error. This means that we have a race condition between async front-end requests and Spring session security. Each request gets a new session ID and if there are several requests before the previous one returns, our custom session storage becomes inaccessible.

This PR removes the dependency on MobileIdSession, reducing the chances that it gets invalidated before the user reaches the mandate signing step.