### PR TITLE
Integrate jspecify and NullAway

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,4 @@
+import net.ltgt.gradle.errorprone.errorprone
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
 import org.gradle.api.tasks.testing.logging.TestLogEvent.FAILED
 import org.gradle.api.tasks.testing.logging.TestLogEvent.PASSED
@@ -25,6 +26,7 @@ plugins {
     id("com.gorylenko.gradle-git-properties") version "2.5.0"
     id("com.diffplug.spotless") version "7.0.4"
     id("io.freefair.lombok") version "8.13.1"
+    id("net.ltgt.errorprone") version "4.2.0"
     jacoco
 }
 
@@ -75,6 +77,9 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-aop")
     implementation("org.springframework.boot:spring-boot-starter-json")
     implementation("org.springframework.boot:spring-boot-starter-validation")
+    compileOnly("org.jspecify:jspecify:1.0.0")
+    annotationProcessor("com.uber.nullaway:nullaway:0.12.7")
+    errorprone("com.google.errorprone:error_prone_core:2.38.0")
     developmentOnly("org.springframework.boot:spring-boot-devtools")
     implementation("io.micrometer:micrometer-tracing-bridge-otel")
 
@@ -366,6 +371,16 @@ tasks.withType<JavaCompile> {
 //    options.compilerArgs.add("-Xlint:-serial")
 //    options.compilerArgs.add("-Xlint:-deprecation")
 //    options.compilerArgs.add("-Werror")
+    options.errorprone {
+        disableAllChecks.set(true)
+        warn("NullAway")
+        option("NullAway:AnnotatedPackages", "ee.tuleva.onboarding")
+        disableWarningsInGeneratedCode.set(true)
+    }
+}
+
+tasks.named<JavaCompile>("compileJava") {
+    options.errorprone.warn("NullAway")
 }
 
 tasks.withType<JavaExec> {

--- a/src/main/java/ee/tuleva/onboarding/package-info.java
+++ b/src/main/java/ee/tuleva/onboarding/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package ee.tuleva.onboarding;
+
+import org.jspecify.annotations.NullMarked;


### PR DESCRIPTION
## Summary
- add errorprone plugin with NullAway and jspecify dependencies
- configure JavaCompile tasks to run NullAway as a warning
- mark the base package with `@NullMarked`

## Testing
- `./gradlew test` *(fails: analytics-administration-data.s3.eu-central-1.amazonaws.com blocked)*

------
https://chatgpt.com/codex/tasks/task_b_685bcf6e4b688331b241da336e4ba2a5