### PR TITLE
Add partial withdrawal mandates

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/epis/mandate/details/FundPensionOpeningMandateDetails.java
+++ b/src/main/java/ee/tuleva/onboarding/epis/mandate/details/FundPensionOpeningMandateDetails.java
@@ -3,15 +3,15 @@ package ee.tuleva.onboarding.epis.mandate.details;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import ee.tuleva.onboarding.mandate.MandateType;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 
 @Getter
 public class FundPensionOpeningMandateDetails extends MandateDetails {
-
-  private final Pillar pillar;
-  private final FundPensionFrequency frequency;
-  private final FundPensionDuration duration;
-  private final BankAccountDetails bankAccountDetails;
+  @NotNull private final Pillar pillar;
+  @NotNull private final FundPensionFrequency frequency;
+  @NotNull private final FundPensionDuration duration;
+  @NotNull private final BankAccountDetails bankAccountDetails;
 
   @JsonCreator
   public FundPensionOpeningMandateDetails(

--- a/src/main/java/ee/tuleva/onboarding/epis/mandate/details/MandateDetailsDeserializer.java
+++ b/src/main/java/ee/tuleva/onboarding/epis/mandate/details/MandateDetailsDeserializer.java
@@ -32,9 +32,9 @@ public class MandateDetailsDeserializer extends JsonDeserializer<MandateDetails>
 
     // initializing new ObjectMapper, disabling annotation inspector used to find deserializer
     // to prevent infinite loop
-    ObjectMapper anotherMapper = mapper.copy();
-    anotherMapper.setAnnotationIntrospector(customIntrospector);
+    ObjectMapper mapperWithoutAnnotationInspector = mapper.copy();
+    mapperWithoutAnnotationInspector.setAnnotationIntrospector(customIntrospector);
 
-    return anotherMapper.treeToValue(root, type.getMandateDetailsClass());
+    return mapperWithoutAnnotationInspector.treeToValue(root, type.getMandateDetailsClass());
   }
 }

--- a/src/main/java/ee/tuleva/onboarding/epis/mandate/details/PartialWithdrawalMandateDetails.java
+++ b/src/main/java/ee/tuleva/onboarding/epis/mandate/details/PartialWithdrawalMandateDetails.java
@@ -1,0 +1,36 @@
+package ee.tuleva.onboarding.epis.mandate.details;
+
+import static ee.tuleva.onboarding.mandate.MandateType.PARTIAL_WITHDRAWAL;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotNull;
+import java.math.BigDecimal;
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class PartialWithdrawalMandateDetails extends MandateDetails {
+
+  @NotNull private final Pillar pillar;
+  @NotNull private final BankAccountDetails bankAccountDetails;
+  @NotNull private final List<FundWithdrawalAmount> fundWithdrawalAmounts;
+
+  @Valid3LetterCountryCode private final String taxResidency;
+
+  @JsonCreator
+  public PartialWithdrawalMandateDetails(
+      @JsonProperty("pillar") Pillar pillar,
+      @JsonProperty("bankAccountDetails") BankAccountDetails bankAccountDetails,
+      @JsonProperty("fundWithdrawalAmounts") List<FundWithdrawalAmount> fundWithdrawalAmounts,
+      @JsonProperty("taxResidency") String taxResidency) {
+    super(PARTIAL_WITHDRAWAL);
+
+    this.pillar = pillar;
+    this.bankAccountDetails = bankAccountDetails;
+    this.fundWithdrawalAmounts = fundWithdrawalAmounts;
+    this.taxResidency = taxResidency;
+  }
+
+  public record FundWithdrawalAmount(String isin, int percentage, BigDecimal units) {}
+}

--- a/src/main/java/ee/tuleva/onboarding/epis/mandate/details/ThreeLetterCountryCodeValidator.java
+++ b/src/main/java/ee/tuleva/onboarding/epis/mandate/details/ThreeLetterCountryCodeValidator.java
@@ -1,0 +1,19 @@
+package ee.tuleva.onboarding.epis.mandate.details;
+
+import static java.util.Locale.IsoCountryCode.PART3;
+
+import java.util.Locale;
+import java.util.Set;
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class ThreeLetterCountryCodeValidator
+    implements ConstraintValidator<Valid3LetterCountryCode, String> {
+
+  private static final Set<String> VALID_ISO3_COUNTRIES = Locale.getISOCountries(PART3);
+
+  @Override
+  public boolean isValid(String countryCode, ConstraintValidatorContext context) {
+    return VALID_ISO3_COUNTRIES.contains(countryCode.toUpperCase());
+  }
+}

--- a/src/main/java/ee/tuleva/onboarding/epis/mandate/details/TransferCancellationMandateDetails.java
+++ b/src/main/java/ee/tuleva/onboarding/epis/mandate/details/TransferCancellationMandateDetails.java
@@ -4,13 +4,14 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import ee.tuleva.onboarding.mandate.FundTransferExchange;
 import ee.tuleva.onboarding.mandate.MandateType;
+import jakarta.validation.constraints.NotNull;
 import java.util.List;
 import lombok.Getter;
 
 @Getter
 public class TransferCancellationMandateDetails extends MandateDetails {
-  private final String sourceFundIsinOfTransferToCancel;
-  private final Pillar pillar;
+  @NotNull private final String sourceFundIsinOfTransferToCancel;
+  @NotNull private final Pillar pillar;
 
   @JsonCreator
   public TransferCancellationMandateDetails(

--- a/src/main/java/ee/tuleva/onboarding/epis/mandate/details/Valid3LetterCountryCode.java
+++ b/src/main/java/ee/tuleva/onboarding/epis/mandate/details/Valid3LetterCountryCode.java
@@ -1,0 +1,19 @@
+package ee.tuleva.onboarding.epis.mandate.details;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+@Constraint(validatedBy = ThreeLetterCountryCodeValidator.class)
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Valid3LetterCountryCode {
+  String message() default "Invalid country code";
+
+  Class<?>[] groups() default {};
+
+  Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/ee/tuleva/onboarding/mandate/MandateType.java
+++ b/src/main/java/ee/tuleva/onboarding/mandate/MandateType.java
@@ -8,6 +8,7 @@ public enum MandateType {
   WITHDRAWAL_CANCELLATION(WithdrawalCancellationMandateDetails.class),
   EARLY_WITHDRAWAL_CANCELLATION(EarlyWithdrawalCancellationMandateDetails.class),
   TRANSFER_CANCELLATION(TransferCancellationMandateDetails.class),
+  PARTIAL_WITHDRAWAL(PartialWithdrawalMandateDetails.class),
   /*TRANSFER,
   SELECTION,
   PAYMENT,

--- a/src/main/java/ee/tuleva/onboarding/mandate/content/EarlyWithdrawalCancellationMandateFileCreator.java
+++ b/src/main/java/ee/tuleva/onboarding/mandate/content/EarlyWithdrawalCancellationMandateFileCreator.java
@@ -28,7 +28,6 @@ class EarlyWithdrawalCancellationMandateFileCreator implements MandateFileCreato
     return List.of(
         MandateContentFile.builder()
             .name("avalduse_tyhistamise_avaldus_" + documentNumber + ".html")
-            .mimeType("text/html")
             .content(htmlContent.getBytes())
             .build());
   }

--- a/src/main/java/ee/tuleva/onboarding/mandate/content/FundPensionOpeningMandateFileCreator.java
+++ b/src/main/java/ee/tuleva/onboarding/mandate/content/FundPensionOpeningMandateFileCreator.java
@@ -27,7 +27,6 @@ class FundPensionOpeningMandateFileCreator implements MandateFileCreator {
     return List.of(
         MandateContentFile.builder()
             .name("fondipensioni_avamise_avaldus_" + documentNumber + ".html")
-            .mimeType("text/html")
             .content(htmlContent.getBytes())
             .build());
   }

--- a/src/main/java/ee/tuleva/onboarding/mandate/content/MandateContentCreator.java
+++ b/src/main/java/ee/tuleva/onboarding/mandate/content/MandateContentCreator.java
@@ -44,7 +44,6 @@ class MandateContentCreator {
 
     return MandateContentFile.builder()
         .name("makse_maara_muutmise_avaldus_" + documentNumber + ".html")
-        .mimeType("text/html")
         .content(htmlContent.getBytes())
         .build();
   }
@@ -58,7 +57,6 @@ class MandateContentCreator {
 
     return MandateContentFile.builder()
         .name("valikuavaldus_" + documentNumber + ".html")
-        .mimeType("text/html")
         .content(html.getBytes())
         .build();
   }
@@ -101,7 +99,6 @@ class MandateContentCreator {
 
     return MandateContentFile.builder()
         .name("vahetuseavaldus_" + documentNumber + ".html")
-        .mimeType("text/html")
         .content(html.getBytes())
         .build();
   }

--- a/src/main/java/ee/tuleva/onboarding/mandate/content/MandateContentFile.java
+++ b/src/main/java/ee/tuleva/onboarding/mandate/content/MandateContentFile.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 @Getter
 @Builder
 public class MandateContentFile {
+  private final String mimeType = "text/html";
   private String name;
-  private String mimeType;
   private byte[] content;
 }

--- a/src/main/java/ee/tuleva/onboarding/mandate/content/MandateContentService.java
+++ b/src/main/java/ee/tuleva/onboarding/mandate/content/MandateContentService.java
@@ -2,6 +2,7 @@ package ee.tuleva.onboarding.mandate.content;
 
 import ee.tuleva.onboarding.epis.contact.ContactDetails;
 import ee.tuleva.onboarding.epis.mandate.details.FundPensionOpeningMandateDetails;
+import ee.tuleva.onboarding.epis.mandate.details.PartialWithdrawalMandateDetails;
 import ee.tuleva.onboarding.fund.Fund;
 import ee.tuleva.onboarding.mandate.FundTransferExchange;
 import ee.tuleva.onboarding.mandate.Mandate;
@@ -65,6 +66,30 @@ class MandateContentService {
             .build();
 
     return templateEngine.process("future_contributions_fund_pillar_" + mandate.getPillar(), ctx);
+  }
+
+  String getPartialWithdrawalHtml(
+      User user, Mandate mandate, ContactDetails contactDetails, List<Fund> funds) {
+    String transactionId = UUID.randomUUID().toString();
+
+    String documentNumber = mandate.getId().toString();
+
+    PartialWithdrawalMandateDetails mandateDetails =
+        (PartialWithdrawalMandateDetails) mandate.getGenericMandateDto().getDetails();
+
+    Context ctx =
+        ContextBuilder.builder()
+            .mandate(mandate)
+            .user(user)
+            .address(mandate.getAddress())
+            .contactDetails(contactDetails)
+            .transactionId(transactionId)
+            .documentNumber(documentNumber)
+            .partialWithdrawalDetails(mandateDetails, funds)
+            .build();
+
+    return templateEngine.process(
+        "partial_withdrawal_pillar_" + mandateDetails.getPillar().toInt(), ctx);
   }
 
   String getFundPensionOpeningHtml(User user, Mandate mandate, ContactDetails contactDetails) {

--- a/src/main/java/ee/tuleva/onboarding/mandate/content/PartialWithdrawalMandateFileCreator.java
+++ b/src/main/java/ee/tuleva/onboarding/mandate/content/PartialWithdrawalMandateFileCreator.java
@@ -1,0 +1,56 @@
+package ee.tuleva.onboarding.mandate.content;
+
+import static ee.tuleva.onboarding.fund.Fund.FundStatus.ACTIVE;
+import static ee.tuleva.onboarding.mandate.MandateType.PARTIAL_WITHDRAWAL;
+
+import ee.tuleva.onboarding.epis.contact.ContactDetails;
+import ee.tuleva.onboarding.epis.mandate.details.PartialWithdrawalMandateDetails;
+import ee.tuleva.onboarding.fund.Fund;
+import ee.tuleva.onboarding.fund.FundRepository;
+import ee.tuleva.onboarding.mandate.Mandate;
+import ee.tuleva.onboarding.mandate.MandateType;
+import ee.tuleva.onboarding.user.User;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+class PartialWithdrawalMandateFileCreator implements MandateFileCreator {
+
+  private final MandateContentService mandateContentService;
+
+  private final FundRepository fundRepository;
+
+  @Override
+  public List<MandateContentFile> getContentFiles(
+      User user, Mandate mandate, ContactDetails contactDetails) {
+
+    List<Fund> funds = fundRepository.findAllByPillarAndStatus(mandate.getPillar(), ACTIVE);
+
+    String htmlContent =
+        mandateContentService.getPartialWithdrawalHtml(user, mandate, contactDetails, funds);
+
+    return List.of(
+        MandateContentFile.builder()
+            .name(getFileName(mandate))
+            .content(htmlContent.getBytes())
+            .build());
+  }
+
+  public String getFileName(Mandate mandate) {
+    var documentNumber = mandate.getId().toString();
+    var pillar =
+        ((PartialWithdrawalMandateDetails) mandate.getGenericMandateDto().getDetails()).getPillar();
+
+    return switch (pillar) {
+      case SECOND -> "yhekordse_valjamakse_avaldus" + documentNumber + ".html";
+      case THIRD -> "tagasivotmise_avaldus" + documentNumber + ".html";
+    };
+  }
+
+  @Override
+  public boolean supports(MandateType mandateType) {
+    return mandateType == PARTIAL_WITHDRAWAL;
+  }
+}

--- a/src/main/java/ee/tuleva/onboarding/mandate/content/WithdrawalCancellationMandateFileCreator.java
+++ b/src/main/java/ee/tuleva/onboarding/mandate/content/WithdrawalCancellationMandateFileCreator.java
@@ -29,7 +29,6 @@ class WithdrawalCancellationMandateFileCreator implements MandateFileCreator {
     return List.of(
         MandateContentFile.builder()
             .name("avalduse_tyhistamise_avaldus_" + documentNumber + ".html")
-            .mimeType("text/html")
             .content(htmlContent.getBytes())
             .build());
   }

--- a/src/main/java/ee/tuleva/onboarding/mandate/content/thymeleaf/ContextBuilder.java
+++ b/src/main/java/ee/tuleva/onboarding/mandate/content/thymeleaf/ContextBuilder.java
@@ -2,6 +2,7 @@ package ee.tuleva.onboarding.mandate.content.thymeleaf;
 
 import ee.tuleva.onboarding.epis.contact.ContactDetails;
 import ee.tuleva.onboarding.epis.mandate.details.FundPensionOpeningMandateDetails;
+import ee.tuleva.onboarding.epis.mandate.details.PartialWithdrawalMandateDetails;
 import ee.tuleva.onboarding.fund.Fund;
 import ee.tuleva.onboarding.mandate.FundTransferExchange;
 import ee.tuleva.onboarding.mandate.Mandate;
@@ -82,7 +83,15 @@ public class ContextBuilder {
 
   public ContextBuilder fundPensionOpeningDetails(FundPensionOpeningMandateDetails details) {
     ctx.setVariable("fundPensionOpeningDetails", details);
+    ctx.setVariable("bankAccountDetails", details.getBankAccountDetails());
     return this;
+  }
+
+  public ContextBuilder partialWithdrawalDetails(
+      PartialWithdrawalMandateDetails details, List<Fund> funds) {
+    ctx.setVariable("partialWithdrawalDetails", details);
+    ctx.setVariable("bankAccountDetails", details.getBankAccountDetails());
+    return this.funds(funds);
   }
 
   public ContextBuilder fundTransferExchanges(List<FundTransferExchange> fundTransferExchanges) {

--- a/src/main/java/ee/tuleva/onboarding/mandate/generic/FundPensionOpeningMandateFactory.java
+++ b/src/main/java/ee/tuleva/onboarding/mandate/generic/FundPensionOpeningMandateFactory.java
@@ -34,8 +34,6 @@ public class FundPensionOpeningMandateFactory
     // TODO legacy field
     mandate.setPillar(details.getPillar().toInt());
 
-    mandate.setDetails(details);
-
     return mandate;
   }
 

--- a/src/main/java/ee/tuleva/onboarding/mandate/generic/PartialWithdrawalMandateFactory.java
+++ b/src/main/java/ee/tuleva/onboarding/mandate/generic/PartialWithdrawalMandateFactory.java
@@ -1,12 +1,10 @@
 package ee.tuleva.onboarding.mandate.generic;
 
-import static ee.tuleva.onboarding.mandate.MandateType.*;
-
 import ee.tuleva.onboarding.auth.principal.AuthenticatedPerson;
 import ee.tuleva.onboarding.conversion.UserConversionService;
 import ee.tuleva.onboarding.epis.EpisService;
 import ee.tuleva.onboarding.epis.mandate.GenericMandateCreationDto;
-import ee.tuleva.onboarding.epis.mandate.details.EarlyWithdrawalCancellationMandateDetails;
+import ee.tuleva.onboarding.epis.mandate.details.PartialWithdrawalMandateDetails;
 import ee.tuleva.onboarding.mandate.Mandate;
 import ee.tuleva.onboarding.mandate.MandateType;
 import ee.tuleva.onboarding.mandate.builder.ConversionDecorator;
@@ -14,10 +12,10 @@ import ee.tuleva.onboarding.user.UserService;
 import org.springframework.stereotype.Component;
 
 @Component
-public class EarlyWithdrawalCancellationMandateFactory
-    extends MandateFactory<EarlyWithdrawalCancellationMandateDetails> {
+public class PartialWithdrawalMandateFactory
+    extends MandateFactory<PartialWithdrawalMandateDetails> {
 
-  public EarlyWithdrawalCancellationMandateFactory(
+  public PartialWithdrawalMandateFactory(
       UserService userService,
       EpisService episService,
       UserConversionService conversionService,
@@ -28,17 +26,18 @@ public class EarlyWithdrawalCancellationMandateFactory
   @Override
   public Mandate createMandate(
       AuthenticatedPerson authenticatedPerson,
-      GenericMandateCreationDto<EarlyWithdrawalCancellationMandateDetails> mandateCreationDto) {
+      GenericMandateCreationDto<PartialWithdrawalMandateDetails> mandateCreationDto) {
     Mandate mandate = this.setupMandate(authenticatedPerson, mandateCreationDto);
+    PartialWithdrawalMandateDetails details = mandateCreationDto.getDetails();
 
-    // TODO legacy fields
-    mandate.setPillar(2);
+    // TODO legacy field
+    mandate.setPillar(details.getPillar().toInt());
 
     return mandate;
   }
 
   @Override
   public boolean supports(MandateType mandateType) {
-    return mandateType == EARLY_WITHDRAWAL_CANCELLATION;
+    return mandateType == MandateType.PARTIAL_WITHDRAWAL;
   }
 }

--- a/src/main/java/ee/tuleva/onboarding/mandate/generic/TransferCancellationMandateFactory.java
+++ b/src/main/java/ee/tuleva/onboarding/mandate/generic/TransferCancellationMandateFactory.java
@@ -50,15 +50,9 @@ public class TransferCancellationMandateFactory
             .mandate(mandate)
             .build();
 
-    var exchanges = List.of(exchange);
-
     // TODO legacy fields
     mandate.setPillar(sourceFund.getPillar());
     mandate.setFundTransferExchanges(List.of(exchange));
-
-    mandate.setDetails(
-        TransferCancellationMandateDetails.fromFundTransferExchanges(
-            exchanges, sourceFund.getPillar()));
 
     return mandate;
   }

--- a/src/main/java/ee/tuleva/onboarding/mandate/generic/WithdrawalCancellationMandateFactory.java
+++ b/src/main/java/ee/tuleva/onboarding/mandate/generic/WithdrawalCancellationMandateFactory.java
@@ -34,8 +34,6 @@ public class WithdrawalCancellationMandateFactory
     // TODO legacy fields
     mandate.setPillar(2);
 
-    mandate.setDetails(new WithdrawalCancellationMandateDetails());
-
     return mandate;
   }
 

--- a/src/main/resources/templates/partial_withdrawal_pillar_2.html
+++ b/src/main/resources/templates/partial_withdrawal_pillar_2.html
@@ -9,25 +9,24 @@
   <h1>Kohustuslikust kogumispensionist osalise väljamakse avaldus nr <span
       th:text="${documentNumber}"></span></h1>
   <div th:insert="sections/personal_details_section" th:remove="tag"></div>
-
   <h2>3. Tagasivõtmisele kuuluvad osakud</h2>
-  <table>
-    <thead>
-      <tr>
-        <td>Pensionifondi nimetus, mille osakute
-        tagasivõtmist summa väljamaksmiseks soovin kasutada</td>
-        <td>Tagasivõetavate osakute osakaal saldost (%)</td>
-      </tr>
-    </thead>
-
-    <tbody>
-      <tr th:each="fundWithdrawalAmount : ${partialWithdrawalDetails.getFundWithdrawalAmounts()}">
-        <td th:text="${fundIsinNames.get(fundWithdrawalAmount.isin())}"></td>
-        <td ><span th:text="${fundWithdrawalAmount.percentage()}"></span><span>%</span></td>
-      </tr>
-    </tbody>
+  <div class="form-grouping">
+    <table>
+      <thead>
+        <tr>
+          <td>Pensionifondi nimetus, mille osakute
+          tagasivõtmist summa väljamaksmiseks soovin kasutada</td>
+          <td>Tagasivõetavate osakute osakaal saldost (%)</td>
+        </tr>
+      </thead>
+      <tbody>
+        <tr th:each="fundWithdrawalAmount : ${partialWithdrawalDetails.getFundWithdrawalAmounts()}">
+          <td th:text="${fundIsinNames.get(fundWithdrawalAmount.isin())}"></td>
+          <td ><span th:text="${fundWithdrawalAmount.percentage()}"></span><span>%</span></td>
+        </tr>
+      </tbody>
   </table>
-
+  </div>
   <div th:insert="sections/withdrawals_bank_account_details_section" th:remove="tag"></div>
   <div class="disclaimer">
     Olen teadlik, et:<br>

--- a/src/main/resources/templates/partial_withdrawal_pillar_2.html
+++ b/src/main/resources/templates/partial_withdrawal_pillar_2.html
@@ -1,0 +1,55 @@
+<!DOCTYPE HTML>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+  <title>Kohustuslikust kogumispensionist osalise väljamakse avaldus</title>
+  <meta content="text/html; charset=UTF-8" http-equiv="Content-Type"/>
+  <div th:insert="sections/new_styles" th:remove="tag"></div>
+</head>
+<body>
+  <h1>Kohustuslikust kogumispensionist osalise väljamakse avaldus nr <span
+      th:text="${documentNumber}"></span></h1>
+  <div th:insert="sections/personal_details_section" th:remove="tag"></div>
+
+  <h2>3. Tagasivõtmisele kuuluvad osakud</h2>
+  <table>
+    <thead>
+      <tr>
+        <td>Pensionifondi nimetus, mille osakute
+        tagasivõtmist summa väljamaksmiseks soovin kasutada</td>
+        <td>Tagasivõetavate osakute osakaal saldost (%)</td>
+      </tr>
+    </thead>
+
+    <tbody>
+      <tr th:each="fundWithdrawalAmount : ${partialWithdrawalDetails.getFundWithdrawalAmounts()}">
+        <td th:text="${fundIsinNames.get(fundWithdrawalAmount.isin())}"></td>
+        <td ><span th:text="${fundWithdrawalAmount.percentage()}"></span><span>%</span></td>
+      </tr>
+    </tbody>
+  </table>
+
+  <div th:insert="sections/withdrawals_bank_account_details_section" th:remove="tag"></div>
+  <div class="disclaimer">
+    Olen teadlik, et:<br>
+    1) käesoleva avalduse esitamisel tehakse väljamakse minu avaldusel märgitud kogumispensioni
+    fondi(de)st avalduse esitamisele järgneval kuul kogumispensionide seaduses sätestatud tähtajal.
+    Väljamakselt peetakse kinni tulumaks vastavalt tulumaksuseadusele ja kogu tulumaksu arvestuse
+    aluseks olev summa deklareeritakse Maksu- ja Tolliametis füüsilise isiku tuludeklaratsioonis
+    minu tuluna.<br>
+    2) käesoleva avalduse esitamisega peatub minu kohustusliku kogumispensioni maksete tasumise
+    kohustus automaatselt alates kogumispensionide seaduses sätestatud tähtajast, vastavalt kas 1.
+    jaanuarist, 1. maist või 1. septembrist. Eraldi avaldust ei ole maksete peatamiseks vaja esitada.
+    Makse tasumist ei saa hiljem taastada.<br>
+    3) esitatud avaldust saab tühistada avalduse esitamisega samal kalendrikuul vastavalt
+    kogumispensionide seadusele.<br>
+    4) kui avalduse esitajal on pensioniregistris registreeritud kehtivaid aresti või pankroti nõudeid, ei
+    ole võimalik väljamakse avaldust tühistada. Avalduse tühistamiseks peab olema nõue lõpetatud
+    (täidetud või tühistatud).<br>
+    Olen teadlik, et AS Pensionikeskus kogub ja töötleb minu isikuandmeid kogumispensionide seaduses
+    ja väärtpaberite registri pidamise seaduses sätestatud ulatuses Euroopa Liidu piires.
+    NB! AS Pensionikeskus isikuandmete töötlemise ja privaatsuspõhimõtted on kättesaadavad AS
+    Pensionikeskus veebilehel.<br>
+  </div>
+  <div th:insert="sections/footer_section" th:remove="tag"></div>
+</body>
+</html>

--- a/src/main/resources/templates/partial_withdrawal_pillar_3.html
+++ b/src/main/resources/templates/partial_withdrawal_pillar_3.html
@@ -9,31 +9,29 @@
   <h1>Vabatahtlikust pensionifondist väljamakse avaldus nr <span
       th:text="${documentNumber}"></span></h1>
   <div th:insert="sections/personal_details_section" th:remove="tag"></div>
-
   <h2>3. Vabatahtlik(ud) pensionifond(id), mille osakute tagasivõtmist taotlen</h2>
-  <table>
-    <thead>
-      <tr>
-        <td>Pensionifond</td>
-        <td>Tagasivõetavate osakute arv</td>
-      </tr>
-    </thead>
-
-    <tbody>
-      <tr th:each="fundWithdrawalAmount : ${partialWithdrawalDetails.getFundWithdrawalAmounts()}">
-        <td th:text="${fundIsinNames.get(fundWithdrawalAmount.isin())}"></td>
-        <td th:text="${fundWithdrawalAmount.units()}"></td>
-      </tr>
-    </tbody>
-  </table>
-
+  <div class="form-grouping">
+    <table>
+      <thead>
+        <tr>
+          <td>Pensionifond</td>
+          <td>Tagasivõetavate osakute arv</td>
+        </tr>
+      </thead>
+      <tbody>
+        <tr th:each="fundWithdrawalAmount : ${partialWithdrawalDetails.getFundWithdrawalAmounts()}">
+          <td th:text="${fundIsinNames.get(fundWithdrawalAmount.isin())}"></td>
+          <td th:text="${fundWithdrawalAmount.units()}"></td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
   <div class="form-grouping">
     <div class="form-group">
       <div class="form-label">Maksuresidentsus</div>
       <div class="form-value" th:text="${partialWithdrawalDetails.getTaxResidency()}"></div>
     </div>
   </div>
-
   <div th:insert="sections/withdrawals_bank_account_details_section" th:remove="tag"></div>
   <div class="disclaimer">
     Olen teadlik, et osakute tagasivõtmisel ja raha arvelduskontole kandmisel peetakse väljamakstavalt

--- a/src/main/resources/templates/partial_withdrawal_pillar_3.html
+++ b/src/main/resources/templates/partial_withdrawal_pillar_3.html
@@ -1,0 +1,49 @@
+<!DOCTYPE HTML>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+  <title>Vabatahtlikust pensionifondist väljamakse avaldus</title>
+  <meta content="text/html; charset=UTF-8" http-equiv="Content-Type"/>
+  <div th:insert="sections/new_styles" th:remove="tag"></div>
+</head>
+<body>
+  <h1>Vabatahtlikust pensionifondist väljamakse avaldus nr <span
+      th:text="${documentNumber}"></span></h1>
+  <div th:insert="sections/personal_details_section" th:remove="tag"></div>
+
+  <h2>3. Vabatahtlik(ud) pensionifond(id), mille osakute tagasivõtmist taotlen</h2>
+  <table>
+    <thead>
+      <tr>
+        <td>Pensionifond</td>
+        <td>Tagasivõetavate osakute arv</td>
+      </tr>
+    </thead>
+
+    <tbody>
+      <tr th:each="fundWithdrawalAmount : ${partialWithdrawalDetails.getFundWithdrawalAmounts()}">
+        <td th:text="${fundIsinNames.get(fundWithdrawalAmount.isin())}"></td>
+        <td th:text="${fundWithdrawalAmount.units()}"></td>
+      </tr>
+    </tbody>
+  </table>
+
+  <div class="form-grouping">
+    <div class="form-group">
+      <div class="form-label">Maksuresidentsus</div>
+      <div class="form-value" th:text="${partialWithdrawalDetails.getTaxResidency()}"></div>
+    </div>
+  </div>
+
+  <div th:insert="sections/withdrawals_bank_account_details_section" th:remove="tag"></div>
+  <div class="disclaimer">
+    Olen teadlik, et osakute tagasivõtmisel ja raha arvelduskontole kandmisel peetakse väljamakstavalt
+    summalt kinni tulumaks vastavalt tulumaksuseadusele ja kogu tulumaksu arvestuse aluseks olev summa
+    deklareeritakse Maksu- ja Tolliametis füüsilise isiku tuludeklaratsioonis minu tuluna.<br>
+    Olen teadlik, et AS Pensionikeskus kogub ja töötleb minu isikuandmeid kogumispensionide seaduses ja
+    väärtpaberite registri pidamise seaduses sätestatud ulatuses Euroopa Liidu piires.
+    NB! AS Pensionikeskus isikuandmete töötlemise ja privaatsuspõhimõtted on kättesaadavad AS
+    Pensionikeskus veebilehel.<br>
+  </div>
+  <div th:insert="sections/footer_section" th:remove="tag"></div>
+</body>
+</html>

--- a/src/main/resources/templates/sections/fund_pension_opening_details_sections.html
+++ b/src/main/resources/templates/sections/fund_pension_opening_details_sections.html
@@ -14,30 +14,4 @@
     </div>
   </div>
 </div>
-
-<h2>4. Pensionikonto omaniku pangakonto</h2>
-<div class="form-grouping">
-  <div class="form-group">
-    <div class="form-label">Pangakonto number</div>
-    <div class="form-value" th:text="${fundPensionOpeningDetails.bankAccountDetails.accountIban()}"></div>
-  </div>
-  <div class="form-group">
-    <div class="form-label">Pank</div>
-    <div class="form-value" th:text="${fundPensionOpeningDetails.bankAccountDetails.bank().getDisplayName()}"></div>
-  </div>
-
-  <div class="form-group">
-    <div class="form-label">Swift/BIC</div>
-    <div class="form-value"><br></div>
-  </div>
-
-  <div class="form-group">
-    <div class="form-label">Välisriigi panga aadress</div>
-    <div class="form-value"><br></div>
-  </div>
-
-  <div class="form-group">
-    <div class="form-label">Täiendavad andmed välismaksete kohta</div>
-    <div class="form-value"><br></div>
-  </div>
-</div>
+<div th:insert="sections/withdrawals_bank_account_details_section" th:remove="tag"></div>

--- a/src/main/resources/templates/sections/new_styles.html
+++ b/src/main/resources/templates/sections/new_styles.html
@@ -81,5 +81,13 @@
     td {
       padding: 8px 16px;
     }
+
+    td:first-child {
+      padding-left: 0;
+    }
+
+    td:last-child {
+      padding-right: 0;
+    }
   }
 </style>

--- a/src/main/resources/templates/sections/new_styles.html
+++ b/src/main/resources/templates/sections/new_styles.html
@@ -66,4 +66,20 @@
       width: 100px;
     }
   }
+
+  table {
+    width: 100%;
+    font-family: sans-serif;
+
+    thead {
+      tr {
+        font-weight: bold;
+        border-bottom: 1px solid black;
+      }
+    }
+
+    td {
+      padding: 8px 16px;
+    }
+  }
 </style>

--- a/src/main/resources/templates/sections/personal_details_section.html
+++ b/src/main/resources/templates/sections/personal_details_section.html
@@ -26,7 +26,6 @@
   </div>
 </div>
 <h2>2. Isiku eelistused</h2>
-
 <div class="form-grouping">
   <div class="form-group">
     <div class="form-label">Soovin pensioniregistri teatist pensionikonto jäägi kohta</div>

--- a/src/main/resources/templates/sections/withdrawals_bank_account_details_section.html
+++ b/src/main/resources/templates/sections/withdrawals_bank_account_details_section.html
@@ -8,17 +8,14 @@
     <div class="form-label">Pank</div>
     <div class="form-value" th:text="${bankAccountDetails.bank().getDisplayName()}"></div>
   </div>
-
   <div class="form-group">
     <div class="form-label">Swift/BIC</div>
     <div class="form-value"><br></div>
   </div>
-
   <div class="form-group">
     <div class="form-label">Välisriigi panga aadress</div>
     <div class="form-value"><br></div>
   </div>
-
   <div class="form-group">
     <div class="form-label">Täiendavad andmed välismaksete kohta</div>
     <div class="form-value"><br></div>

--- a/src/main/resources/templates/sections/withdrawals_bank_account_details_section.html
+++ b/src/main/resources/templates/sections/withdrawals_bank_account_details_section.html
@@ -1,0 +1,26 @@
+<h2>4. Pensionikonto omaniku pangakonto</h2>
+<div class="form-grouping">
+  <div class="form-group">
+    <div class="form-label">Pangakonto number</div>
+    <div class="form-value" th:text="${bankAccountDetails.accountIban()}"></div>
+  </div>
+  <div class="form-group">
+    <div class="form-label">Pank</div>
+    <div class="form-value" th:text="${bankAccountDetails.bank().getDisplayName()}"></div>
+  </div>
+
+  <div class="form-group">
+    <div class="form-label">Swift/BIC</div>
+    <div class="form-value"><br></div>
+  </div>
+
+  <div class="form-group">
+    <div class="form-label">Välisriigi panga aadress</div>
+    <div class="form-value"><br></div>
+  </div>
+
+  <div class="form-group">
+    <div class="form-label">Täiendavad andmed välismaksete kohta</div>
+    <div class="form-value"><br></div>
+  </div>
+</div>

--- a/src/test/groovy/ee/tuleva/onboarding/mandate/GenericMandateIntegrationTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/mandate/GenericMandateIntegrationTest.java
@@ -65,7 +65,8 @@ class GenericMandateIntegrationTest {
                 SECOND,
                 FundPensionOpeningMandateDetails.FundPensionFrequency.MONTHLY,
                 new FundPensionOpeningMandateDetails.FundPensionDuration(20, false),
-                new BankAccountDetails(ESTONIAN, BankAccountDetails.Bank.LHV, "EE_TEST_IBAN"))));
+                new BankAccountDetails(ESTONIAN, BankAccountDetails.Bank.LHV, "EE_TEST_IBAN"))),
+        Arguments.of(aPartialWithdrawalMandateDetails));
   }
 
   @AfterEach

--- a/src/test/groovy/ee/tuleva/onboarding/mandate/MandateFileServiceSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/mandate/MandateFileServiceSpec.groovy
@@ -44,12 +44,12 @@ class MandateFileServiceSpec extends Specification {
 
     then:
     files.size() == 1
-    files.get(0).mimeType == "html/text"
+    files.get(0).mimeType == "text/html"
     files.get(0).content.length == 4
   }
 
   List<MandateContentFile> sampleFiles() {
-    return [new MandateContentFile("file", "html/text", "file".getBytes())]
+    return [new MandateContentFile("file", "file".getBytes())]
   }
 
   def mockMandateFiles(User user, Long mandateId, ContactDetails contactDetails) {

--- a/src/test/groovy/ee/tuleva/onboarding/mandate/MandateFixture.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/mandate/MandateFixture.groovy
@@ -5,6 +5,7 @@ import ee.tuleva.onboarding.epis.mandate.details.BankAccountDetails
 import ee.tuleva.onboarding.epis.mandate.details.EarlyWithdrawalCancellationMandateDetails
 import ee.tuleva.onboarding.epis.mandate.details.FundPensionOpeningMandateDetails
 import ee.tuleva.onboarding.epis.mandate.details.MandateDetails
+import ee.tuleva.onboarding.epis.mandate.details.PartialWithdrawalMandateDetails
 import ee.tuleva.onboarding.epis.mandate.details.Pillar
 import ee.tuleva.onboarding.epis.mandate.details.TransferCancellationMandateDetails
 import ee.tuleva.onboarding.epis.mandate.details.WithdrawalCancellationMandateDetails
@@ -30,6 +31,20 @@ import static ee.tuleva.onboarding.mandate.Mandate.builder
 import static ee.tuleva.onboarding.user.address.AddressFixture.addressFixture
 
 class MandateFixture {
+
+  public static PartialWithdrawalMandateDetails aPartialWithdrawalMandateDetails = new PartialWithdrawalMandateDetails(SECOND,
+      new BankAccountDetails(ESTONIAN, BankAccountDetails.Bank.fromIban("EE3477123123123"), "EE_TEST_IBAN"),
+      List.of(new PartialWithdrawalMandateDetails.FundWithdrawalAmount("EE3600109435", 10, BigDecimal.valueOf(20)),
+          new PartialWithdrawalMandateDetails.FundWithdrawalAmount("EE3600019766", 5, BigDecimal.valueOf(30))),
+      "EST"
+  )
+
+  public static PartialWithdrawalMandateDetails aThirdPillarPartialWithdrawalMandateDetails = new PartialWithdrawalMandateDetails(THIRD,
+      new BankAccountDetails(ESTONIAN, BankAccountDetails.Bank.fromIban("EE3477123123123"), "EE_TEST_IBAN"),
+      List.of(new PartialWithdrawalMandateDetails.FundWithdrawalAmount("EE3600109435", 10, BigDecimal.valueOf(20)),
+          new PartialWithdrawalMandateDetails.FundWithdrawalAmount("EE3600019766", 5, BigDecimal.valueOf(30))),
+      "EST"
+  )
 
   public static FundPensionOpeningMandateDetails aFundPensionOpeningMandateDetails = new FundPensionOpeningMandateDetails(SECOND, MONTHLY,
       new FundPensionOpeningMandateDetails.FundPensionDuration(20, false),
@@ -206,6 +221,22 @@ class MandateFixture {
     mandate.setCreatedDate(Instant.parse("2021-03-10T12:00:00Z"))
     mandate.setMandate("file".getBytes())
     mandate.pillar = SECOND.toInt()
+    return mandate
+  }
+
+  static Mandate samplePartialWithdrawalMandate(PartialWithdrawalMandateDetails details = aPartialWithdrawalMandateDetails) {
+    Mandate mandate = builder()
+        .address(addressFixture().build())
+        .pillar(details.pillar.toInt())
+        .details(details)
+        .fundTransferExchanges([])
+        .user(sampleUser().build())
+        .build()
+
+    mandate.setId(123)
+    mandate.setCreatedDate(Instant.parse("2021-03-10T12:00:00Z"))
+    mandate.setMandate("file".getBytes())
+    mandate.pillar = details.getPillar().toInt()
     return mandate
   }
 

--- a/src/test/groovy/ee/tuleva/onboarding/mandate/MandateServiceSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/mandate/MandateServiceSpec.groovy
@@ -357,7 +357,7 @@ class MandateServiceSpec extends Specification {
   ErrorsResponse sampleEmptyErrorsResponse = new ErrorsResponse([])
 
   private List<MandateContentFile> sampleFiles() {
-    return [new MandateContentFile("file", "html/text", "file".getBytes())]
+    return [new MandateContentFile("file",  "file".getBytes())]
   }
 
 }

--- a/src/test/groovy/ee/tuleva/onboarding/mandate/content/CompositeMandateFileCreatorIntTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/mandate/content/CompositeMandateFileCreatorIntTest.java
@@ -45,7 +45,11 @@ public class CompositeMandateFileCreatorIntTest {
         Arguments.of(sampleFundPensionOpeningMandate(), "SecondPillarFundPensionOpeningMandate"),
         Arguments.of(
             sampleFundPensionOpeningMandate(aThirdPillarFundPensionOpeningMandateDetails),
-            "ThirdPillarFundPensionOpeningMandate"));
+            "ThirdPillarFundPensionOpeningMandate"),
+        Arguments.of(samplePartialWithdrawalMandate(), "SecondPillarPartialWithdrawalMandate"),
+        Arguments.of(
+            samplePartialWithdrawalMandate(aThirdPillarPartialWithdrawalMandateDetails),
+            "ThirdPillarPartialWithdrawalMandate"));
   }
 
   void writeMandateFile(MandateContentFile file, String snapshotName) {
@@ -66,6 +70,10 @@ public class CompositeMandateFileCreatorIntTest {
   void testMandatesSnapshot(Mandate aMandate, String snapshotName) {
     var anUser = sampleUser().build();
     var anContactDetails = contactDetailsFixture();
+
+    var aFund = tuleva2ndPillarStockFund();
+    var aFund2 = lhv2ndPillarFund();
+    when(fundRepository.findAllByPillarAndStatus(any(), any())).thenReturn(List.of(aFund, aFund2));
 
     List<MandateContentFile> files =
         compositeMandateFileCreator.getContentFiles(anUser, aMandate, anContactDetails);

--- a/src/test/groovy/ee/tuleva/onboarding/mandate/content/CompositeMandateFileCreatorTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/mandate/content/CompositeMandateFileCreatorTest.java
@@ -45,7 +45,7 @@ public class CompositeMandateFileCreatorTest {
     when(mandateFileCreator2.supports(aMandate.getMandateType())).thenReturn(true);
 
     when(mandateFileCreator2.getContentFiles(aUser, aMandate, aContactDetails))
-        .thenReturn(List.of(new MandateContentFile("test", "text/html", new byte[0])));
+        .thenReturn(List.of(new MandateContentFile("test", new byte[0])));
 
     List<MandateContentFile> files =
         compositeMandateFileCreator.getContentFiles(aUser, aMandate, aContactDetails);

--- a/src/test/groovy/ee/tuleva/onboarding/mandate/content/NonGenericMandateFileCreatorTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/mandate/content/NonGenericMandateFileCreatorTest.java
@@ -41,7 +41,7 @@ public class NonGenericMandateFileCreatorTest {
     when(fundRepository.findAllByPillarAndStatus(eq(aMandate.getPillar()), any()))
         .thenReturn(List.of(aFund));
     when(mandateContentCreator.getContentFiles(aUser, aMandate, List.of(aFund), aContactDetails))
-        .thenReturn(List.of(new MandateContentFile(aTestFileName, "text/html", new byte[0])));
+        .thenReturn(List.of(new MandateContentFile(aTestFileName, new byte[0])));
 
     List<MandateContentFile> files =
         nonGenericMandateFileCreator.getContentFiles(aUser, aMandate, aContactDetails);

--- a/src/test/groovy/ee/tuleva/onboarding/mandate/content/TransferCancellationMandateFileCreatorTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/mandate/content/TransferCancellationMandateFileCreatorTest.java
@@ -42,7 +42,7 @@ public class TransferCancellationMandateFileCreatorTest {
     when(fundRepository.findAllByPillarAndStatus(eq(aMandate.getPillar()), any()))
         .thenReturn(List.of(aFund));
     when(mandateContentCreator.getContentFiles(aUser, aMandate, List.of(aFund), aContactDetails))
-        .thenReturn(List.of(new MandateContentFile(aTestFileName, "text/html", new byte[0])));
+        .thenReturn(List.of(new MandateContentFile(aTestFileName, new byte[0])));
 
     List<MandateContentFile> files =
         transferCancellationMandateFileCreator.getContentFiles(aUser, aMandate, aContactDetails);

--- a/src/test/groovy/ee/tuleva/onboarding/mandate/content/__snapshots__/CompositeMandateFileCreatorIntTest.snap
+++ b/src/test/groovy/ee/tuleva/onboarding/mandate/content/__snapshots__/CompositeMandateFileCreatorIntTest.snap
@@ -638,6 +638,22 @@ ee.tuleva.onboarding.mandate.content.CompositeMandateFileCreatorIntTest.testMand
       width: 100px;
     }
   }
+
+  table {
+    width: 100%;
+    font-family: sans-serif;
+
+    thead {
+      tr {
+        font-weight: bold;
+        border-bottom: 1px solid black;
+      }
+    }
+
+    td {
+      padding: 8px 16px;
+    }
+  }
 </style>
 
 </head>
@@ -702,7 +718,6 @@ ee.tuleva.onboarding.mandate.content.CompositeMandateFileCreatorIntTest.testMand
     </div>
   </div>
 </div>
-
 <h2>4. Pensionikonto omaniku pangakonto</h2>
 <div class="form-grouping">
   <div class="form-group">
@@ -729,7 +744,8 @@ ee.tuleva.onboarding.mandate.content.CompositeMandateFileCreatorIntTest.testMand
     <div class="form-value"><br></div>
   </div>
 </div>
-
+.
+.
   <div class="disclaimer">
     Olen teadlik, et:<br>
     1) valides fondipensioni soovitusliku kestuse, arvestatakse minu fondipensioni kestus vastavalt kogumispensionide seaduse § 523 lõikes 3 nimetatule ja Eesti Statistikaameti poolt avaldatud meeste ja naiste keskmiselt elada jäänud aastate alusel. Vastavalt tulumaksuseaduse § 201 lõikele 38 3 ei maksustata tulumaksuga soovitusliku kestusega sõlmitud fondipensioni väljamakseid, mida tehakse perioodiliselt vähemalt üks kord kolme kuu jooksul.<br>
@@ -855,6 +871,22 @@ ee.tuleva.onboarding.mandate.content.CompositeMandateFileCreatorIntTest.testMand
       width: 100px;
     }
   }
+
+  table {
+    width: 100%;
+    font-family: sans-serif;
+
+    thead {
+      tr {
+        font-weight: bold;
+        border-bottom: 1px solid black;
+      }
+    }
+
+    td {
+      padding: 8px 16px;
+    }
+  }
 </style>
 
 </head>
@@ -919,8 +951,248 @@ ee.tuleva.onboarding.mandate.content.CompositeMandateFileCreatorIntTest.testMand
     </div>
   </div>
 </div>
-
 <h2>4. Pensionikonto omaniku pangakonto</h2>
+<div class="form-grouping">
+  <div class="form-group">
+    <div class="form-label">Pangakonto number</div>
+    <div class="form-value">EE_TEST_IBAN</div>
+  </div>
+  <div class="form-group">
+    <div class="form-label">Pank</div>
+    <div class="form-value">AS LHV Pank</div>
+  </div>
+
+  <div class="form-group">
+    <div class="form-label">Swift/BIC</div>
+    <div class="form-value"><br></div>
+  </div>
+
+  <div class="form-group">
+    <div class="form-label">Välisriigi panga aadress</div>
+    <div class="form-value"><br></div>
+  </div>
+
+  <div class="form-group">
+    <div class="form-label">Täiendavad andmed välismaksete kohta</div>
+    <div class="form-value"><br></div>
+  </div>
+</div>
+.
+.
+  <div class="disclaimer">
+    Olen teadlik, et:<br>
+    1) valides fondipensioni soovitusliku kestuse, arvestatakse minu fondipensioni kestus vastavalt kogumispensionide seaduse § 523 lõikes 3 nimetatule ja Eesti Statistikaameti poolt avaldatud meeste ja naiste keskmiselt elada jäänud aastate alusel. Vastavalt tulumaksuseaduse § 201 lõikele 38 3 ei maksustata tulumaksuga soovitusliku kestusega sõlmitud fondipensioni väljamakseid, mida tehakse perioodiliselt vähemalt üks kord kolme kuu jooksul.<br>
+    2) valides fondipensioni määratud kestuse aastates, tehakse väljamakse minu avaldusel märgitud sagedusega kogumispensionide seaduses sätestatud tähtajal<br>
+    • avalduse esitamisele järgneval kuul, kui avaldusele märgiti igakuise väljamakse soov;<br>
+    • kvartali viimasel kuul, kui avaldusele märgiti kvartaalse väljamakse soov;<br>
+    • pensioniaasta viimasel kuul, kui avaldusele märgiti aastase väljamakse soov;<br>
+    3) väljamakselt peetakse kinni tulumaks vastavalt tulumaksuseadusele ja kogu tulumaksu arvestuse aluseks olev summa deklareeritakse Maksu- ja Tolliametis füüsilise isiku tuludeklaratsioonis minu tuluna. 4) käesoleva avalduse esitamisega peatub minu kohustusliku kogumispensioni maksete tasumise kohustus  automaatselt alates kogumispensionide seaduses sätestatud tähtajast, vastavalt kas 1. jaanuarist, 1. maist või 1. septembrist. Eraldi avaldust ei ole maksete peatamiseks vaja esitada. Makse tasumist ei saa hiljem taastada.<br>
+    5) esitatud avaldust saab tühistada avalduse esitamisega samal kalendrikuul vastavalt kogumispensionide seadusele.<br>
+    6) kui avalduse esitajal on pensioniregistris registreeritud kehtivaid aresti või pankroti nõudeid, ei ole võimalik väljamakse avaldust tühistada. Avalduse tühistamiseks peab olema nõue lõpetatud (täidetud või tühistatud).<br>
+    7) fondipensioni väljamaksed on erineva suurusega, tulenevalt osakute arvu või puhasväärtuse muutustest.<br>
+    <br>
+    Olen teadlik, et AS Pensionikeskus kogub ja töötleb minu isikuandmeid kogumispensionide seaduses ja väärtpaberite registri pidamise seaduses sätestatud ulatuses Euroopa Liidu piires.  NB! AS Pensionikeskus isikuandmete töötlemise ja privaatsuspõhimõtted on kättesaadavad AS Pensionikeskus veebilehel.<br>
+  </div>
+  <div class="form-grouping no-separator" style="padding-bottom: 100px">
+  <div class="form-group">
+    <div class="form-label">Kuupäev</div>
+    <div class="form-value">10.03.2021</div>
+  </div>
+  <div class="form-group">
+    <div class="form-label">Allkiri</div>
+    <div class="form-value"><span>Jordan Valdma</span></div>
+  </div>
+</div>
+
+<div class="footer">
+  <div class="address">
+    Telliskivi 60/1, Tallinn, 10412<br>
+    +372 644 5100 · tuleva@tuleva.ee
+  </div>
+  <div class="logo">
+    <svg fill="none" height="48" viewBox="0 0 107 48" width="107" xmlns="http://www.w3.org/2000/svg">
+      <path clip-rule="evenodd" d="M69.6827 36.8483C68.9344 34.3312 67.0631 33.0047 64.818 33.0047C62.5737 33.0047 60.7366 34.3989 60.1577 36.8483H69.6827ZM72.9482 43.2098C70.9751 45.6927 68.2537 47.1894 65.2944 47.2236C59.546 47.2236 56.2122 42.9036 56.2122 38.5487C56.2122 34.1952 59.546 29.8752 65.2944 29.8752C68.73 29.8752 73.8326 32.6985 73.8326 39.1276V39.7734H60.1577C60.3627 42.2905 62.7097 44.0942 65.1926 44.0942C67.0973 44.0942 68.73 43.1756 69.9548 41.5429L72.9482 43.2098ZM101.813 38.995C100.773 39.1987 99.7782 39.3812 98.7891 39.5921C97.9374 39.7732 97.0749 39.9339 96.2509 40.2045C95.5491 40.4343 94.9651 40.8896 94.864 41.7041C94.7265 42.8052 95.3585 43.5783 96.4974 43.7667C97.3949 43.9143 98.2873 43.883 99.1636 43.659C100.402 43.3427 101.431 42.7208 101.687 41.3703C101.836 40.5783 101.78 39.7478 101.813 38.995ZM106.999 46.6648C105.763 47.1187 104.529 47.1601 103.444 46.4918C102.971 46.2008 102.72 45.7267 102.541 45.1667C102.323 45.3696 102.142 45.5579 101.941 45.7223C101.132 46.3841 100.182 46.7332 99.1687 46.9208C97.6283 47.2067 96.0894 47.2714 94.5564 46.8503C92.5556 46.2998 91.2982 44.9361 91.0924 42.9448C90.8822 40.9085 91.6407 39.3063 93.4233 38.2336C94.7658 37.4256 96.2531 37.0518 97.7745 36.7834C98.7556 36.611 99.7447 36.4787 100.723 36.2925C101.153 36.2103 101.635 36.1034 101.743 35.5739C101.862 34.9885 101.79 34.4219 101.345 33.9652C100.809 33.4139 100.108 33.2518 99.3818 33.1965C97.3476 33.043 95.8313 33.7688 94.1389 35.4394C93.336 34.6823 92.6182 34.0067 91.8713 33.3034C92.9018 31.9558 93.9753 31.1587 95.408 30.595C97.1571 29.9063 98.9636 29.8154 100.801 30.0961C102.003 30.2794 103.119 30.6758 104.039 31.5085C104.948 32.331 105.394 33.3856 105.502 34.5834C105.559 35.2219 105.555 35.8678 105.557 36.5107C105.564 38.363 105.559 40.2154 105.559 42.0678C105.559 42.1674 105.559 42.267 105.561 42.3667C105.59 43.3441 105.84 43.5987 106.809 43.6358C106.863 43.6379 106.918 43.6387 106.999 43.6387V46.6648ZM37.648 47.1154C38.9629 47.1307 40.2494 46.8936 41.4887 46.3038C43.5178 45.3365 44.6545 43.7016 44.9811 41.4958C45.0502 41.0259 45.072 40.3619 45.072 40.071V30.4776H41.1818V39.6827C41.1789 40.1765 41.1222 40.6798 41.0131 41.1612C40.7105 42.4972 39.8196 43.2434 38.5033 43.4878C38.2174 43.5408 37.9316 43.5707 37.6473 43.5736C37.3629 43.5707 37.0771 43.5408 36.7913 43.4878C35.4756 43.2434 34.584 42.4972 34.2814 41.1612C34.1724 40.6798 34.1156 40.1765 34.1134 39.6827V30.4776H30.2225V40.071C30.2225 40.3619 30.2444 41.0259 30.3142 41.4958C30.6407 43.7016 31.7767 45.3365 33.8058 46.3038C35.0451 46.8936 36.3331 47.1307 37.648 47.1154Z" fill="#002F63" fill-rule="evenodd"/>
+      <path clip-rule="evenodd" d="M91.2794 30.1614L82.5266 47.5389L73.7746 30.1614L77.6721 30.1418L82.5266 39.7811L87.3724 30.1614H91.2794Z" fill="#002F63" fill-rule="evenodd"/>
+      <path clip-rule="evenodd" d="M54.0823 43.6538C53.15 43.6051 52.6358 43.1411 52.4947 42.2174C52.4372 41.8407 52.4198 41.4553 52.4198 41.0742V24.2742H48.4896V41.4989C48.4903 42.0938 48.5071 42.6967 48.5943 43.2844C48.8016 44.6793 49.3791 45.8662 50.6685 46.5884C51.5158 47.0633 52.4481 47.2269 53.4009 47.232C54.1129 47.2364 54.8256 47.1556 55.5361 47.1134V43.6582C55.0409 43.6582 54.5601 43.6793 54.0823 43.6538Z" fill="#002F63" fill-rule="evenodd"/>
+      <path clip-rule="evenodd" d="M1.59192 20.3636L19.7272 30.4466V24.2756L12.8181 20.3636H1.59192Z" fill="#002F63" fill-rule="evenodd"/>
+      <path clip-rule="evenodd" d="M5.14106 0L3.94324 5.55636L19.4 13.8182H30.7752L5.14106 0Z" fill="#002F63" fill-rule="evenodd"/>
+      <path clip-rule="evenodd" d="M14.6364 46.9091H19.7273V31.6364L14.6364 28.7273V46.9091Z" fill="#00AEEA" fill-rule="evenodd"/>
+      <path clip-rule="evenodd" d="M2.01884 14.5774L0.818115 19.6363H30.509L31.6596 14.5774H2.01884Z" fill="#00AEEA" fill-rule="evenodd"/>
+      <path clip-rule="evenodd" d="M20.4545 24.2742V27.8749V46.9091H24.1519V27.8749H30.2225V24.2742H20.4545Z" fill="#002F63" fill-rule="evenodd"/>
+    </svg>
+
+  </div>
+</div>
+
+</body>
+</html>
+
+]
+
+
+ee.tuleva.onboarding.mandate.content.CompositeMandateFileCreatorIntTest.testMandatesSnapshot[SecondPillarPartialWithdrawalMandate]=[
+<!DOCTYPE HTML>
+<html>
+<head>
+  <title>Kohustuslikust kogumispensionist osalise väljamakse avaldus</title>
+  <meta content="text/html; charset=UTF-8" http-equiv="Content-Type"/>
+  <style>
+  body {
+    padding: 96px 96px 48px;
+  }
+  h1 {
+    font-family: serif;
+    font-size: 32px;
+    line-height: 40px;
+  }
+
+  .form-grouping {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    padding: 48px 0;
+    border-bottom: 1px solid #DCDCDC;
+  }
+  .form-grouping.no-separator {
+    border-bottom: none;
+  }
+
+  .form-group {
+    display: flex;
+    flex-direction: column;
+    justify-content: end;
+    flex-basis: 40%;
+    flex-grow: 0;
+    flex-shrink: 0;
+    font-family: 'Helvetica', sans-serif;
+    font-size: 16px;
+    line-height: 24px;
+    padding-bottom: 24px;
+
+    .form-label {
+      display: block;
+      font-weight: 400;
+      padding-bottom: 8px;
+    }
+
+    .form-value {
+      display: block;
+      font-weight: 700;
+    }
+  }
+  .disclaimer {
+    font-size: 16px;
+    line-height: 24px;
+    text-align: justify;
+    padding: 24px 0;
+    font-family: sans-serif;
+    border-bottom: 1px solid #DCDCDC;
+  }
+
+  .footer {
+    display: flex;
+    justify-content: space-between;
+    .address {
+      color: #808080;
+      font-size: 16px;
+      line-height: 24px;
+      font-family: sans-serif;
+    }
+
+    .logo {
+      width: 100px;
+    }
+  }
+
+  table {
+    width: 100%;
+    font-family: sans-serif;
+
+    thead {
+      tr {
+        font-weight: bold;
+        border-bottom: 1px solid black;
+      }
+    }
+
+    td {
+      padding: 8px 16px;
+    }
+  }
+</style>
+
+</head>
+<body>
+  <h1>Kohustuslikust kogumispensionist osalise väljamakse avaldus nr <span>123</span></h1>
+  <h2>1. Avalduse esitaja</h2>
+<div class="form-grouping">
+  <div class="form-group">
+    <div class="form-label">Isikukood</div>
+    <div class="form-value">38812121215</div>
+  </div>
+  <div class="form-group">
+    <div class="form-label">Alalise / peamise elukoha riik</div>
+    <div class="form-value">US</div>
+  </div>
+  <div class="form-group">
+    <div class="form-label">Eesnimi</div>
+    <div class="form-value">Jordan</div>
+  </div>
+  <div class="form-group">
+    <div class="form-label">Perekonnanimi</div>
+    <div class="form-value">Valdma</div>
+  </div>
+  <div class="form-group">
+    <div class="form-label">Kontakttelefon</div>
+    <div class="form-value">5555555</div>
+  </div>
+  <div class="form-group">
+    <div class="form-label">E-posti aadress</div>
+    <div class="form-value">jordan.valdma@gmail.com</div>
+  </div>
+</div>
+<h2>2. Isiku eelistused</h2>
+
+<div class="form-grouping">
+  <div class="form-group">
+    <div class="form-label">Soovin pensioniregistri teatist pensionikonto jäägi kohta</div>
+    <div class="form-value">Jah</div>
+  </div>
+  <div class="form-group">
+    <div class="form-label">Keel</div>
+    <div class="form-value">
+      <span>Eesti keel</span>
+      
+      
+    </div>
+  </div>
+</div>
+.
+.
+  <h2>3. Tagasivõtmisele kuuluvad osakud</h2>
+  <table>
+    <thead>
+      <tr>
+        <td>Pensionifondi nimetus, mille osakute
+        tagasivõtmist summa väljamaksmiseks soovin kasutada</td>
+        <td>Tagasivõetavate osakute osakaal saldost (%)</td>
+      </tr>
+    </thead>
+
+    <tbody>
+      <tr>
+        <td>Tuleva maailma aktsiate pensionifond</td>
+        <td ><span>10</span><span>%</span></td>
+      </tr>
+      <tr>
+        <td>LHV XL</td>
+        <td ><span>5</span><span>%</span></td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h2>4. Pensionikonto omaniku pangakonto</h2>
 <div class="form-grouping">
   <div class="form-group">
     <div class="form-label">Pangakonto number</div>
@@ -949,17 +1221,24 @@ ee.tuleva.onboarding.mandate.content.CompositeMandateFileCreatorIntTest.testMand
 
   <div class="disclaimer">
     Olen teadlik, et:<br>
-    1) valides fondipensioni soovitusliku kestuse, arvestatakse minu fondipensioni kestus vastavalt kogumispensionide seaduse § 523 lõikes 3 nimetatule ja Eesti Statistikaameti poolt avaldatud meeste ja naiste keskmiselt elada jäänud aastate alusel. Vastavalt tulumaksuseaduse § 201 lõikele 38 3 ei maksustata tulumaksuga soovitusliku kestusega sõlmitud fondipensioni väljamakseid, mida tehakse perioodiliselt vähemalt üks kord kolme kuu jooksul.<br>
-    2) valides fondipensioni määratud kestuse aastates, tehakse väljamakse minu avaldusel märgitud sagedusega kogumispensionide seaduses sätestatud tähtajal<br>
-    • avalduse esitamisele järgneval kuul, kui avaldusele märgiti igakuise väljamakse soov;<br>
-    • kvartali viimasel kuul, kui avaldusele märgiti kvartaalse väljamakse soov;<br>
-    • pensioniaasta viimasel kuul, kui avaldusele märgiti aastase väljamakse soov;<br>
-    3) väljamakselt peetakse kinni tulumaks vastavalt tulumaksuseadusele ja kogu tulumaksu arvestuse aluseks olev summa deklareeritakse Maksu- ja Tolliametis füüsilise isiku tuludeklaratsioonis minu tuluna. 4) käesoleva avalduse esitamisega peatub minu kohustusliku kogumispensioni maksete tasumise kohustus  automaatselt alates kogumispensionide seaduses sätestatud tähtajast, vastavalt kas 1. jaanuarist, 1. maist või 1. septembrist. Eraldi avaldust ei ole maksete peatamiseks vaja esitada. Makse tasumist ei saa hiljem taastada.<br>
-    5) esitatud avaldust saab tühistada avalduse esitamisega samal kalendrikuul vastavalt kogumispensionide seadusele.<br>
-    6) kui avalduse esitajal on pensioniregistris registreeritud kehtivaid aresti või pankroti nõudeid, ei ole võimalik väljamakse avaldust tühistada. Avalduse tühistamiseks peab olema nõue lõpetatud (täidetud või tühistatud).<br>
-    7) fondipensioni väljamaksed on erineva suurusega, tulenevalt osakute arvu või puhasväärtuse muutustest.<br>
-    <br>
-    Olen teadlik, et AS Pensionikeskus kogub ja töötleb minu isikuandmeid kogumispensionide seaduses ja väärtpaberite registri pidamise seaduses sätestatud ulatuses Euroopa Liidu piires.  NB! AS Pensionikeskus isikuandmete töötlemise ja privaatsuspõhimõtted on kättesaadavad AS Pensionikeskus veebilehel.<br>
+    1) käesoleva avalduse esitamisel tehakse väljamakse minu avaldusel märgitud kogumispensioni
+    fondi(de)st avalduse esitamisele järgneval kuul kogumispensionide seaduses sätestatud tähtajal.
+    Väljamakselt peetakse kinni tulumaks vastavalt tulumaksuseadusele ja kogu tulumaksu arvestuse
+    aluseks olev summa deklareeritakse Maksu- ja Tolliametis füüsilise isiku tuludeklaratsioonis
+    minu tuluna.<br>
+    2) käesoleva avalduse esitamisega peatub minu kohustusliku kogumispensioni maksete tasumise
+    kohustus automaatselt alates kogumispensionide seaduses sätestatud tähtajast, vastavalt kas 1.
+    jaanuarist, 1. maist või 1. septembrist. Eraldi avaldust ei ole maksete peatamiseks vaja esitada.
+    Makse tasumist ei saa hiljem taastada.<br>
+    3) esitatud avaldust saab tühistada avalduse esitamisega samal kalendrikuul vastavalt
+    kogumispensionide seadusele.<br>
+    4) kui avalduse esitajal on pensioniregistris registreeritud kehtivaid aresti või pankroti nõudeid, ei
+    ole võimalik väljamakse avaldust tühistada. Avalduse tühistamiseks peab olema nõue lõpetatud
+    (täidetud või tühistatud).<br>
+    Olen teadlik, et AS Pensionikeskus kogub ja töötleb minu isikuandmeid kogumispensionide seaduses
+    ja väärtpaberite registri pidamise seaduses sätestatud ulatuses Euroopa Liidu piires.
+    NB! AS Pensionikeskus isikuandmete töötlemise ja privaatsuspõhimõtted on kättesaadavad AS
+    Pensionikeskus veebilehel.<br>
   </div>
   <div class="form-grouping no-separator" style="padding-bottom: 100px">
   <div class="form-group">
@@ -1072,6 +1351,22 @@ ee.tuleva.onboarding.mandate.content.CompositeMandateFileCreatorIntTest.testMand
       width: 100px;
     }
   }
+
+  table {
+    width: 100%;
+    font-family: sans-serif;
+
+    thead {
+      tr {
+        font-weight: bold;
+        border-bottom: 1px solid black;
+      }
+    }
+
+    td {
+      padding: 8px 16px;
+    }
+  }
 </style>
 
 </head>
@@ -1136,8 +1431,252 @@ ee.tuleva.onboarding.mandate.content.CompositeMandateFileCreatorIntTest.testMand
     </div>
   </div>
 </div>
-
 <h2>4. Pensionikonto omaniku pangakonto</h2>
+<div class="form-grouping">
+  <div class="form-group">
+    <div class="form-label">Pangakonto number</div>
+    <div class="form-value">EE_TEST_IBAN</div>
+  </div>
+  <div class="form-group">
+    <div class="form-label">Pank</div>
+    <div class="form-value">AS LHV Pank</div>
+  </div>
+
+  <div class="form-group">
+    <div class="form-label">Swift/BIC</div>
+    <div class="form-value"><br></div>
+  </div>
+
+  <div class="form-group">
+    <div class="form-label">Välisriigi panga aadress</div>
+    <div class="form-value"><br></div>
+  </div>
+
+  <div class="form-group">
+    <div class="form-label">Täiendavad andmed välismaksete kohta</div>
+    <div class="form-value"><br></div>
+  </div>
+</div>
+.
+.
+  <div class="disclaimer">
+    Olen teadlik, et: <br>
+    1) valides fondipensioni soovitusliku kestuse, arvestatakse minu fondipensioni kestus vastavalt kogumispensionide seaduse § 523 lõikes 3 nimetatule ja Eesti Statistikaameti poolt avaldatud meeste ja naiste keskmiselt elada jäänud aastate alusel. Vastavalt tulumaksuseaduse § 21 lõikele 4 77 ei maksustata tulumaksuga soovitusliku kestusega sõlmitud fondipensioni väljamakseid, mida tehakse perioodiliselt vähemalt üks kord kolme kuu jooksul.<br>
+    2) valides fondipensioni määratud kestuse aastates, tehakse väljamakse minu avaldusel märgitud sagedusega kogumispensionide seaduses sätestatud tähtajal:<br>
+    • avalduse esitamisele järgneval kuul, kui avaldusele märgiti igakuise väljamakse soov; <br>
+    • kvartali viimasel kuul, kui avaldusele märgiti kvartaalse väljamakse soov;<br>
+    • pensioniaasta viimasel kuul, kui avaldusele märgiti aastase väljamakse soov;<br>
+    3) väljamakselt peetakse kinni tulumaks vastavalt tulumaksuseadusele ja kogu tulumaksu arvestuse aluseks olev summa deklareeritakse Maksu- ja Tolliametis füüsilise isiku tuludeklaratsioonis minu tuluna.<br>
+    4) esitatud avaldust saab tühistada avalduse esitamisega samal kalendrikuul vastavalt kogumispensionide seadusele.<br>
+    5) fondipensioni väljamaksed on erineva suurusega tulenevalt osakute arvu või puhasväärtuse muutustest.<br>
+    Olen teadlik, et AS Pensionikeskus kogub ja töötleb minu isikuandmeid kogumispensionide seaduses ja väärtpaberite registri pidamise seaduses sätestatud ulatuses Euroopa Liidu piires.  NB! AS Pensionikeskus isikuandmete töötlemise ja privaatsuspõhimõtted on kättesaadavad AS Pensionikeskus veebilehel.<br>
+  </div>
+  <div class="form-grouping no-separator" style="padding-bottom: 100px">
+  <div class="form-group">
+    <div class="form-label">Kuupäev</div>
+    <div class="form-value">10.03.2021</div>
+  </div>
+  <div class="form-group">
+    <div class="form-label">Allkiri</div>
+    <div class="form-value"><span>Jordan Valdma</span></div>
+  </div>
+</div>
+
+<div class="footer">
+  <div class="address">
+    Telliskivi 60/1, Tallinn, 10412<br>
+    +372 644 5100 · tuleva@tuleva.ee
+  </div>
+  <div class="logo">
+    <svg fill="none" height="48" viewBox="0 0 107 48" width="107" xmlns="http://www.w3.org/2000/svg">
+      <path clip-rule="evenodd" d="M69.6827 36.8483C68.9344 34.3312 67.0631 33.0047 64.818 33.0047C62.5737 33.0047 60.7366 34.3989 60.1577 36.8483H69.6827ZM72.9482 43.2098C70.9751 45.6927 68.2537 47.1894 65.2944 47.2236C59.546 47.2236 56.2122 42.9036 56.2122 38.5487C56.2122 34.1952 59.546 29.8752 65.2944 29.8752C68.73 29.8752 73.8326 32.6985 73.8326 39.1276V39.7734H60.1577C60.3627 42.2905 62.7097 44.0942 65.1926 44.0942C67.0973 44.0942 68.73 43.1756 69.9548 41.5429L72.9482 43.2098ZM101.813 38.995C100.773 39.1987 99.7782 39.3812 98.7891 39.5921C97.9374 39.7732 97.0749 39.9339 96.2509 40.2045C95.5491 40.4343 94.9651 40.8896 94.864 41.7041C94.7265 42.8052 95.3585 43.5783 96.4974 43.7667C97.3949 43.9143 98.2873 43.883 99.1636 43.659C100.402 43.3427 101.431 42.7208 101.687 41.3703C101.836 40.5783 101.78 39.7478 101.813 38.995ZM106.999 46.6648C105.763 47.1187 104.529 47.1601 103.444 46.4918C102.971 46.2008 102.72 45.7267 102.541 45.1667C102.323 45.3696 102.142 45.5579 101.941 45.7223C101.132 46.3841 100.182 46.7332 99.1687 46.9208C97.6283 47.2067 96.0894 47.2714 94.5564 46.8503C92.5556 46.2998 91.2982 44.9361 91.0924 42.9448C90.8822 40.9085 91.6407 39.3063 93.4233 38.2336C94.7658 37.4256 96.2531 37.0518 97.7745 36.7834C98.7556 36.611 99.7447 36.4787 100.723 36.2925C101.153 36.2103 101.635 36.1034 101.743 35.5739C101.862 34.9885 101.79 34.4219 101.345 33.9652C100.809 33.4139 100.108 33.2518 99.3818 33.1965C97.3476 33.043 95.8313 33.7688 94.1389 35.4394C93.336 34.6823 92.6182 34.0067 91.8713 33.3034C92.9018 31.9558 93.9753 31.1587 95.408 30.595C97.1571 29.9063 98.9636 29.8154 100.801 30.0961C102.003 30.2794 103.119 30.6758 104.039 31.5085C104.948 32.331 105.394 33.3856 105.502 34.5834C105.559 35.2219 105.555 35.8678 105.557 36.5107C105.564 38.363 105.559 40.2154 105.559 42.0678C105.559 42.1674 105.559 42.267 105.561 42.3667C105.59 43.3441 105.84 43.5987 106.809 43.6358C106.863 43.6379 106.918 43.6387 106.999 43.6387V46.6648ZM37.648 47.1154C38.9629 47.1307 40.2494 46.8936 41.4887 46.3038C43.5178 45.3365 44.6545 43.7016 44.9811 41.4958C45.0502 41.0259 45.072 40.3619 45.072 40.071V30.4776H41.1818V39.6827C41.1789 40.1765 41.1222 40.6798 41.0131 41.1612C40.7105 42.4972 39.8196 43.2434 38.5033 43.4878C38.2174 43.5408 37.9316 43.5707 37.6473 43.5736C37.3629 43.5707 37.0771 43.5408 36.7913 43.4878C35.4756 43.2434 34.584 42.4972 34.2814 41.1612C34.1724 40.6798 34.1156 40.1765 34.1134 39.6827V30.4776H30.2225V40.071C30.2225 40.3619 30.2444 41.0259 30.3142 41.4958C30.6407 43.7016 31.7767 45.3365 33.8058 46.3038C35.0451 46.8936 36.3331 47.1307 37.648 47.1154Z" fill="#002F63" fill-rule="evenodd"/>
+      <path clip-rule="evenodd" d="M91.2794 30.1614L82.5266 47.5389L73.7746 30.1614L77.6721 30.1418L82.5266 39.7811L87.3724 30.1614H91.2794Z" fill="#002F63" fill-rule="evenodd"/>
+      <path clip-rule="evenodd" d="M54.0823 43.6538C53.15 43.6051 52.6358 43.1411 52.4947 42.2174C52.4372 41.8407 52.4198 41.4553 52.4198 41.0742V24.2742H48.4896V41.4989C48.4903 42.0938 48.5071 42.6967 48.5943 43.2844C48.8016 44.6793 49.3791 45.8662 50.6685 46.5884C51.5158 47.0633 52.4481 47.2269 53.4009 47.232C54.1129 47.2364 54.8256 47.1556 55.5361 47.1134V43.6582C55.0409 43.6582 54.5601 43.6793 54.0823 43.6538Z" fill="#002F63" fill-rule="evenodd"/>
+      <path clip-rule="evenodd" d="M1.59192 20.3636L19.7272 30.4466V24.2756L12.8181 20.3636H1.59192Z" fill="#002F63" fill-rule="evenodd"/>
+      <path clip-rule="evenodd" d="M5.14106 0L3.94324 5.55636L19.4 13.8182H30.7752L5.14106 0Z" fill="#002F63" fill-rule="evenodd"/>
+      <path clip-rule="evenodd" d="M14.6364 46.9091H19.7273V31.6364L14.6364 28.7273V46.9091Z" fill="#00AEEA" fill-rule="evenodd"/>
+      <path clip-rule="evenodd" d="M2.01884 14.5774L0.818115 19.6363H30.509L31.6596 14.5774H2.01884Z" fill="#00AEEA" fill-rule="evenodd"/>
+      <path clip-rule="evenodd" d="M20.4545 24.2742V27.8749V46.9091H24.1519V27.8749H30.2225V24.2742H20.4545Z" fill="#002F63" fill-rule="evenodd"/>
+    </svg>
+
+  </div>
+</div>
+
+</body>
+</html>
+
+]
+
+
+ee.tuleva.onboarding.mandate.content.CompositeMandateFileCreatorIntTest.testMandatesSnapshot[ThirdPillarPartialWithdrawalMandate]=[
+<!DOCTYPE HTML>
+<html>
+<head>
+  <title>Vabatahtlikust pensionifondist väljamakse avaldus</title>
+  <meta content="text/html; charset=UTF-8" http-equiv="Content-Type"/>
+  <style>
+  body {
+    padding: 96px 96px 48px;
+  }
+  h1 {
+    font-family: serif;
+    font-size: 32px;
+    line-height: 40px;
+  }
+
+  .form-grouping {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    padding: 48px 0;
+    border-bottom: 1px solid #DCDCDC;
+  }
+  .form-grouping.no-separator {
+    border-bottom: none;
+  }
+
+  .form-group {
+    display: flex;
+    flex-direction: column;
+    justify-content: end;
+    flex-basis: 40%;
+    flex-grow: 0;
+    flex-shrink: 0;
+    font-family: 'Helvetica', sans-serif;
+    font-size: 16px;
+    line-height: 24px;
+    padding-bottom: 24px;
+
+    .form-label {
+      display: block;
+      font-weight: 400;
+      padding-bottom: 8px;
+    }
+
+    .form-value {
+      display: block;
+      font-weight: 700;
+    }
+  }
+  .disclaimer {
+    font-size: 16px;
+    line-height: 24px;
+    text-align: justify;
+    padding: 24px 0;
+    font-family: sans-serif;
+    border-bottom: 1px solid #DCDCDC;
+  }
+
+  .footer {
+    display: flex;
+    justify-content: space-between;
+    .address {
+      color: #808080;
+      font-size: 16px;
+      line-height: 24px;
+      font-family: sans-serif;
+    }
+
+    .logo {
+      width: 100px;
+    }
+  }
+
+  table {
+    width: 100%;
+    font-family: sans-serif;
+
+    thead {
+      tr {
+        font-weight: bold;
+        border-bottom: 1px solid black;
+      }
+    }
+
+    td {
+      padding: 8px 16px;
+    }
+  }
+</style>
+
+</head>
+<body>
+  <h1>Vabatahtlikust pensionifondist väljamakse avaldus nr <span>123</span></h1>
+  <h2>1. Avalduse esitaja</h2>
+<div class="form-grouping">
+  <div class="form-group">
+    <div class="form-label">Isikukood</div>
+    <div class="form-value">38812121215</div>
+  </div>
+  <div class="form-group">
+    <div class="form-label">Alalise / peamise elukoha riik</div>
+    <div class="form-value">US</div>
+  </div>
+  <div class="form-group">
+    <div class="form-label">Eesnimi</div>
+    <div class="form-value">Jordan</div>
+  </div>
+  <div class="form-group">
+    <div class="form-label">Perekonnanimi</div>
+    <div class="form-value">Valdma</div>
+  </div>
+  <div class="form-group">
+    <div class="form-label">Kontakttelefon</div>
+    <div class="form-value">5555555</div>
+  </div>
+  <div class="form-group">
+    <div class="form-label">E-posti aadress</div>
+    <div class="form-value">jordan.valdma@gmail.com</div>
+  </div>
+</div>
+<h2>2. Isiku eelistused</h2>
+
+<div class="form-grouping">
+  <div class="form-group">
+    <div class="form-label">Soovin pensioniregistri teatist pensionikonto jäägi kohta</div>
+    <div class="form-value">Jah</div>
+  </div>
+  <div class="form-group">
+    <div class="form-label">Keel</div>
+    <div class="form-value">
+      <span>Eesti keel</span>
+      
+      
+    </div>
+  </div>
+</div>
+.
+.
+  <h2>3. Vabatahtlik(ud) pensionifond(id), mille osakute tagasivõtmist taotlen</h2>
+  <table>
+    <thead>
+      <tr>
+        <td>Pensionifond</td>
+        <td>Tagasivõetavate osakute arv</td>
+      </tr>
+    </thead>
+
+    <tbody>
+      <tr>
+        <td>Tuleva maailma aktsiate pensionifond</td>
+        <td>20</td>
+      </tr>
+      <tr>
+        <td>LHV XL</td>
+        <td>30</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <div class="form-grouping">
+    <div class="form-group">
+      <div class="form-label">Maksuresidentsus</div>
+      <div class="form-value">EST</div>
+    </div>
+  </div>
+
+  <h2>4. Pensionikonto omaniku pangakonto</h2>
 <div class="form-grouping">
   <div class="form-group">
     <div class="form-label">Pangakonto number</div>
@@ -1165,16 +1704,13 @@ ee.tuleva.onboarding.mandate.content.CompositeMandateFileCreatorIntTest.testMand
 </div>
 
   <div class="disclaimer">
-    Olen teadlik, et: <br>
-    1) valides fondipensioni soovitusliku kestuse, arvestatakse minu fondipensioni kestus vastavalt kogumispensionide seaduse § 523 lõikes 3 nimetatule ja Eesti Statistikaameti poolt avaldatud meeste ja naiste keskmiselt elada jäänud aastate alusel. Vastavalt tulumaksuseaduse § 21 lõikele 4 77 ei maksustata tulumaksuga soovitusliku kestusega sõlmitud fondipensioni väljamakseid, mida tehakse perioodiliselt vähemalt üks kord kolme kuu jooksul.<br>
-    2) valides fondipensioni määratud kestuse aastates, tehakse väljamakse minu avaldusel märgitud sagedusega kogumispensionide seaduses sätestatud tähtajal:<br>
-    • avalduse esitamisele järgneval kuul, kui avaldusele märgiti igakuise väljamakse soov; <br>
-    • kvartali viimasel kuul, kui avaldusele märgiti kvartaalse väljamakse soov;<br>
-    • pensioniaasta viimasel kuul, kui avaldusele märgiti aastase väljamakse soov;<br>
-    3) väljamakselt peetakse kinni tulumaks vastavalt tulumaksuseadusele ja kogu tulumaksu arvestuse aluseks olev summa deklareeritakse Maksu- ja Tolliametis füüsilise isiku tuludeklaratsioonis minu tuluna.<br>
-    4) esitatud avaldust saab tühistada avalduse esitamisega samal kalendrikuul vastavalt kogumispensionide seadusele.<br>
-    5) fondipensioni väljamaksed on erineva suurusega tulenevalt osakute arvu või puhasväärtuse muutustest.<br>
-    Olen teadlik, et AS Pensionikeskus kogub ja töötleb minu isikuandmeid kogumispensionide seaduses ja väärtpaberite registri pidamise seaduses sätestatud ulatuses Euroopa Liidu piires.  NB! AS Pensionikeskus isikuandmete töötlemise ja privaatsuspõhimõtted on kättesaadavad AS Pensionikeskus veebilehel.<br>
+    Olen teadlik, et osakute tagasivõtmisel ja raha arvelduskontole kandmisel peetakse väljamakstavalt
+    summalt kinni tulumaks vastavalt tulumaksuseadusele ja kogu tulumaksu arvestuse aluseks olev summa
+    deklareeritakse Maksu- ja Tolliametis füüsilise isiku tuludeklaratsioonis minu tuluna.<br>
+    Olen teadlik, et AS Pensionikeskus kogub ja töötleb minu isikuandmeid kogumispensionide seaduses ja
+    väärtpaberite registri pidamise seaduses sätestatud ulatuses Euroopa Liidu piires.
+    NB! AS Pensionikeskus isikuandmete töötlemise ja privaatsuspõhimõtted on kättesaadavad AS
+    Pensionikeskus veebilehel.<br>
   </div>
   <div class="form-grouping no-separator" style="padding-bottom: 100px">
   <div class="form-group">

--- a/src/test/groovy/ee/tuleva/onboarding/mandate/content/__snapshots__/CompositeMandateFileCreatorIntTest.snap
+++ b/src/test/groovy/ee/tuleva/onboarding/mandate/content/__snapshots__/CompositeMandateFileCreatorIntTest.snap
@@ -653,6 +653,14 @@ ee.tuleva.onboarding.mandate.content.CompositeMandateFileCreatorIntTest.testMand
     td {
       padding: 8px 16px;
     }
+
+    td:first-child {
+      padding-left: 0;
+    }
+
+    td:last-child {
+      padding-right: 0;
+    }
   }
 </style>
 
@@ -687,7 +695,6 @@ ee.tuleva.onboarding.mandate.content.CompositeMandateFileCreatorIntTest.testMand
   </div>
 </div>
 <h2>2. Isiku eelistused</h2>
-
 <div class="form-grouping">
   <div class="form-group">
     <div class="form-label">Soovin pensioniregistri teatist pensionikonto jäägi kohta</div>
@@ -728,17 +735,14 @@ ee.tuleva.onboarding.mandate.content.CompositeMandateFileCreatorIntTest.testMand
     <div class="form-label">Pank</div>
     <div class="form-value">AS LHV Pank</div>
   </div>
-
   <div class="form-group">
     <div class="form-label">Swift/BIC</div>
     <div class="form-value"><br></div>
   </div>
-
   <div class="form-group">
     <div class="form-label">Välisriigi panga aadress</div>
     <div class="form-value"><br></div>
   </div>
-
   <div class="form-group">
     <div class="form-label">Täiendavad andmed välismaksete kohta</div>
     <div class="form-value"><br></div>
@@ -886,6 +890,14 @@ ee.tuleva.onboarding.mandate.content.CompositeMandateFileCreatorIntTest.testMand
     td {
       padding: 8px 16px;
     }
+
+    td:first-child {
+      padding-left: 0;
+    }
+
+    td:last-child {
+      padding-right: 0;
+    }
   }
 </style>
 
@@ -920,7 +932,6 @@ ee.tuleva.onboarding.mandate.content.CompositeMandateFileCreatorIntTest.testMand
   </div>
 </div>
 <h2>2. Isiku eelistused</h2>
-
 <div class="form-grouping">
   <div class="form-group">
     <div class="form-label">Soovin pensioniregistri teatist pensionikonto jäägi kohta</div>
@@ -961,17 +972,14 @@ ee.tuleva.onboarding.mandate.content.CompositeMandateFileCreatorIntTest.testMand
     <div class="form-label">Pank</div>
     <div class="form-value">AS LHV Pank</div>
   </div>
-
   <div class="form-group">
     <div class="form-label">Swift/BIC</div>
     <div class="form-value"><br></div>
   </div>
-
   <div class="form-group">
     <div class="form-label">Välisriigi panga aadress</div>
     <div class="form-value"><br></div>
   </div>
-
   <div class="form-group">
     <div class="form-label">Täiendavad andmed välismaksete kohta</div>
     <div class="form-value"><br></div>
@@ -1119,6 +1127,14 @@ ee.tuleva.onboarding.mandate.content.CompositeMandateFileCreatorIntTest.testMand
     td {
       padding: 8px 16px;
     }
+
+    td:first-child {
+      padding-left: 0;
+    }
+
+    td:last-child {
+      padding-right: 0;
+    }
   }
 </style>
 
@@ -1153,7 +1169,6 @@ ee.tuleva.onboarding.mandate.content.CompositeMandateFileCreatorIntTest.testMand
   </div>
 </div>
 <h2>2. Isiku eelistused</h2>
-
 <div class="form-grouping">
   <div class="form-group">
     <div class="form-label">Soovin pensioniregistri teatist pensionikonto jäägi kohta</div>
@@ -1168,30 +1183,29 @@ ee.tuleva.onboarding.mandate.content.CompositeMandateFileCreatorIntTest.testMand
     </div>
   </div>
 </div>
-.
-.
+
   <h2>3. Tagasivõtmisele kuuluvad osakud</h2>
-  <table>
-    <thead>
-      <tr>
-        <td>Pensionifondi nimetus, mille osakute
-        tagasivõtmist summa väljamaksmiseks soovin kasutada</td>
-        <td>Tagasivõetavate osakute osakaal saldost (%)</td>
-      </tr>
-    </thead>
-
-    <tbody>
-      <tr>
-        <td>Tuleva maailma aktsiate pensionifond</td>
-        <td ><span>10</span><span>%</span></td>
-      </tr>
-      <tr>
-        <td>LHV XL</td>
-        <td ><span>5</span><span>%</span></td>
-      </tr>
-    </tbody>
+  <div class="form-grouping">
+    <table>
+      <thead>
+        <tr>
+          <td>Pensionifondi nimetus, mille osakute
+          tagasivõtmist summa väljamaksmiseks soovin kasutada</td>
+          <td>Tagasivõetavate osakute osakaal saldost (%)</td>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Tuleva maailma aktsiate pensionifond</td>
+          <td ><span>10</span><span>%</span></td>
+        </tr>
+        <tr>
+          <td>LHV XL</td>
+          <td ><span>5</span><span>%</span></td>
+        </tr>
+      </tbody>
   </table>
-
+  </div>
   <h2>4. Pensionikonto omaniku pangakonto</h2>
 <div class="form-grouping">
   <div class="form-group">
@@ -1202,17 +1216,14 @@ ee.tuleva.onboarding.mandate.content.CompositeMandateFileCreatorIntTest.testMand
     <div class="form-label">Pank</div>
     <div class="form-value">AS LHV Pank</div>
   </div>
-
   <div class="form-group">
     <div class="form-label">Swift/BIC</div>
     <div class="form-value"><br></div>
   </div>
-
   <div class="form-group">
     <div class="form-label">Välisriigi panga aadress</div>
     <div class="form-value"><br></div>
   </div>
-
   <div class="form-group">
     <div class="form-label">Täiendavad andmed välismaksete kohta</div>
     <div class="form-value"><br></div>
@@ -1366,6 +1377,14 @@ ee.tuleva.onboarding.mandate.content.CompositeMandateFileCreatorIntTest.testMand
     td {
       padding: 8px 16px;
     }
+
+    td:first-child {
+      padding-left: 0;
+    }
+
+    td:last-child {
+      padding-right: 0;
+    }
   }
 </style>
 
@@ -1400,7 +1419,6 @@ ee.tuleva.onboarding.mandate.content.CompositeMandateFileCreatorIntTest.testMand
   </div>
 </div>
 <h2>2. Isiku eelistused</h2>
-
 <div class="form-grouping">
   <div class="form-group">
     <div class="form-label">Soovin pensioniregistri teatist pensionikonto jäägi kohta</div>
@@ -1441,17 +1459,14 @@ ee.tuleva.onboarding.mandate.content.CompositeMandateFileCreatorIntTest.testMand
     <div class="form-label">Pank</div>
     <div class="form-value">AS LHV Pank</div>
   </div>
-
   <div class="form-group">
     <div class="form-label">Swift/BIC</div>
     <div class="form-value"><br></div>
   </div>
-
   <div class="form-group">
     <div class="form-label">Välisriigi panga aadress</div>
     <div class="form-value"><br></div>
   </div>
-
   <div class="form-group">
     <div class="form-label">Täiendavad andmed välismaksete kohta</div>
     <div class="form-value"><br></div>
@@ -1597,6 +1612,14 @@ ee.tuleva.onboarding.mandate.content.CompositeMandateFileCreatorIntTest.testMand
     td {
       padding: 8px 16px;
     }
+
+    td:first-child {
+      padding-left: 0;
+    }
+
+    td:last-child {
+      padding-right: 0;
+    }
   }
 </style>
 
@@ -1631,7 +1654,6 @@ ee.tuleva.onboarding.mandate.content.CompositeMandateFileCreatorIntTest.testMand
   </div>
 </div>
 <h2>2. Isiku eelistused</h2>
-
 <div class="form-grouping">
   <div class="form-group">
     <div class="form-label">Soovin pensioniregistri teatist pensionikonto jäägi kohta</div>
@@ -1646,36 +1668,34 @@ ee.tuleva.onboarding.mandate.content.CompositeMandateFileCreatorIntTest.testMand
     </div>
   </div>
 </div>
-.
-.
+
   <h2>3. Vabatahtlik(ud) pensionifond(id), mille osakute tagasivõtmist taotlen</h2>
-  <table>
-    <thead>
-      <tr>
-        <td>Pensionifond</td>
-        <td>Tagasivõetavate osakute arv</td>
-      </tr>
-    </thead>
-
-    <tbody>
-      <tr>
-        <td>Tuleva maailma aktsiate pensionifond</td>
-        <td>20</td>
-      </tr>
-      <tr>
-        <td>LHV XL</td>
-        <td>30</td>
-      </tr>
-    </tbody>
-  </table>
-
+  <div class="form-grouping">
+    <table>
+      <thead>
+        <tr>
+          <td>Pensionifond</td>
+          <td>Tagasivõetavate osakute arv</td>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Tuleva maailma aktsiate pensionifond</td>
+          <td>20</td>
+        </tr>
+        <tr>
+          <td>LHV XL</td>
+          <td>30</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
   <div class="form-grouping">
     <div class="form-group">
       <div class="form-label">Maksuresidentsus</div>
       <div class="form-value">EST</div>
     </div>
   </div>
-
   <h2>4. Pensionikonto omaniku pangakonto</h2>
 <div class="form-grouping">
   <div class="form-group">
@@ -1686,17 +1706,14 @@ ee.tuleva.onboarding.mandate.content.CompositeMandateFileCreatorIntTest.testMand
     <div class="form-label">Pank</div>
     <div class="form-value">AS LHV Pank</div>
   </div>
-
   <div class="form-group">
     <div class="form-label">Swift/BIC</div>
     <div class="form-value"><br></div>
   </div>
-
   <div class="form-group">
     <div class="form-label">Välisriigi panga aadress</div>
     <div class="form-value"><br></div>
   </div>
-
   <div class="form-group">
     <div class="form-label">Täiendavad andmed välismaksete kohta</div>
     <div class="form-value"><br></div>

--- a/src/test/groovy/ee/tuleva/onboarding/mandate/generic/PartialWithdrawalMandateFactoryTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/mandate/generic/PartialWithdrawalMandateFactoryTest.java
@@ -1,0 +1,74 @@
+package ee.tuleva.onboarding.mandate.generic;
+
+import static ee.tuleva.onboarding.auth.UserFixture.sampleUser;
+import static ee.tuleva.onboarding.conversion.ConversionResponseFixture.fullyConverted;
+import static ee.tuleva.onboarding.epis.contact.ContactDetailsFixture.contactDetailsFixture;
+import static ee.tuleva.onboarding.mandate.MandateType.*;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import ee.tuleva.onboarding.auth.AuthenticatedPersonFixture;
+import ee.tuleva.onboarding.conversion.UserConversionService;
+import ee.tuleva.onboarding.epis.EpisService;
+import ee.tuleva.onboarding.epis.mandate.details.PartialWithdrawalMandateDetails;
+import ee.tuleva.onboarding.mandate.Mandate;
+import ee.tuleva.onboarding.mandate.MandateFixture;
+import ee.tuleva.onboarding.mandate.builder.ConversionDecorator;
+import ee.tuleva.onboarding.user.UserService;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class PartialWithdrawalMandateFactoryTest {
+
+  @Mock private EpisService episService;
+
+  @Mock private UserService userService;
+
+  @Mock private UserConversionService conversionService;
+
+  @Mock private ConversionDecorator conversionDecorator;
+
+  @InjectMocks private PartialWithdrawalMandateFactory partialWithdrawalMandateFactory;
+
+  @Test
+  @DisplayName("delegates mandate creation to mandate factory")
+  void testDelegateToMandateFactory() {
+    var anUser = sampleUser().build();
+    var aContactDetails = contactDetailsFixture();
+    var aMandateDetails = MandateFixture.aPartialWithdrawalMandateDetails;
+
+    var anDto = MandateFixture.sampleGenericMandateCreationDto(aMandateDetails);
+
+    when(userService.getById(any())).thenReturn(anUser);
+    when(conversionService.getConversion(any())).thenReturn(fullyConverted());
+    when(episService.getContactDetails(any())).thenReturn(aContactDetails);
+
+    Mandate genericMandate =
+        partialWithdrawalMandateFactory.createMandate(
+            AuthenticatedPersonFixture.authenticatedPersonFromUser(anUser).build(), anDto);
+
+    assertThat(genericMandate.getUser()).isEqualTo(anUser);
+    assertThat(genericMandate.getAddress()).isEqualTo(aContactDetails.getAddress());
+    assertThat(genericMandate.getFundTransferExchanges()).isEqualTo(List.of());
+    verify(conversionDecorator, times(1)).addConversionMetadata(any(), any(), any(), any());
+
+    assertThat(genericMandate.getDetails()).isInstanceOf(PartialWithdrawalMandateDetails.class);
+    assertThat(genericMandate.getPillar()).isEqualTo(aMandateDetails.getPillar().toInt());
+    assertThat(genericMandate.getGenericMandateDto().getMandateType())
+        .isEqualTo(PARTIAL_WITHDRAWAL);
+  }
+
+  @Test
+  @DisplayName("supports PARTIAL_WITHDRAWAL mandates")
+  void testSupports() {
+    assertThat(partialWithdrawalMandateFactory.supports(PARTIAL_WITHDRAWAL)).isTrue();
+    assertThat(partialWithdrawalMandateFactory.supports(WITHDRAWAL_CANCELLATION)).isFalse();
+  }
+}


### PR DESCRIPTION
* Adds partial withdrawal mandates along with mandate files
* Removes mime type from `MandateContentFile` – `text/html` is default
* Removes redundant details setting in `MandateFactories`