### PR TITLE
Add latest fulfillment date for withdrawals

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/deadline/MandateDeadlines.java
+++ b/src/main/java/ee/tuleva/onboarding/deadline/MandateDeadlines.java
@@ -83,6 +83,11 @@ public class MandateDeadlines {
         withdrawalCancellationDeadline().plusDays(15).toLocalDate());
   }
 
+  public LocalDate getWithdrawalLatestFulfillmentDate() {
+    return publicHolidays.nextWorkingDay(
+        withdrawalCancellationDeadline().plusDays(20).toLocalDate());
+  }
+
   public LocalDate getFulfillmentDate(ApplicationType applicationType) {
     return switch (applicationType) {
       case TRANSFER -> getTransferMandateFulfillmentDate();

--- a/src/test/groovy/ee/tuleva/onboarding/deadline/MandateDeadlinesSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/deadline/MandateDeadlinesSpec.groovy
@@ -142,6 +142,7 @@ class MandateDeadlinesSpec extends Specification {
 
       Instant.parse("2021-03-31T20:59:59.999999999Z") == getWithdrawalCancellationDeadline()
       LocalDate.parse("2021-04-16") == getWithdrawalFulfillmentDate()
+      LocalDate.parse("2021-04-21") == getWithdrawalLatestFulfillmentDate()
     }
   }
 


### PR DESCRIPTION
Adds latest fulfillment date (20. of next month) to withdrawal mandate deadlines.
https://www.riigiteataja.ee/akt/128122020002?leiaKehtiv#:~:text=(6)%20Fondipensioni%20v%C3%A4ljamakse,s%C3%B5lmitud%20kolmepoolsest%20lepingust.