### PR TITLE
Add followup migration to cover non-generic mandates created from Aug 13 to Sept 12

### DIFF
--- a/src/main/resources/db/migration/V1_88__mandate_details_null.sql
+++ b/src/main/resources/db/migration/V1_88__mandate_details_null.sql
@@ -1,0 +1,4 @@
+UPDATE mandate SET details = null,
+                   mandate_type = 'UNKNOWN'
+               WHERE details = '{}' AND
+                     mandate_type is null;


### PR DESCRIPTION
Covers one more case: non-generic mandates that were created between #901 and #926. 
Historic mandates created before that were covered in #901 and #926 already:
* `mandate_type`, [with default value](https://github.com/TulevaEE/onboarding-service/pull/901/files#diff-b9f466ae047d0435cb576d509a5e23ac2bbe83122c8dd96e3f5a67542b25d197R6)
* `details`, with [migration in](https://github.com/TulevaEE/onboarding-service/pull/926/files#diff-bf225f67883a6a64689b6c9a403eec6aa39ebad740771b5b350dae7ee7e1ab3cR8) #901