### PR TITLE
Keep spring session in memory

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -52,7 +52,7 @@ spring:
             user.name: ${spring.security.user.name}
             user.password: ${spring.security.user.password}
   session:
-    store-type: jdbc
+    store-type: none
     jdbc:
       initialize-schema: never
 


### PR DESCRIPTION
Spring security oAuth has a bug which causes sessions to not be found in the database, causing a "Failed to find access token for token" error for some clients. Since our client session survives a server restart even without a DB session, we'll use in-memory session until the bug is fixed. 

More info here: https://github.com/spring-projects/spring-security-oauth/issues/788