### PR TITLE
Take null e-mails into account when creating a user

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/epis/contact/UserPreferences.java
+++ b/src/main/java/ee/tuleva/onboarding/epis/contact/UserPreferences.java
@@ -24,89 +24,8 @@ import lombok.Setter;
 // TODO: rename to ContactDetails
 public class UserPreferences implements Person {
 
-  public enum ContactPreferenceType {
-    E,
-    P
-  } // E - email, P - postal
-
-  private String firstName;
-
-  private String lastName;
-
-  private String personalCode;
-
-  @Builder.Default private ContactPreferenceType contactPreference = E;
-
-  private String districtCode;
-
-  private String addressRow1;
-
-  private String addressRow2;
-
-  private String addressRow3;
-
-  private String postalIndex;
-
-  @Builder.Default private String country = "EE";
-
-  public enum LanguagePreferenceType {
-    EST,
-    RUS,
-    ENG
-  }
-
-  @Builder.Default private LanguagePreferenceType languagePreference = EST;
-
-  @Builder.Default private String noticeNeeded = "Y"; // boolean { 'Y', 'N' }
-
-  private String email;
-
-  private String phoneNumber;
-
-  private String pensionAccountNumber;
-
-  private List<Distribution> thirdPillarDistribution;
-
-  @Data
-  @Builder
-  @NoArgsConstructor
-  @AllArgsConstructor
-  public static class Distribution {
-    private String activeThirdPillarFundIsin;
-    private BigDecimal percentage;
-  }
-
-  private String activeSecondPillarFundIsin;
-
-  private boolean isSecondPillarActive;
-
-  private boolean isThirdPillarActive;
-
-  public Address getAddress() {
-    return Address.builder()
-        .street(addressRow1)
-        .countryCode(country)
-        .postalCode(postalIndex)
-        .districtCode(districtCode)
-        .build();
-  }
-
-  public UserPreferences setAddress(Address address) {
-    addressRow1 = address.getStreet();
-    addressRow2 = null;
-    addressRow3 = null;
-    country = address.getCountryCode();
-    districtCode = address.getDistrictCode();
-    postalIndex = address.getPostalCode();
-    return this;
-  }
-
-  public String getDistrictName() {
-    return districtCodeToName.get(districtCode);
-  }
-
   private static Map<String, String> districtCodeToName =
-      new HashMap<String, String>() {
+      new HashMap<>() {
         {
           put("1060", "Abja-Paluoja linn");
           put("1301", "Antsla linn");
@@ -172,4 +91,66 @@ public class UserPreferences implements Person {
           put("0086", "Võru maakond");
         }
       };
+  private String firstName;
+  private String lastName;
+  private String personalCode;
+  @Builder.Default private ContactPreferenceType contactPreference = E;
+  private String districtCode;
+  private String addressRow1;
+  private String addressRow2;
+  private String addressRow3;
+  private String postalIndex;
+  @Builder.Default private String country = "EE";
+  @Builder.Default private LanguagePreferenceType languagePreference = EST;
+  @Builder.Default private String noticeNeeded = "Y"; // boolean { 'Y', 'N' }
+  private String email;
+  private String phoneNumber;
+  private String pensionAccountNumber;
+  private List<Distribution> thirdPillarDistribution;
+  private String activeSecondPillarFundIsin;
+  private boolean isSecondPillarActive;
+  private boolean isThirdPillarActive;
+
+  public Address getAddress() {
+    return Address.builder()
+        .street(addressRow1)
+        .countryCode(country)
+        .postalCode(postalIndex)
+        .districtCode(districtCode)
+        .build();
+  }
+
+  public UserPreferences setAddress(Address address) {
+    addressRow1 = address.getStreet();
+    addressRow2 = null;
+    addressRow3 = null;
+    country = address.getCountryCode();
+    districtCode = address.getDistrictCode();
+    postalIndex = address.getPostalCode();
+    return this;
+  }
+
+  public String getDistrictName() {
+    return districtCodeToName.get(districtCode);
+  }
+
+  public enum ContactPreferenceType {
+    E,
+    P
+  } // E - email, P - postal
+
+  public enum LanguagePreferenceType {
+    EST,
+    RUS,
+    ENG
+  }
+
+  @Data
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class Distribution {
+    private String activeThirdPillarFundIsin;
+    private BigDecimal percentage;
+  }
 }

--- a/src/main/java/ee/tuleva/onboarding/epis/contact/UserPreferences.java
+++ b/src/main/java/ee/tuleva/onboarding/epis/contact/UserPreferences.java
@@ -15,6 +15,7 @@ import lombok.Data;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.jetbrains.annotations.Nullable;
 
 @Getter
 @Setter
@@ -103,7 +104,7 @@ public class UserPreferences implements Person {
   @Builder.Default private String country = "EE";
   @Builder.Default private LanguagePreferenceType languagePreference = EST;
   @Builder.Default private String noticeNeeded = "Y"; // boolean { 'Y', 'N' }
-  private String email;
+  @Nullable private String email;
   private String phoneNumber;
   private String pensionAccountNumber;
   private List<Distribution> thirdPillarDistribution;

--- a/src/main/java/ee/tuleva/onboarding/user/UserController.java
+++ b/src/main/java/ee/tuleva/onboarding/user/UserController.java
@@ -9,6 +9,7 @@ import ee.tuleva.onboarding.error.ValidationErrorsException;
 import ee.tuleva.onboarding.user.command.UpdateUserCommand;
 import ee.tuleva.onboarding.user.response.UserResponse;
 import io.swagger.annotations.ApiOperation;
+import java.util.Optional;
 import javax.validation.Valid;
 import lombok.AllArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -58,7 +59,9 @@ public class UserController {
 
     User user =
         userService.updateUser(
-            authenticatedPerson.getPersonalCode(), cmd.getEmail(), cmd.getPhoneNumber());
+            authenticatedPerson.getPersonalCode(),
+            Optional.of(cmd.getEmail()),
+            cmd.getPhoneNumber());
 
     if (cmd.getAddress() != null) {
       UserPreferences contactDetails =

--- a/src/main/java/ee/tuleva/onboarding/user/UserDetailsUpdater.java
+++ b/src/main/java/ee/tuleva/onboarding/user/UserDetailsUpdater.java
@@ -7,6 +7,7 @@ import ee.tuleva.onboarding.auth.event.BeforeTokenGrantedEvent;
 import ee.tuleva.onboarding.auth.principal.Person;
 import ee.tuleva.onboarding.epis.contact.ContactDetailsService;
 import ee.tuleva.onboarding.epis.contact.UserPreferences;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
@@ -54,13 +55,17 @@ public class UserDetailsUpdater {
     if (!user.hasContactDetails()) {
       UserPreferences contactDetails = contactDetailsService.getContactDetails(person, token);
       String phoneNumber = StringUtils.trim(contactDetails.getPhoneNumber());
-      String email = StringUtils.trim(contactDetails.getEmail());
+
+      Optional<String> email =
+          contactDetails.getEmail() != null
+              ? Optional.of(StringUtils.trim(contactDetails.getEmail()))
+              : Optional.empty();
 
       if (userService.isExistingEmail(person.getPersonalCode(), email)) {
         log.info(
             "User with given e-mail already exists, leaving the field empty for the user to fill: userId={}",
             user.getId());
-        email = null;
+        email = Optional.empty();
       }
 
       log.info("User contact details missing. Filling them in with EPIS data");

--- a/src/main/java/ee/tuleva/onboarding/user/UserService.java
+++ b/src/main/java/ee/tuleva/onboarding/user/UserService.java
@@ -35,7 +35,7 @@ public class UserService {
     return userRepository.save(user);
   }
 
-  public User updateUser(String personalCode, String email, String phoneNumber) {
+  public User updateUser(String personalCode, Optional<String> email, String phoneNumber) {
     if (isExistingEmail(personalCode, email)) {
       throw DuplicateEmailException.newInstance();
     }
@@ -44,7 +44,7 @@ public class UserService {
         findByPersonalCode(personalCode)
             .map(
                 existingUser -> {
-                  existingUser.setEmail(email);
+                  existingUser.setEmail(email.orElse(null));
                   existingUser.setPhoneNumber(phoneNumber);
                   return existingUser;
                 })
@@ -88,8 +88,10 @@ public class UserService {
     return userRepository.save(user);
   }
 
-  public boolean isExistingEmail(String personalCode, String email) {
-    Optional<User> existingUser = userRepository.findByEmail(email);
+  public boolean isExistingEmail(String personalCode, Optional<String> email) {
+    if (email.isEmpty()) return false;
+
+    Optional<User> existingUser = userRepository.findByEmail(email.get());
     return existingUser.isPresent() && !personalCode.equals(existingUser.get().getPersonalCode());
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/user/UserControllerSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/user/UserControllerSpec.groovy
@@ -13,192 +13,195 @@ import static ee.tuleva.onboarding.auth.UserFixture.sampleUserNonMember
 import static ee.tuleva.onboarding.epis.contact.ContactDetailsFixture.contactDetailsFixture
 import static ee.tuleva.onboarding.user.address.AddressFixture.addressFixture
 import static org.hamcrest.Matchers.*
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
 
 class UserControllerSpec extends BaseControllerSpec {
 
-    UserService userService = Mock()
-    EpisService episService = Mock()
-    ContactDetailsService contactDetailsService = Mock()
+  UserService userService = Mock()
+  EpisService episService = Mock()
+  ContactDetailsService contactDetailsService = Mock()
 
-    UserController controller = new UserController(userService, episService, contactDetailsService)
+  UserController controller = new UserController(userService, episService, contactDetailsService)
 
-    def "/me endpoint works with non member"() {
-        given:
-        def contactDetails = contactDetailsFixture()
-        def user = userFrom(sampleAuthenticatedPerson)
-        1 * userService.getById(sampleAuthenticatedPerson.userId) >> user
-        1 * episService.getContactDetails(sampleAuthenticatedPerson) >> contactDetails
+  def "/me endpoint works with non member"() {
+    given:
+    def contactDetails = contactDetailsFixture()
+    def user = userFrom(sampleAuthenticatedPerson)
+    1 * userService.getById(sampleAuthenticatedPerson.userId) >> user
+    1 * episService.getContactDetails(sampleAuthenticatedPerson) >> contactDetails
 
-        expect:
-        mockMvcWithAuthenticationPrincipal(sampleAuthenticatedPerson, controller)
-            .perform(get("/v1/me"))
-            .andExpect(status().isOk())
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-            .andExpect(jsonPath('$.id', is(2)))
-            .andExpect(jsonPath('$.firstName', is(sampleAuthenticatedPerson.firstName)))
-            .andExpect(jsonPath('$.lastName', is(sampleAuthenticatedPerson.lastName)))
-            .andExpect(jsonPath('$.personalCode', is(sampleAuthenticatedPerson.personalCode)))
-            .andExpect(jsonPath('$.age', is(user.age)))
-            .andExpect(jsonPath('$.email', is(user.email)))
-            .andExpect(jsonPath('$.phoneNumber', is(user.phoneNumber)))
-            .andExpect(jsonPath('$.memberNumber', is(nullValue())))
-            .andExpect(jsonPath('$.pensionAccountNumber', is(contactDetails.pensionAccountNumber)))
-            .andExpect(jsonPath('$.address.street', is(contactDetails.addressRow1)))
-            .andExpect(jsonPath('$.address.districtCode', is(contactDetails.districtCode)))
-            .andExpect(jsonPath('$.address.postalCode', is(contactDetails.postalIndex)))
-            .andExpect(jsonPath('$.address.countryCode', is(contactDetails.country)))
-            .andExpect(jsonPath('$.secondPillarActive', is(contactDetails.secondPillarActive)))
-            .andExpect(jsonPath('$.thirdPillarActive', is(contactDetails.thirdPillarActive)))
-    }
+    expect:
+    mockMvcWithAuthenticationPrincipal(sampleAuthenticatedPerson, controller)
+        .perform(get("/v1/me"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath('$.id', is(2)))
+        .andExpect(jsonPath('$.firstName', is(sampleAuthenticatedPerson.firstName)))
+        .andExpect(jsonPath('$.lastName', is(sampleAuthenticatedPerson.lastName)))
+        .andExpect(jsonPath('$.personalCode', is(sampleAuthenticatedPerson.personalCode)))
+        .andExpect(jsonPath('$.age', is(user.age)))
+        .andExpect(jsonPath('$.email', is(user.email)))
+        .andExpect(jsonPath('$.phoneNumber', is(user.phoneNumber)))
+        .andExpect(jsonPath('$.memberNumber', is(nullValue())))
+        .andExpect(jsonPath('$.pensionAccountNumber', is(contactDetails.pensionAccountNumber)))
+        .andExpect(jsonPath('$.address.street', is(contactDetails.addressRow1)))
+        .andExpect(jsonPath('$.address.districtCode', is(contactDetails.districtCode)))
+        .andExpect(jsonPath('$.address.postalCode', is(contactDetails.postalIndex)))
+        .andExpect(jsonPath('$.address.countryCode', is(contactDetails.country)))
+        .andExpect(jsonPath('$.secondPillarActive', is(contactDetails.secondPillarActive)))
+        .andExpect(jsonPath('$.thirdPillarActive', is(contactDetails.thirdPillarActive)))
+  }
 
-    def "/me endpoint works with a member"() {
-        given:
-        def authenticatedPerson = sampleAuthenticatedPersonAndMember().build()
-        def user = sampleUser().build()
-        def contactDetails = contactDetailsFixture()
-        1 * userService.getById(user.id) >> user
-        1 * episService.getContactDetails(authenticatedPerson) >> contactDetails
+  def "/me endpoint works with a member"() {
+    given:
+    def authenticatedPerson = sampleAuthenticatedPersonAndMember().build()
+    def user = sampleUser().build()
+    def contactDetails = contactDetailsFixture()
+    1 * userService.getById(user.id) >> user
+    1 * episService.getContactDetails(authenticatedPerson) >> contactDetails
 
-        expect:
-        mockMvcWithAuthenticationPrincipal(authenticatedPerson, controller)
-            .perform(get("/v1/me"))
-            .andExpect(status().isOk())
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-            .andExpect(jsonPath('$.id', is(authenticatedPerson.userId.intValue())))
-            .andExpect(jsonPath('$.firstName', is(authenticatedPerson.firstName)))
-            .andExpect(jsonPath('$.lastName', is(authenticatedPerson.lastName)))
-            .andExpect(jsonPath('$.personalCode', is(authenticatedPerson.personalCode)))
-            .andExpect(jsonPath('$.age', is(user.age)))
-            .andExpect(jsonPath('$.email', is(user.email)))
-            .andExpect(jsonPath('$.phoneNumber', is(user.phoneNumber)))
-            .andExpect(jsonPath('$.memberNumber', is(user.member.get().memberNumber)))
-            .andExpect(jsonPath('$.pensionAccountNumber', is(contactDetails.pensionAccountNumber)))
-            .andExpect(jsonPath('$.address.street', is(contactDetails.addressRow1)))
-            .andExpect(jsonPath('$.address.districtCode', is(contactDetails.districtCode)))
-            .andExpect(jsonPath('$.address.postalCode', is(contactDetails.postalIndex)))
-            .andExpect(jsonPath('$.address.countryCode', is(contactDetails.country)))
-    }
+    expect:
+    mockMvcWithAuthenticationPrincipal(authenticatedPerson, controller)
+        .perform(get("/v1/me"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath('$.id', is(authenticatedPerson.userId.intValue())))
+        .andExpect(jsonPath('$.firstName', is(authenticatedPerson.firstName)))
+        .andExpect(jsonPath('$.lastName', is(authenticatedPerson.lastName)))
+        .andExpect(jsonPath('$.personalCode', is(authenticatedPerson.personalCode)))
+        .andExpect(jsonPath('$.age', is(user.age)))
+        .andExpect(jsonPath('$.email', is(user.email)))
+        .andExpect(jsonPath('$.phoneNumber', is(user.phoneNumber)))
+        .andExpect(jsonPath('$.memberNumber', is(user.member.get().memberNumber)))
+        .andExpect(jsonPath('$.pensionAccountNumber', is(contactDetails.pensionAccountNumber)))
+        .andExpect(jsonPath('$.address.street', is(contactDetails.addressRow1)))
+        .andExpect(jsonPath('$.address.districtCode', is(contactDetails.districtCode)))
+        .andExpect(jsonPath('$.address.postalCode', is(contactDetails.postalIndex)))
+        .andExpect(jsonPath('$.address.countryCode', is(contactDetails.country)))
+  }
 
-    def "/me/principal endpoint works"() {
-        expect:
-        mockMvcWithAuthenticationPrincipal(sampleAuthenticatedPerson, controller)
-            .perform(get("/v1/me/principal"))
-            .andExpect(status().isOk())
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-            .andExpect(jsonPath('$.userId', is(2)))
-            .andExpect(jsonPath('$.firstName', is(sampleAuthenticatedPerson.firstName)))
-            .andExpect(jsonPath('$.lastName', is(sampleAuthenticatedPerson.lastName)))
-            .andExpect(jsonPath('$.personalCode', is(sampleAuthenticatedPerson.personalCode)))
-    }
+  def "/me/principal endpoint works"() {
+    expect:
+    mockMvcWithAuthenticationPrincipal(sampleAuthenticatedPerson, controller)
+        .perform(get("/v1/me/principal"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath('$.userId', is(2)))
+        .andExpect(jsonPath('$.firstName', is(sampleAuthenticatedPerson.firstName)))
+        .andExpect(jsonPath('$.lastName', is(sampleAuthenticatedPerson.lastName)))
+        .andExpect(jsonPath('$.personalCode', is(sampleAuthenticatedPerson.personalCode)))
+  }
 
-    def "updates an existing user"() {
-        given:
-        def contactDetails = contactDetailsFixture()
-        def address = addressFixture().build()
-        def command = new UpdateUserCommand(
-            email: "erko@risthein.ee",
-            phoneNumber: "5555555",
-            address: address
-        )
-        def updatedUser = userFrom(sampleAuthenticatedPerson, command)
+  def "updates an existing user"() {
+    given:
+    def contactDetails = contactDetailsFixture()
+    def address = addressFixture().build()
+    def command = new UpdateUserCommand(
+        email: "erko@risthein.ee",
+        phoneNumber: "5555555",
+        address: address
+    )
+    def updatedUser = userFrom(sampleAuthenticatedPerson, command)
 
-        1 * userService.updateUser(sampleAuthenticatedPerson.personalCode, command.email, command.phoneNumber) >>
-            updatedUser
-        1 * contactDetailsService.updateContactDetails(updatedUser, command.address) >>
-            contactDetails.setAddress(address)
+    1 * userService
+        .updateUser(sampleAuthenticatedPerson.personalCode, Optional.of(command.email), command.phoneNumber) >>
+        updatedUser
+    1 * contactDetailsService.updateContactDetails(updatedUser, command.address) >>
+        contactDetails.setAddress(address)
 
-        def mvc = mockMvcWithAuthenticationPrincipal(sampleAuthenticatedPerson, controller)
+    def mvc = mockMvcWithAuthenticationPrincipal(sampleAuthenticatedPerson, controller)
 
-        when:
-        def performCall = mvc
-            .perform(patch("/v1/me")
-                .content(mapper.writeValueAsString(command))
-                .contentType(MediaType.APPLICATION_JSON))
+    when:
+    def performCall = mvc
+        .perform(patch("/v1/me")
+            .content(mapper.writeValueAsString(command))
+            .contentType(MediaType.APPLICATION_JSON))
 
-        then:
-        performCall.andExpect(status().isOk())
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-            .andExpect(jsonPath('$.firstName', is("Erko")))
-            .andExpect(jsonPath('$.lastName', is("Risthein")))
-            .andExpect(jsonPath('$.personalCode', is("38501010002")))
-            .andExpect(jsonPath('$.email', is("erko@risthein.ee")))
-            .andExpect(jsonPath('$.phoneNumber', is("5555555")))
-            .andExpect(jsonPath('$.age', isA(Integer)))
-            .andExpect(jsonPath('$.pensionAccountNumber', is(contactDetails.pensionAccountNumber)))
-            .andExpect(jsonPath('$.address.street', is(address.street)))
-            .andExpect(jsonPath('$.address.districtCode', is(address.districtCode)))
-            .andExpect(jsonPath('$.address.postalCode', is(address.postalCode)))
-            .andExpect(jsonPath('$.address.countryCode', is(address.countryCode)))
-    }
+    then:
+    performCall.andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath('$.firstName', is("Erko")))
+        .andExpect(jsonPath('$.lastName', is("Risthein")))
+        .andExpect(jsonPath('$.personalCode', is("38501010002")))
+        .andExpect(jsonPath('$.email', is("erko@risthein.ee")))
+        .andExpect(jsonPath('$.phoneNumber', is("5555555")))
+        .andExpect(jsonPath('$.age', isA(Integer)))
+        .andExpect(jsonPath('$.pensionAccountNumber', is(contactDetails.pensionAccountNumber)))
+        .andExpect(jsonPath('$.address.street', is(address.street)))
+        .andExpect(jsonPath('$.address.districtCode', is(address.districtCode)))
+        .andExpect(jsonPath('$.address.postalCode', is(address.postalCode)))
+        .andExpect(jsonPath('$.address.countryCode', is(address.countryCode)))
+  }
 
-    def "can update just email and phone number"() {
-        given:
-        def command = new UpdateUserCommand(
-            email: "erko@risthein.ee",
-            phoneNumber: "5555555"
-        )
-        def updatedUser = userFrom(sampleAuthenticatedPerson, command)
+  def "can update just email and phone number"() {
+    given:
+    def command = new UpdateUserCommand(
+        email: "erko@risthein.ee",
+        phoneNumber: "5555555"
+    )
+    def updatedUser = userFrom(sampleAuthenticatedPerson, command)
 
-        1 * userService.updateUser(sampleAuthenticatedPerson.personalCode, command.email, command.phoneNumber) >>
-            updatedUser
-        0 * contactDetailsService.updateContactDetails(_ , _)
+    1 * userService
+        .updateUser(sampleAuthenticatedPerson.personalCode, Optional.of(command.email), command.phoneNumber) >>
+        updatedUser
+    0 * contactDetailsService.updateContactDetails(_, _)
 
-        def mvc = mockMvcWithAuthenticationPrincipal(sampleAuthenticatedPerson, controller)
+    def mvc = mockMvcWithAuthenticationPrincipal(sampleAuthenticatedPerson, controller)
 
-        when:
-        def performCall = mvc
-            .perform(patch("/v1/me")
-                .content(mapper.writeValueAsString(command))
-                .contentType(MediaType.APPLICATION_JSON))
+    when:
+    def performCall = mvc
+        .perform(patch("/v1/me")
+            .content(mapper.writeValueAsString(command))
+            .contentType(MediaType.APPLICATION_JSON))
 
-        then:
-        performCall.andExpect(status().isOk())
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-            .andExpect(jsonPath('$.firstName', is("Erko")))
-            .andExpect(jsonPath('$.lastName', is("Risthein")))
-            .andExpect(jsonPath('$.personalCode', is("38501010002")))
-            .andExpect(jsonPath('$.email', is("erko@risthein.ee")))
-            .andExpect(jsonPath('$.phoneNumber', is("5555555")))
-            .andExpect(jsonPath('$.age', isA(Integer)))
-            .andExpect(jsonPath('$.pensionAccountNumber', is(null)))
-            .andExpect(jsonPath('$.address', is(null)))
-    }
+    then:
+    performCall.andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath('$.firstName', is("Erko")))
+        .andExpect(jsonPath('$.lastName', is("Risthein")))
+        .andExpect(jsonPath('$.personalCode', is("38501010002")))
+        .andExpect(jsonPath('$.email', is("erko@risthein.ee")))
+        .andExpect(jsonPath('$.phoneNumber', is("5555555")))
+        .andExpect(jsonPath('$.age', isA(Integer)))
+        .andExpect(jsonPath('$.pensionAccountNumber', is(null)))
+        .andExpect(jsonPath('$.address', is(null)))
+  }
 
-    def "validates a new user before saving"() {
-        given:
-        def command = new UpdateUserCommand()
-        def mvc = mockMvcWithAuthenticationPrincipal(sampleAuthenticatedPerson, controller)
+  def "validates a new user before saving"() {
+    given:
+    def command = new UpdateUserCommand()
+    def mvc = mockMvcWithAuthenticationPrincipal(sampleAuthenticatedPerson, controller)
 
-        when:
-        def performCall = mvc
-            .perform(patch("/v1/me")
-                .content(mapper.writeValueAsString(command))
-                .contentType(MediaType.APPLICATION_JSON))
+    when:
+    def performCall = mvc
+        .perform(patch("/v1/me")
+            .content(mapper.writeValueAsString(command))
+            .contentType(MediaType.APPLICATION_JSON))
 
-        then:
-        0 * userService.updateUser(*_)
-        performCall.andExpect(status().isBadRequest())
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-            .andExpect(jsonPath('$.errors', hasSize(1)))
-    }
+    then:
+    0 * userService.updateUser(*_)
+    performCall.andExpect(status().isBadRequest())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath('$.errors', hasSize(1)))
+  }
 
-    private User userFrom(AuthenticatedPerson authenticatedPerson, UpdateUserCommand command = null) {
-        sampleUserNonMember()
-            .id(authenticatedPerson.userId)
-            .firstName(authenticatedPerson.firstName)
-            .lastName(authenticatedPerson.lastName)
-            .personalCode(authenticatedPerson.personalCode)
-            .email(command?.email)
-            .phoneNumber(command?.phoneNumber)
-            .build()
-    }
-
-    AuthenticatedPerson sampleAuthenticatedPerson = AuthenticatedPerson.builder()
-        .firstName("Erko")
-        .lastName("Risthein")
-        .personalCode("38501010002")
-        .userId(2L)
+  private static User userFrom(AuthenticatedPerson authenticatedPerson, UpdateUserCommand command = null) {
+    sampleUserNonMember()
+        .id(authenticatedPerson.userId)
+        .firstName(authenticatedPerson.firstName)
+        .lastName(authenticatedPerson.lastName)
+        .personalCode(authenticatedPerson.personalCode)
+        .email(command?.email)
+        .phoneNumber(command?.phoneNumber)
         .build()
+  }
+
+  AuthenticatedPerson sampleAuthenticatedPerson = AuthenticatedPerson.builder()
+      .firstName("Erko")
+      .lastName("Risthein")
+      .personalCode("38501010002")
+      .userId(2L)
+      .build()
 }

--- a/src/test/groovy/ee/tuleva/onboarding/user/UserDetailsUpdaterSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/user/UserDetailsUpdaterSpec.groovy
@@ -10,26 +10,26 @@ import static ee.tuleva.onboarding.epis.contact.ContactDetailsFixture.contactDet
 
 class UserDetailsUpdaterSpec extends Specification {
 
-    UserService userService = Mock()
-    ContactDetailsService contactDetailsService = Mock()
+  UserService userService = Mock()
+  ContactDetailsService contactDetailsService = Mock()
 
-    UserDetailsUpdater service = new UserDetailsUpdater(userService, contactDetailsService)
+  UserDetailsUpdater service = new UserDetailsUpdater(userService, contactDetailsService)
 
-    def "updates user email and phone number based on epis info"() {
-        given:
-        def user = sampleUser().email(null).phoneNumber(null).build()
-        def token = "token"
-        def accessToken = Mock(OAuth2AccessToken, {
-            getValue() >> token
-        })
-        def contactDetails = contactDetailsFixture()
-        1 * userService.findByPersonalCode(user.personalCode) >> Optional.of(user)
-        1 * contactDetailsService.getContactDetails(user, token) >> contactDetails
+  def "updates user email and phone number based on epis info"() {
+    given:
+    def user = sampleUser().email(null).phoneNumber(null).build()
+    def token = "token"
+    def accessToken = Mock(OAuth2AccessToken, {
+      getValue() >> token
+    })
+    def contactDetails = contactDetailsFixture()
+    1 * userService.findByPersonalCode(user.personalCode) >> Optional.of(user)
+    1 * contactDetailsService.getContactDetails(user, token) >> contactDetails
 
-        when:
-        service.onAfterTokenGrantedEvent(new AfterTokenGrantedEvent(this, user, accessToken))
+    when:
+    service.onAfterTokenGrantedEvent(new AfterTokenGrantedEvent(this, user, accessToken))
 
-        then:
-        1 * userService.updateUser(user.personalCode, contactDetails.email, contactDetails.phoneNumber)
-    }
+    then:
+    1 * userService.updateUser(user.personalCode, Optional.of(contactDetails.email), contactDetails.phoneNumber)
+  }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/user/UserServiceSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/user/UserServiceSpec.groovy
@@ -45,7 +45,7 @@ class UserServiceSpec extends Specification {
     userRepository.findByEmail(newEmail) >> Optional.empty()
 
     when:
-    def updatedUser = service.updateUser(user.personalCode, newEmail, "555555")
+    def updatedUser = service.updateUser(user.personalCode, Optional.of(newEmail), "555555")
 
     then:
     updatedUser.email == newEmail
@@ -63,7 +63,7 @@ class UserServiceSpec extends Specification {
     userRepository.findByEmail(newEmail) >> Optional.of(userWithExistingEmail)
 
     when:
-    service.updateUser(user.personalCode, newEmail, "555555")
+    service.updateUser(user.personalCode, Optional.of(newEmail), "555555")
 
     then:
     thrown(DuplicateEmailException)
@@ -134,7 +134,7 @@ class UserServiceSpec extends Specification {
     userRepository.findByEmail(email) >> existingUser
 
     when:
-    def result = service.isExistingEmail(personalCode, email)
+    def result = service.isExistingEmail(personalCode, Optional.of(email))
 
     then:
     result == isExistingEmail


### PR DESCRIPTION
Our current code didn't take into account that pulled e-mails can be "null" from Pensionikeskus for some users. Now we don't try to compare "null" e-mails to find out if they are a duplicate of any existing e-mails.