### PR TITLE
Add optional end date to returns endpoint

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/comparisons/returns/ReturnsController.java
+++ b/src/main/java/ee/tuleva/onboarding/comparisons/returns/ReturnsController.java
@@ -26,8 +26,10 @@ public class ReturnsController {
   public Returns getReturns(
       @AuthenticationPrincipal AuthenticatedPerson person,
       @RequestParam(required = false) @DateTimeFormat(iso = DATE) LocalDate from,
+      @RequestParam(required = false) @DateTimeFormat(iso = DATE) LocalDate to,
       @RequestParam(required = false, name = "keys[]") List<String> keys) {
     LocalDate startDate = (from == null) ? BEGINNING_OF_TIMES : from;
-    return returnsService.get(person, startDate, keys);
+    LocalDate endDate = (to == null) ? LocalDate.now() : to;
+    return returnsService.get(person, startDate, endDate, keys);
   }
 }

--- a/src/main/java/ee/tuleva/onboarding/comparisons/returns/ReturnsService.java
+++ b/src/main/java/ee/tuleva/onboarding/comparisons/returns/ReturnsService.java
@@ -29,9 +29,10 @@ public class ReturnsService {
   private final FundValueRepository fundValueRepository;
   private final MandateDeadlinesService mandateDeadlinesService;
 
-  public Returns get(Person person, LocalDate fromDate, List<String> keys) {
+  public Returns get(Person person, LocalDate fromDate, LocalDate toDate, List<String> keys) {
     int pillar = getPillar(keys);
     Instant fromTime = getRevisedFromTime(fromDate, keys, pillar);
+    Instant toTime = toDate.atStartOfDay().atZone(ZoneOffset.UTC).toInstant();
 
     List<Return> allReturns = new ArrayList<>();
 
@@ -41,7 +42,7 @@ public class ReturnsService {
       Returns providerReturns =
           provider.getReturns(
               new ReturnCalculationParameters(
-                  person, fromTime, pillar, relevantKeysForTheProvider));
+                  person, fromTime, toTime, pillar, relevantKeysForTheProvider));
 
       if (providerReturns != null && providerReturns.getReturns() != null) {
         allReturns.addAll(providerReturns.getReturns());

--- a/src/main/java/ee/tuleva/onboarding/comparisons/returns/provider/FundReturnProvider.java
+++ b/src/main/java/ee/tuleva/onboarding/comparisons/returns/provider/FundReturnProvider.java
@@ -30,7 +30,7 @@ public class FundReturnProvider implements ReturnProvider {
 
     AccountOverview accountOverview =
         accountOverviewProvider.getAccountOverview(
-            parameters.person(), parameters.startTime(), parameters.pillar());
+            parameters.person(), parameters.startTime(), parameters.endTime(), parameters.pillar());
 
     List<Return> returns =
         fundIsins().stream()

--- a/src/main/java/ee/tuleva/onboarding/comparisons/returns/provider/IndexReturnProvider.java
+++ b/src/main/java/ee/tuleva/onboarding/comparisons/returns/provider/IndexReturnProvider.java
@@ -34,7 +34,7 @@ public class IndexReturnProvider implements ReturnProvider {
   public Returns getReturns(ReturnCalculationParameters parameters) {
     AccountOverview accountOverview =
         accountOverviewProvider.getAccountOverview(
-            parameters.person(), parameters.startTime(), parameters.pillar());
+            parameters.person(), parameters.startTime(), parameters.endTime(), parameters.pillar());
 
     List<Return> returns =
         comparisonIndexes().stream()

--- a/src/main/java/ee/tuleva/onboarding/comparisons/returns/provider/PersonalReturnProvider.java
+++ b/src/main/java/ee/tuleva/onboarding/comparisons/returns/provider/PersonalReturnProvider.java
@@ -29,7 +29,7 @@ public class PersonalReturnProvider implements ReturnProvider {
 
     AccountOverview accountOverview =
         accountOverviewProvider.getAccountOverview(
-            parameters.person(), parameters.startTime(), parameters.pillar());
+            parameters.person(), parameters.startTime(), parameters.endTime(), parameters.pillar());
     ReturnDto aReturn = rateOfReturnCalculator.getReturn(accountOverview);
 
     var returns =

--- a/src/main/java/ee/tuleva/onboarding/comparisons/returns/provider/ReturnCalculationParameters.java
+++ b/src/main/java/ee/tuleva/onboarding/comparisons/returns/provider/ReturnCalculationParameters.java
@@ -5,4 +5,4 @@ import java.time.Instant;
 import java.util.List;
 
 public record ReturnCalculationParameters(
-    Person person, Instant startTime, Integer pillar, List<String> keys) {}
+    Person person, Instant startTime, Instant endTime, Integer pillar, List<String> keys) {}

--- a/src/test/groovy/ee/tuleva/onboarding/comparisons/overview/AccountOverviewProviderSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/comparisons/overview/AccountOverviewProviderSpec.groovy
@@ -46,7 +46,7 @@ class AccountOverviewProviderSpec extends Specification {
 
     def "it sets the right start and end times"() {
         when:
-        AccountOverview accountOverview = accountOverviewProvider.getAccountOverview(person, startTime, pillar)
+    AccountOverview accountOverview = accountOverviewProvider.getAccountOverview(person, startTime, endTime, pillar)
         then:
         accountOverview.startTime == startTime
         verifyTimeCloseToNow(accountOverview.endTime)
@@ -54,7 +54,7 @@ class AccountOverviewProviderSpec extends Specification {
 
     def "it bunches together and converts the starting and ending balance"() {
         when:
-        AccountOverview accountOverview = accountOverviewProvider.getAccountOverview(person, startTime, pillar)
+    AccountOverview accountOverview = accountOverviewProvider.getAccountOverview(person, startTime, endTime, pillar)
         then:
         accountOverview.beginningBalance == 1000.00 + 115.00
         accountOverview.endingBalance == 1100.00 + 125.00
@@ -62,7 +62,7 @@ class AccountOverviewProviderSpec extends Specification {
 
     def "it converts all transactions"() {
         when:
-        AccountOverview accountOverview = accountOverviewProvider.getAccountOverview(person, startTime, pillar)
+    AccountOverview accountOverview = accountOverviewProvider.getAccountOverview(person, startTime, endTime, pillar)
         then:
         accountOverview.pillar == pillar
         accountOverview.transactions.size() == 2
@@ -80,7 +80,7 @@ class AccountOverviewProviderSpec extends Specification {
 
     when:
         1 * cashFlowService.getCashFlowStatement(person, futureStartDate, futureStartDate) >> cashFlowStatement
-        AccountOverview accountOverview = accountOverviewProvider.getAccountOverview(person, futureStartTime, pillar)
+        AccountOverview accountOverview = accountOverviewProvider.getAccountOverview(person, futureStartTime, null, pillar)
 
     then:
         0 * cashFlowService.getCashFlowStatement(person, futureStartDate, endDate)

--- a/src/test/groovy/ee/tuleva/onboarding/comparisons/returns/ReturnsControllerSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/comparisons/returns/ReturnsControllerSpec.groovy
@@ -29,6 +29,7 @@ class ReturnsControllerSpec extends BaseControllerSpec {
     def "can GET /returns"() {
         given:
         def fromDate = "2017-01-01"
+        def toDate = "2017-02-01"
         def type = FUND
         def key = "EE123"
         def rate = 1.0
@@ -46,11 +47,12 @@ class ReturnsControllerSpec extends BaseControllerSpec {
         def returns = Returns.builder()
             .returns([aReturn])
             .build()
-        returnsService.get(_ as Person, LocalDate.parse(fromDate), null) >> returns
+        returnsService.get(_ as Person, LocalDate.parse(fromDate), LocalDate.parse(toDate), null) >> returns
 
         expect:
         mockMvc.perform(get("/v1/returns")
-            .param("from", fromDate))
+            .param("from", fromDate)
+            .param("to", toDate))
             .andExpect(status().isOk())
             .andExpect(content().contentType(MediaType.APPLICATION_JSON))
             .andExpect(jsonPath('$.from', is(fromDate)))
@@ -73,7 +75,8 @@ class ReturnsControllerSpec extends BaseControllerSpec {
         def returns = Returns.builder()
             .returns([aReturn])
             .build()
-        returnsService.get(_ as Person, BEGINNING_OF_TIMES, null) >> returns
+        def today = LocalDate.now()
+        returnsService.get(_ as Person, BEGINNING_OF_TIMES, today, null) >> returns
 
         expect:
         mockMvc.perform(get("/v1/returns"))
@@ -104,11 +107,12 @@ class ReturnsControllerSpec extends BaseControllerSpec {
                 Return.builder().key(key3).type(INDEX).rate(rate).amount(amount).paymentsSum(paymentsSum).currency(EUR).from(LocalDate.parse(fromDate)).build(),
             ])
             .build()
-        returnsService.get(_ as Person, LocalDate.parse(fromDate), [key1, key2, key3]) >> returns
+        returnsService.get(_ as Person, LocalDate.parse(fromDate), LocalDate.parse(toDate), [key1, key2, key3]) >> returns
 
         expect:
         mockMvc.perform(get("/v1/returns")
             .param("from", fromDate)
+            .param("to", toDate)
             .param("keys[]", key1)
             .param("keys[]", key2)
             .param("keys[]", key3))

--- a/src/test/groovy/ee/tuleva/onboarding/comparisons/returns/ReturnsServiceSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/comparisons/returns/ReturnsServiceSpec.groovy
@@ -35,16 +35,18 @@ class ReturnsServiceSpec extends Specification {
     given:
     def person = samplePerson()
     def fromDate = LocalDate.parse("2019-08-28")
+    def toDate = LocalDate.now()
     def startTime = fromDate.plusDays(2).atStartOfDay().toInstant(ZoneOffset.UTC)
+    def endTime = toDate.atStartOfDay().toInstant(ZoneOffset.UTC)
     def pillar = 3
 
     def (return1, returns1) = sampleReturns1(fromDate)
     def (return2, returns2) = sampleReturns2(fromDate)
     def (return3, returns3) = sampleReturns3(fromDate)
 
-    returnProvider1.getReturns(new ReturnCalculationParameters(person, startTime, pillar, [return1.key])) >> returns1
-    returnProvider2.getReturns(new ReturnCalculationParameters(person, startTime, pillar, [return2.key])) >> returns2
-    returnProvider3.getReturns(new ReturnCalculationParameters(person, startTime, pillar, [return3.key])) >> returns3
+    returnProvider1.getReturns(new ReturnCalculationParameters(person, startTime, endTime, pillar, [return1.key])) >> returns1
+    returnProvider2.getReturns(new ReturnCalculationParameters(person, startTime, endTime, pillar, [return2.key])) >> returns2
+    returnProvider3.getReturns(new ReturnCalculationParameters(person, startTime, endTime, pillar, [return3.key])) >> returns3
 
     returnProvider1.getKeys() >> [return1.key]
     returnProvider2.getKeys() >> [return2.key]
@@ -55,7 +57,7 @@ class ReturnsServiceSpec extends Specification {
     fundValueRepository.findEarliestDateForKey(return3.key) >> Optional.of(return3.from)
 
     when:
-    def theReturns = returnsService.get(person, fromDate, [return1.key, return2.key, return3.key])
+    def theReturns = returnsService.get(person, fromDate, toDate, [return1.key, return2.key, return3.key])
 
     then:
     with(theReturns) {
@@ -82,7 +84,7 @@ class ReturnsServiceSpec extends Specification {
     returnProvider3.getKeys() >> [return3.key]
 
     when:
-    def theReturns = returnsService.get(person, fromDate, null)
+    def theReturns = returnsService.get(person, fromDate, toDate, null)
 
     then:
     with(theReturns) {
@@ -117,7 +119,7 @@ class ReturnsServiceSpec extends Specification {
     fundValueRepository.findEarliestDateForKey(return3.key) >> Optional.of(return3.from)
 
     when:
-    def theReturns = returnsService.get(person, fromDate, [return1.key])
+    def theReturns = returnsService.get(person, fromDate, toDate, [return1.key])
 
     then:
     with(theReturns) {
@@ -130,6 +132,7 @@ class ReturnsServiceSpec extends Specification {
     given:
         def person = samplePerson()
         LocalDate originalFromDate = LocalDate.parse("2020-01-01")
+        LocalDate toDate = LocalDate.now()
         LocalDate earliestNavDate = LocalDate.parse("2020-02-01")
         Instant adjustedStartTime = Instant.parse("2020-05-01T00:00:00Z")
         LocalDate adjustedStartDate = LocalDate.parse("2020-05-01")
@@ -139,9 +142,10 @@ class ReturnsServiceSpec extends Specification {
         def (return3, returns3) = sampleReturns3(adjustedStartDate)
 
 
-        returnProvider1.getReturns(new ReturnCalculationParameters(person, adjustedStartTime, 2, [return1.key])) >> returns1
-        returnProvider2.getReturns(new ReturnCalculationParameters(person, adjustedStartTime, 2, [return2.key])) >> returns2
-        returnProvider3.getReturns(new ReturnCalculationParameters(person, adjustedStartTime, 2, [return3.key])) >> returns3
+        Instant endTime = toDate.atStartOfDay().toInstant(ZoneOffset.UTC)
+        returnProvider1.getReturns(new ReturnCalculationParameters(person, adjustedStartTime, endTime, 2, [return1.key])) >> returns1
+        returnProvider2.getReturns(new ReturnCalculationParameters(person, adjustedStartTime, endTime, 2, [return2.key])) >> returns2
+        returnProvider3.getReturns(new ReturnCalculationParameters(person, adjustedStartTime, endTime, 2, [return3.key])) >> returns3
 
         returnProvider1.getKeys() >> [return1.key]
         returnProvider2.getKeys() >> [return2.key]
@@ -153,7 +157,7 @@ class ReturnsServiceSpec extends Specification {
         fundValueRepository.findEarliestDateForKey(return2.key) >> Optional.of(earliestNavDate)
 
     when:
-        Returns returns = returnsService.get(person, originalFromDate, keys)
+        Returns returns = returnsService.get(person, originalFromDate, toDate, keys)
 
     then:
         returns.returns.size() == 2
@@ -165,15 +169,17 @@ class ReturnsServiceSpec extends Specification {
     given:
         def person = samplePerson()
         LocalDate originalFromDate = LocalDate.parse("2020-01-01")
+        LocalDate toDate = LocalDate.now()
         Instant fromTime = originalFromDate.plusDays(2).atStartOfDay().toInstant(ZoneOffset.UTC)
+        Instant endTime = toDate.atStartOfDay().toInstant(ZoneOffset.UTC)
 
         def (return1, returns1) = sampleReturns1(originalFromDate)
         def (return2, returns2) = sampleReturns2(originalFromDate)
         def (return3, returns3) = sampleReturns3(originalFromDate)
 
-        returnProvider1.getReturns(new ReturnCalculationParameters(person, fromTime, 3, [return1.key])) >> returns1
-        returnProvider2.getReturns(new ReturnCalculationParameters(person, fromTime, 3, [return2.key])) >> returns2
-        returnProvider3.getReturns(new ReturnCalculationParameters(person, fromTime, 3, [return3.key])) >> returns3
+        returnProvider1.getReturns(new ReturnCalculationParameters(person, fromTime, endTime, 3, [return1.key])) >> returns1
+        returnProvider2.getReturns(new ReturnCalculationParameters(person, fromTime, endTime, 3, [return2.key])) >> returns2
+        returnProvider3.getReturns(new ReturnCalculationParameters(person, fromTime, endTime, 3, [return3.key])) >> returns3
 
         returnProvider1.getKeys() >> [return1.key]
         returnProvider2.getKeys() >> [return2.key]
@@ -186,7 +192,7 @@ class ReturnsServiceSpec extends Specification {
         fundValueRepository.findEarliestDateForKey(return3.key) >> Optional.of(originalFromDate)
 
     when:
-        Returns returns = returnsService.get(person, originalFromDate, keys)
+        Returns returns = returnsService.get(person, originalFromDate, toDate, keys)
 
     then:
         returns.returns.size() == 3

--- a/src/test/groovy/ee/tuleva/onboarding/comparisons/returns/provider/FundReturnProviderSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/comparisons/returns/provider/FundReturnProviderSpec.groovy
@@ -43,14 +43,14 @@ class FundReturnProviderSpec extends Specification {
     def returnAsAmount = 123.12
     def payments = 234.12
 
-    accountOverviewProvider.getAccountOverview(person, startTime, pillar) >> overview
+    accountOverviewProvider.getAccountOverview(person, startTime, endTime, pillar) >> overview
     rateOfReturnCalculator.getSimulatedReturn(overview, _ as String) >>
         new ReturnDto(expectedReturn, returnAsAmount, payments, EUR, earliestTransactionDate)
     fundRepository.findAllByStatus(ACTIVE) >> List.of(tuleva2ndPillarBondFund(), tuleva2ndPillarStockFund())
 
     when:
     Returns returns = returnProvider.getReturns(
-        new ReturnCalculationParameters(person, startTime, pillar, returnProvider.getKeys()))
+        new ReturnCalculationParameters(person, startTime, endTime, pillar, returnProvider.getKeys()))
 
     then:
     with(returns.returns[0]) {
@@ -81,7 +81,7 @@ class FundReturnProviderSpec extends Specification {
         def returnAsAmount = 123.12
         def payments = 234.12
 
-        accountOverviewProvider.getAccountOverview(person, startTime, pillar) >> overview
+        accountOverviewProvider.getAccountOverview(person, startTime, endTime, pillar) >> overview
         rateOfReturnCalculator.getSimulatedReturn(overview, _ as String) >>
             new ReturnDto(expectedReturn, returnAsAmount, payments, EUR, earliestTransactionDate)
         fundRepository.findAllByStatus(ACTIVE) >> List.of(tuleva2ndPillarBondFund(), tuleva2ndPillarStockFund())
@@ -90,7 +90,7 @@ class FundReturnProviderSpec extends Specification {
 
     when:
         Returns returns = returnProvider.getReturns(
-            new ReturnCalculationParameters(person, startTime, pillar, specifiedKeys))
+            new ReturnCalculationParameters(person, startTime, endTime, pillar, specifiedKeys))
 
     then:
         with(returns.returns[0]) {

--- a/src/test/groovy/ee/tuleva/onboarding/comparisons/returns/provider/IndexReturnProviderSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/comparisons/returns/provider/IndexReturnProviderSpec.groovy
@@ -39,7 +39,7 @@ class IndexReturnProviderSpec extends Specification {
         def returnAsAmount = 123.12
         def payments = 234.12
 
-        accountOverviewProvider.getAccountOverview(person, startTime, pillar) >> overview
+        accountOverviewProvider.getAccountOverview(person, startTime, endTime, pillar) >> overview
         rateOfReturnCalculator.getSimulatedReturn(overview, EpiFundValueRetriever.KEY) >>
             new ReturnDto(expectedReturn, returnAsAmount, payments, EUR, earliestTransactionDate)
         rateOfReturnCalculator.getSimulatedReturn(overview, UnionStockIndexRetriever.KEY) >>
@@ -50,7 +50,7 @@ class IndexReturnProviderSpec extends Specification {
 
         when:
         def returns = returnProvider.getReturns(
-            new ReturnCalculationParameters(person, startTime, pillar, returnProvider.getKeys()))
+            new ReturnCalculationParameters(person, startTime, endTime, pillar, returnProvider.getKeys()))
 
         then:
         with(returns.returns[0]) {

--- a/src/test/groovy/ee/tuleva/onboarding/comparisons/returns/provider/PersonalReturnProviderSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/comparisons/returns/provider/PersonalReturnProviderSpec.groovy
@@ -38,13 +38,13 @@ class PersonalReturnProviderSpec extends Specification {
         def returnAsAmount = 123.12
         def payments = 234.12
 
-        accountOverviewProvider.getAccountOverview(person, startTime, pillar) >> overview
+        accountOverviewProvider.getAccountOverview(person, startTime, endTime, pillar) >> overview
         rateOfReturnCalculator.getReturn(overview) >>
             new ReturnDto(expectedReturn, returnAsAmount, payments, EUR, earliestTransactionDate)
 
         when:
         def returns = returnProvider.getReturns(
-            new ReturnCalculationParameters(person, startTime, pillar, returnProvider.getKeys()))
+            new ReturnCalculationParameters(person, startTime, endTime, pillar, returnProvider.getKeys()))
 
         then:
         with(returns.returns[0]) {
@@ -74,13 +74,13 @@ class PersonalReturnProviderSpec extends Specification {
         def returnAsAmount = 123.21
         def payments = 234.45
 
-        accountOverviewProvider.getAccountOverview(person, startTime, pillar) >> overview
+        accountOverviewProvider.getAccountOverview(person, startTime, endTime, pillar) >> overview
         rateOfReturnCalculator.getReturn(overview) >>
             new ReturnDto(expectedReturn, returnAsAmount, payments, EUR, earliestTransactionDate)
 
         when:
         def returns = returnProvider.getReturns(
-            new ReturnCalculationParameters(person, startTime, pillar, returnProvider.getKeys()))
+            new ReturnCalculationParameters(person, startTime, endTime, pillar, returnProvider.getKeys()))
 
         then:
         with(returns.returns[0]) {
@@ -110,13 +110,13 @@ class PersonalReturnProviderSpec extends Specification {
         def returnAsAmount = 123.21
         def payments = 234.45
 
-        accountOverviewProvider.getAccountOverview(person, startTime, pillar) >> overview
+        accountOverviewProvider.getAccountOverview(person, startTime, endTime, pillar) >> overview
         rateOfReturnCalculator.getReturn(overview) >>
             new ReturnDto(expectedReturn, returnAsAmount, payments, EUR, earliestTransactionDate)
 
     when:
         returnProvider.getReturns(
-            new ReturnCalculationParameters(person, startTime, pillar, returnProvider.getKeys()))
+            new ReturnCalculationParameters(person, startTime, endTime, pillar, returnProvider.getKeys()))
 
     then:
         thrown(IllegalArgumentException)


### PR DESCRIPTION
## Summary
- allow specifying `to` date for `/returns` endpoint
- support end date in returns service and calculation parameters
- update account overview to handle end date
- adjust return providers and tests for new parameter

## Testing
- `./gradlew test` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_b_685401129e608331ba385d29d49efa79