### PR TITLE
Use newer version of docker compose in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 
 PostgreSQL
 
-Running locally with Docker: `docker-compose up database -d`
+Running locally with Docker: `docker compose up database -d`
 
 **Spring Profile**
 
@@ -127,7 +127,7 @@ In order to test ID-card locally, you need to run nginx locally with the right c
    127.0.0.1 pension.tuleva.ee
    127.0.0.1 onboarding-service.tuleva.ee
    ```
-4. Run nginx with docker: `docker-compose up nginx`
+4. Run nginx with docker: `docker compose up nginx`
 5. Add `DANGEROUSLY_DISABLE_HOST_CHECK=true` to `.env` in `onboarding-client`
 6. add `server.servlet.session.cookie.domain: tuleva.ee` to `application.yml`
 7. Test through https://pension.tuleva.ee


### PR DESCRIPTION
Switches README to `docker compose` instead of `docker-compose`, [the older version of the CLI](https://stackoverflow.com/a/66516826).