### PR TITLE
Replace Springfox with Springdoc and update spring-cloud-sleuth

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,7 +14,7 @@ buildscript {
 }
 
 val springBootAdminVersion = "2.5.5"
-val springCloudSleuthVersion = "3.0.4"
+val springCloudSleuthVersion = "3.1.0"
 val springCloudAwsVersion = "2.2.5.RELEASE"
 
 plugins {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -65,15 +65,18 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-aop")
     implementation("org.springframework.boot:spring-boot-starter-json")
     implementation("org.springframework.boot:spring-boot-starter-validation")
-    implementation("org.springframework.cloud:spring-cloud-starter-sleuth")
-    implementation("io.springfox:springfox-boot-starter:3.0.0")
-    implementation("org.springframework.session:spring-session-jdbc")
+    developmentOnly("org.springframework.boot:spring-boot-devtools")
 
-    implementation("de.codecentric:spring-boot-admin-starter-client")
+    implementation("org.springframework.cloud:spring-cloud-starter-sleuth")
+    implementation("org.springframework.session:spring-session-jdbc")
     implementation("org.springframework.security.oauth.boot:spring-security-oauth2-autoconfigure:2.6.2")
     implementation("org.springframework.security.oauth:spring-security-oauth2:2.5.1.RELEASE")
 
-    developmentOnly("org.springframework.boot:spring-boot-devtools")
+    implementation("org.springdoc:springdoc-openapi-ui:1.6.3")
+    implementation("org.springdoc:springdoc-openapi-security:1.6.3")
+
+    implementation("de.codecentric:spring-boot-admin-starter-client")
+
     runtimeOnly("org.postgresql:postgresql")
 
     implementation("org.flywaydb:flyway-core")

--- a/src/main/java/ee/tuleva/onboarding/account/AccountStatementController.java
+++ b/src/main/java/ee/tuleva/onboarding/account/AccountStatementController.java
@@ -6,13 +6,12 @@ import static org.springframework.web.bind.annotation.RequestMethod.GET;
 import ee.tuleva.onboarding.auth.principal.AuthenticatedPerson;
 import ee.tuleva.onboarding.fund.response.FundBalanceResponseDto;
 import ee.tuleva.onboarding.locale.LocaleService;
-import io.swagger.annotations.ApiOperation;
+import io.swagger.v3.oas.annotations.Operation;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import springfox.documentation.annotations.ApiIgnore;
 
 @RestController
 @RequestMapping("/v1")
@@ -22,10 +21,10 @@ public class AccountStatementController {
   private final AccountStatementService accountStatementService;
   private final LocaleService localeService;
 
-  @ApiOperation(value = "Get pension register account statement")
+  @Operation(summary = "Get pension register account statement")
   @RequestMapping(method = GET, value = "/pension-account-statement")
   public List<FundBalanceResponseDto> getMyPensionAccountStatement(
-      @ApiIgnore @AuthenticationPrincipal AuthenticatedPerson authenticatedPerson) {
+      @AuthenticationPrincipal AuthenticatedPerson authenticatedPerson) {
     List<FundBalance> fundBalances =
         accountStatementService.getAccountStatement(authenticatedPerson);
     return convertToDtos(fundBalances, localeService.getLanguage());

--- a/src/main/java/ee/tuleva/onboarding/aml/AmlCheckController.java
+++ b/src/main/java/ee/tuleva/onboarding/aml/AmlCheckController.java
@@ -5,14 +5,17 @@ import static java.util.stream.Collectors.toList;
 import ee.tuleva.onboarding.aml.dto.AmlCheckAddCommand;
 import ee.tuleva.onboarding.aml.dto.AmlCheckResponse;
 import ee.tuleva.onboarding.auth.principal.AuthenticatedPerson;
-import io.swagger.annotations.ApiOperation;
+import io.swagger.v3.oas.annotations.Operation;
 import java.util.List;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
-import springfox.documentation.annotations.ApiIgnore;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/v1/amlchecks")
@@ -23,9 +26,9 @@ class AmlCheckController {
   private final AmlCheckService amlCheckService;
 
   @GetMapping
-  @ApiOperation(value = "Get missing AML checks")
+  @Operation(summary = "Get missing AML checks")
   public List<AmlCheckResponse> getMissing(
-      @ApiIgnore @AuthenticationPrincipal AuthenticatedPerson authenticatedPerson) {
+      @AuthenticationPrincipal AuthenticatedPerson authenticatedPerson) {
     Long userId = authenticatedPerson.getUserId();
     return amlCheckService.getMissingChecks(userId).stream()
         .map(type -> AmlCheckResponse.builder().type(type).success(false).build())
@@ -33,9 +36,9 @@ class AmlCheckController {
   }
 
   @PostMapping
-  @ApiOperation(value = "Add manual AML check")
+  @Operation(summary = "Add manual AML check")
   public AmlCheckResponse addManualCheck(
-      @ApiIgnore @AuthenticationPrincipal AuthenticatedPerson authenticatedPerson,
+      @AuthenticationPrincipal AuthenticatedPerson authenticatedPerson,
       @Valid @RequestBody AmlCheckAddCommand command) {
     Long userId = authenticatedPerson.getUserId();
     amlCheckService.addCheckIfMissing(userId, command);

--- a/src/main/java/ee/tuleva/onboarding/auth/AuthController.java
+++ b/src/main/java/ee/tuleva/onboarding/auth/AuthController.java
@@ -15,7 +15,8 @@ import ee.tuleva.onboarding.auth.session.GenericSessionStore;
 import ee.tuleva.onboarding.auth.smartid.SmartIdAuthService;
 import ee.tuleva.onboarding.auth.smartid.SmartIdSession;
 import ee.tuleva.onboarding.error.ValidationErrorsException;
-import io.swagger.annotations.ApiOperation;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import java.net.URLDecoder;
 import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
@@ -29,8 +30,11 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.oauth2.common.exceptions.UnauthorizedClientException;
 import org.springframework.validation.Errors;
-import org.springframework.web.bind.annotation.*;
-import springfox.documentation.annotations.ApiIgnore;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @Slf4j
@@ -45,13 +49,14 @@ public class AuthController {
   @Value("${frontend.url}")
   private String frontendUrl;
 
-  @ApiOperation(value = "Initiate authentication")
+  @Operation(summary = "Initiate authentication")
   @RequestMapping(
       method = POST,
       value = "/authenticate",
       consumes = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<AuthenticateResponse> authenticate(
-      @Valid @RequestBody AuthenticateCommand authenticateCommand, @ApiIgnore Errors errors) {
+      @Valid @RequestBody AuthenticateCommand authenticateCommand,
+      @Parameter(hidden = true) Errors errors) {
 
     if (errors != null && errors.hasErrors()) {
       throw new ValidationErrorsException(errors);
@@ -74,7 +79,7 @@ public class AuthController {
   }
 
   @SneakyThrows
-  @ApiOperation(value = "ID card login")
+  @Operation(summary = "ID card login")
   @RequestMapping(
       method = {GET, POST},
       value = "/idLogin")
@@ -82,8 +87,8 @@ public class AuthController {
   public IdCardLoginResponse idLogin(
       @RequestHeader(value = "ssl-client-verify") String clientCertificateVerification,
       @RequestHeader(value = "ssl-client-cert") String clientCertificate,
-      @ApiIgnore HttpServletResponse response,
-      @ApiIgnore HttpMethod httpMethod) {
+      @Parameter(hidden = true) HttpServletResponse response,
+      @Parameter(hidden = true) HttpMethod httpMethod) {
     if (!"SUCCESS".equals(clientCertificateVerification)) {
       throw new UnauthorizedClientException("Client certificate not verified");
     }

--- a/src/main/java/ee/tuleva/onboarding/capital/CapitalController.java
+++ b/src/main/java/ee/tuleva/onboarding/capital/CapitalController.java
@@ -3,13 +3,12 @@ package ee.tuleva.onboarding.capital;
 import ee.tuleva.onboarding.auth.principal.AuthenticatedPerson;
 import ee.tuleva.onboarding.user.User;
 import ee.tuleva.onboarding.user.UserService;
-import io.swagger.annotations.ApiOperation;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import springfox.documentation.annotations.ApiIgnore;
 
 @RestController
 @RequestMapping("/v1")
@@ -20,10 +19,10 @@ public class CapitalController {
   private final UserService userService;
   private final CapitalService capitalService;
 
-  @ApiOperation(value = "Get info about current user initial capital")
+  @Operation(summary = "Get info about current user initial capital")
   @GetMapping(CAPITAL_URI)
   public CapitalStatement capitalStatement(
-      @ApiIgnore @AuthenticationPrincipal AuthenticatedPerson authenticatedPerson) {
+      @AuthenticationPrincipal AuthenticatedPerson authenticatedPerson) {
     Long userId = authenticatedPerson.getUserId();
     User user = userService.getById(userId);
     return user.getMember()

--- a/src/main/java/ee/tuleva/onboarding/comparisons/FundComparisonController.java
+++ b/src/main/java/ee/tuleva/onboarding/comparisons/FundComparisonController.java
@@ -1,7 +1,7 @@
 package ee.tuleva.onboarding.comparisons;
 
 import ee.tuleva.onboarding.auth.principal.AuthenticatedPerson;
-import io.swagger.annotations.ApiOperation;
+import io.swagger.v3.oas.annotations.Operation;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.Instant;
@@ -14,7 +14,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import springfox.documentation.annotations.ApiIgnore;
 
 @RestController
 @RequestMapping("/v1")
@@ -25,10 +24,18 @@ public class FundComparisonController {
 
   private final FundComparisonCalculatorService fundComparisonCalculatorService;
 
-  @ApiOperation(value = "Compare the current user's return to estonian and world average")
+  private static Instant parseInstant(String format) {
+    try {
+      return new SimpleDateFormat("yyyy-MM-dd").parse(format).toInstant();
+    } catch (ParseException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Operation(summary = "Compare the current user's return to estonian and world average")
   @GetMapping("/fund-comparison")
   public FundComparison getComparison(
-      @ApiIgnore @AuthenticationPrincipal AuthenticatedPerson authenticatedPerson,
+      @AuthenticationPrincipal AuthenticatedPerson authenticatedPerson,
       @RequestParam(value = "from", required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") @Past
           Date startDate,
       @RequestParam(value = "pillar", required = false, defaultValue = "2") Integer pillar) {
@@ -38,13 +45,5 @@ public class FundComparisonController {
     }
     return fundComparisonCalculatorService.calculateComparison(
         authenticatedPerson, startTime, pillar);
-  }
-
-  private static Instant parseInstant(String format) {
-    try {
-      return new SimpleDateFormat("yyyy-MM-dd").parse(format).toInstant();
-    } catch (ParseException e) {
-      throw new RuntimeException(e);
-    }
   }
 }

--- a/src/main/java/ee/tuleva/onboarding/comparisons/returns/ReturnsController.java
+++ b/src/main/java/ee/tuleva/onboarding/comparisons/returns/ReturnsController.java
@@ -12,7 +12,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import springfox.documentation.annotations.ApiIgnore;
 
 @RestController
 @RequestMapping("/v1")
@@ -25,7 +24,7 @@ public class ReturnsController {
 
   @GetMapping("/returns")
   public Returns getReturns(
-      @ApiIgnore @AuthenticationPrincipal AuthenticatedPerson person,
+      @AuthenticationPrincipal AuthenticatedPerson person,
       @RequestParam(required = false) @DateTimeFormat(iso = DATE) LocalDate from,
       @RequestParam(required = false, name = "keys[]") List<String> keys) {
     LocalDate startDate = (from == null) ? BEGINNING_OF_TIMES : from;

--- a/src/main/java/ee/tuleva/onboarding/config/SecurityConfiguration.java
+++ b/src/main/java/ee/tuleva/onboarding/config/SecurityConfiguration.java
@@ -103,7 +103,7 @@ public class SecurityConfiguration {
               "/swagger-ui/**",
               "/webjars/**",
               "/swagger-resources/**",
-              "/v2/api-docs",
+              "/v3/api-docs",
               "/authenticate",
               "/idLogin",
               "/oauth/token",

--- a/src/main/java/ee/tuleva/onboarding/config/SwaggerConfiguration.java
+++ b/src/main/java/ee/tuleva/onboarding/config/SwaggerConfiguration.java
@@ -1,35 +1,25 @@
 package ee.tuleva.onboarding.config;
 
-import static springfox.documentation.builders.PathSelectors.regex;
-
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import springfox.documentation.builders.ApiInfoBuilder;
-import springfox.documentation.builders.RequestHandlerSelectors;
-import springfox.documentation.service.ApiInfo;
-import springfox.documentation.service.Contact;
-import springfox.documentation.spi.DocumentationType;
-import springfox.documentation.spring.web.plugins.Docket;
 
 @Configuration
 public class SwaggerConfiguration {
 
   @Bean
-  public Docket accountIdentityApi() {
-    return new Docket(DocumentationType.SWAGGER_2)
-        .apiInfo(apiInfo())
-        .select()
-        .apis(RequestHandlerSelectors.any())
-        .paths(regex("/auth.*|/v1/.*"))
-        .build();
+  public OpenAPI accountIdentityApi() {
+    return new OpenAPI().info(apiInfo());
   }
 
-  private ApiInfo apiInfo() {
-    return new ApiInfoBuilder()
-        .title("Tuleva onboarding service")
-        .description("")
-        .contact(new Contact("Tuleva", "https://github.com/TulevaEE", "tonu.pekk@tuleva.ee"))
-        .version("1.0")
-        .build();
+  private Info apiInfo() {
+    Contact contact =
+        new Contact()
+            .name("Tuleva")
+            .url("https://github.com/TulevaEE")
+            .email("tonu.pekk@tuleva.ee");
+    return new Info().title("Tuleva onboarding service").contact(contact).version("1.0");
   }
 }

--- a/src/main/java/ee/tuleva/onboarding/conversion/ConversionController.java
+++ b/src/main/java/ee/tuleva/onboarding/conversion/ConversionController.java
@@ -1,13 +1,12 @@
 package ee.tuleva.onboarding.conversion;
 
 import ee.tuleva.onboarding.auth.principal.AuthenticatedPerson;
-import io.swagger.annotations.ApiOperation;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.AllArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import springfox.documentation.annotations.ApiIgnore;
 
 @RestController
 @RequestMapping("/v1")
@@ -16,10 +15,10 @@ public class ConversionController {
 
   private final UserConversionService userConversionService;
 
-  @ApiOperation(value = "Get info about the current user conversion")
+  @Operation(summary = "Get info about the current user conversion")
   @GetMapping("/me/conversion")
   public ConversionResponse conversion(
-      @ApiIgnore @AuthenticationPrincipal AuthenticatedPerson authenticatedPerson) {
+      @AuthenticationPrincipal AuthenticatedPerson authenticatedPerson) {
     return userConversionService.getConversion(authenticatedPerson);
   }
 }

--- a/src/main/java/ee/tuleva/onboarding/deadline/MandateDeadlinesController.java
+++ b/src/main/java/ee/tuleva/onboarding/deadline/MandateDeadlinesController.java
@@ -2,7 +2,7 @@ package ee.tuleva.onboarding.deadline;
 
 import static ee.tuleva.onboarding.deadline.MandateDeadlinesController.MANDATE_DEADLINES_URI;
 
-import io.swagger.annotations.ApiOperation;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -19,7 +19,7 @@ public class MandateDeadlinesController {
 
   private final MandateDeadlinesService mandateDeadlinesService;
 
-  @ApiOperation(value = "Get mandate deadlines")
+  @Operation(summary = "Get mandate deadlines")
   @GetMapping
   public MandateDeadlines get() {
     return mandateDeadlinesService.getDeadlines();

--- a/src/main/java/ee/tuleva/onboarding/error/ErrorHandlingController.java
+++ b/src/main/java/ee/tuleva/onboarding/error/ErrorHandlingController.java
@@ -33,9 +33,4 @@ public class ErrorHandlingController implements ErrorController {
         errorAttributes.getErrorAttributes(webRequest, of(STACK_TRACE, MESSAGE));
     return errorAttributesConverter.convert(errors);
   }
-
-  @Override
-  public String getErrorPath() {
-    return PATH;
-  }
 }

--- a/src/main/java/ee/tuleva/onboarding/fund/FundController.java
+++ b/src/main/java/ee/tuleva/onboarding/fund/FundController.java
@@ -3,7 +3,7 @@ package ee.tuleva.onboarding.fund;
 import static org.springframework.web.bind.annotation.RequestMethod.GET;
 
 import ee.tuleva.onboarding.fund.response.FundResponse;
-import io.swagger.annotations.ApiOperation;
+import io.swagger.v3.oas.annotations.Operation;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -18,7 +18,7 @@ public class FundController {
 
   private final FundService fundService;
 
-  @ApiOperation(value = "Get info about available funds")
+  @Operation(summary = "Get info about available funds")
   @RequestMapping(method = GET, value = "/funds")
   public List<FundResponse> get(
       @RequestParam("fundManager.name") Optional<String> fundManagerName) {

--- a/src/main/java/ee/tuleva/onboarding/mandate/MandateController.java
+++ b/src/main/java/ee/tuleva/onboarding/mandate/MandateController.java
@@ -22,7 +22,8 @@ import ee.tuleva.onboarding.mandate.signature.SignatureFile;
 import ee.tuleva.onboarding.mandate.signature.idcard.IdCardSignatureSession;
 import ee.tuleva.onboarding.mandate.signature.mobileid.MobileIdSignatureSession;
 import ee.tuleva.onboarding.mandate.signature.smartid.SmartIdSignatureSession;
-import io.swagger.annotations.ApiOperation;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.List;
@@ -41,7 +42,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.LocaleResolver;
-import springfox.documentation.annotations.ApiIgnore;
 
 @Slf4j
 @RestController
@@ -58,13 +58,13 @@ public class MandateController {
   private final MandateFileService mandateFileService;
   private final LocaleResolver localeResolver;
 
-  @ApiOperation(value = "Create a mandate")
+  @Operation(summary = "Create a mandate")
   @RequestMapping(method = POST)
   @JsonView(MandateView.Default.class)
   public Mandate create(
-      @ApiIgnore @AuthenticationPrincipal AuthenticatedPerson authenticatedPerson,
+      @AuthenticationPrincipal AuthenticatedPerson authenticatedPerson,
       @Valid @RequestBody CreateMandateCommand createMandateCommand,
-      @ApiIgnore Errors errors) {
+      @Parameter(hidden = true) Errors errors) {
     if (errors.hasErrors()) {
       log.info("Create mandate command is not valid: {}", errors);
       throw new ValidationErrorsException(errors);
@@ -74,11 +74,11 @@ public class MandateController {
     return mandateService.save(authenticatedPerson.getUserId(), createMandateCommand);
   }
 
-  @ApiOperation(value = "Start signing mandate with mobile ID")
+  @Operation(summary = "Start signing mandate with mobile ID")
   @RequestMapping(method = PUT, value = "/{id}/signature/mobileId")
   public MobileSignatureResponse startMobileIdSignature(
       @PathVariable("id") Long mandateId,
-      @ApiIgnore @AuthenticationPrincipal AuthenticatedPerson authenticatedPerson) {
+      @AuthenticationPrincipal AuthenticatedPerson authenticatedPerson) {
 
     MobileIdSignatureSession signatureSession =
         mandateService.mobileIdSign(
@@ -88,12 +88,12 @@ public class MandateController {
     return new MobileSignatureResponse(signatureSession.getVerificationCode());
   }
 
-  @ApiOperation(value = "Is mandate successfully signed with mobile ID")
+  @Operation(summary = "Is mandate successfully signed with mobile ID")
   @RequestMapping(method = GET, value = "/{id}/signature/mobileId/status")
   public MobileSignatureStatusResponse getMobileIdSignatureStatus(
       @PathVariable("id") Long mandateId,
-      @ApiIgnore @AuthenticationPrincipal AuthenticatedPerson authenticatedPerson,
-      @ApiIgnore HttpServletRequest request) {
+      @AuthenticationPrincipal AuthenticatedPerson authenticatedPerson,
+      @Parameter(hidden = true) HttpServletRequest request) {
 
     Optional<MobileIdSignatureSession> signatureSession =
         sessionStore.get(MobileIdSignatureSession.class);
@@ -109,11 +109,11 @@ public class MandateController {
     return new MobileSignatureStatusResponse(statusCode, session.getVerificationCode());
   }
 
-  @ApiOperation(value = "Start signing mandate with Smart ID")
+  @Operation(summary = "Start signing mandate with Smart ID")
   @RequestMapping(method = PUT, value = "/{id}/signature/smartId")
   public MobileSignatureResponse startSmartIdSignature(
       @PathVariable("id") Long mandateId,
-      @ApiIgnore @AuthenticationPrincipal AuthenticatedPerson authenticatedPerson) {
+      @AuthenticationPrincipal AuthenticatedPerson authenticatedPerson) {
     SmartIdSignatureSession signatureSession =
         mandateService.smartIdSign(mandateId, authenticatedPerson.getUserId());
     sessionStore.save(signatureSession);
@@ -121,11 +121,11 @@ public class MandateController {
     return new MobileSignatureResponse(signatureSession.getVerificationCode());
   }
 
-  @ApiOperation(value = "Is mandate successfully signed with Smart ID")
+  @Operation(summary = "Is mandate successfully signed with Smart ID")
   @RequestMapping(method = GET, value = "/{id}/signature/smartId/status")
   public MobileSignatureStatusResponse getSmartIdSignatureStatus(
       @PathVariable("id") Long mandateId,
-      @ApiIgnore @AuthenticationPrincipal AuthenticatedPerson authenticatedPerson,
+      @AuthenticationPrincipal AuthenticatedPerson authenticatedPerson,
       HttpServletRequest request) {
 
     Optional<SmartIdSignatureSession> signatureSession =
@@ -142,11 +142,11 @@ public class MandateController {
     return new MobileSignatureStatusResponse(statusCode, session.getVerificationCode());
   }
 
-  @ApiOperation(value = "Start signing mandate with ID card")
+  @Operation(summary = "Start signing mandate with ID card")
   @RequestMapping(method = PUT, value = "/{id}/signature/idCard")
   public IdCardSignatureResponse startIdCardSign(
       @PathVariable("id") Long mandateId,
-      @ApiIgnore @AuthenticationPrincipal AuthenticatedPerson authenticatedPerson,
+      @AuthenticationPrincipal AuthenticatedPerson authenticatedPerson,
       @Valid @RequestBody StartIdCardSignCommand signCommand) {
 
     IdCardSignatureSession signatureSession =
@@ -158,12 +158,12 @@ public class MandateController {
     return new IdCardSignatureResponse(signatureSession.getHashToSignInHex());
   }
 
-  @ApiOperation(value = "Is mandate successfully signed with ID card")
+  @Operation(summary = "Is mandate successfully signed with ID card")
   @RequestMapping(method = PUT, value = "/{id}/signature/idCard/status")
   public IdCardSignatureStatusResponse getIdCardSignatureStatus(
       @PathVariable("id") Long mandateId,
       @Valid @RequestBody FinishIdCardSignCommand signCommand,
-      @ApiIgnore @AuthenticationPrincipal AuthenticatedPerson authenticatedPerson,
+      @AuthenticationPrincipal AuthenticatedPerson authenticatedPerson,
       HttpServletRequest request) {
 
     Optional<IdCardSignatureSession> signatureSession =
@@ -184,11 +184,11 @@ public class MandateController {
     return new IdCardSignatureStatusResponse(statusCode);
   }
 
-  @ApiOperation(value = "Get mandate file")
+  @Operation(summary = "Get mandate file")
   @RequestMapping(method = GET, value = "/{id}/file")
   public void getMandateFile(
       @PathVariable("id") Long mandateId,
-      @ApiIgnore @AuthenticationPrincipal AuthenticatedPerson authenticatedPerson,
+      @AuthenticationPrincipal AuthenticatedPerson authenticatedPerson,
       HttpServletResponse response)
       throws IOException {
 
@@ -202,11 +202,11 @@ public class MandateController {
     response.flushBuffer();
   }
 
-  @ApiOperation(value = "Get mandate file")
+  @Operation(summary = "Get mandate file")
   @RequestMapping(method = GET, value = "/{id}/file/preview", produces = "application/zip")
   public void getMandateFilePreview(
       @PathVariable("id") Long mandateId,
-      @ApiIgnore @AuthenticationPrincipal AuthenticatedPerson authenticatedPerson,
+      @AuthenticationPrincipal AuthenticatedPerson authenticatedPerson,
       HttpServletResponse response)
       throws IOException {
 

--- a/src/main/java/ee/tuleva/onboarding/mandate/application/ApplicationController.java
+++ b/src/main/java/ee/tuleva/onboarding/mandate/application/ApplicationController.java
@@ -4,7 +4,7 @@ import static ee.tuleva.onboarding.mandate.application.ApplicationController.APP
 
 import ee.tuleva.onboarding.auth.principal.AuthenticatedPerson;
 import ee.tuleva.onboarding.epis.mandate.ApplicationStatus;
-import io.swagger.annotations.ApiOperation;
+import io.swagger.v3.oas.annotations.Operation;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -15,7 +15,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import springfox.documentation.annotations.ApiIgnore;
 
 @Slf4j
 @RestController
@@ -28,26 +27,25 @@ public class ApplicationController {
   private final ApplicationCancellationService applicationCancellationService;
   private final ApplicationService applicationService;
 
-  @ApiOperation(value = "Get application")
+  @Operation(summary = "Get application")
   @GetMapping("/{id}")
   public Application getApplication(
-      @ApiIgnore @AuthenticationPrincipal AuthenticatedPerson authenticatedPerson,
-      @PathVariable Long id) {
+      @AuthenticationPrincipal AuthenticatedPerson authenticatedPerson, @PathVariable Long id) {
     return applicationService.getApplication(id, authenticatedPerson);
   }
 
-  @ApiOperation(value = "Get applications")
+  @Operation(summary = "Get applications")
   @GetMapping
   public List<Application> getApplications(
-      @ApiIgnore @AuthenticationPrincipal AuthenticatedPerson authenticatedPerson,
+      @AuthenticationPrincipal AuthenticatedPerson authenticatedPerson,
       @RequestParam("status") ApplicationStatus status) {
     return applicationService.getApplications(status, authenticatedPerson);
   }
 
-  @ApiOperation(value = "Cancel an application")
+  @Operation(summary = "Cancel an application")
   @PostMapping("/{id}/cancellations")
   public ApplicationCancellationResponse cancel(
-      @ApiIgnore @AuthenticationPrincipal AuthenticatedPerson authenticatedPerson,
+      @AuthenticationPrincipal AuthenticatedPerson authenticatedPerson,
       @PathVariable("id") Long applicationId) {
     log.info("Cancelling application {}", applicationId);
     return applicationCancellationService.createCancellationMandate(

--- a/src/main/java/ee/tuleva/onboarding/member/MemberController.java
+++ b/src/main/java/ee/tuleva/onboarding/member/MemberController.java
@@ -3,7 +3,7 @@ package ee.tuleva.onboarding.member;
 import static org.springframework.web.bind.annotation.RequestMethod.HEAD;
 
 import ee.tuleva.onboarding.user.member.MemberRepository;
-import io.swagger.annotations.ApiOperation;
+import io.swagger.v3.oas.annotations.Operation;
 import java.util.stream.StreamSupport;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -21,7 +21,7 @@ public class MemberController {
 
   private final MemberRepository memberRepository;
 
-  @ApiOperation(value = "Get total count of members")
+  @Operation(summary = "Get total count of members")
   @RequestMapping(method = HEAD, value = "/members")
   public ResponseEntity head() {
     Long memberCount =

--- a/src/main/java/ee/tuleva/onboarding/notification/payment/PaymentController.java
+++ b/src/main/java/ee/tuleva/onboarding/notification/payment/PaymentController.java
@@ -5,6 +5,7 @@ import ee.tuleva.onboarding.error.ValidationErrorsException;
 import ee.tuleva.onboarding.member.listener.MemberCreatedEvent;
 import ee.tuleva.onboarding.user.User;
 import ee.tuleva.onboarding.user.UserService;
+import io.swagger.v3.oas.annotations.Parameter;
 import java.io.IOException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -19,7 +20,6 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import springfox.documentation.annotations.ApiIgnore;
 
 @RestController
 @RequiredArgsConstructor
@@ -40,9 +40,9 @@ public class PaymentController {
   @PostMapping("/payments")
   public void incomingPayment(
       @ModelAttribute @Valid IncomingPayment incomingPayment,
-      @ApiIgnore HttpServletResponse response,
-      @ApiIgnore HttpServletRequest request,
-      @ApiIgnore Errors errors)
+      @Parameter(hidden = true) HttpServletResponse response,
+      @Parameter(hidden = true) HttpServletRequest request,
+      @Parameter(hidden = true) Errors errors)
       throws IOException {
 
     log.info("Incoming payment");

--- a/src/main/java/ee/tuleva/onboarding/statistics/ThirdPillarStatisticsController.java
+++ b/src/main/java/ee/tuleva/onboarding/statistics/ThirdPillarStatisticsController.java
@@ -1,6 +1,6 @@
 package ee.tuleva.onboarding.statistics;
 
-import io.swagger.annotations.ApiOperation;
+import io.swagger.v3.oas.annotations.Operation;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,7 +18,7 @@ public class ThirdPillarStatisticsController {
   private final ThirdPillarStatisticsRepository repository;
 
   @PostMapping
-  @ApiOperation(value = "Post third pillar statistics")
+  @Operation(summary = "Post third pillar statistics")
   public ThirdPillarStatistics postStats(@Valid @RequestBody ThirdPillarStatistics statistics) {
     return repository.save(statistics);
   }

--- a/src/main/java/ee/tuleva/onboarding/user/UserController.java
+++ b/src/main/java/ee/tuleva/onboarding/user/UserController.java
@@ -8,7 +8,8 @@ import ee.tuleva.onboarding.epis.contact.ContactDetailsService;
 import ee.tuleva.onboarding.error.ValidationErrorsException;
 import ee.tuleva.onboarding.user.command.UpdateUserCommand;
 import ee.tuleva.onboarding.user.response.UserResponse;
-import io.swagger.annotations.ApiOperation;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import java.util.Optional;
 import javax.validation.Valid;
 import lombok.AllArgsConstructor;
@@ -19,7 +20,6 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import springfox.documentation.annotations.ApiIgnore;
 
 @RestController
 @RequestMapping("/v1")
@@ -30,10 +30,9 @@ public class UserController {
   private final EpisService episService;
   private final ContactDetailsService contactDetailsService;
 
-  @ApiOperation(value = "Get info about the current user")
+  @Operation(summary = "Get info about the current user")
   @GetMapping("/me")
-  public UserResponse me(
-      @ApiIgnore @AuthenticationPrincipal AuthenticatedPerson authenticatedPerson) {
+  public UserResponse me(@AuthenticationPrincipal AuthenticatedPerson authenticatedPerson) {
     Long userId = authenticatedPerson.getUserId();
     User user = userService.getById(userId);
     ContactDetails contactDetails = episService.getContactDetails(authenticatedPerson);
@@ -41,17 +40,16 @@ public class UserController {
   }
 
   @GetMapping("/me/principal")
-  public Person getPrincipal(
-      @ApiIgnore @AuthenticationPrincipal AuthenticatedPerson authenticatedPerson) {
+  public Person getPrincipal(@AuthenticationPrincipal AuthenticatedPerson authenticatedPerson) {
     return authenticatedPerson;
   }
 
-  @ApiOperation(value = "Update the current user")
+  @Operation(summary = "Update the current user")
   @PatchMapping("/me")
   public UserResponse patchMe(
-      @ApiIgnore @AuthenticationPrincipal AuthenticatedPerson authenticatedPerson,
+      @AuthenticationPrincipal AuthenticatedPerson authenticatedPerson,
       @Valid @RequestBody UpdateUserCommand cmd,
-      @ApiIgnore Errors errors) {
+      @Parameter(hidden = true) Errors errors) {
 
     if (errors != null && errors.hasErrors()) {
       throw new ValidationErrorsException(errors);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -76,6 +76,10 @@ truststore:
   path: "test_keys/truststore.jks"
   password: changeit
 
+springdoc:
+  swagger-ui:
+    path: /swagger-ui
+
 mandate:
   email:
     from: "tuleva@tuleva.ee"

--- a/src/test/groovy/ee/tuleva/onboarding/error/ErrorHandlingControllerSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/error/ErrorHandlingControllerSpec.groovy
@@ -32,7 +32,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(ErrorHandlingController)
 @WithMockUser
 @Import([ErrorResponseEntityFactory, InputErrorsConverter, ErrorAttributesConverter,
-  OAuthConfiguration.ResourceServerPathConfiguration, SecurityConfiguration, ConversionDecorator])
+    OAuthConfiguration.ResourceServerPathConfiguration, SecurityConfiguration, ConversionDecorator])
 class ErrorHandlingControllerSpec extends Specification {
 
   @MockBean
@@ -40,9 +40,10 @@ class ErrorHandlingControllerSpec extends Specification {
 
   @TestConfiguration
   static class ErrorAttributesConfiguration {
+
     @Bean
     ErrorAttributes defaultErrorAttributes() {
-      return new DefaultErrorAttributes(true)
+      return new DefaultErrorAttributes()
     }
   }
 
@@ -58,15 +59,15 @@ class ErrorHandlingControllerSpec extends Specification {
   def "error handling works"() {
     expect:
     mvc.perform(get("/error")
-      .requestAttr(RequestDispatcher.ERROR_EXCEPTION, new RuntimeException())
-      .requestAttr(RequestDispatcher.ERROR_STATUS_CODE, 403)
-      .requestAttr(RequestDispatcher.ERROR_REQUEST_URI, "/asdf")
-      .requestAttr(RequestDispatcher.ERROR_MESSAGE, "oops!"))
-      .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-      .andExpect(jsonPath('$.errors[0].code', is("Forbidden")))
-      .andExpect(jsonPath('$.errors[0].message').doesNotExist())
-      .andExpect(jsonPath('$.errors[0].path').doesNotExist())
-      .andExpect(jsonPath('$.errors[0].arguments').isEmpty())
+        .requestAttr(RequestDispatcher.ERROR_EXCEPTION, new RuntimeException())
+        .requestAttr(RequestDispatcher.ERROR_STATUS_CODE, 403)
+        .requestAttr(RequestDispatcher.ERROR_REQUEST_URI, "/asdf")
+        .requestAttr(RequestDispatcher.ERROR_MESSAGE, "oops!"))
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath('$.errors[0].code', is("Forbidden")))
+        .andExpect(jsonPath('$.errors[0].message').doesNotExist())
+        .andExpect(jsonPath('$.errors[0].path').doesNotExist())
+        .andExpect(jsonPath('$.errors[0].arguments').isEmpty())
   }
 
 }


### PR DESCRIPTION
Springfox has not had an update for over a year and they have conflicts with Spring Boot upgrades. The prevalent notion is to migrate to Springdoc, which is a more maintained Swagger UI provider.

With the addition of `springdoc-openapi-security`, we can also get rid of all @ApiIgnore usages - AuthenticatedPerson parameters will now be ignored automatically.