### PR TITLE
Remove scheduled e-mails from queue if user signs mandate

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/mandate/email/MandateEmailService.java
+++ b/src/main/java/ee/tuleva/onboarding/mandate/email/MandateEmailService.java
@@ -6,6 +6,8 @@ import static java.util.Collections.singletonList;
 import com.microtripit.mandrillapp.lutung.view.MandrillMessage;
 import ee.tuleva.onboarding.epis.contact.UserPreferences;
 import ee.tuleva.onboarding.mandate.Mandate;
+import ee.tuleva.onboarding.mandate.email.scheduledEmail.ScheduledEmailService;
+import ee.tuleva.onboarding.mandate.email.scheduledEmail.ScheduledEmailType;
 import ee.tuleva.onboarding.notification.email.EmailService;
 import ee.tuleva.onboarding.user.User;
 import java.time.Clock;
@@ -24,6 +26,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class MandateEmailService {
   private final EmailService emailService;
+  private final ScheduledEmailService scheduledEmailService;
   private final MandateEmailContentService emailContentService;
   private final Clock clock;
   private final MessageSource messageSource;
@@ -117,7 +120,12 @@ public class MandateEmailService {
             content,
             List.of("pillar_3.1", "suggest_2"),
             null);
-    emailService.send(user, message, sendAt);
+    emailService
+        .send(user, message, sendAt)
+        .ifPresent(
+            messageId ->
+                scheduledEmailService.create(
+                    user, messageId, ScheduledEmailType.SUGGEST_SECOND_PILLAR));
   }
 
   private List<MandrillMessage.MessageContent> getMandateAttachments(

--- a/src/main/java/ee/tuleva/onboarding/mandate/email/scheduledEmail/ScheduledEmail.java
+++ b/src/main/java/ee/tuleva/onboarding/mandate/email/scheduledEmail/ScheduledEmail.java
@@ -1,11 +1,14 @@
 package ee.tuleva.onboarding.mandate.email.scheduledEmail;
 
+import static javax.persistence.EnumType.STRING;
+
 import javax.persistence.Entity;
+import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Table;
-import javax.validation.constraints.NotBlank;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -14,10 +17,14 @@ import lombok.RequiredArgsConstructor;
 @Table(name = "scheduled_email")
 @NoArgsConstructor
 @RequiredArgsConstructor
+@Getter
 public class ScheduledEmail {
-  @NotBlank @NonNull Long userId;
-  @NotBlank @NonNull String mandrillMessageId;
-  @NotBlank @NonNull ScheduledEmailType type;
+  @NonNull private Long userId;
+  @NonNull private String mandrillMessageId;
+
+  @Enumerated(STRING)
+  @NonNull
+  private ScheduledEmailType type;
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/ee/tuleva/onboarding/mandate/email/scheduledEmail/ScheduledEmail.java
+++ b/src/main/java/ee/tuleva/onboarding/mandate/email/scheduledEmail/ScheduledEmail.java
@@ -1,0 +1,28 @@
+package ee.tuleva.onboarding.mandate.email.scheduledEmail;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import javax.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "scheduled_email")
+@AllArgsConstructor
+@NoArgsConstructor
+public class ScheduledEmail {
+  @NotBlank Long userId;
+  @NotBlank String mandrillMessageId;
+  @NotBlank ScheduledEmailType type;
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  enum ScheduledEmailType {
+    SUGGEST_SECOND_PILLAR
+  }
+}

--- a/src/main/java/ee/tuleva/onboarding/mandate/email/scheduledEmail/ScheduledEmail.java
+++ b/src/main/java/ee/tuleva/onboarding/mandate/email/scheduledEmail/ScheduledEmail.java
@@ -6,23 +6,20 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Table;
 import javax.validation.constraints.NotBlank;
-import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 
 @Entity
 @Table(name = "scheduled_email")
-@AllArgsConstructor
 @NoArgsConstructor
+@RequiredArgsConstructor
 public class ScheduledEmail {
-  @NotBlank Long userId;
-  @NotBlank String mandrillMessageId;
-  @NotBlank ScheduledEmailType type;
+  @NotBlank @NonNull Long userId;
+  @NotBlank @NonNull String mandrillMessageId;
+  @NotBlank @NonNull ScheduledEmailType type;
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
-
-  enum ScheduledEmailType {
-    SUGGEST_SECOND_PILLAR
-  }
 }

--- a/src/main/java/ee/tuleva/onboarding/mandate/email/scheduledEmail/ScheduledEmailCanceller.java
+++ b/src/main/java/ee/tuleva/onboarding/mandate/email/scheduledEmail/ScheduledEmailCanceller.java
@@ -1,0 +1,20 @@
+package ee.tuleva.onboarding.mandate.email.scheduledEmail;
+
+import ee.tuleva.onboarding.mandate.event.AfterMandateSignedEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ScheduledEmailCanceller {
+
+  private final ScheduledEmailService scheduledEmailService;
+
+  @EventListener
+  public void cancelEmail(AfterMandateSignedEvent event) {
+    if (event.getPillar() == 2) {
+      scheduledEmailService.cancel(event.getUser(), ScheduledEmailType.SUGGEST_SECOND_PILLAR);
+    }
+  }
+}

--- a/src/main/java/ee/tuleva/onboarding/mandate/email/scheduledEmail/ScheduledEmailRepository.java
+++ b/src/main/java/ee/tuleva/onboarding/mandate/email/scheduledEmail/ScheduledEmailRepository.java
@@ -1,0 +1,8 @@
+package ee.tuleva.onboarding.mandate.email.scheduledEmail;
+
+import org.springframework.data.repository.CrudRepository;
+
+public interface ScheduledEmailRepository extends CrudRepository<ScheduledEmail, Long> {
+
+  ScheduledEmail findByMandrillMessageId(String mandrillMessageId);
+}

--- a/src/main/java/ee/tuleva/onboarding/mandate/email/scheduledEmail/ScheduledEmailRepository.java
+++ b/src/main/java/ee/tuleva/onboarding/mandate/email/scheduledEmail/ScheduledEmailRepository.java
@@ -1,8 +1,9 @@
 package ee.tuleva.onboarding.mandate.email.scheduledEmail;
 
+import java.util.List;
 import org.springframework.data.repository.CrudRepository;
 
 public interface ScheduledEmailRepository extends CrudRepository<ScheduledEmail, Long> {
 
-  ScheduledEmail findByMandrillMessageId(String mandrillMessageId);
+  List<ScheduledEmail> findAllByUserIdAndType(long userId, ScheduledEmailType type);
 }

--- a/src/main/java/ee/tuleva/onboarding/mandate/email/scheduledEmail/ScheduledEmailService.java
+++ b/src/main/java/ee/tuleva/onboarding/mandate/email/scheduledEmail/ScheduledEmailService.java
@@ -1,6 +1,8 @@
 package ee.tuleva.onboarding.mandate.email.scheduledEmail;
 
+import ee.tuleva.onboarding.notification.email.EmailService;
 import ee.tuleva.onboarding.user.User;
+import java.util.List;
 import javax.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -10,9 +12,17 @@ import org.springframework.stereotype.Service;
 @Transactional
 public class ScheduledEmailService {
   private final ScheduledEmailRepository scheduledEmailRepository;
+  private final EmailService emailService;
 
   public void create(User user, String messageId, ScheduledEmailType type) {
     ScheduledEmail scheduledEmail = new ScheduledEmail(user.getId(), messageId, type);
     scheduledEmailRepository.save(scheduledEmail);
+  }
+
+  public void cancel(User user, ScheduledEmailType type) {
+    List<ScheduledEmail> emails =
+        scheduledEmailRepository.findAllByUserIdAndType(user.getId(), type);
+    emails.forEach(email -> emailService.cancelScheduledEmail(email.getMandrillMessageId()));
+    scheduledEmailRepository.deleteAll(emails);
   }
 }

--- a/src/main/java/ee/tuleva/onboarding/mandate/email/scheduledEmail/ScheduledEmailService.java
+++ b/src/main/java/ee/tuleva/onboarding/mandate/email/scheduledEmail/ScheduledEmailService.java
@@ -1,0 +1,18 @@
+package ee.tuleva.onboarding.mandate.email.scheduledEmail;
+
+import ee.tuleva.onboarding.user.User;
+import javax.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ScheduledEmailService {
+  private final ScheduledEmailRepository scheduledEmailRepository;
+
+  public void create(User user, String messageId, ScheduledEmailType type) {
+    ScheduledEmail scheduledEmail = new ScheduledEmail(user.getId(), messageId, type);
+    scheduledEmailRepository.save(scheduledEmail);
+  }
+}

--- a/src/main/java/ee/tuleva/onboarding/mandate/email/scheduledEmail/ScheduledEmailType.java
+++ b/src/main/java/ee/tuleva/onboarding/mandate/email/scheduledEmail/ScheduledEmailType.java
@@ -1,0 +1,5 @@
+package ee.tuleva.onboarding.mandate.email.scheduledEmail;
+
+public enum ScheduledEmailType {
+  SUGGEST_SECOND_PILLAR
+}

--- a/src/main/java/ee/tuleva/onboarding/notification/email/EmailService.java
+++ b/src/main/java/ee/tuleva/onboarding/notification/email/EmailService.java
@@ -117,4 +117,14 @@ public class EmailService {
   private String getFromName() {
     return "Tuleva";
   }
+
+  public void cancelScheduledEmail(String mandrillMessageId) {
+    try {
+      mandrillApi.messages().cancelScheduled(mandrillMessageId);
+    } catch (MandrillApiError mandrillApiError) {
+      log.error(mandrillApiError.getMandrillErrorAsJson(), mandrillApiError);
+    } catch (IOException e) {
+      log.error(e.getLocalizedMessage(), e);
+    }
+  }
 }

--- a/src/main/resources/db/migration/V1_53__create_scheduled_email.sql
+++ b/src/main/resources/db/migration/V1_53__create_scheduled_email.sql
@@ -1,0 +1,9 @@
+CREATE TABLE scheduled_email
+(
+    id                  SERIAL PRIMARY KEY,
+    user_id             INTEGER      NOT NULL REFERENCES users,
+    mandrill_message_id VARCHAR(255),
+    type                VARCHAR(255) NOT NULL
+);
+
+CREATE INDEX scheduled_email_user_id_index ON scheduled_email (user_id);

--- a/src/main/resources/db/migration/V1_53__create_scheduled_email.sql
+++ b/src/main/resources/db/migration/V1_53__create_scheduled_email.sql
@@ -2,7 +2,7 @@ CREATE TABLE scheduled_email
 (
     id                  SERIAL PRIMARY KEY,
     user_id             INTEGER      NOT NULL REFERENCES users,
-    mandrill_message_id VARCHAR(255),
+    mandrill_message_id VARCHAR(255) NOT NULL,
     type                VARCHAR(255) NOT NULL
 );
 

--- a/src/test/groovy/ee/tuleva/onboarding/mandate/email/scheduledEmail/ScheduledEmailCancellerTest.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/mandate/email/scheduledEmail/ScheduledEmailCancellerTest.groovy
@@ -1,0 +1,30 @@
+package ee.tuleva.onboarding.mandate.email.scheduledEmail
+
+import ee.tuleva.onboarding.mandate.Mandate
+import ee.tuleva.onboarding.mandate.event.AfterMandateSignedEvent
+import ee.tuleva.onboarding.user.User
+import spock.lang.Specification
+
+class ScheduledEmailCancellerTest extends Specification {
+
+  ScheduledEmailService scheduledEmailService = Mock()
+  ScheduledEmailCanceller scheduledEmailCanceller = new ScheduledEmailCanceller(scheduledEmailService)
+
+  def "cancels second pillar scheduled emails when mandate signed"() {
+    given:
+    User user = Mock()
+    Mandate mandate = new Mandate(pillar: pillar)
+    AfterMandateSignedEvent event = new AfterMandateSignedEvent(new Object(), user, mandate, Locale.ENGLISH)
+
+    when:
+    scheduledEmailCanceller.cancelEmail(event)
+
+    then:
+    callCount * scheduledEmailService.cancel(user, ScheduledEmailType.SUGGEST_SECOND_PILLAR)
+
+    where:
+    pillar | callCount
+    2      | 1
+    3      | 0
+  }
+}

--- a/src/test/groovy/ee/tuleva/onboarding/mandate/email/scheduledEmail/ScheduledEmailServiceSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/mandate/email/scheduledEmail/ScheduledEmailServiceSpec.groovy
@@ -1,0 +1,30 @@
+package ee.tuleva.onboarding.mandate.email.scheduledEmail
+
+import ee.tuleva.onboarding.user.User
+import spock.lang.Specification
+
+import static ee.tuleva.onboarding.mandate.email.scheduledEmail.ScheduledEmailType.SUGGEST_SECOND_PILLAR
+
+class ScheduledEmailServiceSpec extends Specification {
+
+  ScheduledEmailRepository scheduledEmailRepository = Mock()
+  ScheduledEmailService service = new ScheduledEmailService(scheduledEmailRepository)
+
+  def 'creates scheduled email with correct attributes'() {
+    given:
+    User user = User.builder().id(13L).build();
+    String messageId = "12345"
+    ScheduledEmailType type = SUGGEST_SECOND_PILLAR
+
+    when:
+    service.create(user, messageId, type)
+
+    then:
+    1 * scheduledEmailRepository.save({
+      ScheduledEmail email ->
+        email.userId == user.getId() &&
+            email.type == SUGGEST_SECOND_PILLAR &&
+            email.mandrillMessageId == messageId
+    })
+  }
+}

--- a/src/test/groovy/ee/tuleva/onboarding/mandate/email/scheduledEmail/ScheduledEmailServiceSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/mandate/email/scheduledEmail/ScheduledEmailServiceSpec.groovy
@@ -1,5 +1,6 @@
 package ee.tuleva.onboarding.mandate.email.scheduledEmail
 
+import ee.tuleva.onboarding.notification.email.EmailService
 import ee.tuleva.onboarding.user.User
 import spock.lang.Specification
 
@@ -8,11 +9,13 @@ import static ee.tuleva.onboarding.mandate.email.scheduledEmail.ScheduledEmailTy
 class ScheduledEmailServiceSpec extends Specification {
 
   ScheduledEmailRepository scheduledEmailRepository = Mock()
-  ScheduledEmailService service = new ScheduledEmailService(scheduledEmailRepository)
+  EmailService emailService = Mock()
+
+  ScheduledEmailService service = new ScheduledEmailService(scheduledEmailRepository, emailService)
 
   def 'creates scheduled email with correct attributes'() {
     given:
-    User user = User.builder().id(13L).build();
+    User user = new User(id: 13);
     String messageId = "12345"
     ScheduledEmailType type = SUGGEST_SECOND_PILLAR
 
@@ -26,5 +29,24 @@ class ScheduledEmailServiceSpec extends Specification {
             email.type == SUGGEST_SECOND_PILLAR &&
             email.mandrillMessageId == messageId
     })
+  }
+
+  def 'calls correct methods when cancelling scheduled emails'() {
+    given:
+    User user = new User(id: 13)
+    ScheduledEmailType type = SUGGEST_SECOND_PILLAR
+    List<ScheduledEmail> emails = [
+        new ScheduledEmail(userId: user.id, mandrillMessageId: "100", type: type),
+        new ScheduledEmail(userId: user.id, mandrillMessageId: "200", type: type)
+    ]
+
+    when:
+    service.cancel(user, type)
+
+    then:
+    1 * scheduledEmailRepository.findAllByUserIdAndType(user.id, type) >> emails
+    1 * emailService.cancelScheduledEmail("100")
+    1 * emailService.cancelScheduledEmail("200")
+    1 * scheduledEmailRepository.deleteAll(emails)
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/notification/email/EmailServiceSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/notification/email/EmailServiceSpec.groovy
@@ -56,4 +56,15 @@ class EmailServiceSpec extends Specification {
     1 * mandrillMessagesApi.send(message, false, null, Date.from(sendAt)) >> [mandrillMessageStatus]
     messageId == Optional.of("13")
   }
+
+  def "cancels scheduled email"() {
+    given:
+    String mandrillMessageId = "100"
+
+    when:
+    service.cancelScheduledEmail(mandrillMessageId)
+
+    then:
+    1 * mandrillApi.messages().cancelScheduled(mandrillMessageId)
+  }
 }


### PR DESCRIPTION
Currently, when a user joins our third pillar and they don't have a second pillar, we schedule an e-mail in 3 days that suggests to join the second pillar as well. If the user completes the second pillar before getting the e-mail, they get confused.

This PR removes these e-mails from Mandrill schedule when the user signs their second pillar mandate.