### PR TITLE
Fix deserializing MandateDetails when reading Mandate with Hibernate

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/config/ObjectMapperConfiguration.java
+++ b/src/main/java/ee/tuleva/onboarding/config/ObjectMapperConfiguration.java
@@ -2,13 +2,9 @@ package ee.tuleva.onboarding.config;
 
 import static com.fasterxml.jackson.core.JsonGenerator.Feature.WRITE_BIGDECIMAL_AS_PLAIN;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import org.hibernate.cfg.AvailableSettings;
-import org.hibernate.type.format.jackson.JacksonJsonFormatMapper;
 import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
-import org.springframework.boot.autoconfigure.orm.jpa.HibernatePropertiesCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -21,12 +17,5 @@ public class ObjectMapperConfiguration {
         jacksonObjectMapperBuilder
             .featuresToEnable(WRITE_BIGDECIMAL_AS_PLAIN)
             .modules(new Jdk8Module(), new JavaTimeModule());
-  }
-
-  @Bean
-  public HibernatePropertiesCustomizer jsonFormatMapperCustomizer(ObjectMapper objectMapper) {
-    return properties ->
-        properties.put(
-            AvailableSettings.JSON_FORMAT_MAPPER, new JacksonJsonFormatMapper(objectMapper));
   }
 }

--- a/src/main/java/ee/tuleva/onboarding/config/ObjectMapperConfiguration.java
+++ b/src/main/java/ee/tuleva/onboarding/config/ObjectMapperConfiguration.java
@@ -2,11 +2,13 @@ package ee.tuleva.onboarding.config;
 
 import static com.fasterxml.jackson.core.JsonGenerator.Feature.WRITE_BIGDECIMAL_AS_PLAIN;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import ee.tuleva.onboarding.epis.mandate.GenericMandateCreationDto;
-import ee.tuleva.onboarding.epis.mandate.GenericMandateCreationDtoDeserializer;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.type.format.jackson.JacksonJsonFormatMapper;
 import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
+import org.springframework.boot.autoconfigure.orm.jpa.HibernatePropertiesCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -17,9 +19,14 @@ public class ObjectMapperConfiguration {
   public Jackson2ObjectMapperBuilderCustomizer customizeObjectMapper() {
     return jacksonObjectMapperBuilder ->
         jacksonObjectMapperBuilder
-            .deserializerByType(
-                GenericMandateCreationDto.class, new GenericMandateCreationDtoDeserializer())
             .featuresToEnable(WRITE_BIGDECIMAL_AS_PLAIN)
             .modules(new Jdk8Module(), new JavaTimeModule());
+  }
+
+  @Bean
+  public HibernatePropertiesCustomizer jsonFormatMapperCustomizer(ObjectMapper objectMapper) {
+    return properties ->
+        properties.put(
+            AvailableSettings.JSON_FORMAT_MAPPER, new JacksonJsonFormatMapper(objectMapper));
   }
 }

--- a/src/main/java/ee/tuleva/onboarding/epis/mandate/details/MandateDetails.java
+++ b/src/main/java/ee/tuleva/onboarding/epis/mandate/details/MandateDetails.java
@@ -1,6 +1,7 @@
 package ee.tuleva.onboarding.epis.mandate.details;
 
 import com.fasterxml.jackson.annotation.JsonView;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import ee.tuleva.onboarding.mandate.MandateType;
 import ee.tuleva.onboarding.mandate.MandateView;
 import lombok.Getter;
@@ -11,6 +12,7 @@ import lombok.RequiredArgsConstructor;
  */
 @Getter
 @RequiredArgsConstructor
+@JsonDeserialize(using = MandateDetailsDeserializer.class)
 public abstract class MandateDetails {
 
   @JsonView(MandateView.Default.class)

--- a/src/main/java/ee/tuleva/onboarding/epis/mandate/details/MandateDetailsDeserializer.java
+++ b/src/main/java/ee/tuleva/onboarding/epis/mandate/details/MandateDetailsDeserializer.java
@@ -31,7 +31,7 @@ public class MandateDetailsDeserializer extends JsonDeserializer<MandateDetails>
     }
 
     // initializing new ObjectMapper, disabling annotation inspector used to find deserializer
-    // to prevent infinite loop where it
+    // to prevent infinite loop
     ObjectMapper anotherMapper = mapper.copy();
     anotherMapper.setAnnotationIntrospector(customIntrospector);
 

--- a/src/main/java/ee/tuleva/onboarding/epis/mandate/details/MandateDetailsDeserializer.java
+++ b/src/main/java/ee/tuleva/onboarding/epis/mandate/details/MandateDetailsDeserializer.java
@@ -1,0 +1,40 @@
+package ee.tuleva.onboarding.epis.mandate.details;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.introspect.Annotated;
+import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
+import ee.tuleva.onboarding.mandate.MandateType;
+import java.io.IOException;
+
+// MandateDetails deserializer is required for reading from database
+// GenericMandateCreationDTO is required for reading from request
+public class MandateDetailsDeserializer extends JsonDeserializer<MandateDetails> {
+
+  private final JacksonAnnotationIntrospector customIntrospector =
+      new JacksonAnnotationIntrospector() {
+        @Override
+        public Object findDeserializer(Annotated a) {
+          return null;
+        }
+      };
+
+  @Override
+  public MandateDetails deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+    ObjectMapper mapper = (ObjectMapper) p.getCodec();
+    JsonNode root = mapper.readTree(p);
+
+    MandateType type = MandateType.valueOf(root.get("mandateType").asText());
+
+    if (type == MandateType.UNKNOWN) {
+      throw new IllegalArgumentException("Unknown mandateType: " + type);
+    }
+
+    // initializing new ObjectMapper, disabling annotation inspector used to find deserializer
+    // to prevent infinite loop where it
+    ObjectMapper anotherMapper = mapper.copy();
+    anotherMapper.setAnnotationIntrospector(customIntrospector);
+
+    return anotherMapper.treeToValue(root, type.getMandateDetailsClass());
+  }
+}

--- a/src/test/groovy/ee/tuleva/onboarding/mandate/MandateRepositorySpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/mandate/MandateRepositorySpec.groovy
@@ -1,5 +1,7 @@
 package ee.tuleva.onboarding.mandate
 
+import ee.tuleva.onboarding.epis.mandate.details.Pillar
+import ee.tuleva.onboarding.epis.mandate.details.TransferCancellationMandateDetails
 import ee.tuleva.onboarding.user.User
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
@@ -9,6 +11,8 @@ import spock.lang.Specification
 
 import java.time.Instant
 
+import static ee.tuleva.onboarding.epis.mandate.details.Pillar.SECOND
+import static ee.tuleva.onboarding.mandate.MandateType.TRANSFER_CANCELLATION
 import static ee.tuleva.onboarding.user.address.AddressFixture.addressFixture
 
 @DataJpaTest
@@ -41,6 +45,7 @@ class MandateRepositorySpec extends Specification {
       .user(savedUser)
       .futureContributionFundIsin("isin")
       .pillar(2)
+      .details(new TransferCancellationMandateDetails("EE_TEST_ISIN", SECOND))
       .address(address)
       .metadata(metadata)
       .build()
@@ -56,13 +61,18 @@ class MandateRepositorySpec extends Specification {
     when:
     def mandate = repository.findByIdAndUserId(savedMandate.id, savedUser.id)
 
+    // does not actually check for deserialization, unlike @SpringBootTest
+    def castDetails = (TransferCancellationMandateDetails) mandate.details
+
     then:
     mandate.user == savedUser
     mandate.futureContributionFundIsin == Optional.of("isin")
     mandate.fundTransferExchanges == [fundTransferExchange]
     mandate.address == address
     mandate.metadata == metadata
-
+    castDetails.mandateType == TRANSFER_CANCELLATION
+    castDetails.pillar == SECOND
+    castDetails.sourceFundIsinOfTransferToCancel == "EE_TEST_ISIN"
   }
 
 }


### PR DESCRIPTION
What this does:
* Removes custom deserializer registration, as they aren't needed, only `@JsonDeserialize` annotations matter.
* Adds another deserializer, this time for `MandateDetails` themselves, with some quite crazy logic:
  * Instantiates another `ObjectMapper`, disabling annotation inspector which would resolve to the deserializer itself causing an infinite loop.
  * Using that `ObjectMapper.treeToValue`, instantiates the `MandateDetails` itself 
* Adds `@SpringBootTest` integration test for validating that mandate can be read from database.