### PR TITLE
Add logic to be able to sign existing container

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/capital/transfer/CapitalTransferFileService.java
+++ b/src/main/java/ee/tuleva/onboarding/capital/transfer/CapitalTransferFileService.java
@@ -48,6 +48,10 @@ public class CapitalTransferFileService {
   private byte[] getContentToSign(CapitalTransferContract contract) {
     if (contract.getState() == CapitalTransferContractState.SELLER_SIGNED
         && contract.getDigiDocContainer() != null) {
+      // TODO: Lift this logic up and use it at signing point – do we need to create new container
+      // oad signature to it?
+      // TODO: or don't lift and use magic bytes at signer level... digidoc container magic bytes
+      // appear to be zip ones 50 4b
       return contract.getDigiDocContainer();
     }
     return contract.getOriginalContent();

--- a/src/main/java/ee/tuleva/onboarding/capital/transfer/CapitalTransferFileService.java
+++ b/src/main/java/ee/tuleva/onboarding/capital/transfer/CapitalTransferFileService.java
@@ -48,10 +48,6 @@ public class CapitalTransferFileService {
   private byte[] getContentToSign(CapitalTransferContract contract) {
     if (contract.getState() == CapitalTransferContractState.SELLER_SIGNED
         && contract.getDigiDocContainer() != null) {
-      // TODO: Lift this logic up and use it at signing point – do we need to create new container
-      // oad signature to it?
-      // TODO: or don't lift and use magic bytes at signer level... digidoc container magic bytes
-      // appear to be zip ones 50 4b
       return contract.getDigiDocContainer();
     }
     return contract.getOriginalContent();

--- a/src/main/java/ee/tuleva/onboarding/capital/transfer/CapitalTransferFileService.java
+++ b/src/main/java/ee/tuleva/onboarding/capital/transfer/CapitalTransferFileService.java
@@ -1,9 +1,12 @@
 package ee.tuleva.onboarding.capital.transfer;
 
+import static ee.tuleva.onboarding.mandate.signature.SignatureFile.SignatureFileType.DIGIDOC_CONTAINER;
+import static ee.tuleva.onboarding.mandate.signature.SignatureFile.SignatureFileType.HTML;
 import static java.util.stream.Collectors.toList;
 
 import ee.tuleva.onboarding.capital.transfer.content.CapitalTransferContentFile;
 import ee.tuleva.onboarding.mandate.signature.SignatureFile;
+import ee.tuleva.onboarding.mandate.signature.SignatureFile.SignatureFileType;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -28,19 +31,19 @@ public class CapitalTransferFileService {
 
   public List<SignatureFile> getContractFiles(CapitalTransferContract contract) {
     return getContentFiles(contract).stream()
-        .map(file -> new SignatureFile(file.getName(), file.getMimeType(), file.getContent()))
+        .map(file -> new SignatureFile(file.getName(), file.getFileType(), file.getContent()))
         .collect(toList());
   }
 
   private List<CapitalTransferContentFile> getContentFiles(CapitalTransferContract contract) {
     byte[] contentToSign = getContentToSign(contract);
-    String mimeType = getMimeType(contract);
+    SignatureFileType fileType = getFileType(contract);
     String fileName = getFileName(contract);
 
     return List.of(
         CapitalTransferContentFile.builder()
             .name(fileName)
-            .mimeType(mimeType)
+            .fileType(fileType)
             .content(contentToSign)
             .build());
   }
@@ -53,13 +56,13 @@ public class CapitalTransferFileService {
     return contract.getOriginalContent();
   }
 
-  private String getMimeType(CapitalTransferContract contract) {
+  private SignatureFileType getFileType(CapitalTransferContract contract) {
     if (contract.getState() == CapitalTransferContractState.SELLER_SIGNED
         && contract.getDigiDocContainer() != null) {
       // https://www.id.ee/en/article/bdoc2-1-new-estonian-digital-signature-standard-format/
-      return "application/vnd.etsi.asic-e+zip";
+      return DIGIDOC_CONTAINER;
     }
-    return "text/html";
+    return HTML;
   }
 
   private String getFileName(CapitalTransferContract contract) {

--- a/src/main/java/ee/tuleva/onboarding/capital/transfer/content/CapitalTransferContentFile.java
+++ b/src/main/java/ee/tuleva/onboarding/capital/transfer/content/CapitalTransferContentFile.java
@@ -1,12 +1,15 @@
 package ee.tuleva.onboarding.capital.transfer.content;
 
+import static ee.tuleva.onboarding.mandate.signature.SignatureFile.SignatureFileType.HTML;
+
+import ee.tuleva.onboarding.mandate.signature.SignatureFile.SignatureFileType;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @Builder
 public class CapitalTransferContentFile {
-  @Builder.Default private String mimeType = "text/html";
+  @Builder.Default private SignatureFileType fileType = HTML;
   private String name;
   private byte[] content;
 }

--- a/src/main/java/ee/tuleva/onboarding/mandate/signature/DigiDocFacade.java
+++ b/src/main/java/ee/tuleva/onboarding/mandate/signature/DigiDocFacade.java
@@ -40,10 +40,6 @@ public class DigiDocFacade {
     return builder.build();
   }
 
-  // This has the unfortunate side effect that containers with a single zip archive are not
-  // signable,
-  // but since the container itself is a zip archive which can hold multiple files,
-  // it seems like a very small edge case
   private boolean isExistingContainer(List<SignatureFile> files) {
     if (files.size() != 1) {
       return false;

--- a/src/main/java/ee/tuleva/onboarding/mandate/signature/DigiDocFacade.java
+++ b/src/main/java/ee/tuleva/onboarding/mandate/signature/DigiDocFacade.java
@@ -26,6 +26,16 @@ public class DigiDocFacade {
     return builder.build();
   }
 
+  public Container buildContainerFromExistingContainer(SignatureFile containerFile) {
+    if (!containerFile.isContainer()) {
+      throw new IllegalArgumentException("File is not an existing container");
+    }
+
+    ContainerBuilder builder = ContainerBuilder.aContainer().withConfiguration(digiDocConfig);
+    builder.fromStream(new ByteArrayInputStream(containerFile.getContent()));
+    return builder.build();
+  }
+
   public DataToSign dataToSign(Container container, X509Certificate certificate) {
     return SignatureBuilder.aSignature(container)
         .withSigningCertificate(certificate)

--- a/src/main/java/ee/tuleva/onboarding/mandate/signature/SignatureFile.java
+++ b/src/main/java/ee/tuleva/onboarding/mandate/signature/SignatureFile.java
@@ -1,20 +1,31 @@
 package ee.tuleva.onboarding.mandate.signature;
 
-import static java.util.Arrays.copyOfRange;
+import static ee.tuleva.onboarding.mandate.signature.SignatureFile.SignatureFileType.DIGIDOC_CONTAINER;
 
 import java.io.Serial;
 import java.io.Serializable;
-import java.util.Arrays;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @Getter
 public class SignatureFile implements Serializable {
+  public SignatureFile(String name, SignatureFileType fileType, byte[] content) {
+    this.name = name;
+    this.mimeType = fileType.getMimeType();
+    this.content = content;
+  }
 
-  private static final byte[] EXISTING_SIGNATURE_CONTAINER_MAGIC_BYTES = {
-    0x50, 0x4b
-  }; // ZIP archive/signature container magic bytes
+  public enum SignatureFileType {
+    HTML("text/html"),
+    DIGIDOC_CONTAINER("application/vnd.etsi.asic-e+zip");
+
+    @Getter private final String mimeType;
+
+    SignatureFileType(String mimeType) {
+      this.mimeType = mimeType;
+    }
+  }
 
   @Serial private static final long serialVersionUID = -2405222829412049325L;
 
@@ -23,10 +34,6 @@ public class SignatureFile implements Serializable {
   private final byte[] content;
 
   public boolean isContainer() {
-    // TODO use mimetype?
-    var fileMagicBytes = copyOfRange(content, 0, 2);
-
-    // is zip archive?
-    return Arrays.equals(fileMagicBytes, EXISTING_SIGNATURE_CONTAINER_MAGIC_BYTES);
+    return this.mimeType.equals(DIGIDOC_CONTAINER.getMimeType());
   }
 }

--- a/src/main/java/ee/tuleva/onboarding/mandate/signature/SignatureFile.java
+++ b/src/main/java/ee/tuleva/onboarding/mandate/signature/SignatureFile.java
@@ -1,7 +1,10 @@
 package ee.tuleva.onboarding.mandate.signature;
 
+import static java.util.Arrays.copyOfRange;
+
 import java.io.Serial;
 import java.io.Serializable;
+import java.util.Arrays;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -9,9 +12,21 @@ import lombok.RequiredArgsConstructor;
 @Getter
 public class SignatureFile implements Serializable {
 
+  private static final byte[] EXISTING_SIGNATURE_CONTAINER_MAGIC_BYTES = {
+    0x50, 0x4b
+  }; // ZIP archive/signature container magic bytes
+
   @Serial private static final long serialVersionUID = -2405222829412049325L;
 
   private final String name;
   private final String mimeType;
   private final byte[] content;
+
+  public boolean isContainer() {
+    // TODO use mimetype?
+    var fileMagicBytes = copyOfRange(content, 0, 2);
+
+    // is zip archive?
+    return Arrays.equals(fileMagicBytes, EXISTING_SIGNATURE_CONTAINER_MAGIC_BYTES);
+  }
 }

--- a/src/main/java/ee/tuleva/onboarding/mandate/signature/smartid/SmartIdSigner.java
+++ b/src/main/java/ee/tuleva/onboarding/mandate/signature/smartid/SmartIdSigner.java
@@ -87,10 +87,7 @@ public class SmartIdSigner {
     X509Certificate certificate = smartIdCertificate.getCertificate();
     List<SignatureFile> files = session.getFiles();
 
-    Container container =
-        isExistingContainer(session)
-            ? digiDocFacade.buildContainerFromExistingContainer(session.getFiles().getFirst())
-            : digiDocFacade.buildContainer(files);
+    Container container = digiDocFacade.buildContainer(files);
 
     DataToSign dataToSign = digiDocFacade.dataToSign(container, certificate);
     byte[] digestToSign = digiDocFacade.digestToSign(dataToSign);
@@ -108,16 +105,6 @@ public class SmartIdSigner {
     session.setSignableHash(signableHash);
     session.setContainer(container);
     sessionStore.save(session);
-  }
-
-  private boolean isExistingContainer(SmartIdSignatureSession session) {
-    var files = session.getFiles();
-
-    if (files.size() != 1) {
-      return false;
-    }
-
-    return files.getFirst().isContainer();
   }
 
   @SneakyThrows

--- a/src/main/java/ee/tuleva/onboarding/mandate/signature/smartid/SmartIdSigner.java
+++ b/src/main/java/ee/tuleva/onboarding/mandate/signature/smartid/SmartIdSigner.java
@@ -86,7 +86,11 @@ public class SmartIdSigner {
 
     X509Certificate certificate = smartIdCertificate.getCertificate();
     List<SignatureFile> files = session.getFiles();
-    Container container = digiDocFacade.buildContainer(files);
+
+    Container container =
+        isExistingContainer(session)
+            ? digiDocFacade.buildContainerFromExistingContainer(session.getFiles().getFirst())
+            : digiDocFacade.buildContainer(files);
 
     DataToSign dataToSign = digiDocFacade.dataToSign(container, certificate);
     byte[] digestToSign = digiDocFacade.digestToSign(dataToSign);
@@ -104,6 +108,16 @@ public class SmartIdSigner {
     session.setSignableHash(signableHash);
     session.setContainer(container);
     sessionStore.save(session);
+  }
+
+  private boolean isExistingContainer(SmartIdSignatureSession session) {
+    var files = session.getFiles();
+
+    if (files.size() != 1) {
+      return false;
+    }
+
+    return files.getFirst().isContainer();
   }
 
   @SneakyThrows


### PR DESCRIPTION
Adds capability to sign existing container – for member capital transfers, where both parties sign. Previously, this resulted in nested containers with one signature each.

This has the unfortunate side effect that containers with a single zip archive are not signable, but since the container itself is a zip archive which can hold multiple files, it seems like a very small edge case.