### PR TITLE
clean up swedbank payment splitting

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/savings/fund/SavingFundPaymentExtractor.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/SavingFundPaymentExtractor.java
@@ -40,20 +40,20 @@ public class SavingFundPaymentExtractor {
   private SavingFundPayment convertToSavingFundPayment(
       BankStatementEntry entry, BankStatementAccount account, Instant receivedAt) {
 
-    if (!Objects.equals(entry.getCurrencyCode(), "EUR")) {
+    if (!Objects.equals(entry.currencyCode(), "EUR")) {
       throw new PaymentProcessingException(
-          "Bank transfer currency not supported: " + entry.getCurrencyCode());
+          "Bank transfer currency not supported: " + entry.currencyCode());
     }
 
     var currency = Currency.EUR;
 
-    var counterParty = entry.getDetails();
+    var counterParty = entry.details();
 
     // For CREDIT: counterparty is remitter, account holder is beneficiary
     // For DEBIT: account holder is remitter, counterparty is beneficiary
-    if (entry.getTransactionType() == TransactionType.CREDIT) {
+    if (entry.transactionType() == TransactionType.CREDIT) {
       return SavingFundPayment.builder()
-          .amount(entry.getAmount())
+          .amount(entry.amount())
           .currency(currency)
           .remitterIban(counterParty.getIban())
           .remitterIdCode(counterParty.getPersonalCode().orElse(null))
@@ -61,13 +61,13 @@ public class SavingFundPaymentExtractor {
           .beneficiaryIban(account.iban())
           .beneficiaryIdCode(account.accountHolderIdCode())
           .beneficiaryName(account.accountHolderName())
-          .description(entry.getRemittanceInformation())
-          .externalId(entry.getExternalId())
+          .description(entry.remittanceInformation())
+          .externalId(entry.externalId())
           .receivedAt(receivedAt)
           .build();
     } else { // DEBIT
       return SavingFundPayment.builder()
-          .amount(entry.getAmount()) // Already negative for debits
+          .amount(entry.amount()) // Already negative for debits
           .currency(currency)
           .remitterIban(account.iban())
           .remitterIdCode(account.accountHolderIdCode())
@@ -75,8 +75,8 @@ public class SavingFundPaymentExtractor {
           .beneficiaryIban(counterParty.getIban())
           .beneficiaryIdCode(counterParty.getPersonalCode().orElse(null))
           .beneficiaryName(counterParty.getName())
-          .description(entry.getRemittanceInformation())
-          .externalId(entry.getExternalId())
+          .description(entry.remittanceInformation())
+          .externalId(entry.externalId())
           .receivedAt(receivedAt)
           .build();
     }

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/SavingFundPaymentExtractor.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/SavingFundPaymentExtractor.java
@@ -51,34 +51,32 @@ public class SavingFundPaymentExtractor {
 
     // For CREDIT: counterparty is remitter, account holder is beneficiary
     // For DEBIT: account holder is remitter, counterparty is beneficiary
+    var builder =
+        SavingFundPayment.builder()
+            .amount(entry.amount())
+            .currency(currency)
+            .description(entry.remittanceInformation())
+            .externalId(entry.externalId())
+            .receivedAt(receivedAt);
+
     if (entry.transactionType() == TransactionType.CREDIT) {
-      return SavingFundPayment.builder()
-          .amount(entry.amount())
-          .currency(currency)
+      builder
           .remitterIban(counterParty.getIban())
           .remitterIdCode(counterParty.getPersonalCode().orElse(null))
           .remitterName(counterParty.getName())
           .beneficiaryIban(account.iban())
           .beneficiaryIdCode(account.accountHolderIdCode())
-          .beneficiaryName(account.accountHolderName())
-          .description(entry.remittanceInformation())
-          .externalId(entry.externalId())
-          .receivedAt(receivedAt)
-          .build();
+          .beneficiaryName(account.accountHolderName());
     } else { // DEBIT
-      return SavingFundPayment.builder()
-          .amount(entry.amount()) // Already negative for debits
-          .currency(currency)
+      builder
           .remitterIban(account.iban())
           .remitterIdCode(account.accountHolderIdCode())
           .remitterName(account.accountHolderName())
           .beneficiaryIban(counterParty.getIban())
           .beneficiaryIdCode(counterParty.getPersonalCode().orElse(null))
-          .beneficiaryName(counterParty.getName())
-          .description(entry.remittanceInformation())
-          .externalId(entry.externalId())
-          .receivedAt(receivedAt)
-          .build();
+          .beneficiaryName(counterParty.getName());
     }
+
+    return builder.build();
   }
 }

--- a/src/main/java/ee/tuleva/onboarding/swedbank/statement/BankStatement.java
+++ b/src/main/java/ee/tuleva/onboarding/swedbank/statement/BankStatement.java
@@ -2,7 +2,6 @@ package ee.tuleva.onboarding.swedbank.statement;
 
 import static ee.tuleva.onboarding.swedbank.statement.BankStatement.BankStatementType.HISTORIC_STATEMENT;
 import static ee.tuleva.onboarding.swedbank.statement.BankStatement.BankStatementType.INTRA_DAY_REPORT;
-import static lombok.AccessLevel.PRIVATE;
 
 import ee.swedbank.gateway.iso.response.report.AccountReport11;
 import ee.swedbank.gateway.iso.response.report.BankToCustomerAccountReportV02;
@@ -13,7 +12,7 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
-@RequiredArgsConstructor(access = PRIVATE)
+@RequiredArgsConstructor
 public class BankStatement {
 
   public enum BankStatementType {
@@ -27,7 +26,7 @@ public class BankStatement {
   // TODO check entries against TtlCdtNtries and TttlDbtEntries count from balances?
   private final List<BankStatementEntry> entries;
 
-  public static BankStatement from(BankToCustomerAccountReportV02 accountReport) {
+  static BankStatement from(BankToCustomerAccountReportV02 accountReport) {
     var report = Require.exactlyOne(accountReport.getRpt(), "report");
     return from(report);
   }

--- a/src/main/java/ee/tuleva/onboarding/swedbank/statement/BankStatementAccount.java
+++ b/src/main/java/ee/tuleva/onboarding/swedbank/statement/BankStatementAccount.java
@@ -26,7 +26,7 @@ public record BankStatementAccount(
   }
 
   static BankStatementAccount from(AccountReport11 report) {
-    var iban = report.getAcct().getId().getIBAN();
+    var iban = Require.notNullOrBlank(report.getAcct().getId().getIBAN(), "account IBAN");
 
     // Extract account holder information from Ownr section
     var owner = Require.notNull(report.getAcct().getOwnr(), "account owner");
@@ -52,7 +52,7 @@ public record BankStatementAccount(
   }
 
   static BankStatementAccount from(AccountStatement2 statement) {
-    var iban = statement.getAcct().getId().getIBAN();
+    var iban = Require.notNullOrBlank(statement.getAcct().getId().getIBAN(), "account IBAN");
 
     // Extract account holder information from Ownr section
     var owner = Require.notNull(statement.getAcct().getOwnr(), "account owner");

--- a/src/main/java/ee/tuleva/onboarding/swedbank/statement/BankStatementEntry.java
+++ b/src/main/java/ee/tuleva/onboarding/swedbank/statement/BankStatementEntry.java
@@ -35,9 +35,8 @@ public class BankStatementEntry {
     public static CounterPartyDetails from(ReportEntry2 entry) {
       var creditOrDebit = entry.getCdtDbtInd();
 
-      // TODO this can have multiple ones depending on bank logic, test response from Swed only has
-      // one
-      var transactionDetails = entry.getNtryDtls().getFirst().getTxDtls().getFirst();
+      var entryDetails = Require.exactlyOne(entry.getNtryDtls(), "entry details");
+      var transactionDetails = Require.exactlyOne(entryDetails.getTxDtls(), "transaction details");
       var relatedParties = transactionDetails.getRltdPties();
 
       // TODO entry group can break this?
@@ -70,9 +69,8 @@ public class BankStatementEntry {
     static CounterPartyDetails from(ee.swedbank.gateway.iso.response.statement.ReportEntry2 entry) {
       var creditOrDebit = entry.getCdtDbtInd();
 
-      // TODO this can have multiple ones depending on bank logic, test response from Swed only has
-      // one
-      var transactionDetails = entry.getNtryDtls().getFirst().getTxDtls().getFirst();
+      var entryDetails = Require.exactlyOne(entry.getNtryDtls(), "entry details");
+      var transactionDetails = Require.exactlyOne(entryDetails.getTxDtls(), "transaction details");
       var relatedParties = transactionDetails.getRltdPties();
 
       // TODO entry group can break this?

--- a/src/main/java/ee/tuleva/onboarding/swedbank/statement/BankStatementEntry.java
+++ b/src/main/java/ee/tuleva/onboarding/swedbank/statement/BankStatementEntry.java
@@ -54,7 +54,7 @@ public class BankStatementEntry {
       var otherPartyAccount =
           creditOrDebit == CRDT ? relatedParties.getDbtrAcct() : relatedParties.getCdtrAcct();
 
-      var iban = otherPartyAccount.getId().getIBAN();
+      var iban = Require.notNullOrBlank(otherPartyAccount.getId().getIBAN(), "counter-party IBAN");
 
       return new CounterPartyDetails(name, iban, personalIdCode);
     }
@@ -87,7 +87,7 @@ public class BankStatementEntry {
               ? relatedParties.getDbtrAcct()
               : relatedParties.getCdtrAcct();
 
-      var iban = otherPartyAccount.getId().getIBAN();
+      var iban = Require.notNullOrBlank(otherPartyAccount.getId().getIBAN(), "counter-party IBAN");
 
       return new CounterPartyDetails(name, iban, personalIdCode);
     }

--- a/src/main/java/ee/tuleva/onboarding/swedbank/statement/BankStatementEntry.java
+++ b/src/main/java/ee/tuleva/onboarding/swedbank/statement/BankStatementEntry.java
@@ -2,6 +2,7 @@ package ee.tuleva.onboarding.swedbank.statement;
 
 import static ee.swedbank.gateway.iso.response.report.CreditDebitCode.CRDT;
 
+import ee.swedbank.gateway.iso.response.report.GenericPersonIdentification1;
 import ee.swedbank.gateway.iso.response.report.Party6Choice;
 import ee.swedbank.gateway.iso.response.report.ReportEntry2;
 import ee.swedbank.gateway.iso.response.statement.CreditDebitCode;
@@ -13,17 +14,17 @@ import java.util.stream.Stream;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
-public class BankStatementEntry {
-  @Getter private final CounterPartyDetails details;
-  @Getter private final BigDecimal amount;
-  @Getter private final String currencyCode;
-  @Getter private final TransactionType transactionType;
-  @Getter private final String remittanceInformation;
-  @Getter private final String externalId;
+public record BankStatementEntry(
+    CounterPartyDetails details,
+    BigDecimal amount,
+    String currencyCode,
+    TransactionType transactionType,
+    String remittanceInformation,
+    String externalId) {
 
   @RequiredArgsConstructor
   public static final class CounterPartyDetails {
+
     @Getter private final String name;
     @Getter private final String iban;
     @Nullable private final String personalCode;
@@ -50,9 +51,7 @@ public class BankStatementEntry {
               .map(
                   prvtId ->
                       prvtId.getOthr().stream()
-                          .map(
-                              ee.swedbank.gateway.iso.response.report.GenericPersonIdentification1
-                                  ::getId)
+                          .map(GenericPersonIdentification1::getId)
                           .filter(id -> id != null && !id.isBlank())
                           .toList())
               .orElseGet(List::of);

--- a/src/main/java/ee/tuleva/onboarding/swedbank/statement/Require.java
+++ b/src/main/java/ee/tuleva/onboarding/swedbank/statement/Require.java
@@ -18,18 +18,6 @@ class Require {
         list, (lst) -> "Expected exactly one " + entityName + ", but found: " + lst.size());
   }
 
-  static <T> T atMostOne(List<T> list, Function<List<T>, String> exceptionMessageGenerator) {
-    if (list != null && list.size() > 1) {
-      throw new BankStatementParseException(exceptionMessageGenerator.apply(list));
-    }
-    return (list == null || list.isEmpty()) ? null : list.getFirst();
-  }
-
-  static <T> T atMostOne(List<T> list, String entityName) {
-    return atMostOne(
-        list, (lst) -> "Expected at most one " + entityName + ", but found: " + lst.size());
-  }
-
   static <T> T notNull(T value, String entityName) {
     if (value == null) {
       throw new BankStatementParseException(entityName + " is required");

--- a/src/main/java/ee/tuleva/onboarding/swedbank/statement/Require.java
+++ b/src/main/java/ee/tuleva/onboarding/swedbank/statement/Require.java
@@ -18,6 +18,18 @@ class Require {
         list, (lst) -> "Expected exactly one " + entityName + ", but found: " + lst.size());
   }
 
+  static <T> T atMostOne(List<T> list, Function<List<T>, String> exceptionMessageGenerator) {
+    if (list != null && list.size() > 1) {
+      throw new BankStatementParseException(exceptionMessageGenerator.apply(list));
+    }
+    return (list == null || list.isEmpty()) ? null : list.getFirst();
+  }
+
+  static <T> T atMostOne(List<T> list, String entityName) {
+    return atMostOne(
+        list, (lst) -> "Expected at most one " + entityName + ", but found: " + lst.size());
+  }
+
   static <T> T notNull(T value, String entityName) {
     if (value == null) {
       throw new BankStatementParseException(entityName + " is required");

--- a/src/test/groovy/ee/tuleva/onboarding/swedbank/http/SwedbankGatewayMarshallerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/swedbank/http/SwedbankGatewayMarshallerTest.java
@@ -89,27 +89,27 @@ public class SwedbankGatewayMarshallerTest {
     assertEquals(4, parsed.getEntries().size());
 
     var firstEntry = parsed.getEntries().get(0);
-    assertEquals("Toomas Raudsepp", firstEntry.getDetails().getName());
-    assertEquals("EE042200000000100031", firstEntry.getDetails().getIban());
-    assertEquals(Optional.of("38009293505"), firstEntry.getDetails().getPersonalCode());
-    assertEquals(0, new BigDecimal("772.88").compareTo(firstEntry.getAmount()));
+    assertEquals("Toomas Raudsepp", firstEntry.details().getName());
+    assertEquals("EE042200000000100031", firstEntry.details().getIban());
+    assertEquals(Optional.of("38009293505"), firstEntry.details().getPersonalCode());
+    assertEquals(0, new BigDecimal("772.88").compareTo(firstEntry.amount()));
 
     var secondEntry = parsed.getEntries().get(1);
-    assertEquals("Kristjan Värk", secondEntry.getDetails().getName());
-    assertEquals("EE082200000000100056", secondEntry.getDetails().getIban());
-    assertEquals(Optional.of("39609307495"), secondEntry.getDetails().getPersonalCode());
-    assertEquals(0, new BigDecimal("612.37").compareTo(secondEntry.getAmount()));
+    assertEquals("Kristjan Värk", secondEntry.details().getName());
+    assertEquals("EE082200000000100056", secondEntry.details().getIban());
+    assertEquals(Optional.of("39609307495"), secondEntry.details().getPersonalCode());
+    assertEquals(0, new BigDecimal("612.37").compareTo(secondEntry.amount()));
 
     var thirdEntry = parsed.getEntries().get(2);
-    assertEquals("Jüri Tamm", thirdEntry.getDetails().getName());
-    assertEquals("EE532200000000010006", thirdEntry.getDetails().getIban());
-    assertEquals(Optional.of("39910273027"), thirdEntry.getDetails().getPersonalCode());
-    assertEquals(0, new BigDecimal("454.76").compareTo(thirdEntry.getAmount()));
+    assertEquals("Jüri Tamm", thirdEntry.details().getName());
+    assertEquals("EE532200000000010006", thirdEntry.details().getIban());
+    assertEquals(Optional.of("39910273027"), thirdEntry.details().getPersonalCode());
+    assertEquals(0, new BigDecimal("454.76").compareTo(thirdEntry.amount()));
 
     var fourthEntry = parsed.getEntries().get(3);
-    assertEquals("Rasmus Lind", fourthEntry.getDetails().getName());
-    assertEquals("EE522200000000100040", fourthEntry.getDetails().getIban());
-    assertEquals(Optional.of("37603135585"), fourthEntry.getDetails().getPersonalCode());
-    assertEquals(0, new BigDecimal("726.06").compareTo(fourthEntry.getAmount()));
+    assertEquals("Rasmus Lind", fourthEntry.details().getName());
+    assertEquals("EE522200000000100040", fourthEntry.details().getIban());
+    assertEquals(Optional.of("37603135585"), fourthEntry.details().getPersonalCode());
+    assertEquals(0, new BigDecimal("726.06").compareTo(fourthEntry.amount()));
   }
 }

--- a/src/test/java/ee/tuleva/onboarding/savings/fund/SavingFundPaymentExtractorTest.java
+++ b/src/test/java/ee/tuleva/onboarding/savings/fund/SavingFundPaymentExtractorTest.java
@@ -3,178 +3,46 @@ package ee.tuleva.onboarding.savings.fund;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import ee.swedbank.gateway.iso.response.report.Document;
 import ee.tuleva.onboarding.currency.Currency;
-import ee.tuleva.onboarding.swedbank.http.SwedbankGatewayMarshaller;
 import ee.tuleva.onboarding.swedbank.statement.BankStatement;
-import jakarta.xml.bind.JAXBElement;
+import ee.tuleva.onboarding.swedbank.statement.BankStatementAccount;
+import ee.tuleva.onboarding.swedbank.statement.BankStatementEntry;
+import ee.tuleva.onboarding.swedbank.statement.TransactionType;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.List;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-@Disabled // TODO: rework tests, instead of parsing XML, create BankStatement directly
 class SavingFundPaymentExtractorTest {
 
   private final SavingFundPaymentExtractor extractor = new SavingFundPaymentExtractor();
-  private final SwedbankGatewayMarshaller marshaller = new SwedbankGatewayMarshaller();
 
   @Test
   void extractPayments_shouldExtractPaymentsFromDocument() {
     // given
-    List<String> entries =
-        List.of(
-            """
-        <Ntry>
-          <NtryRef>2025092900654847-1</NtryRef>
-          <Amt Ccy="EUR">0.10</Amt>
-          <CdtDbtInd>CRDT</CdtDbtInd>
-          <Sts>BOOK</Sts>
-          <BookgDt>
-            <Dt>2025-09-29</Dt>
-          </BookgDt>
-          <ValDt>
-            <Dt>2025-09-29</Dt>
-          </ValDt>
-          <AcctSvcrRef>2025092900654847-1</AcctSvcrRef>
-          <BkTxCd>
-            <Domn>
-              <Cd>PMNT</Cd>
-              <Fmly>
-                <Cd>RCDT</Cd>
-                <SubFmlyCd>ESCT</SubFmlyCd>
-              </Fmly>
-            </Domn>
-            <Prtry>
-              <Cd>MK</Cd>
-              <Issr>Swedbank AS</Issr>
-            </Prtry>
-          </BkTxCd>
-          <NtryDtls>
-            <TxDtls>
-              <Refs>
-                <AcctSvcrRef>2025092900654847-1</AcctSvcrRef>
-                <EndToEndId>1277</EndToEndId>
-              </Refs>
-              <AmtDtls>
-                <InstdAmt>
-                  <Amt Ccy="EUR">0.10</Amt>
-                </InstdAmt>
-                <TxAmt>
-                  <Amt Ccy="EUR">0.10</Amt>
-                </TxAmt>
-              </AmtDtls>
-              <RltdPties>
-                <Dbtr>
-                  <Nm>Jüri Tamm</Nm>
-                  <Id>
-                    <PrvtId>
-                      <Othr>
-                        <Id>39910273027</Id>
-                        <SchmeNm>
-                          <Cd>NIDN</Cd>
-                        </SchmeNm>
-                      </Othr>
-                    </PrvtId>
-                  </Id>
-                </Dbtr>
-                <DbtrAcct>
-                  <Id>
-                    <IBAN>EE157700771001802057</IBAN>
-                  </Id>
-                </DbtrAcct>
-              </RltdPties>
-              <RltdAgts>
-                <DbtrAgt>
-                  <FinInstnId>
-                    <BIC>LHVBEE22</BIC>
-                  </FinInstnId>
-                </DbtrAgt>
-              </RltdAgts>
-              <RmtInf>
-                <Ustrd>39910273027</Ustrd>
-              </RmtInf>
-            </TxDtls>
-          </NtryDtls>
-        </Ntry>
-        """
-                .stripIndent(),
-            """
-        <Ntry>
-          <NtryRef>2025092900673437-1</NtryRef>
-          <Amt Ccy="EUR">0.10</Amt>
-          <CdtDbtInd>DBIT</CdtDbtInd>
-          <Sts>BOOK</Sts>
-          <BookgDt>
-            <Dt>2025-09-29</Dt>
-          </BookgDt>
-          <ValDt>
-            <Dt>2025-09-29</Dt>
-          </ValDt>
-          <AcctSvcrRef>2025092900673437-1</AcctSvcrRef>
-          <BkTxCd>
-            <Domn>
-              <Cd>PMNT</Cd>
-              <Fmly>
-                <Cd>ICDT</Cd>
-                <SubFmlyCd>ESCT</SubFmlyCd>
-              </Fmly>
-            </Domn>
-            <Prtry>
-              <Cd>MK</Cd>
-              <Issr>Swedbank AS</Issr>
-            </Prtry>
-          </BkTxCd>
-          <NtryDtls>
-            <TxDtls>
-              <Refs>
-                <AcctSvcrRef>2025092900673437-1</AcctSvcrRef>
-                <InstrId>1</InstrId>
-              </Refs>
-              <AmtDtls>
-                <InstdAmt>
-                  <Amt Ccy="EUR">0.10</Amt>
-                </InstdAmt>
-                <TxAmt>
-                  <Amt Ccy="EUR">0.10</Amt>
-                </TxAmt>
-              </AmtDtls>
-              <RltdPties>
-                <Cdtr>
-                  <Nm>Jüri Tamm</Nm>
-                </Cdtr>
-                <CdtrAcct>
-                  <Id>
-                    <IBAN>EE157700771001802057</IBAN>
-                  </Id>
-                </CdtrAcct>
-              </RltdPties>
-              <RltdAgts>
-                <CdtrAgt>
-                  <FinInstnId>
-                    <BIC>LHVBEE22XXX</BIC>
-                  </FinInstnId>
-                </CdtrAgt>
-              </RltdAgts>
-              <RmtInf>
-                <Ustrd>bounce-back</Ustrd>
-              </RmtInf>
-            </TxDtls>
-          </NtryDtls>
-        </Ntry>
-        """
-                .stripIndent());
+    var account =
+        createBankStatementAccount("EE442200221092874625", "TULEVA FONDID AS", "14118923");
 
-    String swedbankXmlResponse = createCamtXml(entries);
-    JAXBElement<Document> response =
-        marshaller.unMarshal(
-            swedbankXmlResponse,
-            JAXBElement.class,
-            ee.swedbank.gateway.iso.response.report.ObjectFactory.class);
-    Document document = response.getValue();
+    var creditEntry =
+        createCreditEntry(
+            new BigDecimal("0.10"),
+            "EE157700771001802057",
+            "Jüri Tamm",
+            "39910273027",
+            "39910273027",
+            "2025092900654847-1");
+
+    var debitEntry =
+        createDebitEntry(
+            new BigDecimal("-0.10"),
+            "EE157700771001802057",
+            "Jüri Tamm",
+            null,
+            "bounce-back",
+            "2025092900673437-1");
+
+    var statement = createBankStatement(account, List.of(creditEntry, debitEntry));
     Instant receivedAt = Instant.parse("2025-09-29T15:37:46Z");
-    var statement = BankStatement.from(document.getBkToCstmrAcctRpt());
 
     // when
     List<SavingFundPayment> payments = extractor.extractPayments(statement, receivedAt);
@@ -213,16 +81,10 @@ class SavingFundPaymentExtractorTest {
   @Test
   void extractPayments_shouldHandleEmptyStatements() {
     // given
-    List<String> entries = List.of(); // No entries
-    String swedbankXmlResponse = createCamtXml(entries);
-    JAXBElement<Document> response =
-        marshaller.unMarshal(
-            swedbankXmlResponse,
-            JAXBElement.class,
-            ee.swedbank.gateway.iso.response.report.ObjectFactory.class);
-    Document document = response.getValue();
+    var account =
+        createBankStatementAccount("EE442200221092874625", "TULEVA FONDID AS", "14118923");
+    var statement = createBankStatement(account, List.of());
     Instant receivedAt = Instant.parse("2025-09-29T15:37:46Z");
-    var statement = BankStatement.from(document.getBkToCstmrAcctRpt());
 
     // when
     List<SavingFundPayment> payments = extractor.extractPayments(statement, receivedAt);
@@ -232,478 +94,71 @@ class SavingFundPaymentExtractorTest {
   }
 
   @Test
-  void extractPayments_shouldThrowExceptionWhenAccountHolderNameIsNull() {
-    // given
-    String xmlWithoutAccountHolderName =
-        """
-        <?xml version="1.0" encoding="UTF-8"?>
-        <Document xmlns="urn:iso:std:iso:20022:tech:xsd:camt.052.001.02">
-          <BkToCstmrAcctRpt>
-            <GrpHdr>
-              <MsgId>test</MsgId>
-              <CreDtTm>2025-09-29T15:37:46</CreDtTm>
-            </GrpHdr>
-            <Rpt>
-              <Id>test</Id>
-              <CreDtTm>2025-09-29T15:37:46</CreDtTm>
-              <Acct>
-                <Id>
-                  <IBAN>EE442200221092874625</IBAN>
-                </Id>
-                <Ccy>EUR</Ccy>
-                <Ownr>
-                  <!-- Missing Nm element -->
-                  <Id>
-                    <OrgId>
-                      <Othr>
-                        <Id>14118923</Id>
-                      </Othr>
-                    </OrgId>
-                  </Id>
-                </Ownr>
-              </Acct>
-            </Rpt>
-          </BkToCstmrAcctRpt>
-        </Document>
-        """
-            .stripIndent();
-
-    // when & then
-    assertThatThrownBy(
-            () -> {
-              JAXBElement<Document> response =
-                  marshaller.unMarshal(
-                      xmlWithoutAccountHolderName,
-                      JAXBElement.class,
-                      ee.swedbank.gateway.iso.response.report.ObjectFactory.class);
-              Document document = response.getValue();
-              Instant receivedAt = Instant.parse("2025-09-29T15:37:46Z");
-              var statement = BankStatement.from(document.getBkToCstmrAcctRpt());
-              extractor.extractPayments(statement, receivedAt);
-            })
-        .isInstanceOf(PaymentProcessingException.class)
-        .hasMessage("Bank statement account holder name not found");
-  }
-
-  @Test
-  void extractPayments_shouldThrowExceptionWhenAccountHolderHasNoIdCodes() {
-    // given
-    String xmlWithoutIdCodes =
-        """
-        <?xml version="1.0" encoding="UTF-8"?>
-        <Document xmlns="urn:iso:std:iso:20022:tech:xsd:camt.052.001.02">
-          <BkToCstmrAcctRpt>
-            <GrpHdr>
-              <MsgId>test</MsgId>
-              <CreDtTm>2025-09-29T15:37:46</CreDtTm>
-            </GrpHdr>
-            <Rpt>
-              <Id>test</Id>
-              <CreDtTm>2025-09-29T15:37:46</CreDtTm>
-              <Acct>
-                <Id>
-                  <IBAN>EE442200221092874625</IBAN>
-                </Id>
-                <Ccy>EUR</Ccy>
-                <Ownr>
-                  <Nm>TULEVA FONDID AS</Nm>
-                  <!-- Missing Id element -->
-                </Ownr>
-              </Acct>
-            </Rpt>
-          </BkToCstmrAcctRpt>
-        </Document>
-        """
-            .stripIndent();
-
-    // when & then
-    assertThatThrownBy(
-            () -> {
-              JAXBElement<Document> response =
-                  marshaller.unMarshal(
-                      xmlWithoutIdCodes,
-                      JAXBElement.class,
-                      ee.swedbank.gateway.iso.response.report.ObjectFactory.class);
-              Document document = response.getValue();
-              Instant receivedAt = Instant.parse("2025-09-29T15:37:46Z");
-              var statement = BankStatement.from(document.getBkToCstmrAcctRpt());
-              extractor.extractPayments(statement, receivedAt);
-            })
-        .isInstanceOf(ee.tuleva.onboarding.swedbank.statement.BankStatementParseException.class)
-        .hasMessageContaining("Expected exactly one account holder ID code, but found: 0");
-  }
-
-  @Test
-  void extractPayments_shouldThrowExceptionWhenAccountHolderHasMultipleIdCodes() {
-    // given
-    String xmlWithMultipleIdCodes =
-        """
-        <?xml version="1.0" encoding="UTF-8"?>
-        <Document xmlns="urn:iso:std:iso:20022:tech:xsd:camt.052.001.02">
-          <BkToCstmrAcctRpt>
-            <GrpHdr>
-              <MsgId>test</MsgId>
-              <CreDtTm>2025-09-29T15:37:46</CreDtTm>
-            </GrpHdr>
-            <Rpt>
-              <Id>test</Id>
-              <CreDtTm>2025-09-29T15:37:46</CreDtTm>
-              <Acct>
-                <Id>
-                  <IBAN>EE442200221092874625</IBAN>
-                </Id>
-                <Ccy>EUR</Ccy>
-                <Ownr>
-                  <Nm>TULEVA FONDID AS</Nm>
-                  <Id>
-                    <OrgId>
-                      <Othr>
-                        <Id>14118923</Id>
-                      </Othr>
-                      <Othr>
-                        <Id>14118924</Id>
-                      </Othr>
-                    </OrgId>
-                  </Id>
-                </Ownr>
-              </Acct>
-            </Rpt>
-          </BkToCstmrAcctRpt>
-        </Document>
-        """
-            .stripIndent();
-
-    // when & then
-    assertThatThrownBy(
-            () -> {
-              JAXBElement<Document> response =
-                  marshaller.unMarshal(
-                      xmlWithMultipleIdCodes,
-                      JAXBElement.class,
-                      ee.swedbank.gateway.iso.response.report.ObjectFactory.class);
-              Document document = response.getValue();
-              Instant receivedAt = Instant.parse("2025-09-29T15:37:46Z");
-              var statement = BankStatement.from(document.getBkToCstmrAcctRpt());
-              extractor.extractPayments(statement, receivedAt);
-            })
-        .isInstanceOf(ee.tuleva.onboarding.swedbank.statement.BankStatementParseException.class)
-        .hasMessageContaining("Expected exactly one account holder ID code, but found: 2");
-  }
-
-  @Test
   void extractPayments_shouldThrowExceptionForUnsupportedCurrency() {
     // given
-    List<String> entries =
-        List.of(
-            """
-      <Ntry>
-        <NtryRef>test-ref</NtryRef>
-        <Amt Ccy="USD">100.00</Amt>
-        <CdtDbtInd>CRDT</CdtDbtInd>
-        <Sts>BOOK</Sts>
-        <BookgDt>
-          <Dt>2025-09-29</Dt>
-        </BookgDt>
-        <ValDt>
-          <Dt>2025-09-29</Dt>
-        </ValDt>
-        <NtryDtls>
-          <TxDtls>
-            <Refs>
-              <AcctSvcrRef>test-ref</AcctSvcrRef>
-              <EndToEndId>test-id</EndToEndId>
-            </Refs>
-            <AmtDtls>
-              <InstdAmt>
-                <Amt Ccy="USD">100.00</Amt>
-              </InstdAmt>
-              <TxAmt>
-                <Amt Ccy="USD">100.00</Amt>
-              </TxAmt>
-            </AmtDtls>
-            <RltdPties>
-              <Dbtr>
-                <Nm>Test Person</Nm>
-                <Id>
-                  <PrvtId>
-                    <Othr>
-                      <Id>12345678901</Id>
-                      <SchmeNm>
-                        <Cd>NIDN</Cd>
-                      </SchmeNm>
-                    </Othr>
-                  </PrvtId>
-                </Id>
-              </Dbtr>
-              <DbtrAcct>
-                <Id>
-                  <IBAN>EE123456789012345678</IBAN>
-                </Id>
-              </DbtrAcct>
-            </RltdPties>
-            <RmtInf>
-              <Ustrd>Test payment</Ustrd>
-            </RmtInf>
-          </TxDtls>
-        </NtryDtls>
-      </Ntry>
-      """
-                .stripIndent());
+    var account =
+        createBankStatementAccount("EE442200221092874625", "TULEVA FONDID AS", "14118923");
 
-    String swedbankXmlResponse = createCamtXml(entries);
-    JAXBElement<Document> response =
-        marshaller.unMarshal(
-            swedbankXmlResponse,
-            JAXBElement.class,
-            ee.swedbank.gateway.iso.response.report.ObjectFactory.class);
-    Document document = response.getValue();
+    var counterParty =
+        createCounterPartyDetails("Test Person", "EE123456789012345678", "12345678901");
+    var usdEntry =
+        new BankStatementEntry(
+            counterParty,
+            new BigDecimal("100.00"),
+            "USD",
+            TransactionType.CREDIT,
+            "Test payment",
+            "test-ref");
+
+    var statement = createBankStatement(account, List.of(usdEntry));
     Instant receivedAt = Instant.parse("2025-09-29T15:37:46Z");
 
     // when & then
-    assertThatThrownBy(
-            () -> {
-              var statement = BankStatement.from(document.getBkToCstmrAcctRpt());
-              extractor.extractPayments(statement, receivedAt);
-            })
+    assertThatThrownBy(() -> extractor.extractPayments(statement, receivedAt))
         .isInstanceOf(PaymentProcessingException.class)
         .hasMessage("Bank transfer currency not supported: USD");
   }
 
-  @Test
-  void extractPayments_shouldThrowExceptionForMultipleEndToEndIds() {
-    // given
-    List<String> entries =
-        List.of(
-            """
-        <Ntry>
-          <NtryRef>test-ref</NtryRef>
-          <Amt Ccy="EUR">100.00</Amt>
-          <CdtDbtInd>CRDT</CdtDbtInd>
-          <Sts>BOOK</Sts>
-          <BookgDt>
-            <Dt>2025-09-29</Dt>
-          </BookgDt>
-          <ValDt>
-            <Dt>2025-09-29</Dt>
-          </ValDt>
-          <NtryDtls>
-            <TxDtls>
-              <Refs>
-                <AcctSvcrRef>test-ref</AcctSvcrRef>
-                <EndToEndId>first-id</EndToEndId>
-              </Refs>
-              <AmtDtls>
-                <InstdAmt>
-                  <Amt Ccy="EUR">100.00</Amt>
-                </InstdAmt>
-                <TxAmt>
-                  <Amt Ccy="EUR">100.00</Amt>
-                </TxAmt>
-              </AmtDtls>
-              <RltdPties>
-                <Dbtr>
-                  <Nm>Test Person</Nm>
-                  <Id>
-                    <PrvtId>
-                      <Othr>
-                        <Id>12345678901</Id>
-                        <SchmeNm>
-                          <Cd>NIDN</Cd>
-                        </SchmeNm>
-                      </Othr>
-                    </PrvtId>
-                  </Id>
-                </Dbtr>
-                <DbtrAcct>
-                  <Id>
-                    <IBAN>EE123456789012345678</IBAN>
-                  </Id>
-                </DbtrAcct>
-              </RltdPties>
-              <RmtInf>
-                <Ustrd>Test payment</Ustrd>
-              </RmtInf>
-            </TxDtls>
-            <TxDtls>
-              <Refs>
-                <AcctSvcrRef>test-ref-2</AcctSvcrRef>
-                <EndToEndId>second-id</EndToEndId>
-              </Refs>
-              <AmtDtls>
-                <InstdAmt>
-                  <Amt Ccy="EUR">50.00</Amt>
-                </InstdAmt>
-                <TxAmt>
-                  <Amt Ccy="EUR">50.00</Amt>
-                </TxAmt>
-              </AmtDtls>
-              <RltdPties>
-                <Dbtr>
-                  <Nm>Another Person</Nm>
-                </Dbtr>
-                <DbtrAcct>
-                  <Id>
-                    <IBAN>EE987654321098765432</IBAN>
-                  </Id>
-                </DbtrAcct>
-              </RltdPties>
-              <RmtInf>
-                <Ustrd>Another payment</Ustrd>
-              </RmtInf>
-            </TxDtls>
-          </NtryDtls>
-        </Ntry>
-        """
-                .stripIndent());
+  // Helper methods for manual BankStatement construction
 
-    String swedbankXmlResponse = createCamtXml(entries);
-    JAXBElement<Document> response =
-        marshaller.unMarshal(
-            swedbankXmlResponse,
-            JAXBElement.class,
-            ee.swedbank.gateway.iso.response.report.ObjectFactory.class);
-    Document document = response.getValue();
-    Instant receivedAt = Instant.parse("2025-09-29T15:37:46Z");
-
-    // when & then
-    assertThatThrownBy(
-            () -> {
-              var statement = BankStatement.from(document.getBkToCstmrAcctRpt());
-              extractor.extractPayments(statement, receivedAt);
-            })
-        .isInstanceOf(ee.tuleva.onboarding.swedbank.statement.BankStatementParseException.class)
-        .hasMessageContaining("Expected at most one end-to-end ID, but found: 2");
+  private BankStatement createBankStatement(
+      BankStatementAccount account, List<BankStatementEntry> entries) {
+    return new BankStatement(
+        BankStatement.BankStatementType.INTRA_DAY_REPORT, account, List.of(), entries);
   }
 
-  private String createCamtXml(List<String> entries) {
-    StringBuilder entriesXml = new StringBuilder();
-    for (String entry : entries) {
-      entriesXml.append("      ").append(entry).append("\n");
-    }
+  private BankStatementAccount createBankStatementAccount(String iban, String name, String idCode) {
+    return new BankStatementAccount(iban, name, idCode);
+  }
 
-    return """
-      <?xml version="1.0" encoding="UTF-8"?>
-      <Document xmlns="urn:iso:std:iso:20022:tech:xsd:camt.052.001.02">
-        <BkToCstmrAcctRpt>
-          <GrpHdr>
-            <MsgId>2025092913110088760001</MsgId>
-            <CreDtTm>2025-09-29T15:37:46</CreDtTm>
-          </GrpHdr>
-          <Rpt>
-            <Id>1311008876-EUR-1</Id>
-            <CreDtTm>2025-09-29T15:37:46</CreDtTm>
-            <FrToDt>
-              <FrDtTm>2025-09-29T00:00:00</FrDtTm>
-              <ToDtTm>2025-09-29T15:37:46</ToDtTm>
-            </FrToDt>
-            <Acct>
-              <Id>
-                <IBAN>EE442200221092874625</IBAN>
-              </Id>
-              <Ccy>EUR</Ccy>
-              <Ownr>
-                <Nm>TULEVA FONDID AS</Nm>
-                <PstlAdr>
-                  <Ctry>EE</Ctry>
-                  <AdrLine>TELLISKIVI TN 60, HARJUMAA, TALLINN</AdrLine>
-                </PstlAdr>
-                <Id>
-                  <OrgId>
-                    <Othr>
-                      <Id>14118923</Id>
-                    </Othr>
-                  </OrgId>
-                </Id>
-              </Ownr>
-              <Svcr>
-                <FinInstnId>
-                  <BIC>HABAEE2X</BIC>
-                  <Nm>Swedbank AS</Nm>
-                  <PstlAdr>
-                    <Ctry>EE</Ctry>
-                    <AdrLine>LIIVALAIA 34, TALLINN, 15040</AdrLine>
-                  </PstlAdr>
-                  <Othr>
-                    <Id>10060701</Id>
-                    <SchmeNm>
-                      <Cd>COID</Cd>
-                    </SchmeNm>
-                  </Othr>
-                </FinInstnId>
-              </Svcr>
-            </Acct>
-            <Bal>
-              <Tp>
-                <CdOrPrtry>
-                  <Cd>OPBD</Cd>
-                </CdOrPrtry>
-              </Tp>
-              <CdtLine>
-                <Incl>false</Incl>
-              </CdtLine>
-              <Amt Ccy="EUR">0.00</Amt>
-              <CdtDbtInd>CRDT</CdtDbtInd>
-              <Dt>
-                <Dt>2025-09-29</Dt>
-              </Dt>
-            </Bal>
-            <Bal>
-              <Tp>
-                <CdOrPrtry>
-                  <Cd>ITBD</Cd>
-                </CdOrPrtry>
-              </Tp>
-              <Amt Ccy="EUR">0.00</Amt>
-              <CdtDbtInd>CRDT</CdtDbtInd>
-              <Dt>
-                <Dt>2025-09-29</Dt>
-              </Dt>
-            </Bal>
-            <Bal>
-              <Tp>
-                <CdOrPrtry>
-                  <Prtry>RESERVED</Prtry>
-                </CdOrPrtry>
-              </Tp>
-              <Amt Ccy="EUR">0.00</Amt>
-              <CdtDbtInd>CRDT</CdtDbtInd>
-              <Dt>
-                <Dt>2025-09-29</Dt>
-              </Dt>
-            </Bal>
-            <Bal>
-              <Tp>
-                <CdOrPrtry>
-                  <Cd>ITAV</Cd>
-                </CdOrPrtry>
-              </Tp>
-              <CdtLine>
-                <Incl>true</Incl>
-                <Amt Ccy="EUR">0.00</Amt>
-              </CdtLine>
-              <Amt Ccy="EUR">0.00</Amt>
-              <CdtDbtInd>CRDT</CdtDbtInd>
-              <Dt>
-                <Dt>2025-09-29</Dt>
-              </Dt>
-            </Bal>
-            <TxsSummry>
-              <TtlCdtNtries>
-                <NbOfNtries>1</NbOfNtries>
-                <Sum>0.10</Sum>
-              </TtlCdtNtries>
-              <TtlDbtNtries>
-                <NbOfNtries>1</NbOfNtries>
-                <Sum>0.10</Sum>
-              </TtlDbtNtries>
-            </TxsSummry>
-      """
-        + entriesXml
-        + """
-          </Rpt>
-        </BkToCstmrAcctRpt>
-      </Document>
-     """
-            .stripIndent();
+  private BankStatementEntry createCreditEntry(
+      BigDecimal amount,
+      String counterPartyIban,
+      String counterPartyName,
+      String counterPartyIdCode,
+      String description,
+      String externalId) {
+    var counterParty =
+        createCounterPartyDetails(counterPartyName, counterPartyIban, counterPartyIdCode);
+    return new BankStatementEntry(
+        counterParty, amount, "EUR", TransactionType.CREDIT, description, externalId);
+  }
+
+  private BankStatementEntry createDebitEntry(
+      BigDecimal amount,
+      String counterPartyIban,
+      String counterPartyName,
+      String counterPartyIdCode,
+      String description,
+      String externalId) {
+    var counterParty =
+        createCounterPartyDetails(counterPartyName, counterPartyIban, counterPartyIdCode);
+    return new BankStatementEntry(
+        counterParty, amount, "EUR", TransactionType.DEBIT, description, externalId);
+  }
+
+  private BankStatementEntry.CounterPartyDetails createCounterPartyDetails(
+      String name, String iban, String personalCode) {
+    return new BankStatementEntry.CounterPartyDetails(name, iban, personalCode);
   }
 }

--- a/src/test/java/ee/tuleva/onboarding/swedbank/statement/SwedbankBankStatementExtractorHistoricStatementTest.java
+++ b/src/test/java/ee/tuleva/onboarding/swedbank/statement/SwedbankBankStatementExtractorHistoricStatementTest.java
@@ -6,6 +6,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import ee.tuleva.onboarding.swedbank.http.SwedbankGatewayMarshaller;
 import ee.tuleva.onboarding.swedbank.statement.BankStatement.BankStatementType;
 import java.math.BigDecimal;
+import java.util.List;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -58,6 +60,358 @@ class SwedbankBankStatementExtractorHistoricStatementTest {
     assertThatThrownBy(() -> extractor.extractFromHistoricStatement(emptyStatementXml))
         .isInstanceOf(BankStatementParseException.class)
         .hasMessageContaining("Expected exactly one statement");
+  }
+
+  @org.junit.jupiter.api.Nested
+  class BankAccountIssues {
+
+    @Test
+    void extractFromHistoricStatement_shouldThrowExceptionWhenAccountHolderNameIsNull() {
+      String xmlWithoutAccountHolderName =
+          """
+          <?xml version="1.0" encoding="UTF-8"?>
+          <Document xmlns="urn:iso:std:iso:20022:tech:xsd:camt.053.001.02">
+            <BkToCstmrStmt>
+              <GrpHdr>
+                <MsgId>test</MsgId>
+                <CreDtTm>2025-09-29T15:37:46</CreDtTm>
+              </GrpHdr>
+              <Stmt>
+                <Id>test</Id>
+                <CreDtTm>2025-09-29T15:37:46</CreDtTm>
+                <Acct>
+                  <Id>
+                    <IBAN>EE062200221055091966</IBAN>
+                  </Id>
+                  <Ccy>EUR</Ccy>
+                  <Ownr>
+                    <!-- Missing Nm element -->
+                    <Id>
+                      <OrgId>
+                        <Othr>
+                          <Id>10006901</Id>
+                        </Othr>
+                      </OrgId>
+                    </Id>
+                  </Ownr>
+                </Acct>
+              </Stmt>
+            </BkToCstmrStmt>
+          </Document>
+          """;
+
+      assertThatThrownBy(() -> extractor.extractFromHistoricStatement(xmlWithoutAccountHolderName))
+          .isInstanceOf(BankStatementParseException.class)
+          .hasMessageContaining("account holder name is required");
+    }
+
+    @Test
+    void extractFromHistoricStatement_shouldThrowExceptionWhenAccountHolderHasNoIdCodes() {
+      String xmlWithoutIdCodes =
+          """
+          <?xml version="1.0" encoding="UTF-8"?>
+          <Document xmlns="urn:iso:std:iso:20022:tech:xsd:camt.053.001.02">
+            <BkToCstmrStmt>
+              <GrpHdr>
+                <MsgId>test</MsgId>
+                <CreDtTm>2025-09-29T15:37:46</CreDtTm>
+              </GrpHdr>
+              <Stmt>
+                <Id>test</Id>
+                <CreDtTm>2025-09-29T15:37:46</CreDtTm>
+                <Acct>
+                  <Id>
+                    <IBAN>EE062200221055091966</IBAN>
+                  </Id>
+                  <Ccy>EUR</Ccy>
+                  <Ownr>
+                    <Nm>Pööripäeva Päikesekell OÜ</Nm>
+                    <!-- Missing Id element -->
+                  </Ownr>
+                </Acct>
+              </Stmt>
+            </BkToCstmrStmt>
+          </Document>
+          """;
+
+      assertThatThrownBy(() -> extractor.extractFromHistoricStatement(xmlWithoutIdCodes))
+          .isInstanceOf(BankStatementParseException.class)
+          .hasMessageContaining("Expected exactly one account holder ID code, but found: 0");
+    }
+
+    @Test
+    void extractFromHistoricStatement_shouldThrowExceptionWhenAccountHolderHasMultipleIdCodes() {
+      String xmlWithMultipleIdCodes =
+          """
+          <?xml version="1.0" encoding="UTF-8"?>
+          <Document xmlns="urn:iso:std:iso:20022:tech:xsd:camt.053.001.02">
+            <BkToCstmrStmt>
+              <GrpHdr>
+                <MsgId>test</MsgId>
+                <CreDtTm>2025-09-29T15:37:46</CreDtTm>
+              </GrpHdr>
+              <Stmt>
+                <Id>test</Id>
+                <CreDtTm>2025-09-29T15:37:46</CreDtTm>
+                <Acct>
+                  <Id>
+                    <IBAN>EE062200221055091966</IBAN>
+                  </Id>
+                  <Ccy>EUR</Ccy>
+                  <Ownr>
+                    <Nm>Pööripäeva Päikesekell OÜ</Nm>
+                    <Id>
+                      <OrgId>
+                        <Othr>
+                          <Id>10006901</Id>
+                        </Othr>
+                        <Othr>
+                          <Id>10006902</Id>
+                        </Othr>
+                      </OrgId>
+                    </Id>
+                  </Ownr>
+                </Acct>
+              </Stmt>
+            </BkToCstmrStmt>
+          </Document>
+          """;
+
+      assertThatThrownBy(() -> extractor.extractFromHistoricStatement(xmlWithMultipleIdCodes))
+          .isInstanceOf(BankStatementParseException.class)
+          .hasMessageContaining("Expected exactly one account holder ID code, but found: 2");
+    }
+  }
+
+  @org.junit.jupiter.api.Nested
+  class EntriesIssues {
+
+    @Test
+    void extractFromHistoricStatement_shouldThrowExceptionForMissingRemittanceInformation() {
+      var entries =
+          List.of(
+              """
+          <Ntry>
+            <NtryRef>test-ref</NtryRef>
+            <Amt Ccy="EUR">100.00</Amt>
+            <CdtDbtInd>CRDT</CdtDbtInd>
+            <Sts>BOOK</Sts>
+            <BookgDt>
+              <Dt>2025-06-05</Dt>
+            </BookgDt>
+            <ValDt>
+              <Dt>2025-06-05</Dt>
+            </ValDt>
+            <NtryDtls>
+              <TxDtls>
+                <Refs>
+                  <AcctSvcrRef>test-ref</AcctSvcrRef>
+                  <InstrId>test-id</InstrId>
+                </Refs>
+                <AmtDtls>
+                  <InstdAmt>
+                    <Amt Ccy="EUR">100.00</Amt>
+                  </InstdAmt>
+                  <TxAmt>
+                    <Amt Ccy="EUR">100.00</Amt>
+                  </TxAmt>
+                </AmtDtls>
+                <RltdPties>
+                  <Dbtr>
+                    <Nm>Test Person</Nm>
+                    <Id>
+                      <PrvtId>
+                        <Othr>
+                          <Id>12345678901</Id>
+                          <SchmeNm>
+                            <Cd>NIDN</Cd>
+                          </SchmeNm>
+                        </Othr>
+                      </PrvtId>
+                    </Id>
+                  </Dbtr>
+                  <DbtrAcct>
+                    <Id>
+                      <IBAN>EE123456789012345678</IBAN>
+                    </Id>
+                  </DbtrAcct>
+                </RltdPties>
+                <!-- Missing RmtInf element -->
+              </TxDtls>
+            </NtryDtls>
+          </Ntry>
+          """
+                  .stripIndent());
+
+      String xmlWithMissingRemittance = createCamt053Xml(entries);
+
+      assertThatThrownBy(() -> extractor.extractFromHistoricStatement(xmlWithMissingRemittance))
+          .isInstanceOf(BankStatementParseException.class)
+          .hasMessageContaining("Expected exactly one remittance information, but found: 0");
+    }
+
+    @Test
+    void extractFromHistoricStatement_shouldThrowExceptionForMissingPersonalCode() {
+      var entries =
+          List.of(
+              """
+          <Ntry>
+            <NtryRef>test-ref</NtryRef>
+            <Amt Ccy="EUR">100.00</Amt>
+            <CdtDbtInd>CRDT</CdtDbtInd>
+            <Sts>BOOK</Sts>
+            <BookgDt>
+              <Dt>2025-06-05</Dt>
+            </BookgDt>
+            <ValDt>
+              <Dt>2025-06-05</Dt>
+            </ValDt>
+            <NtryDtls>
+              <TxDtls>
+                <Refs>
+                  <AcctSvcrRef>test-ref</AcctSvcrRef>
+                  <InstrId>test-id</InstrId>
+                </Refs>
+                <AmtDtls>
+                  <InstdAmt>
+                    <Amt Ccy="EUR">100.00</Amt>
+                  </InstdAmt>
+                  <TxAmt>
+                    <Amt Ccy="EUR">100.00</Amt>
+                  </TxAmt>
+                </AmtDtls>
+                <RltdPties>
+                  <Dbtr>
+                    <Nm>Test Person</Nm>
+                    <!-- Missing Id element -->
+                  </Dbtr>
+                  <DbtrAcct>
+                    <Id>
+                      <IBAN>EE123456789012345678</IBAN>
+                    </Id>
+                  </DbtrAcct>
+                </RltdPties>
+                <RmtInf>
+                  <Ustrd>Test payment</Ustrd>
+                </RmtInf>
+              </TxDtls>
+            </NtryDtls>
+          </Ntry>
+          """
+                  .stripIndent());
+
+      String xmlWithMissingPersonalCode = createCamt053Xml(entries);
+
+      assertThatThrownBy(() -> extractor.extractFromHistoricStatement(xmlWithMissingPersonalCode))
+          .isInstanceOf(BankStatementParseException.class)
+          .hasMessageContaining("Personal code is required");
+    }
+
+    @Test
+    void extractFromHistoricStatement_shouldHandleEmptyEntries() {
+      var entries = List.<String>of();
+      String xmlWithEmptyEntries = createCamt053Xml(entries);
+
+      var statement = extractor.extractFromHistoricStatement(xmlWithEmptyEntries);
+
+      assertThat(statement).isNotNull();
+      assertThat(statement.getEntries()).isEmpty();
+    }
+  }
+
+  private String createCamt053Xml(List<String> entries) {
+    StringBuilder entriesXml = new StringBuilder();
+    for (String entry : entries) {
+      entriesXml.append("      ").append(entry).append("\n");
+    }
+
+    return """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <Document xmlns="urn:iso:std:iso:20022:tech:xsd:camt.053.001.02">
+          <BkToCstmrStmt>
+            <GrpHdr>
+              <MsgId>202506051114025350001</MsgId>
+              <CreDtTm>2025-06-05T09:04:24</CreDtTm>
+            </GrpHdr>
+            <Stmt>
+              <Id>111402535-EUR-1</Id>
+              <ElctrncSeqNb>111402535</ElctrncSeqNb>
+              <CreDtTm>2025-06-05T09:04:24</CreDtTm>
+              <FrToDt>
+                <FrDtTm>2025-06-05T00:00:00</FrDtTm>
+                <ToDtTm>2025-06-05T23:59:59</ToDtTm>
+              </FrToDt>
+              <Acct>
+                <Id>
+                  <IBAN>EE062200221055091966</IBAN>
+                </Id>
+                <Ccy>EUR</Ccy>
+                <Ownr>
+                  <Nm>Pööripäeva Päikesekell OÜ</Nm>
+                  <PstlAdr>
+                    <Ctry>EE</Ctry>
+                    <AdrLine>Universumimaagia tee 15, Astrofantaasia, 56789</AdrLine>
+                  </PstlAdr>
+                  <Id>
+                    <OrgId>
+                      <Othr>
+                        <Id>10006901</Id>
+                      </Othr>
+                    </OrgId>
+                  </Id>
+                </Ownr>
+                <Svcr>
+                  <FinInstnId>
+                    <BIC>HABAEE2X</BIC>
+                    <Nm>SWEDBANK AS</Nm>
+                  </FinInstnId>
+                </Svcr>
+              </Acct>
+              <Bal>
+                <Tp>
+                  <CdOrPrtry>
+                    <Cd>OPBD</Cd>
+                  </CdOrPrtry>
+                </Tp>
+                <CdtLine>
+                  <Incl>false</Incl>
+                </CdtLine>
+                <Amt Ccy="EUR">3332.17</Amt>
+                <CdtDbtInd>CRDT</CdtDbtInd>
+                <Dt>
+                  <Dt>2025-06-05</Dt>
+                </Dt>
+              </Bal>
+              <Bal>
+                <Tp>
+                  <CdOrPrtry>
+                    <Cd>CLBD</Cd>
+                  </CdOrPrtry>
+                </Tp>
+                <Amt Ccy="EUR">766.10</Amt>
+                <CdtDbtInd>CRDT</CdtDbtInd>
+                <Dt>
+                  <Dt>2025-06-05</Dt>
+                </Dt>
+              </Bal>
+              <TxsSummry>
+                <TtlCdtNtries>
+                  <NbOfNtries>4</NbOfNtries>
+                  <Sum>2566.07</Sum>
+                </TtlCdtNtries>
+                <TtlDbtNtries>
+                  <NbOfNtries>0</NbOfNtries>
+                  <Sum>0</Sum>
+                </TtlDbtNtries>
+              </TxsSummry>
+        """
+        + entriesXml
+        + """
+            </Stmt>
+          </BkToCstmrStmt>
+        </Document>
+        """
+            .stripIndent();
   }
 
   private String createCamt053Xml() {

--- a/src/test/java/ee/tuleva/onboarding/swedbank/statement/SwedbankBankStatementExtractorHistoricStatementTest.java
+++ b/src/test/java/ee/tuleva/onboarding/swedbank/statement/SwedbankBankStatementExtractorHistoricStatementTest.java
@@ -494,6 +494,129 @@ class SwedbankBankStatementExtractorHistoricStatementTest {
     }
 
     @Test
+    void extractFromHistoricStatement_shouldThrowExceptionForMultipleEntryDetails() {
+      var entries =
+          List.of(
+              """
+          <Ntry>
+            <NtryRef>test-ref</NtryRef>
+            <Amt Ccy="EUR">100.00</Amt>
+            <CdtDbtInd>CRDT</CdtDbtInd>
+            <Sts>BOOK</Sts>
+            <BookgDt>
+              <Dt>2025-06-05</Dt>
+            </BookgDt>
+            <ValDt>
+              <Dt>2025-06-05</Dt>
+            </ValDt>
+            <NtryDtls>
+              <TxDtls>
+                <Refs>
+                  <AcctSvcrRef>test-ref</AcctSvcrRef>
+                </Refs>
+                <RmtInf>
+                  <Ustrd>Test payment</Ustrd>
+                </RmtInf>
+              </TxDtls>
+            </NtryDtls>
+            <NtryDtls>
+              <TxDtls>
+                <Refs>
+                  <AcctSvcrRef>test-ref-2</AcctSvcrRef>
+                </Refs>
+                <RmtInf>
+                  <Ustrd>Another payment</Ustrd>
+                </RmtInf>
+              </TxDtls>
+            </NtryDtls>
+          </Ntry>
+          """
+                  .stripIndent());
+
+      String xmlWithMultipleEntryDetails = createCamt053Xml(entries);
+
+      assertThatThrownBy(() -> extractor.extractFromHistoricStatement(xmlWithMultipleEntryDetails))
+          .isInstanceOf(BankStatementParseException.class)
+          .hasMessageContaining("Expected exactly one entry details, but found: 2");
+    }
+
+    @Test
+    void extractFromHistoricStatement_shouldThrowExceptionForMultipleTransactionDetails() {
+      var entries =
+          List.of(
+              """
+          <Ntry>
+            <NtryRef>test-ref</NtryRef>
+            <Amt Ccy="EUR">100.00</Amt>
+            <CdtDbtInd>CRDT</CdtDbtInd>
+            <Sts>BOOK</Sts>
+            <BookgDt>
+              <Dt>2025-06-05</Dt>
+            </BookgDt>
+            <ValDt>
+              <Dt>2025-06-05</Dt>
+            </ValDt>
+            <NtryDtls>
+              <TxDtls>
+                <Refs>
+                  <AcctSvcrRef>test-ref-1</AcctSvcrRef>
+                </Refs>
+                <AmtDtls>
+                  <InstdAmt>
+                    <Amt Ccy="EUR">50.00</Amt>
+                  </InstdAmt>
+                </AmtDtls>
+                <RltdPties>
+                  <Dbtr>
+                    <Nm>First Person</Nm>
+                  </Dbtr>
+                  <DbtrAcct>
+                    <Id>
+                      <IBAN>EE123456789012345678</IBAN>
+                    </Id>
+                  </DbtrAcct>
+                </RltdPties>
+                <RmtInf>
+                  <Ustrd>First payment</Ustrd>
+                </RmtInf>
+              </TxDtls>
+              <TxDtls>
+                <Refs>
+                  <AcctSvcrRef>test-ref-2</AcctSvcrRef>
+                </Refs>
+                <AmtDtls>
+                  <InstdAmt>
+                    <Amt Ccy="EUR">50.00</Amt>
+                  </InstdAmt>
+                </AmtDtls>
+                <RltdPties>
+                  <Dbtr>
+                    <Nm>Second Person</Nm>
+                  </Dbtr>
+                  <DbtrAcct>
+                    <Id>
+                      <IBAN>EE987654321098765432</IBAN>
+                    </Id>
+                  </DbtrAcct>
+                </RltdPties>
+                <RmtInf>
+                  <Ustrd>Second payment</Ustrd>
+                </RmtInf>
+              </TxDtls>
+            </NtryDtls>
+          </Ntry>
+          """
+                  .stripIndent());
+
+      String xmlWithMultipleTransactionDetails = createCamt053Xml(entries);
+
+      assertThatThrownBy(
+              () -> extractor.extractFromHistoricStatement(xmlWithMultipleTransactionDetails))
+          .isInstanceOf(BankStatementParseException.class)
+          .hasMessageContaining("Expected exactly one transaction details, but found: 2");
+    }
+
+    @Test
     void extractFromHistoricStatement_shouldHandleEmptyEntries() {
       var entries = List.<String>of();
       String xmlWithEmptyEntries = createCamt053Xml(entries);

--- a/src/test/java/ee/tuleva/onboarding/swedbank/statement/SwedbankBankStatementExtractorHistoricStatementTest.java
+++ b/src/test/java/ee/tuleva/onboarding/swedbank/statement/SwedbankBankStatementExtractorHistoricStatementTest.java
@@ -9,7 +9,7 @@ import java.math.BigDecimal;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class SwedbankBankStatementExtractorTest {
+class SwedbankBankStatementExtractorHistoricStatementTest {
 
   private SwedbankBankStatementExtractor extractor;
 
@@ -17,32 +17,6 @@ class SwedbankBankStatementExtractorTest {
   void setUp() {
     SwedbankGatewayMarshaller marshaller = new SwedbankGatewayMarshaller();
     extractor = new SwedbankBankStatementExtractor(marshaller);
-  }
-
-  @Test
-  void extractFromIntraDayReport_shouldExtractBankStatement() {
-    // given
-    String rawXml = createCamt052Xml();
-
-    // when
-    var statement = extractor.extractFromIntraDayReport(rawXml);
-
-    // then
-    assertThat(statement).isNotNull();
-    assertThat(statement.getType()).isEqualTo(BankStatementType.INTRA_DAY_REPORT);
-    assertThat(statement.getBankStatementAccount().iban()).isEqualTo("EE442200221092874625");
-    assertThat(statement.getBankStatementAccount().accountHolderName())
-        .isEqualTo("TULEVA FONDID AS");
-    assertThat(statement.getBankStatementAccount().accountHolderIdCode()).isEqualTo("14118923");
-    assertThat(statement.getBalances()).hasSize(4);
-    assertThat(statement.getEntries()).hasSize(1);
-
-    // Verify the entry
-    var entry = statement.getEntries().getFirst();
-    assertThat(entry.getAmount()).isEqualByComparingTo(new BigDecimal("0.10"));
-    assertThat(entry.getDetails().getName()).isEqualTo("Jüri Tamm");
-    assertThat(entry.getDetails().getIban()).isEqualTo("EE157700771001802057");
-    assertThat(entry.getDetails().getPersonalCode()).hasValue("39910273027");
   }
 
   @Test
@@ -67,47 +41,6 @@ class SwedbankBankStatementExtractorTest {
   }
 
   @Test
-  void extractFromIntraDayReport_shouldThrowExceptionForNullXml() {
-    assertThatThrownBy(() -> extractor.extractFromIntraDayReport(null))
-        .isInstanceOf(BankStatementParseException.class)
-        .hasMessage("Raw XML is null or empty");
-  }
-
-  @Test
-  void extractFromIntraDayReport_shouldThrowExceptionForEmptyXml() {
-    assertThatThrownBy(() -> extractor.extractFromIntraDayReport(""))
-        .isInstanceOf(BankStatementParseException.class)
-        .hasMessage("Raw XML is null or empty");
-  }
-
-  @Test
-  void extractFromIntraDayReport_shouldThrowExceptionForBlankXml() {
-    assertThatThrownBy(() -> extractor.extractFromIntraDayReport("   "))
-        .isInstanceOf(BankStatementParseException.class)
-        .hasMessage("Raw XML is null or empty");
-  }
-
-  @Test
-  void extractFromIntraDayReport_shouldThrowExceptionForEmptyReport() {
-    String emptyReportXml =
-        """
-        <?xml version="1.0" encoding="UTF-8"?>
-        <Document xmlns="urn:iso:std:iso:20022:tech:xsd:camt.052.001.02">
-          <BkToCstmrAcctRpt>
-            <GrpHdr>
-              <MsgId>test</MsgId>
-              <CreDtTm>2025-09-29T15:37:46</CreDtTm>
-            </GrpHdr>
-          </BkToCstmrAcctRpt>
-        </Document>
-        """;
-
-    assertThatThrownBy(() -> extractor.extractFromIntraDayReport(emptyReportXml))
-        .isInstanceOf(BankStatementParseException.class)
-        .hasMessageContaining("Expected exactly one report");
-  }
-
-  @Test
   void extractFromHistoricStatement_shouldThrowExceptionForEmptyStatement() {
     String emptyStatementXml =
         """
@@ -125,192 +58,6 @@ class SwedbankBankStatementExtractorTest {
     assertThatThrownBy(() -> extractor.extractFromHistoricStatement(emptyStatementXml))
         .isInstanceOf(BankStatementParseException.class)
         .hasMessageContaining("Expected exactly one statement");
-  }
-
-  private String createCamt052Xml() {
-    return """
-        <?xml version="1.0" encoding="UTF-8"?>
-        <Document xmlns="urn:iso:std:iso:20022:tech:xsd:camt.052.001.02">
-          <BkToCstmrAcctRpt>
-            <GrpHdr>
-              <MsgId>2025092913110088760001</MsgId>
-              <CreDtTm>2025-09-29T15:37:46</CreDtTm>
-            </GrpHdr>
-            <Rpt>
-              <Id>1311008876-EUR-1</Id>
-              <CreDtTm>2025-09-29T15:37:46</CreDtTm>
-              <FrToDt>
-                <FrDtTm>2025-09-29T00:00:00</FrDtTm>
-                <ToDtTm>2025-09-29T15:37:46</ToDtTm>
-              </FrToDt>
-              <Acct>
-                <Id>
-                  <IBAN>EE442200221092874625</IBAN>
-                </Id>
-                <Ccy>EUR</Ccy>
-                <Ownr>
-                  <Nm>TULEVA FONDID AS</Nm>
-                  <PstlAdr>
-                    <Ctry>EE</Ctry>
-                    <AdrLine>TELLISKIVI TN 60, HARJUMAA, TALLINN</AdrLine>
-                  </PstlAdr>
-                  <Id>
-                    <OrgId>
-                      <Othr>
-                        <Id>14118923</Id>
-                      </Othr>
-                    </OrgId>
-                  </Id>
-                </Ownr>
-                <Svcr>
-                  <FinInstnId>
-                    <BIC>HABAEE2X</BIC>
-                    <Nm>Swedbank AS</Nm>
-                  </FinInstnId>
-                </Svcr>
-              </Acct>
-              <Bal>
-                <Tp>
-                  <CdOrPrtry>
-                    <Cd>OPBD</Cd>
-                  </CdOrPrtry>
-                </Tp>
-                <CdtLine>
-                  <Incl>false</Incl>
-                </CdtLine>
-                <Amt Ccy="EUR">0.00</Amt>
-                <CdtDbtInd>CRDT</CdtDbtInd>
-                <Dt>
-                  <Dt>2025-09-29</Dt>
-                </Dt>
-              </Bal>
-              <Bal>
-                <Tp>
-                  <CdOrPrtry>
-                    <Cd>ITBD</Cd>
-                  </CdOrPrtry>
-                </Tp>
-                <Amt Ccy="EUR">0.00</Amt>
-                <CdtDbtInd>CRDT</CdtDbtInd>
-                <Dt>
-                  <Dt>2025-09-29</Dt>
-                </Dt>
-              </Bal>
-              <Bal>
-                <Tp>
-                  <CdOrPrtry>
-                    <Prtry>RESERVED</Prtry>
-                  </CdOrPrtry>
-                </Tp>
-                <Amt Ccy="EUR">0.00</Amt>
-                <CdtDbtInd>CRDT</CdtDbtInd>
-                <Dt>
-                  <Dt>2025-09-29</Dt>
-                </Dt>
-              </Bal>
-              <Bal>
-                <Tp>
-                  <CdOrPrtry>
-                    <Cd>ITAV</Cd>
-                  </CdOrPrtry>
-                </Tp>
-                <CdtLine>
-                  <Incl>true</Incl>
-                  <Amt Ccy="EUR">0.00</Amt>
-                </CdtLine>
-                <Amt Ccy="EUR">0.00</Amt>
-                <CdtDbtInd>CRDT</CdtDbtInd>
-                <Dt>
-                  <Dt>2025-09-29</Dt>
-                </Dt>
-              </Bal>
-              <TxsSummry>
-                <TtlCdtNtries>
-                  <NbOfNtries>1</NbOfNtries>
-                  <Sum>0.10</Sum>
-                </TtlCdtNtries>
-                <TtlDbtNtries>
-                  <NbOfNtries>0</NbOfNtries>
-                  <Sum>0</Sum>
-                </TtlDbtNtries>
-              </TxsSummry>
-              <Ntry>
-                <NtryRef>2025092900654847-1</NtryRef>
-                <Amt Ccy="EUR">0.10</Amt>
-                <CdtDbtInd>CRDT</CdtDbtInd>
-                <Sts>BOOK</Sts>
-                <BookgDt>
-                  <Dt>2025-09-29</Dt>
-                </BookgDt>
-                <ValDt>
-                  <Dt>2025-09-29</Dt>
-                </ValDt>
-                <AcctSvcrRef>2025092900654847-1</AcctSvcrRef>
-                <BkTxCd>
-                  <Domn>
-                    <Cd>PMNT</Cd>
-                    <Fmly>
-                      <Cd>RCDT</Cd>
-                      <SubFmlyCd>ESCT</SubFmlyCd>
-                    </Fmly>
-                  </Domn>
-                  <Prtry>
-                    <Cd>MK</Cd>
-                    <Issr>Swedbank AS</Issr>
-                  </Prtry>
-                </BkTxCd>
-                <NtryDtls>
-                  <TxDtls>
-                    <Refs>
-                      <AcctSvcrRef>2025092900654847-1</AcctSvcrRef>
-                      <EndToEndId>1277</EndToEndId>
-                    </Refs>
-                    <AmtDtls>
-                      <InstdAmt>
-                        <Amt Ccy="EUR">0.10</Amt>
-                      </InstdAmt>
-                      <TxAmt>
-                        <Amt Ccy="EUR">0.10</Amt>
-                      </TxAmt>
-                    </AmtDtls>
-                    <RltdPties>
-                      <Dbtr>
-                        <Nm>Jüri Tamm</Nm>
-                        <Id>
-                          <PrvtId>
-                            <Othr>
-                              <Id>39910273027</Id>
-                              <SchmeNm>
-                                <Cd>NIDN</Cd>
-                              </SchmeNm>
-                            </Othr>
-                          </PrvtId>
-                        </Id>
-                      </Dbtr>
-                      <DbtrAcct>
-                        <Id>
-                          <IBAN>EE157700771001802057</IBAN>
-                        </Id>
-                      </DbtrAcct>
-                    </RltdPties>
-                    <RltdAgts>
-                      <DbtrAgt>
-                        <FinInstnId>
-                          <BIC>LHVBEE22</BIC>
-                        </FinInstnId>
-                      </DbtrAgt>
-                    </RltdAgts>
-                    <RmtInf>
-                      <Ustrd>39910273027</Ustrd>
-                    </RmtInf>
-                  </TxDtls>
-                </NtryDtls>
-              </Ntry>
-            </Rpt>
-          </BkToCstmrAcctRpt>
-        </Document>
-        """
-        .stripIndent();
   }
 
   private String createCamt053Xml() {

--- a/src/test/java/ee/tuleva/onboarding/swedbank/statement/SwedbankBankStatementExtractorHistoricStatementTest.java
+++ b/src/test/java/ee/tuleva/onboarding/swedbank/statement/SwedbankBankStatementExtractorHistoricStatementTest.java
@@ -37,8 +37,8 @@ class SwedbankBankStatementExtractorHistoricStatementTest {
 
     // Verify first entry
     var firstEntry = statement.getEntries().getFirst();
-    assertThat(firstEntry.getAmount()).isEqualByComparingTo(new BigDecimal("772.88"));
-    assertThat(firstEntry.getDetails().getName()).isEqualTo("Toomas Raudsepp");
+    assertThat(firstEntry.amount()).isEqualByComparingTo(new BigDecimal("772.88"));
+    assertThat(firstEntry.details().getName()).isEqualTo("Toomas Raudsepp");
   }
 
   @Test
@@ -348,7 +348,7 @@ class SwedbankBankStatementExtractorHistoricStatementTest {
 
       assertThat(statement).isNotNull();
       assertThat(statement.getEntries()).hasSize(1);
-      assertThat(statement.getEntries().getFirst().getDetails().getPersonalCode()).isEmpty();
+      assertThat(statement.getEntries().getFirst().details().getPersonalCode()).isEmpty();
     }
 
     @Test

--- a/src/test/java/ee/tuleva/onboarding/swedbank/statement/SwedbankBankStatementExtractorIntraDayTest.java
+++ b/src/test/java/ee/tuleva/onboarding/swedbank/statement/SwedbankBankStatementExtractorIntraDayTest.java
@@ -39,10 +39,10 @@ class SwedbankBankStatementExtractorIntraDayTest {
 
     // Verify the entry
     var entry = statement.getEntries().getFirst();
-    assertThat(entry.getAmount()).isEqualByComparingTo(new BigDecimal("0.10"));
-    assertThat(entry.getDetails().getName()).isEqualTo("Jüri Tamm");
-    assertThat(entry.getDetails().getIban()).isEqualTo("EE157700771001802057");
-    assertThat(entry.getDetails().getPersonalCode()).hasValue("39910273027");
+    assertThat(entry.amount()).isEqualByComparingTo(new BigDecimal("0.10"));
+    assertThat(entry.details().getName()).isEqualTo("Jüri Tamm");
+    assertThat(entry.details().getIban()).isEqualTo("EE157700771001802057");
+    assertThat(entry.details().getPersonalCode()).hasValue("39910273027");
   }
 
   @Test

--- a/src/test/java/ee/tuleva/onboarding/swedbank/statement/SwedbankBankStatementExtractorIntraDayTest.java
+++ b/src/test/java/ee/tuleva/onboarding/swedbank/statement/SwedbankBankStatementExtractorIntraDayTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import ee.tuleva.onboarding.swedbank.http.SwedbankGatewayMarshaller;
 import ee.tuleva.onboarding.swedbank.statement.BankStatement.BankStatementType;
 import java.math.BigDecimal;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -84,6 +85,694 @@ class SwedbankBankStatementExtractorIntraDayTest {
     assertThatThrownBy(() -> extractor.extractFromIntraDayReport(emptyReportXml))
         .isInstanceOf(BankStatementParseException.class)
         .hasMessageContaining("Expected exactly one report");
+  }
+
+  @org.junit.jupiter.api.Nested
+  class BankAccountIssues {
+
+    @Test
+    void extractFromIntraDayReport_shouldThrowExceptionWhenAccountHolderNameIsNull() {
+      String xmlWithoutAccountHolderName =
+          """
+          <?xml version="1.0" encoding="UTF-8"?>
+          <Document xmlns="urn:iso:std:iso:20022:tech:xsd:camt.052.001.02">
+            <BkToCstmrAcctRpt>
+              <GrpHdr>
+                <MsgId>test</MsgId>
+                <CreDtTm>2025-09-29T15:37:46</CreDtTm>
+              </GrpHdr>
+              <Rpt>
+                <Id>test</Id>
+                <CreDtTm>2025-09-29T15:37:46</CreDtTm>
+                <Acct>
+                  <Id>
+                    <IBAN>EE442200221092874625</IBAN>
+                  </Id>
+                  <Ccy>EUR</Ccy>
+                  <Ownr>
+                    <!-- Missing Nm element -->
+                    <Id>
+                      <OrgId>
+                        <Othr>
+                          <Id>14118923</Id>
+                        </Othr>
+                      </OrgId>
+                    </Id>
+                  </Ownr>
+                </Acct>
+              </Rpt>
+            </BkToCstmrAcctRpt>
+          </Document>
+          """;
+
+      assertThatThrownBy(() -> extractor.extractFromIntraDayReport(xmlWithoutAccountHolderName))
+          .isInstanceOf(BankStatementParseException.class)
+          .hasMessageContaining("account holder name is required");
+    }
+
+    @Test
+    void extractFromIntraDayReport_shouldThrowExceptionWhenAccountHolderHasNoIdCodes() {
+      String xmlWithoutIdCodes =
+          """
+          <?xml version="1.0" encoding="UTF-8"?>
+          <Document xmlns="urn:iso:std:iso:20022:tech:xsd:camt.052.001.02">
+            <BkToCstmrAcctRpt>
+              <GrpHdr>
+                <MsgId>test</MsgId>
+                <CreDtTm>2025-09-29T15:37:46</CreDtTm>
+              </GrpHdr>
+              <Rpt>
+                <Id>test</Id>
+                <CreDtTm>2025-09-29T15:37:46</CreDtTm>
+                <Acct>
+                  <Id>
+                    <IBAN>EE442200221092874625</IBAN>
+                  </Id>
+                  <Ccy>EUR</Ccy>
+                  <Ownr>
+                    <Nm>TULEVA FONDID AS</Nm>
+                    <!-- Missing Id element -->
+                  </Ownr>
+                </Acct>
+              </Rpt>
+            </BkToCstmrAcctRpt>
+          </Document>
+          """;
+
+      assertThatThrownBy(() -> extractor.extractFromIntraDayReport(xmlWithoutIdCodes))
+          .isInstanceOf(BankStatementParseException.class)
+          .hasMessageContaining("Expected exactly one account holder ID code, but found: 0");
+    }
+
+    @Test
+    void extractFromIntraDayReport_shouldThrowExceptionWhenAccountHolderHasMultipleIdCodes() {
+      String xmlWithMultipleIdCodes =
+          """
+          <?xml version="1.0" encoding="UTF-8"?>
+          <Document xmlns="urn:iso:std:iso:20022:tech:xsd:camt.052.001.02">
+            <BkToCstmrAcctRpt>
+              <GrpHdr>
+                <MsgId>test</MsgId>
+                <CreDtTm>2025-09-29T15:37:46</CreDtTm>
+              </GrpHdr>
+              <Rpt>
+                <Id>test</Id>
+                <CreDtTm>2025-09-29T15:37:46</CreDtTm>
+                <Acct>
+                  <Id>
+                    <IBAN>EE442200221092874625</IBAN>
+                  </Id>
+                  <Ccy>EUR</Ccy>
+                  <Ownr>
+                    <Nm>TULEVA FONDID AS</Nm>
+                    <Id>
+                      <OrgId>
+                        <Othr>
+                          <Id>14118923</Id>
+                        </Othr>
+                        <Othr>
+                          <Id>14118924</Id>
+                        </Othr>
+                      </OrgId>
+                    </Id>
+                  </Ownr>
+                </Acct>
+              </Rpt>
+            </BkToCstmrAcctRpt>
+          </Document>
+          """;
+
+      assertThatThrownBy(() -> extractor.extractFromIntraDayReport(xmlWithMultipleIdCodes))
+          .isInstanceOf(BankStatementParseException.class)
+          .hasMessageContaining("Expected exactly one account holder ID code, but found: 2");
+    }
+
+    @Test
+    void extractFromIntraDayReport_shouldThrowExceptionWhenAccountIbanIsMissing() {
+      String xmlWithoutAccountIban =
+          """
+          <?xml version="1.0" encoding="UTF-8"?>
+          <Document xmlns="urn:iso:std:iso:20022:tech:xsd:camt.052.001.02">
+            <BkToCstmrAcctRpt>
+              <GrpHdr>
+                <MsgId>test</MsgId>
+                <CreDtTm>2025-09-29T15:37:46</CreDtTm>
+              </GrpHdr>
+              <Rpt>
+                <Id>test</Id>
+                <CreDtTm>2025-09-29T15:37:46</CreDtTm>
+                <Acct>
+                  <Id>
+                    <!-- Using Othr instead of IBAN -->
+                    <Othr>
+                      <Id>123456</Id>
+                    </Othr>
+                  </Id>
+                  <Ccy>EUR</Ccy>
+                  <Ownr>
+                    <Nm>TULEVA FONDID AS</Nm>
+                    <Id>
+                      <OrgId>
+                        <Othr>
+                          <Id>14118923</Id>
+                        </Othr>
+                      </OrgId>
+                    </Id>
+                  </Ownr>
+                </Acct>
+              </Rpt>
+            </BkToCstmrAcctRpt>
+          </Document>
+          """;
+
+      assertThatThrownBy(() -> extractor.extractFromIntraDayReport(xmlWithoutAccountIban))
+          .isInstanceOf(BankStatementParseException.class)
+          .hasMessageContaining("account IBAN is required");
+    }
+  }
+
+  @org.junit.jupiter.api.Nested
+  class EntriesIssues {
+
+    @Test
+    void extractFromIntraDayReport_shouldThrowExceptionForMissingRemittanceInformation() {
+      var entries =
+          List.of(
+              """
+          <Ntry>
+            <NtryRef>test-ref</NtryRef>
+            <Amt Ccy="EUR">100.00</Amt>
+            <CdtDbtInd>CRDT</CdtDbtInd>
+            <Sts>BOOK</Sts>
+            <BookgDt>
+              <Dt>2025-09-29</Dt>
+            </BookgDt>
+            <ValDt>
+              <Dt>2025-09-29</Dt>
+            </ValDt>
+            <NtryDtls>
+              <TxDtls>
+                <Refs>
+                  <AcctSvcrRef>test-ref</AcctSvcrRef>
+                  <EndToEndId>test-id</EndToEndId>
+                </Refs>
+                <AmtDtls>
+                  <InstdAmt>
+                    <Amt Ccy="EUR">100.00</Amt>
+                  </InstdAmt>
+                  <TxAmt>
+                    <Amt Ccy="EUR">100.00</Amt>
+                  </TxAmt>
+                </AmtDtls>
+                <RltdPties>
+                  <Dbtr>
+                    <Nm>Test Person</Nm>
+                    <Id>
+                      <PrvtId>
+                        <Othr>
+                          <Id>12345678901</Id>
+                          <SchmeNm>
+                            <Cd>NIDN</Cd>
+                          </SchmeNm>
+                        </Othr>
+                      </PrvtId>
+                    </Id>
+                  </Dbtr>
+                  <DbtrAcct>
+                    <Id>
+                      <IBAN>EE123456789012345678</IBAN>
+                    </Id>
+                  </DbtrAcct>
+                </RltdPties>
+                <!-- Missing RmtInf element -->
+              </TxDtls>
+            </NtryDtls>
+          </Ntry>
+          """
+                  .stripIndent());
+
+      String xmlWithMissingRemittance = createCamt052Xml(entries);
+
+      assertThatThrownBy(() -> extractor.extractFromIntraDayReport(xmlWithMissingRemittance))
+          .isInstanceOf(BankStatementParseException.class)
+          .hasMessageContaining("Expected exactly one remittance information, but found: 0");
+    }
+
+    @Test
+    void extractFromIntraDayReport_shouldAllowMissingPersonalCode() {
+      var entries =
+          List.of(
+              """
+          <Ntry>
+            <NtryRef>test-ref</NtryRef>
+            <Amt Ccy="EUR">100.00</Amt>
+            <CdtDbtInd>CRDT</CdtDbtInd>
+            <Sts>BOOK</Sts>
+            <BookgDt>
+              <Dt>2025-09-29</Dt>
+            </BookgDt>
+            <ValDt>
+              <Dt>2025-09-29</Dt>
+            </ValDt>
+            <NtryDtls>
+              <TxDtls>
+                <Refs>
+                  <AcctSvcrRef>test-ref</AcctSvcrRef>
+                  <EndToEndId>test-id</EndToEndId>
+                </Refs>
+                <AmtDtls>
+                  <InstdAmt>
+                    <Amt Ccy="EUR">100.00</Amt>
+                  </InstdAmt>
+                  <TxAmt>
+                    <Amt Ccy="EUR">100.00</Amt>
+                  </TxAmt>
+                </AmtDtls>
+                <RltdPties>
+                  <Dbtr>
+                    <Nm>Test Person</Nm>
+                    <!-- Missing Id element -->
+                  </Dbtr>
+                  <DbtrAcct>
+                    <Id>
+                      <IBAN>EE123456789012345678</IBAN>
+                    </Id>
+                  </DbtrAcct>
+                </RltdPties>
+                <RmtInf>
+                  <Ustrd>Test payment</Ustrd>
+                </RmtInf>
+              </TxDtls>
+            </NtryDtls>
+          </Ntry>
+          """
+                  .stripIndent());
+
+      String xmlWithMissingPersonalCode = createCamt052Xml(entries);
+
+      var statement = extractor.extractFromIntraDayReport(xmlWithMissingPersonalCode);
+
+      assertThat(statement).isNotNull();
+      assertThat(statement.getEntries()).hasSize(1);
+      assertThat(statement.getEntries().getFirst().details().getPersonalCode()).isEmpty();
+    }
+
+    @Test
+    void extractFromIntraDayReport_shouldThrowExceptionForMultiplePersonalCodes() {
+      var entries =
+          List.of(
+              """
+          <Ntry>
+            <NtryRef>test-ref</NtryRef>
+            <Amt Ccy="EUR">100.00</Amt>
+            <CdtDbtInd>CRDT</CdtDbtInd>
+            <Sts>BOOK</Sts>
+            <BookgDt>
+              <Dt>2025-09-29</Dt>
+            </BookgDt>
+            <ValDt>
+              <Dt>2025-09-29</Dt>
+            </ValDt>
+            <NtryDtls>
+              <TxDtls>
+                <Refs>
+                  <AcctSvcrRef>test-ref</AcctSvcrRef>
+                  <EndToEndId>test-id</EndToEndId>
+                </Refs>
+                <AmtDtls>
+                  <InstdAmt>
+                    <Amt Ccy="EUR">100.00</Amt>
+                  </InstdAmt>
+                  <TxAmt>
+                    <Amt Ccy="EUR">100.00</Amt>
+                  </TxAmt>
+                </AmtDtls>
+                <RltdPties>
+                  <Dbtr>
+                    <Nm>Test Person</Nm>
+                    <Id>
+                      <PrvtId>
+                        <Othr>
+                          <Id>12345678901</Id>
+                          <SchmeNm>
+                            <Cd>NIDN</Cd>
+                          </SchmeNm>
+                        </Othr>
+                        <Othr>
+                          <Id>98765432109</Id>
+                          <SchmeNm>
+                            <Cd>NIDN</Cd>
+                          </SchmeNm>
+                        </Othr>
+                      </PrvtId>
+                    </Id>
+                  </Dbtr>
+                  <DbtrAcct>
+                    <Id>
+                      <IBAN>EE123456789012345678</IBAN>
+                    </Id>
+                  </DbtrAcct>
+                </RltdPties>
+                <RmtInf>
+                  <Ustrd>Test payment</Ustrd>
+                </RmtInf>
+              </TxDtls>
+            </NtryDtls>
+          </Ntry>
+          """
+                  .stripIndent());
+
+      String xmlWithMultiplePersonalCodes = createCamt052Xml(entries);
+
+      assertThatThrownBy(() -> extractor.extractFromIntraDayReport(xmlWithMultiplePersonalCodes))
+          .isInstanceOf(BankStatementParseException.class)
+          .hasMessageContaining("Expected at most one personal ID code, but found: 2");
+    }
+
+    @Test
+    void extractFromIntraDayReport_shouldThrowExceptionForMissingCounterPartyIban() {
+      var entries =
+          List.of(
+              """
+          <Ntry>
+            <NtryRef>test-ref</NtryRef>
+            <Amt Ccy="EUR">100.00</Amt>
+            <CdtDbtInd>CRDT</CdtDbtInd>
+            <Sts>BOOK</Sts>
+            <BookgDt>
+              <Dt>2025-09-29</Dt>
+            </BookgDt>
+            <ValDt>
+              <Dt>2025-09-29</Dt>
+            </ValDt>
+            <NtryDtls>
+              <TxDtls>
+                <Refs>
+                  <AcctSvcrRef>test-ref</AcctSvcrRef>
+                  <EndToEndId>test-id</EndToEndId>
+                </Refs>
+                <AmtDtls>
+                  <InstdAmt>
+                    <Amt Ccy="EUR">100.00</Amt>
+                  </InstdAmt>
+                  <TxAmt>
+                    <Amt Ccy="EUR">100.00</Amt>
+                  </TxAmt>
+                </AmtDtls>
+                <RltdPties>
+                  <Dbtr>
+                    <Nm>Test Person</Nm>
+                    <Id>
+                      <PrvtId>
+                        <Othr>
+                          <Id>12345678901</Id>
+                          <SchmeNm>
+                            <Cd>NIDN</Cd>
+                          </SchmeNm>
+                        </Othr>
+                      </PrvtId>
+                    </Id>
+                  </Dbtr>
+                  <DbtrAcct>
+                    <Id>
+                      <!-- Using Othr instead of IBAN -->
+                      <Othr>
+                        <Id>123456</Id>
+                      </Othr>
+                    </Id>
+                  </DbtrAcct>
+                </RltdPties>
+                <RmtInf>
+                  <Ustrd>Test payment</Ustrd>
+                </RmtInf>
+              </TxDtls>
+            </NtryDtls>
+          </Ntry>
+          """
+                  .stripIndent());
+
+      String xmlWithMissingCounterPartyIban = createCamt052Xml(entries);
+
+      assertThatThrownBy(() -> extractor.extractFromIntraDayReport(xmlWithMissingCounterPartyIban))
+          .isInstanceOf(BankStatementParseException.class)
+          .hasMessageContaining("counter-party IBAN is required");
+    }
+
+    @Test
+    void extractFromIntraDayReport_shouldThrowExceptionForMultipleEntryDetails() {
+      var entries =
+          List.of(
+              """
+          <Ntry>
+            <NtryRef>test-ref</NtryRef>
+            <Amt Ccy="EUR">100.00</Amt>
+            <CdtDbtInd>CRDT</CdtDbtInd>
+            <Sts>BOOK</Sts>
+            <BookgDt>
+              <Dt>2025-09-29</Dt>
+            </BookgDt>
+            <ValDt>
+              <Dt>2025-09-29</Dt>
+            </ValDt>
+            <NtryDtls>
+              <TxDtls>
+                <Refs>
+                  <AcctSvcrRef>test-ref</AcctSvcrRef>
+                </Refs>
+                <RmtInf>
+                  <Ustrd>Test payment</Ustrd>
+                </RmtInf>
+              </TxDtls>
+            </NtryDtls>
+            <NtryDtls>
+              <TxDtls>
+                <Refs>
+                  <AcctSvcrRef>test-ref-2</AcctSvcrRef>
+                </Refs>
+                <RmtInf>
+                  <Ustrd>Another payment</Ustrd>
+                </RmtInf>
+              </TxDtls>
+            </NtryDtls>
+          </Ntry>
+          """
+                  .stripIndent());
+
+      String xmlWithMultipleEntryDetails = createCamt052Xml(entries);
+
+      assertThatThrownBy(() -> extractor.extractFromIntraDayReport(xmlWithMultipleEntryDetails))
+          .isInstanceOf(BankStatementParseException.class)
+          .hasMessageContaining("Expected exactly one entry details, but found: 2");
+    }
+
+    @Test
+    void extractFromIntraDayReport_shouldThrowExceptionForMultipleTransactionDetails() {
+      var entries =
+          List.of(
+              """
+          <Ntry>
+            <NtryRef>test-ref</NtryRef>
+            <Amt Ccy="EUR">100.00</Amt>
+            <CdtDbtInd>CRDT</CdtDbtInd>
+            <Sts>BOOK</Sts>
+            <BookgDt>
+              <Dt>2025-09-29</Dt>
+            </BookgDt>
+            <ValDt>
+              <Dt>2025-09-29</Dt>
+            </ValDt>
+            <NtryDtls>
+              <TxDtls>
+                <Refs>
+                  <AcctSvcrRef>test-ref-1</AcctSvcrRef>
+                </Refs>
+                <AmtDtls>
+                  <InstdAmt>
+                    <Amt Ccy="EUR">50.00</Amt>
+                  </InstdAmt>
+                </AmtDtls>
+                <RltdPties>
+                  <Dbtr>
+                    <Nm>First Person</Nm>
+                  </Dbtr>
+                  <DbtrAcct>
+                    <Id>
+                      <IBAN>EE123456789012345678</IBAN>
+                    </Id>
+                  </DbtrAcct>
+                </RltdPties>
+                <RmtInf>
+                  <Ustrd>First payment</Ustrd>
+                </RmtInf>
+              </TxDtls>
+              <TxDtls>
+                <Refs>
+                  <AcctSvcrRef>test-ref-2</AcctSvcrRef>
+                </Refs>
+                <AmtDtls>
+                  <InstdAmt>
+                    <Amt Ccy="EUR">50.00</Amt>
+                  </InstdAmt>
+                </AmtDtls>
+                <RltdPties>
+                  <Dbtr>
+                    <Nm>Second Person</Nm>
+                  </Dbtr>
+                  <DbtrAcct>
+                    <Id>
+                      <IBAN>EE987654321098765432</IBAN>
+                    </Id>
+                  </DbtrAcct>
+                </RltdPties>
+                <RmtInf>
+                  <Ustrd>Second payment</Ustrd>
+                </RmtInf>
+              </TxDtls>
+            </NtryDtls>
+          </Ntry>
+          """
+                  .stripIndent());
+
+      String xmlWithMultipleTransactionDetails = createCamt052Xml(entries);
+
+      assertThatThrownBy(
+              () -> extractor.extractFromIntraDayReport(xmlWithMultipleTransactionDetails))
+          .isInstanceOf(BankStatementParseException.class)
+          .hasMessageContaining("Expected exactly one transaction details, but found: 2");
+    }
+
+    @Test
+    void extractFromIntraDayReport_shouldHandleEmptyEntries() {
+      var entries = List.<String>of();
+      String xmlWithEmptyEntries = createCamt052Xml(entries);
+
+      var statement = extractor.extractFromIntraDayReport(xmlWithEmptyEntries);
+
+      assertThat(statement).isNotNull();
+      assertThat(statement.getEntries()).isEmpty();
+    }
+  }
+
+  private String createCamt052Xml(List<String> entries) {
+    StringBuilder entriesXml = new StringBuilder();
+    for (String entry : entries) {
+      entriesXml.append("      ").append(entry).append("\n");
+    }
+
+    return """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <Document xmlns="urn:iso:std:iso:20022:tech:xsd:camt.052.001.02">
+          <BkToCstmrAcctRpt>
+            <GrpHdr>
+              <MsgId>2025092913110088760001</MsgId>
+              <CreDtTm>2025-09-29T15:37:46</CreDtTm>
+            </GrpHdr>
+            <Rpt>
+              <Id>1311008876-EUR-1</Id>
+              <CreDtTm>2025-09-29T15:37:46</CreDtTm>
+              <FrToDt>
+                <FrDtTm>2025-09-29T00:00:00</FrDtTm>
+                <ToDtTm>2025-09-29T15:37:46</ToDtTm>
+              </FrToDt>
+              <Acct>
+                <Id>
+                  <IBAN>EE442200221092874625</IBAN>
+                </Id>
+                <Ccy>EUR</Ccy>
+                <Ownr>
+                  <Nm>TULEVA FONDID AS</Nm>
+                  <PstlAdr>
+                    <Ctry>EE</Ctry>
+                    <AdrLine>TELLISKIVI TN 60, HARJUMAA, TALLINN</AdrLine>
+                  </PstlAdr>
+                  <Id>
+                    <OrgId>
+                      <Othr>
+                        <Id>14118923</Id>
+                      </Othr>
+                    </OrgId>
+                  </Id>
+                </Ownr>
+                <Svcr>
+                  <FinInstnId>
+                    <BIC>HABAEE2X</BIC>
+                    <Nm>Swedbank AS</Nm>
+                  </FinInstnId>
+                </Svcr>
+              </Acct>
+              <Bal>
+                <Tp>
+                  <CdOrPrtry>
+                    <Cd>OPBD</Cd>
+                  </CdOrPrtry>
+                </Tp>
+                <CdtLine>
+                  <Incl>false</Incl>
+                </CdtLine>
+                <Amt Ccy="EUR">0.00</Amt>
+                <CdtDbtInd>CRDT</CdtDbtInd>
+                <Dt>
+                  <Dt>2025-09-29</Dt>
+                </Dt>
+              </Bal>
+              <Bal>
+                <Tp>
+                  <CdOrPrtry>
+                    <Cd>ITBD</Cd>
+                  </CdOrPrtry>
+                </Tp>
+                <Amt Ccy="EUR">0.00</Amt>
+                <CdtDbtInd>CRDT</CdtDbtInd>
+                <Dt>
+                  <Dt>2025-09-29</Dt>
+                </Dt>
+              </Bal>
+              <Bal>
+                <Tp>
+                  <CdOrPrtry>
+                    <Prtry>RESERVED</Prtry>
+                  </CdOrPrtry>
+                </Tp>
+                <Amt Ccy="EUR">0.00</Amt>
+                <CdtDbtInd>CRDT</CdtDbtInd>
+                <Dt>
+                  <Dt>2025-09-29</Dt>
+                </Dt>
+              </Bal>
+              <Bal>
+                <Tp>
+                  <CdOrPrtry>
+                    <Cd>ITAV</Cd>
+                  </CdOrPrtry>
+                </Tp>
+                <CdtLine>
+                  <Incl>true</Incl>
+                  <Amt Ccy="EUR">0.00</Amt>
+                </CdtLine>
+                <Amt Ccy="EUR">0.00</Amt>
+                <CdtDbtInd>CRDT</CdtDbtInd>
+                <Dt>
+                  <Dt>2025-09-29</Dt>
+                </Dt>
+              </Bal>
+              <TxsSummry>
+                <TtlCdtNtries>
+                  <NbOfNtries>1</NbOfNtries>
+                  <Sum>0.10</Sum>
+                </TtlCdtNtries>
+                <TtlDbtNtries>
+                  <NbOfNtries>0</NbOfNtries>
+                  <Sum>0</Sum>
+                </TtlDbtNtries>
+              </TxsSummry>
+        """
+        + entriesXml
+        + """
+            </Rpt>
+          </BkToCstmrAcctRpt>
+        </Document>
+        """
+            .stripIndent();
   }
 
   private String createCamt052Xml() {

--- a/src/test/java/ee/tuleva/onboarding/swedbank/statement/SwedbankBankStatementExtractorIntraDayTest.java
+++ b/src/test/java/ee/tuleva/onboarding/swedbank/statement/SwedbankBankStatementExtractorIntraDayTest.java
@@ -1,0 +1,274 @@
+package ee.tuleva.onboarding.swedbank.statement;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import ee.tuleva.onboarding.swedbank.http.SwedbankGatewayMarshaller;
+import ee.tuleva.onboarding.swedbank.statement.BankStatement.BankStatementType;
+import java.math.BigDecimal;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class SwedbankBankStatementExtractorIntraDayTest {
+
+  private SwedbankBankStatementExtractor extractor;
+
+  @BeforeEach
+  void setUp() {
+    SwedbankGatewayMarshaller marshaller = new SwedbankGatewayMarshaller();
+    extractor = new SwedbankBankStatementExtractor(marshaller);
+  }
+
+  @Test
+  void extractFromIntraDayReport_shouldExtractBankStatement() {
+    // given
+    String rawXml = createCamt052Xml();
+
+    // when
+    var statement = extractor.extractFromIntraDayReport(rawXml);
+
+    // then
+    assertThat(statement).isNotNull();
+    assertThat(statement.getType()).isEqualTo(BankStatementType.INTRA_DAY_REPORT);
+    assertThat(statement.getBankStatementAccount().iban()).isEqualTo("EE442200221092874625");
+    assertThat(statement.getBankStatementAccount().accountHolderName())
+        .isEqualTo("TULEVA FONDID AS");
+    assertThat(statement.getBankStatementAccount().accountHolderIdCode()).isEqualTo("14118923");
+    assertThat(statement.getBalances()).hasSize(4);
+    assertThat(statement.getEntries()).hasSize(1);
+
+    // Verify the entry
+    var entry = statement.getEntries().getFirst();
+    assertThat(entry.getAmount()).isEqualByComparingTo(new BigDecimal("0.10"));
+    assertThat(entry.getDetails().getName()).isEqualTo("Jüri Tamm");
+    assertThat(entry.getDetails().getIban()).isEqualTo("EE157700771001802057");
+    assertThat(entry.getDetails().getPersonalCode()).hasValue("39910273027");
+  }
+
+  @Test
+  void extractFromIntraDayReport_shouldThrowExceptionForNullXml() {
+    assertThatThrownBy(() -> extractor.extractFromIntraDayReport(null))
+        .isInstanceOf(BankStatementParseException.class)
+        .hasMessage("Raw XML is null or empty");
+  }
+
+  @Test
+  void extractFromIntraDayReport_shouldThrowExceptionForEmptyXml() {
+    assertThatThrownBy(() -> extractor.extractFromIntraDayReport(""))
+        .isInstanceOf(BankStatementParseException.class)
+        .hasMessage("Raw XML is null or empty");
+  }
+
+  @Test
+  void extractFromIntraDayReport_shouldThrowExceptionForBlankXml() {
+    assertThatThrownBy(() -> extractor.extractFromIntraDayReport("   "))
+        .isInstanceOf(BankStatementParseException.class)
+        .hasMessage("Raw XML is null or empty");
+  }
+
+  @Test
+  void extractFromIntraDayReport_shouldThrowExceptionForEmptyReport() {
+    String emptyReportXml =
+        """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <Document xmlns="urn:iso:std:iso:20022:tech:xsd:camt.052.001.02">
+          <BkToCstmrAcctRpt>
+            <GrpHdr>
+              <MsgId>test</MsgId>
+              <CreDtTm>2025-09-29T15:37:46</CreDtTm>
+            </GrpHdr>
+          </BkToCstmrAcctRpt>
+        </Document>
+        """;
+
+    assertThatThrownBy(() -> extractor.extractFromIntraDayReport(emptyReportXml))
+        .isInstanceOf(BankStatementParseException.class)
+        .hasMessageContaining("Expected exactly one report");
+  }
+
+  private String createCamt052Xml() {
+    return """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <Document xmlns="urn:iso:std:iso:20022:tech:xsd:camt.052.001.02">
+          <BkToCstmrAcctRpt>
+            <GrpHdr>
+              <MsgId>2025092913110088760001</MsgId>
+              <CreDtTm>2025-09-29T15:37:46</CreDtTm>
+            </GrpHdr>
+            <Rpt>
+              <Id>1311008876-EUR-1</Id>
+              <CreDtTm>2025-09-29T15:37:46</CreDtTm>
+              <FrToDt>
+                <FrDtTm>2025-09-29T00:00:00</FrDtTm>
+                <ToDtTm>2025-09-29T15:37:46</ToDtTm>
+              </FrToDt>
+              <Acct>
+                <Id>
+                  <IBAN>EE442200221092874625</IBAN>
+                </Id>
+                <Ccy>EUR</Ccy>
+                <Ownr>
+                  <Nm>TULEVA FONDID AS</Nm>
+                  <PstlAdr>
+                    <Ctry>EE</Ctry>
+                    <AdrLine>TELLISKIVI TN 60, HARJUMAA, TALLINN</AdrLine>
+                  </PstlAdr>
+                  <Id>
+                    <OrgId>
+                      <Othr>
+                        <Id>14118923</Id>
+                      </Othr>
+                    </OrgId>
+                  </Id>
+                </Ownr>
+                <Svcr>
+                  <FinInstnId>
+                    <BIC>HABAEE2X</BIC>
+                    <Nm>Swedbank AS</Nm>
+                  </FinInstnId>
+                </Svcr>
+              </Acct>
+              <Bal>
+                <Tp>
+                  <CdOrPrtry>
+                    <Cd>OPBD</Cd>
+                  </CdOrPrtry>
+                </Tp>
+                <CdtLine>
+                  <Incl>false</Incl>
+                </CdtLine>
+                <Amt Ccy="EUR">0.00</Amt>
+                <CdtDbtInd>CRDT</CdtDbtInd>
+                <Dt>
+                  <Dt>2025-09-29</Dt>
+                </Dt>
+              </Bal>
+              <Bal>
+                <Tp>
+                  <CdOrPrtry>
+                    <Cd>ITBD</Cd>
+                  </CdOrPrtry>
+                </Tp>
+                <Amt Ccy="EUR">0.00</Amt>
+                <CdtDbtInd>CRDT</CdtDbtInd>
+                <Dt>
+                  <Dt>2025-09-29</Dt>
+                </Dt>
+              </Bal>
+              <Bal>
+                <Tp>
+                  <CdOrPrtry>
+                    <Prtry>RESERVED</Prtry>
+                  </CdOrPrtry>
+                </Tp>
+                <Amt Ccy="EUR">0.00</Amt>
+                <CdtDbtInd>CRDT</CdtDbtInd>
+                <Dt>
+                  <Dt>2025-09-29</Dt>
+                </Dt>
+              </Bal>
+              <Bal>
+                <Tp>
+                  <CdOrPrtry>
+                    <Cd>ITAV</Cd>
+                  </CdOrPrtry>
+                </Tp>
+                <CdtLine>
+                  <Incl>true</Incl>
+                  <Amt Ccy="EUR">0.00</Amt>
+                </CdtLine>
+                <Amt Ccy="EUR">0.00</Amt>
+                <CdtDbtInd>CRDT</CdtDbtInd>
+                <Dt>
+                  <Dt>2025-09-29</Dt>
+                </Dt>
+              </Bal>
+              <TxsSummry>
+                <TtlCdtNtries>
+                  <NbOfNtries>1</NbOfNtries>
+                  <Sum>0.10</Sum>
+                </TtlCdtNtries>
+                <TtlDbtNtries>
+                  <NbOfNtries>0</NbOfNtries>
+                  <Sum>0</Sum>
+                </TtlDbtNtries>
+              </TxsSummry>
+              <Ntry>
+                <NtryRef>2025092900654847-1</NtryRef>
+                <Amt Ccy="EUR">0.10</Amt>
+                <CdtDbtInd>CRDT</CdtDbtInd>
+                <Sts>BOOK</Sts>
+                <BookgDt>
+                  <Dt>2025-09-29</Dt>
+                </BookgDt>
+                <ValDt>
+                  <Dt>2025-09-29</Dt>
+                </ValDt>
+                <AcctSvcrRef>2025092900654847-1</AcctSvcrRef>
+                <BkTxCd>
+                  <Domn>
+                    <Cd>PMNT</Cd>
+                    <Fmly>
+                      <Cd>RCDT</Cd>
+                      <SubFmlyCd>ESCT</SubFmlyCd>
+                    </Fmly>
+                  </Domn>
+                  <Prtry>
+                    <Cd>MK</Cd>
+                    <Issr>Swedbank AS</Issr>
+                  </Prtry>
+                </BkTxCd>
+                <NtryDtls>
+                  <TxDtls>
+                    <Refs>
+                      <AcctSvcrRef>2025092900654847-1</AcctSvcrRef>
+                      <EndToEndId>1277</EndToEndId>
+                    </Refs>
+                    <AmtDtls>
+                      <InstdAmt>
+                        <Amt Ccy="EUR">0.10</Amt>
+                      </InstdAmt>
+                      <TxAmt>
+                        <Amt Ccy="EUR">0.10</Amt>
+                      </TxAmt>
+                    </AmtDtls>
+                    <RltdPties>
+                      <Dbtr>
+                        <Nm>Jüri Tamm</Nm>
+                        <Id>
+                          <PrvtId>
+                            <Othr>
+                              <Id>39910273027</Id>
+                              <SchmeNm>
+                                <Cd>NIDN</Cd>
+                              </SchmeNm>
+                            </Othr>
+                          </PrvtId>
+                        </Id>
+                      </Dbtr>
+                      <DbtrAcct>
+                        <Id>
+                          <IBAN>EE157700771001802057</IBAN>
+                        </Id>
+                      </DbtrAcct>
+                    </RltdPties>
+                    <RltdAgts>
+                      <DbtrAgt>
+                        <FinInstnId>
+                          <BIC>LHVBEE22</BIC>
+                        </FinInstnId>
+                      </DbtrAgt>
+                    </RltdAgts>
+                    <RmtInf>
+                      <Ustrd>39910273027</Ustrd>
+                    </RmtInf>
+                  </TxDtls>
+                </NtryDtls>
+              </Ntry>
+            </Rpt>
+          </BkToCstmrAcctRpt>
+        </Document>
+        """
+        .stripIndent();
+  }
+}


### PR DESCRIPTION
- **Split statement extractor tests into two**
- **Cover edge cases with tests in historic statement parisng**
- **Verify that IBANs for both account holder and counter-party are present**
- **Require that at most one personal code is present**
- **Validate that we have exactly one entry detail and exactly one transaction detail**
- **Turn BankStatementEntry into record**
- **Bring Intraday statement test coverage to same level as historical one**
- **Re-work test for SavingsFundPayment extractor**
- **Simplify SavingFundPaymentExtractor**
