### PR TITLE
The payment might not have an attached user at the time of failure. W…

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/savings/fund/PaymentVerificationService.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/PaymentVerificationService.java
@@ -77,13 +77,10 @@ public class PaymentVerificationService {
     savingFundPaymentRepository.changeStatus(payment.getId(), TO_BE_RETURNED);
     savingFundPaymentRepository.addReturnReason(payment.getId(), reason);
 
-    userRepository
-        .findById(payment.getUserId())
-        .ifPresent(
-            user -> {
-              applicationEventPublisher.publishEvent(
-                  new SavingsPaymentFailedEvent(this, user, Locale.of("et")));
-            });
+    Optional.ofNullable(payment.getUserId())
+        .flatMap(userRepository::findById)
+        .ifPresent(user -> applicationEventPublisher.publishEvent(
+                new SavingsPaymentFailedEvent(this, user, Locale.of("et"))));
   }
 
   Optional<String> extractPersonalCode(String description) {


### PR DESCRIPTION
…e can publish the event for only those where the user exists.