### PR TITLE
Fix early withdrawal fulfillment date

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/deadline/MandateDeadlines.java
+++ b/src/main/java/ee/tuleva/onboarding/deadline/MandateDeadlines.java
@@ -9,6 +9,8 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.time.Month;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
@@ -25,15 +27,22 @@ public class MandateDeadlines {
   }
 
   private ZonedDateTime periodEnding() {
-    ZonedDateTime march31ThisYear = now().withMonth(3).with(lastDayOfMonth()).with(LocalTime.MAX);
-    ZonedDateTime july31ThisYear = now().withMonth(7).with(lastDayOfMonth()).with(LocalTime.MAX);
-    ZonedDateTime november30ThisYear =
-        now().withMonth(11).with(lastDayOfMonth()).with(LocalTime.MAX);
-    ZonedDateTime march31NextYear =
-        now().plusYears(1).withMonth(3).with(lastDayOfMonth()).with(LocalTime.MAX);
+    ZoneId timeZone = estonianClock.getZone();
+    ZonedDateTime zonedApplicationDate = applicationDate.atZone(timeZone);
+    int applicationYear = zonedApplicationDate.getYear();
 
-    return Stream.of(march31ThisYear, july31ThisYear, november30ThisYear, march31NextYear)
-        .filter(deadline -> !deadline.isBefore(applicationDate.atZone(estonianClock.getZone())))
+    ZonedDateTime march31 =
+        LocalDate.of(applicationYear, Month.MARCH, 31).atStartOfDay(timeZone).with(LocalTime.MAX);
+    ZonedDateTime july31 =
+        LocalDate.of(applicationYear, Month.JULY, 31).atStartOfDay(timeZone).with(LocalTime.MAX);
+    ZonedDateTime november30 =
+        LocalDate.of(applicationYear, Month.NOVEMBER, 30)
+            .atStartOfDay(timeZone)
+            .with(LocalTime.MAX);
+    ZonedDateTime march31NextYear = march31.plusYears(1);
+
+    return Stream.of(march31, july31, november30, march31NextYear)
+        .filter(deadline -> !deadline.isBefore(zonedApplicationDate))
         .findFirst()
         .get();
   }

--- a/src/test/java/ee/tuleva/onboarding/mandate/email/__snapshots__/MandateEmailContentServiceSpec.snap
+++ b/src/test/java/ee/tuleva/onboarding/mandate/email/__snapshots__/MandateEmailContentServiceSpec.snap
@@ -4,7 +4,7 @@ second_pillar_suggest_membership=[
   <body>
     <p>Hello, Jordan.</p>
     <br>
-    <p>You are now saving for your pension alongside me and other Tuleva members. Your payments will be directed to the chosen pension fund from the next payment made. If you wish to swap any existing shares, the exchange of units will take effect on 02.05.2022.</p>
+    <p>You are now saving for your pension alongside me and other Tuleva members. Your payments will be directed to the chosen pension fund from the next payment made. If you wish to swap any existing shares, the exchange of units will take effect on 03.01.2022.</p>
     <br>
     
     <p>Tuleva's owners are the pension savers themselves. As a Tuleva pension fund client, you have no obligation to become a member of Tuleva. All Estonian citizens are able to save together with us in our modern, low-cost pension funds. Having said that, I would still welcome you to think about becoming a member, since you benefit the most from Tuleva whilst being a co-owner yourself.<br><br><a href="https://tuleva.ee/en/mutual-company-2/?utm_source=autoemail&utm_medium=clients&utm_campaign=sug_mem">More information about the benefits of being a member of Tuleva</a></p>
@@ -25,7 +25,7 @@ second_pillar_suggest_third=[
   <body>
     <p>Hello, Jordan.</p>
     <br>
-    <p>You are now saving for your pension alongside me and other Tuleva members. Your payments will be directed to the chosen pension fund from the next payment made. If you wish to swap any existing shares, the exchange of units will take effect on 02.05.2022.</p>
+    <p>You are now saving for your pension alongside me and other Tuleva members. Your payments will be directed to the chosen pension fund from the next payment made. If you wish to swap any existing shares, the exchange of units will take effect on 03.01.2022.</p>
     <br>
     <p>Next, set up your third pillar. You receive back the income tax on any contributions made this year already next spring. <a href="https://tuleva.ee/iii-sammas/?utm_source=autoemail&utm_medium=clients&utm_campaign=sug_3">Start from here.</a></p>
     


### PR DESCRIPTION
Expectation: When an application is submitted in October 2021, its fulfillment date should be in May 2022. Currently we are showing it to be September 2022. 

This PR rectifies the given situation - we're now taking the application year into account when calculating its deadlines.