### PR TITLE
Do not extend ApplicationEvent in every Event

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/account/OnLoginAccountStatementCacheClearer.java
+++ b/src/main/java/ee/tuleva/onboarding/account/OnLoginAccountStatementCacheClearer.java
@@ -18,10 +18,7 @@ public class OnLoginAccountStatementCacheClearer {
   @EventListener
   public void onBeforeTokenGrantedEvent(BeforeTokenGrantedEvent event) {
     Person person = event.getPerson();
-    log.info(
-        "On BeforeTokenGrantedEvent: timestamp={}, personal code={}",
-        event.getTimestamp(),
-        person.getPersonalCode());
+    log.info("On BeforeTokenGrantedEvent: personalCode={}", person.getPersonalCode());
 
     episService.clearCache(person);
   }

--- a/src/main/java/ee/tuleva/onboarding/aml/AmlAutoChecker.java
+++ b/src/main/java/ee/tuleva/onboarding/aml/AmlAutoChecker.java
@@ -49,7 +49,7 @@ public class AmlAutoChecker {
 
   @EventListener
   public void contactDetailsUpdated(ContactDetailsUpdatedEvent event) {
-    amlService.addContactDetailsCheckIfMissing(event.getUser());
+    amlService.addContactDetailsCheckIfMissing(event.user());
   }
 
   private User getUser(Person person) {
@@ -62,14 +62,14 @@ public class AmlAutoChecker {
 
   @EventListener
   public void beforeMandateCreated(BeforeMandateCreatedEvent event) {
-    User user = event.getUser();
+    User user = event.user();
     Address address = event.getAddress();
 
-    if (amlService.isMandateAmlCheckRequired(user, event.getMandate())) {
+    if (amlService.isMandateAmlCheckRequired(user, event.mandate())) {
       amlService.addSanctionAndPepCheckIfMissing(user, address);
     }
 
-    if (!amlService.allChecksPassed(user, event.getMandate())) {
+    if (!amlService.allChecksPassed(user, event.mandate())) {
       throw AmlChecksMissingException.newInstance();
     }
   }

--- a/src/main/java/ee/tuleva/onboarding/aml/AmlKycCheckEventListener.java
+++ b/src/main/java/ee/tuleva/onboarding/aml/AmlKycCheckEventListener.java
@@ -15,6 +15,6 @@ public class AmlKycCheckEventListener {
   @EventListener
   @Transactional
   public void onKycCheckPerformed(KycCheckPerformedEvent event) {
-    amlService.addKycCheck(event.getPersonalCode(), event.getKycCheck());
+    amlService.addKycCheck(event.personalCode(), event.kycCheck());
   }
 }

--- a/src/main/java/ee/tuleva/onboarding/aml/AmlService.java
+++ b/src/main/java/ee/tuleva/onboarding/aml/AmlService.java
@@ -147,7 +147,7 @@ public class AmlService {
     List<AnalyticsRecentThirdPillar> records = analyticsRecentThirdPillarRepository.findAll();
 
     log.info("Running III pillar AML checks on {} records", records.size());
-    eventPublisher.publishEvent(new AmlChecksRunEvent(this, records));
+    eventPublisher.publishEvent(new AmlChecksRunEvent(records.size()));
 
     records.forEach(
         record -> {
@@ -240,7 +240,7 @@ public class AmlService {
         amlCheck.getPersonalCode(),
         amlCheck.isSuccess());
     AmlCheck saved = amlCheckRepository.save(amlCheck);
-    eventPublisher.publishEvent(new AmlCheckCreatedEvent(this, saved));
+    eventPublisher.publishEvent(new AmlCheckCreatedEvent(saved));
     return saved;
   }
 

--- a/src/main/java/ee/tuleva/onboarding/aml/notification/AmlCheckCreatedEvent.java
+++ b/src/main/java/ee/tuleva/onboarding/aml/notification/AmlCheckCreatedEvent.java
@@ -2,16 +2,8 @@ package ee.tuleva.onboarding.aml.notification;
 
 import ee.tuleva.onboarding.aml.AmlCheck;
 import ee.tuleva.onboarding.aml.AmlCheckType;
-import org.springframework.context.ApplicationEvent;
 
-public class AmlCheckCreatedEvent extends ApplicationEvent {
-
-  private final AmlCheck amlCheck;
-
-  public AmlCheckCreatedEvent(Object source, AmlCheck amlCheck) {
-    super(source);
-    this.amlCheck = amlCheck;
-  }
+public record AmlCheckCreatedEvent(AmlCheck amlCheck) {
 
   public AmlCheckType getAmlCheckType() {
     return amlCheck.getType();

--- a/src/main/java/ee/tuleva/onboarding/aml/notification/AmlCheckNotifier.java
+++ b/src/main/java/ee/tuleva/onboarding/aml/notification/AmlCheckNotifier.java
@@ -32,14 +32,14 @@ public class AmlCheckNotifier {
   @EventListener
   public void onScheduledAmlCheckJobRun(AmlChecksRunEvent event) {
     slackService.sendMessage(
-        "Running AML checks job: numberOfRecords=%d".formatted(event.getNumberOfRecords()), AML);
+        "Running AML checks job: numberOfRecords=%d".formatted(event.numberOfRecords()), AML);
   }
 
   @EventListener
   public void onAmlRiskLevelJobRun(AmlRiskLevelJobRunEvent event) {
     slackService.sendMessage(
         "Ran AML Risk Level job: highRiskRecordCount=%d, amlChecksCreatedCount=%d"
-            .formatted(event.getHighRiskRowCount(), event.getAmlChecksCreatedCount()),
+            .formatted(event.highRiskRowCount(), event.amlChecksCreatedCount()),
         AML);
   }
 }

--- a/src/main/java/ee/tuleva/onboarding/aml/notification/AmlChecksRunEvent.java
+++ b/src/main/java/ee/tuleva/onboarding/aml/notification/AmlChecksRunEvent.java
@@ -1,17 +1,3 @@
 package ee.tuleva.onboarding.aml.notification;
 
-import ee.tuleva.onboarding.analytics.thirdpillar.AnalyticsRecentThirdPillar;
-import java.util.List;
-import lombok.Getter;
-import org.springframework.context.ApplicationEvent;
-
-@Getter
-public class AmlChecksRunEvent extends ApplicationEvent {
-
-  private final int numberOfRecords;
-
-  public AmlChecksRunEvent(Object source, List<AnalyticsRecentThirdPillar> records) {
-    super(source);
-    this.numberOfRecords = records.size();
-  }
-}
+public record AmlChecksRunEvent(int numberOfRecords) {}

--- a/src/main/java/ee/tuleva/onboarding/aml/notification/AmlRiskLevelJobRunEvent.java
+++ b/src/main/java/ee/tuleva/onboarding/aml/notification/AmlRiskLevelJobRunEvent.java
@@ -1,22 +1,17 @@
 package ee.tuleva.onboarding.aml.notification;
 
-import lombok.Getter;
-import org.springframework.context.ApplicationEvent;
-
-@Getter
-public class AmlRiskLevelJobRunEvent extends ApplicationEvent {
-
-  private final int highRiskRowCount;
-  private final int mediumRiskRowCount;
-  private final int totalRowsProcessed;
-  private final int amlChecksCreatedCount;
+public record AmlRiskLevelJobRunEvent(
+    int highRiskRowCount,
+    int mediumRiskRowCount,
+    int totalRowsProcessed,
+    int amlChecksCreatedCount) {
 
   public AmlRiskLevelJobRunEvent(
-      Object source, int highRiskRowCount, int mediumRiskRowCount, int amlChecksCreatedCount) {
-    super(source);
-    this.highRiskRowCount = highRiskRowCount;
-    this.mediumRiskRowCount = mediumRiskRowCount;
-    this.totalRowsProcessed = highRiskRowCount + mediumRiskRowCount;
-    this.amlChecksCreatedCount = amlChecksCreatedCount;
+      int highRiskRowCount, int mediumRiskRowCount, int amlChecksCreatedCount) {
+    this(
+        highRiskRowCount,
+        mediumRiskRowCount,
+        highRiskRowCount + mediumRiskRowCount,
+        amlChecksCreatedCount);
   }
 }

--- a/src/main/java/ee/tuleva/onboarding/aml/risklevel/RiskLevelService.java
+++ b/src/main/java/ee/tuleva/onboarding/aml/risklevel/RiskLevelService.java
@@ -70,7 +70,7 @@ public class RiskLevelService {
         createdCount);
 
     eventPublisher.publishEvent(
-        new AmlRiskLevelJobRunEvent(this, highRiskCount, mediumRiskCount, createdCount));
+        new AmlRiskLevelJobRunEvent(highRiskCount, mediumRiskCount, createdCount));
   }
 
   private AmlCheck buildAmlCheck(RiskLevelResult row, Integer level) {
@@ -96,7 +96,7 @@ public class RiskLevelService {
       }
     }
     AmlCheck saved = amlCheckRepository.save(amlCheck);
-    eventPublisher.publishEvent(new AmlCheckCreatedEvent(this, saved));
+    eventPublisher.publishEvent(new AmlCheckCreatedEvent(saved));
     return true;
   }
 

--- a/src/main/java/ee/tuleva/onboarding/auth/AuthService.java
+++ b/src/main/java/ee/tuleva/onboarding/auth/AuthService.java
@@ -37,14 +37,13 @@ public class AuthService {
 
     final var authorities = grantedAuthorityFactory.from(authenticatedPerson);
 
-    eventPublisher.publishEvent(new BeforeTokenGrantedEvent(this, authenticatedPerson, grantType));
+    eventPublisher.publishEvent(new BeforeTokenGrantedEvent(authenticatedPerson, grantType));
 
     String accessToken = jwtTokenUtil.generateAccessToken(authenticatedPerson, authorities);
     String refreshToken = jwtTokenUtil.generateRefreshToken(authenticatedPerson, authorities);
     final var tokens = new AuthenticationTokens(accessToken, refreshToken);
 
-    eventPublisher.publishEvent(
-        new AfterTokenGrantedEvent(this, authenticatedPerson, grantType, tokens));
+    eventPublisher.publishEvent(new AfterTokenGrantedEvent(authenticatedPerson, grantType, tokens));
 
     return tokens;
   }

--- a/src/main/java/ee/tuleva/onboarding/auth/event/AfterTokenGrantedEvent.java
+++ b/src/main/java/ee/tuleva/onboarding/auth/event/AfterTokenGrantedEvent.java
@@ -8,13 +8,11 @@ import lombok.Getter;
 @Getter
 public class AfterTokenGrantedEvent extends BeforeTokenGrantedEvent {
 
-  private final AuthenticatedPerson person;
   private final AuthenticationTokens tokens;
 
   public AfterTokenGrantedEvent(
-      Object source, AuthenticatedPerson person, GrantType grantType, AuthenticationTokens tokens) {
-    super(source, person, grantType);
-    this.person = person;
+      AuthenticatedPerson person, GrantType grantType, AuthenticationTokens tokens) {
+    super(person, grantType);
     this.tokens = tokens;
   }
 

--- a/src/main/java/ee/tuleva/onboarding/auth/event/BeforeTokenGrantedEvent.java
+++ b/src/main/java/ee/tuleva/onboarding/auth/event/BeforeTokenGrantedEvent.java
@@ -7,7 +7,7 @@ import ee.tuleva.onboarding.auth.GrantType;
 import ee.tuleva.onboarding.auth.idcard.IdDocumentType;
 import ee.tuleva.onboarding.auth.principal.AuthenticatedPerson;
 import lombok.Getter;
-import org.springframework.context.ApplicationEvent;
+import lombok.RequiredArgsConstructor;
 
 /**
  * @deprecated This class is deprecated and will be removed in the future. Use {@link
@@ -15,16 +15,11 @@ import org.springframework.context.ApplicationEvent;
  */
 @Getter
 @Deprecated
-public class BeforeTokenGrantedEvent extends ApplicationEvent {
+@RequiredArgsConstructor
+public class BeforeTokenGrantedEvent {
 
   private final AuthenticatedPerson person;
   private final GrantType grantType;
-
-  public BeforeTokenGrantedEvent(Object source, AuthenticatedPerson person, GrantType grantType) {
-    super(source);
-    this.person = person;
-    this.grantType = grantType;
-  }
 
   public boolean isIdCard() {
     return ID_CARD.equals(grantType);

--- a/src/main/java/ee/tuleva/onboarding/epis/contact/ContactDetailsService.java
+++ b/src/main/java/ee/tuleva/onboarding/epis/contact/ContactDetailsService.java
@@ -31,7 +31,7 @@ public class ContactDetailsService {
       updatedContactDetails = contactDetails;
       log.error("Contact details update failed for user " + user.getId(), e);
     }
-    eventPublisher.publishEvent(new ContactDetailsUpdatedEvent(this, user, updatedContactDetails));
+    eventPublisher.publishEvent(new ContactDetailsUpdatedEvent(user, updatedContactDetails));
     return updatedContactDetails;
   }
 

--- a/src/main/java/ee/tuleva/onboarding/epis/contact/ContactDetailsUpdater.java
+++ b/src/main/java/ee/tuleva/onboarding/epis/contact/ContactDetailsUpdater.java
@@ -15,6 +15,6 @@ public class ContactDetailsUpdater {
 
   @EventListener
   public void updateAddress(AfterMandateSignedEvent event) {
-    contactDetailsService.updateContactDetails(event.getUser(), event.getAddress());
+    contactDetailsService.updateContactDetails(event.user(), event.getAddress());
   }
 }

--- a/src/main/java/ee/tuleva/onboarding/epis/contact/event/ContactDetailsUpdatedEvent.java
+++ b/src/main/java/ee/tuleva/onboarding/epis/contact/event/ContactDetailsUpdatedEvent.java
@@ -2,18 +2,5 @@ package ee.tuleva.onboarding.epis.contact.event;
 
 import ee.tuleva.onboarding.epis.contact.ContactDetails;
 import ee.tuleva.onboarding.user.User;
-import lombok.Getter;
-import org.springframework.context.ApplicationEvent;
 
-@Getter
-public class ContactDetailsUpdatedEvent extends ApplicationEvent {
-
-  private final User user;
-  private final ContactDetails contactDetails;
-
-  public ContactDetailsUpdatedEvent(Object source, User user, ContactDetails contactDetails) {
-    super(source);
-    this.user = user;
-    this.contactDetails = contactDetails;
-  }
-}
+public record ContactDetailsUpdatedEvent(User user, ContactDetails contactDetails) {}

--- a/src/main/java/ee/tuleva/onboarding/event/broadcasting/MandateSuccessfulEventBroadcaster.java
+++ b/src/main/java/ee/tuleva/onboarding/event/broadcasting/MandateSuccessfulEventBroadcaster.java
@@ -21,7 +21,7 @@ public class MandateSuccessfulEventBroadcaster {
   public void publishMandateSuccessfulEvent(AfterMandateSignedEvent event) {
     eventPublisher.publishEvent(
         new TrackableEvent(
-            event.getUser(),
+            event.user(),
             TrackableEventType.MANDATE_SUCCESSFUL,
             Map.of("pillar", event.getPillar())));
   }

--- a/src/main/java/ee/tuleva/onboarding/kyc/KycCheckPerformedEvent.java
+++ b/src/main/java/ee/tuleva/onboarding/kyc/KycCheckPerformedEvent.java
@@ -1,18 +1,10 @@
 package ee.tuleva.onboarding.kyc;
 
 import java.util.Objects;
-import lombok.Getter;
-import org.springframework.context.ApplicationEvent;
 
-@Getter
-public class KycCheckPerformedEvent extends ApplicationEvent {
-
-  private final String personalCode;
-  private final KycCheck kycCheck;
-
-  public KycCheckPerformedEvent(Object source, String personalCode, KycCheck kycCheck) {
-    super(source);
-    this.personalCode = Objects.requireNonNull(personalCode);
-    this.kycCheck = Objects.requireNonNull(kycCheck);
+public record KycCheckPerformedEvent(String personalCode, KycCheck kycCheck) {
+  public KycCheckPerformedEvent {
+    Objects.requireNonNull(personalCode);
+    Objects.requireNonNull(kycCheck);
   }
 }

--- a/src/main/java/ee/tuleva/onboarding/kyc/survey/KycSurveyService.java
+++ b/src/main/java/ee/tuleva/onboarding/kyc/survey/KycSurveyService.java
@@ -21,8 +21,7 @@ public class KycSurveyService {
     KycSurvey saved = kycSurveyRepository.save(survey);
 
     var kycCheck = kycCheckService.check(person.getPersonalCode());
-    eventPublisher.publishEvent(
-        new KycCheckPerformedEvent(this, person.getPersonalCode(), kycCheck));
+    eventPublisher.publishEvent(new KycCheckPerformedEvent(person.getPersonalCode(), kycCheck));
 
     return saved;
   }

--- a/src/main/java/ee/tuleva/onboarding/mandate/MandateService.java
+++ b/src/main/java/ee/tuleva/onboarding/mandate/MandateService.java
@@ -86,7 +86,7 @@ public class MandateService {
 
   public Mandate save(User user, Mandate mandate) {
     log.info("Saving mandate for user {}", user.getId());
-    applicationEventPublisher.publishEvent(new BeforeMandateCreatedEvent(this, user, mandate));
+    applicationEventPublisher.publishEvent(new BeforeMandateCreatedEvent(user, mandate));
     return mandateRepository.save(mandate);
   }
 
@@ -202,8 +202,7 @@ public class MandateService {
   }
 
   private void notifyAboutSignedMandate(User user, Mandate mandate, Locale locale) {
-    applicationEventPublisher.publishEvent(
-        new AfterMandateSignedEvent(this, user, mandate, locale));
+    applicationEventPublisher.publishEvent(new AfterMandateSignedEvent(user, mandate, locale));
   }
 
   private void persistSignedFile(Mandate mandate, byte[] signedFile) {

--- a/src/main/java/ee/tuleva/onboarding/mandate/batch/MandateBatchService.java
+++ b/src/main/java/ee/tuleva/onboarding/mandate/batch/MandateBatchService.java
@@ -257,10 +257,10 @@ public class MandateBatchService {
         .forEach(
             mandate ->
                 applicationEventPublisher.publishEvent(
-                    new AfterMandateSignedEvent(this, user, mandate, locale)));
+                    new AfterMandateSignedEvent(user, mandate, locale)));
 
     applicationEventPublisher.publishEvent(
-        new AfterMandateBatchSignedEvent(this, user, mandateBatch, locale));
+        new AfterMandateBatchSignedEvent(user, mandateBatch, locale));
   }
 
   private void persistSignedFile(MandateBatch mandateBatch, byte[] signedFile) {

--- a/src/main/java/ee/tuleva/onboarding/mandate/batch/poller/MandateBatchProcessingPoller.java
+++ b/src/main/java/ee/tuleva/onboarding/mandate/batch/poller/MandateBatchProcessingPoller.java
@@ -149,7 +149,7 @@ public class MandateBatchProcessingPoller {
       // some weren't
       if (mandates.size() > 1 && successfulMandateCount > 0 && failedMandateCount > 0) {
         applicationEventPublisher.publishEvent(
-            new OnMandateBatchFailedEvent(this, context.user(), context.batch, context.locale));
+            new OnMandateBatchFailedEvent(context.user(), context.batch, context.locale));
       }
 
       throw new MandateProcessingException(errorsResponse);
@@ -163,9 +163,9 @@ public class MandateBatchProcessingPoller {
         .forEach(
             mandate ->
                 applicationEventPublisher.publishEvent(
-                    new AfterMandateSignedEvent(this, context.user(), mandate, context.locale)));
+                    new AfterMandateSignedEvent(context.user(), mandate, context.locale)));
 
     applicationEventPublisher.publishEvent(
-        new AfterMandateBatchSignedEvent(this, context.user(), context.batch, context.locale));
+        new AfterMandateBatchSignedEvent(context.user(), context.batch, context.locale));
   }
 }

--- a/src/main/java/ee/tuleva/onboarding/mandate/email/MandateEmailSender.java
+++ b/src/main/java/ee/tuleva/onboarding/mandate/email/MandateEmailSender.java
@@ -27,35 +27,35 @@ public class MandateEmailSender {
 
   @EventListener
   public void sendEmail(AfterMandateSignedEvent event) {
-    ContactDetails contactDetails = episService.getContactDetails(event.getUser());
-    ConversionResponse conversion = conversionService.getConversion(event.getUser());
-    PaymentRates paymentRates = paymentRateService.getPaymentRates(event.getUser());
+    ContactDetails contactDetails = episService.getContactDetails(event.user());
+    ConversionResponse conversion = conversionService.getConversion(event.user());
+    PaymentRates paymentRates = paymentRateService.getPaymentRates(event.user());
     PillarSuggestion pillarSuggestion =
-        new PillarSuggestion(event.getUser(), contactDetails, conversion, paymentRates);
-    if (!event.getMandate().isPartOfBatch()) {
+        new PillarSuggestion(event.user(), contactDetails, conversion, paymentRates);
+    if (!event.mandate().isPartOfBatch()) {
       mandateEmailService.sendMandate(
-          event.getUser(), event.getMandate(), pillarSuggestion, event.getLocale());
+          event.user(), event.mandate(), pillarSuggestion, event.locale());
     } else {
       log.info(
           "Skipping mandate email because it is part of a batch: mandateId={}",
-          event.getMandate().getId());
+          event.mandate().getId());
     }
   }
 
   @EventListener
   public void sendBatchEmail(AfterMandateBatchSignedEvent event) {
-    ContactDetails contactDetails = episService.getContactDetails(event.getUser());
-    ConversionResponse conversion = conversionService.getConversion(event.getUser());
-    PaymentRates paymentRates = paymentRateService.getPaymentRates(event.getUser());
+    ContactDetails contactDetails = episService.getContactDetails(event.user());
+    ConversionResponse conversion = conversionService.getConversion(event.user());
+    PaymentRates paymentRates = paymentRateService.getPaymentRates(event.user());
     PillarSuggestion pillarSuggestion =
-        new PillarSuggestion(event.getUser(), contactDetails, conversion, paymentRates);
+        new PillarSuggestion(event.user(), contactDetails, conversion, paymentRates);
     mandateBatchEmailService.sendMandateBatch(
-        event.getUser(), event.getMandateBatch(), pillarSuggestion, event.getLocale());
+        event.user(), event.mandateBatch(), pillarSuggestion, event.locale());
   }
 
   @EventListener
   public void sendBatchFailedEmail(OnMandateBatchFailedEvent event) {
     mandateBatchEmailService.sendMandateBatchFailedEmail(
-        event.getUser(), event.getMandateBatch(), event.getLocale());
+        event.user(), event.mandateBatch(), event.locale());
   }
 }

--- a/src/main/java/ee/tuleva/onboarding/mandate/email/persistence/ScheduledEmailCanceller.java
+++ b/src/main/java/ee/tuleva/onboarding/mandate/email/persistence/ScheduledEmailCanceller.java
@@ -14,7 +14,7 @@ public class ScheduledEmailCanceller {
   @EventListener
   public void cancelEmail(AfterMandateSignedEvent event) {
     if (event.getPillar() == 2) {
-      emailPersistenceService.cancel(event.getUser(), EmailType.THIRD_PILLAR_SUGGEST_SECOND);
+      emailPersistenceService.cancel(event.user(), EmailType.THIRD_PILLAR_SUGGEST_SECOND);
     }
   }
 }

--- a/src/main/java/ee/tuleva/onboarding/mandate/event/AfterMandateBatchSignedEvent.java
+++ b/src/main/java/ee/tuleva/onboarding/mandate/event/AfterMandateBatchSignedEvent.java
@@ -3,21 +3,5 @@ package ee.tuleva.onboarding.mandate.event;
 import ee.tuleva.onboarding.mandate.batch.MandateBatch;
 import ee.tuleva.onboarding.user.User;
 import java.util.Locale;
-import lombok.Getter;
-import org.springframework.context.ApplicationEvent;
 
-@Getter
-public class AfterMandateBatchSignedEvent extends ApplicationEvent {
-
-  private final User user;
-  private final MandateBatch mandateBatch;
-  private final Locale locale;
-
-  public AfterMandateBatchSignedEvent(
-      Object source, User user, MandateBatch mandateBatch, Locale locale) {
-    super(source);
-    this.user = user;
-    this.mandateBatch = mandateBatch;
-    this.locale = locale;
-  }
-}
+public record AfterMandateBatchSignedEvent(User user, MandateBatch mandateBatch, Locale locale) {}

--- a/src/main/java/ee/tuleva/onboarding/mandate/event/AfterMandateSignedEvent.java
+++ b/src/main/java/ee/tuleva/onboarding/mandate/event/AfterMandateSignedEvent.java
@@ -4,22 +4,8 @@ import ee.tuleva.onboarding.mandate.Mandate;
 import ee.tuleva.onboarding.user.User;
 import ee.tuleva.onboarding.user.address.Address;
 import java.util.Locale;
-import lombok.Getter;
-import org.springframework.context.ApplicationEvent;
 
-@Getter
-public class AfterMandateSignedEvent extends ApplicationEvent {
-
-  private final User user;
-  private final Mandate mandate;
-  private final Locale locale;
-
-  public AfterMandateSignedEvent(Object source, User user, Mandate mandate, Locale locale) {
-    super(source);
-    this.user = user;
-    this.mandate = mandate;
-    this.locale = locale;
-  }
+public record AfterMandateSignedEvent(User user, Mandate mandate, Locale locale) {
 
   public Integer getPillar() {
     return mandate.getPillar();

--- a/src/main/java/ee/tuleva/onboarding/mandate/event/BeforeMandateCreatedEvent.java
+++ b/src/main/java/ee/tuleva/onboarding/mandate/event/BeforeMandateCreatedEvent.java
@@ -3,20 +3,8 @@ package ee.tuleva.onboarding.mandate.event;
 import ee.tuleva.onboarding.mandate.Mandate;
 import ee.tuleva.onboarding.user.User;
 import ee.tuleva.onboarding.user.address.Address;
-import lombok.Getter;
-import org.springframework.context.ApplicationEvent;
 
-@Getter
-public class BeforeMandateCreatedEvent extends ApplicationEvent {
-
-  private final User user;
-  private final Mandate mandate;
-
-  public BeforeMandateCreatedEvent(Object source, User user, Mandate mandate) {
-    super(source);
-    this.user = user;
-    this.mandate = mandate;
-  }
+public record BeforeMandateCreatedEvent(User user, Mandate mandate) {
 
   public Integer getPillar() {
     return mandate.getPillar();

--- a/src/main/java/ee/tuleva/onboarding/mandate/event/OnMandateBatchFailedEvent.java
+++ b/src/main/java/ee/tuleva/onboarding/mandate/event/OnMandateBatchFailedEvent.java
@@ -3,21 +3,5 @@ package ee.tuleva.onboarding.mandate.event;
 import ee.tuleva.onboarding.mandate.batch.MandateBatch;
 import ee.tuleva.onboarding.user.User;
 import java.util.Locale;
-import lombok.Getter;
-import org.springframework.context.ApplicationEvent;
 
-@Getter
-public class OnMandateBatchFailedEvent extends ApplicationEvent {
-
-  private final User user;
-  private final MandateBatch mandateBatch;
-  private final Locale locale;
-
-  public OnMandateBatchFailedEvent(
-      Object source, User user, MandateBatch mandateBatch, Locale locale) {
-    super(source);
-    this.user = user;
-    this.mandateBatch = mandateBatch;
-    this.locale = locale;
-  }
-}
+public record OnMandateBatchFailedEvent(User user, MandateBatch mandateBatch, Locale locale) {}

--- a/src/main/java/ee/tuleva/onboarding/payment/event/PaymentCreatedEvent.java
+++ b/src/main/java/ee/tuleva/onboarding/payment/event/PaymentCreatedEvent.java
@@ -10,8 +10,8 @@ import lombok.Getter;
 public class PaymentCreatedEvent extends PaymentEvent {
   private final Payment payment;
 
-  public PaymentCreatedEvent(Object source, User user, Payment payment, Locale locale) {
-    super(source, user, locale);
+  public PaymentCreatedEvent(User user, Payment payment, Locale locale) {
+    super(user, locale);
     this.payment = payment;
   }
 

--- a/src/main/java/ee/tuleva/onboarding/payment/event/PaymentEvent.java
+++ b/src/main/java/ee/tuleva/onboarding/payment/event/PaymentEvent.java
@@ -4,18 +4,13 @@ import ee.tuleva.onboarding.payment.PaymentData;
 import ee.tuleva.onboarding.user.User;
 import java.util.Locale;
 import lombok.Getter;
-import org.springframework.context.ApplicationEvent;
+import lombok.RequiredArgsConstructor;
 
 @Getter
-public abstract class PaymentEvent extends ApplicationEvent {
+@RequiredArgsConstructor
+public abstract class PaymentEvent {
   private final User user;
   private final Locale locale;
-
-  public PaymentEvent(Object source, User user, Locale locale) {
-    super(source);
-    this.user = user;
-    this.locale = locale;
-  }
 
   public abstract PaymentData.PaymentType getPaymentType();
 }

--- a/src/main/java/ee/tuleva/onboarding/payment/event/SavingsPaymentCancelledEvent.java
+++ b/src/main/java/ee/tuleva/onboarding/payment/event/SavingsPaymentCancelledEvent.java
@@ -5,8 +5,8 @@ import ee.tuleva.onboarding.user.User;
 import java.util.Locale;
 
 public class SavingsPaymentCancelledEvent extends PaymentEvent {
-  public SavingsPaymentCancelledEvent(Object source, User user, Locale locale) {
-    super(source, user, locale);
+  public SavingsPaymentCancelledEvent(User user, Locale locale) {
+    super(user, locale);
   }
 
   @Override

--- a/src/main/java/ee/tuleva/onboarding/payment/event/SavingsPaymentCreatedEvent.java
+++ b/src/main/java/ee/tuleva/onboarding/payment/event/SavingsPaymentCreatedEvent.java
@@ -5,8 +5,8 @@ import ee.tuleva.onboarding.user.User;
 import java.util.Locale;
 
 public class SavingsPaymentCreatedEvent extends PaymentEvent {
-  public SavingsPaymentCreatedEvent(Object source, User user, Locale locale) {
-    super(source, user, locale);
+  public SavingsPaymentCreatedEvent(User user, Locale locale) {
+    super(user, locale);
   }
 
   @Override

--- a/src/main/java/ee/tuleva/onboarding/payment/event/SavingsPaymentFailedEvent.java
+++ b/src/main/java/ee/tuleva/onboarding/payment/event/SavingsPaymentFailedEvent.java
@@ -5,8 +5,8 @@ import ee.tuleva.onboarding.user.User;
 import java.util.Locale;
 
 public class SavingsPaymentFailedEvent extends PaymentEvent {
-  public SavingsPaymentFailedEvent(Object source, User user, Locale locale) {
-    super(source, user, locale);
+  public SavingsPaymentFailedEvent(User user, Locale locale) {
+    super(user, locale);
   }
 
   @Override

--- a/src/main/java/ee/tuleva/onboarding/payment/provider/montonio/MontonioCallbackService.java
+++ b/src/main/java/ee/tuleva/onboarding/payment/provider/montonio/MontonioCallbackService.java
@@ -75,7 +75,7 @@ public class MontonioCallbackService {
     try {
       Payment payment = paymentRepository.save(paymentToBeSaved);
       eventPublisher.publishEvent(
-          new PaymentCreatedEvent(this, user, payment, internalReference.getLocale()));
+          new PaymentCreatedEvent(user, payment, internalReference.getLocale()));
 
       return Optional.of(payment);
     } catch (DataIntegrityViolationException e) {

--- a/src/main/java/ee/tuleva/onboarding/payment/savings/SavingsCallbackService.java
+++ b/src/main/java/ee/tuleva/onboarding/payment/savings/SavingsCallbackService.java
@@ -66,8 +66,7 @@ public class SavingsCallbackService {
             user -> {
               savingFundPaymentRepository.attachUser(paymentId, user.getId());
               eventPublisher.publishEvent(
-                  new SavingsPaymentCreatedEvent(
-                      this, user, token.getMerchantReference().getLocale()));
+                  new SavingsPaymentCreatedEvent(user, token.getMerchantReference().getLocale()));
             });
 
     return Optional.of(payment);

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/PaymentVerificationService.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/PaymentVerificationService.java
@@ -84,7 +84,7 @@ public class PaymentVerificationService {
         .ifPresent(
             user ->
                 applicationEventPublisher.publishEvent(
-                    new SavingsPaymentFailedEvent(this, user, Locale.of("et"))));
+                    new SavingsPaymentFailedEvent(user, Locale.of("et"))));
   }
 
   Optional<String> extractPersonalCode(String description) {

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/SavingFundPaymentController.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/SavingFundPaymentController.java
@@ -38,7 +38,7 @@ public class SavingFundPaymentController {
     User user = userService.getByIdOrThrow(authenticatedPerson.getUserId());
     savingFundPaymentUpsertionService.cancelUserPayment(user.getId(), paymentId);
     eventPublisher.publishEvent(
-        new SavingsPaymentCancelledEvent(this, user, localeService.getCurrentLocale()));
+        new SavingsPaymentCancelledEvent(user, localeService.getCurrentLocale()));
     return ResponseEntity.noContent().build();
   }
 

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/SavingsFundKycCheckEventListener.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/SavingsFundKycCheckEventListener.java
@@ -18,10 +18,10 @@ public class SavingsFundKycCheckEventListener {
   @Transactional
   public void onKycCheckPerformed(KycCheckPerformedEvent event) {
     userService
-        .findByPersonalCode(event.getPersonalCode())
+        .findByPersonalCode(event.personalCode())
         .ifPresent(
             user ->
                 savingsFundOnboardingService.updateOnboardingStatusIfNeeded(
-                    user, event.getKycCheck()));
+                    user, event.kycCheck()));
   }
 }

--- a/src/main/java/ee/tuleva/onboarding/user/UserDetailsUpdater.java
+++ b/src/main/java/ee/tuleva/onboarding/user/UserDetailsUpdater.java
@@ -26,10 +26,7 @@ public class UserDetailsUpdater {
   public void onBeforeTokenGrantedEvent(BeforeTokenGrantedEvent event) {
     Person person = event.getPerson();
 
-    log.info(
-        "Updating user name: timestamp={}, personal code={}",
-        event.getTimestamp(),
-        person.getPersonalCode());
+    log.info("Updating user name: personalCode={}", person.getPersonalCode());
 
     userService
         .findByPersonalCode(person.getPersonalCode())

--- a/src/test/groovy/ee/tuleva/onboarding/account/OnLoginAccountStatementCacheClearerSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/account/OnLoginAccountStatementCacheClearerSpec.groovy
@@ -18,7 +18,7 @@ class OnLoginAccountStatementCacheClearerSpec extends Specification {
 
     AuthenticatedPerson samplePerson = AuthenticatedPersonFixture.sampleAuthenticatedPersonAndMember().build()
 
-    BeforeTokenGrantedEvent beforeTokenGrantedEvent = new BeforeTokenGrantedEvent(this, samplePerson, GrantType.ID_CARD)
+    BeforeTokenGrantedEvent beforeTokenGrantedEvent = new BeforeTokenGrantedEvent(samplePerson, GrantType.ID_CARD)
 
     when:
     service.onBeforeTokenGrantedEvent(beforeTokenGrantedEvent)

--- a/src/test/groovy/ee/tuleva/onboarding/aml/AmlKycCheckIntegrationTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/aml/AmlKycCheckIntegrationTest.java
@@ -28,7 +28,7 @@ class AmlKycCheckIntegrationTest {
   @Test
   @DisplayName("KycCheckPerformedEvent with LOW risk creates successful AmlCheck")
   void onKycCheckPerformed_lowRisk_createsSuccessfulCheck() {
-    var event = new KycCheckPerformedEvent(this, PERSONAL_CODE, new KycCheck(10, LOW));
+    var event = new KycCheckPerformedEvent(PERSONAL_CODE, new KycCheck(10, LOW));
 
     eventPublisher.publishEvent(event);
 
@@ -47,7 +47,7 @@ class AmlKycCheckIntegrationTest {
   @Test
   @DisplayName("KycCheckPerformedEvent with HIGH risk creates failed AmlCheck")
   void onKycCheckPerformed_highRisk_createsFailedCheck() {
-    var event = new KycCheckPerformedEvent(this, PERSONAL_CODE, new KycCheck(99, HIGH));
+    var event = new KycCheckPerformedEvent(PERSONAL_CODE, new KycCheck(99, HIGH));
 
     eventPublisher.publishEvent(event);
 

--- a/src/test/groovy/ee/tuleva/onboarding/aml/notification/AmlCheckNotifierTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/aml/notification/AmlCheckNotifierTest.java
@@ -64,8 +64,7 @@ class AmlCheckNotifierTest {
   @Test
   @DisplayName("Should always send Slack message when AML checks job is run")
   void onScheduledAmlCheckJobRun_sendsSlackMessage() {
-    AmlChecksRunEvent event = mock(AmlChecksRunEvent.class);
-    when(event.getNumberOfRecords()).thenReturn(10);
+    AmlChecksRunEvent event = new AmlChecksRunEvent(10);
 
     notifier.onScheduledAmlCheckJobRun(event);
 
@@ -78,9 +77,7 @@ class AmlCheckNotifierTest {
   @Test
   @DisplayName("Should always send Slack message with row counts after an AML risk level job run")
   void onAmlRiskLevelJobRun_sendsSlackMessage() {
-    AmlRiskLevelJobRunEvent event = mock(AmlRiskLevelJobRunEvent.class);
-    when(event.getHighRiskRowCount()).thenReturn(3);
-    when(event.getAmlChecksCreatedCount()).thenReturn(2);
+    AmlRiskLevelJobRunEvent event = new AmlRiskLevelJobRunEvent(3, 0, 2);
 
     notifier.onAmlRiskLevelJobRun(event);
 

--- a/src/test/groovy/ee/tuleva/onboarding/aml/risklevel/RiskLevelServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/aml/risklevel/RiskLevelServiceTest.java
@@ -94,10 +94,10 @@ class RiskLevelServiceTest {
         ArgumentCaptor.forClass(AmlRiskLevelJobRunEvent.class);
     verify(eventPublisher).publishEvent(jobEventCaptor.capture());
     AmlRiskLevelJobRunEvent jobRunEvent = jobEventCaptor.getValue();
-    assertEquals(1, jobRunEvent.getHighRiskRowCount());
-    assertEquals(0, jobRunEvent.getMediumRiskRowCount());
-    assertEquals(1, jobRunEvent.getTotalRowsProcessed());
-    assertEquals(1, jobRunEvent.getAmlChecksCreatedCount());
+    assertEquals(1, jobRunEvent.highRiskRowCount());
+    assertEquals(0, jobRunEvent.mediumRiskRowCount());
+    assertEquals(1, jobRunEvent.totalRowsProcessed());
+    assertEquals(1, jobRunEvent.amlChecksCreatedCount());
   }
 
   @Test
@@ -131,10 +131,10 @@ class RiskLevelServiceTest {
         ArgumentCaptor.forClass(AmlRiskLevelJobRunEvent.class);
     verify(eventPublisher).publishEvent(jobEventCaptor.capture());
     AmlRiskLevelJobRunEvent jobRunEvent = jobEventCaptor.getValue();
-    assertEquals(0, jobRunEvent.getHighRiskRowCount());
-    assertEquals(1, jobRunEvent.getMediumRiskRowCount());
-    assertEquals(1, jobRunEvent.getTotalRowsProcessed());
-    assertEquals(1, jobRunEvent.getAmlChecksCreatedCount());
+    assertEquals(0, jobRunEvent.highRiskRowCount());
+    assertEquals(1, jobRunEvent.mediumRiskRowCount());
+    assertEquals(1, jobRunEvent.totalRowsProcessed());
+    assertEquals(1, jobRunEvent.amlChecksCreatedCount());
   }
 
   @Test
@@ -177,10 +177,10 @@ class RiskLevelServiceTest {
         ArgumentCaptor.forClass(AmlRiskLevelJobRunEvent.class);
     verify(eventPublisher).publishEvent(jobEventCaptor.capture());
     AmlRiskLevelJobRunEvent jobRunEvent = jobEventCaptor.getValue();
-    assertEquals(1, jobRunEvent.getHighRiskRowCount());
-    assertEquals(1, jobRunEvent.getMediumRiskRowCount());
-    assertEquals(2, jobRunEvent.getTotalRowsProcessed());
-    assertEquals(2, jobRunEvent.getAmlChecksCreatedCount());
+    assertEquals(1, jobRunEvent.highRiskRowCount());
+    assertEquals(1, jobRunEvent.mediumRiskRowCount());
+    assertEquals(2, jobRunEvent.totalRowsProcessed());
+    assertEquals(2, jobRunEvent.amlChecksCreatedCount());
   }
 
   @Test
@@ -200,10 +200,10 @@ class RiskLevelServiceTest {
         ArgumentCaptor.forClass(AmlRiskLevelJobRunEvent.class);
     verify(eventPublisher).publishEvent(jobEventCaptor.capture());
     AmlRiskLevelJobRunEvent jobRunEvent = jobEventCaptor.getValue();
-    assertEquals(1, jobRunEvent.getHighRiskRowCount());
-    assertEquals(0, jobRunEvent.getMediumRiskRowCount());
-    assertEquals(1, jobRunEvent.getTotalRowsProcessed());
-    assertEquals(0, jobRunEvent.getAmlChecksCreatedCount());
+    assertEquals(1, jobRunEvent.highRiskRowCount());
+    assertEquals(0, jobRunEvent.mediumRiskRowCount());
+    assertEquals(1, jobRunEvent.totalRowsProcessed());
+    assertEquals(0, jobRunEvent.amlChecksCreatedCount());
   }
 
   @Test
@@ -235,10 +235,10 @@ class RiskLevelServiceTest {
         ArgumentCaptor.forClass(AmlRiskLevelJobRunEvent.class);
     verify(eventPublisher).publishEvent(jobEventCaptor.capture());
     AmlRiskLevelJobRunEvent jobRunEvent = jobEventCaptor.getValue();
-    assertEquals(1, jobRunEvent.getHighRiskRowCount());
-    assertEquals(0, jobRunEvent.getMediumRiskRowCount());
-    assertEquals(1, jobRunEvent.getTotalRowsProcessed());
-    assertEquals(0, jobRunEvent.getAmlChecksCreatedCount());
+    assertEquals(1, jobRunEvent.highRiskRowCount());
+    assertEquals(0, jobRunEvent.mediumRiskRowCount());
+    assertEquals(1, jobRunEvent.totalRowsProcessed());
+    assertEquals(0, jobRunEvent.amlChecksCreatedCount());
   }
 
   @Test
@@ -262,10 +262,10 @@ class RiskLevelServiceTest {
         ArgumentCaptor.forClass(AmlRiskLevelJobRunEvent.class);
     verify(eventPublisher).publishEvent(jobEventCaptor.capture());
     AmlRiskLevelJobRunEvent jobRunEvent = jobEventCaptor.getValue();
-    assertEquals(1, jobRunEvent.getHighRiskRowCount());
-    assertEquals(0, jobRunEvent.getMediumRiskRowCount());
-    assertEquals(1, jobRunEvent.getTotalRowsProcessed());
-    assertEquals(1, jobRunEvent.getAmlChecksCreatedCount());
+    assertEquals(1, jobRunEvent.highRiskRowCount());
+    assertEquals(0, jobRunEvent.mediumRiskRowCount());
+    assertEquals(1, jobRunEvent.totalRowsProcessed());
+    assertEquals(1, jobRunEvent.amlChecksCreatedCount());
   }
 
   @Test
@@ -297,10 +297,10 @@ class RiskLevelServiceTest {
         ArgumentCaptor.forClass(AmlRiskLevelJobRunEvent.class);
     verify(eventPublisher).publishEvent(jobEventCaptor.capture());
     AmlRiskLevelJobRunEvent jobRunEvent = jobEventCaptor.getValue();
-    assertEquals(1, jobRunEvent.getHighRiskRowCount());
-    assertEquals(0, jobRunEvent.getMediumRiskRowCount());
-    assertEquals(1, jobRunEvent.getTotalRowsProcessed());
-    assertEquals(1, jobRunEvent.getAmlChecksCreatedCount());
+    assertEquals(1, jobRunEvent.highRiskRowCount());
+    assertEquals(0, jobRunEvent.mediumRiskRowCount());
+    assertEquals(1, jobRunEvent.totalRowsProcessed());
+    assertEquals(1, jobRunEvent.amlChecksCreatedCount());
   }
 
   @Test
@@ -322,10 +322,10 @@ class RiskLevelServiceTest {
         ArgumentCaptor.forClass(AmlRiskLevelJobRunEvent.class);
     verify(eventPublisher, atLeastOnce()).publishEvent(jobEventCaptor.capture());
     AmlRiskLevelJobRunEvent jobRunEvent = jobEventCaptor.getValue();
-    assertEquals(0, jobRunEvent.getHighRiskRowCount());
-    assertEquals(0, jobRunEvent.getMediumRiskRowCount());
-    assertEquals(0, jobRunEvent.getTotalRowsProcessed());
-    assertEquals(0, jobRunEvent.getAmlChecksCreatedCount());
+    assertEquals(0, jobRunEvent.highRiskRowCount());
+    assertEquals(0, jobRunEvent.mediumRiskRowCount());
+    assertEquals(0, jobRunEvent.totalRowsProcessed());
+    assertEquals(0, jobRunEvent.amlChecksCreatedCount());
   }
 
   @Test
@@ -450,10 +450,10 @@ class RiskLevelServiceTest {
         ArgumentCaptor.forClass(AmlRiskLevelJobRunEvent.class);
     verify(eventPublisher).publishEvent(jobEventCaptor.capture());
     AmlRiskLevelJobRunEvent jobRunEvent = jobEventCaptor.getValue();
-    assertEquals(1, jobRunEvent.getHighRiskRowCount());
-    assertEquals(0, jobRunEvent.getMediumRiskRowCount());
-    assertEquals(1, jobRunEvent.getTotalRowsProcessed());
-    assertEquals(0, jobRunEvent.getAmlChecksCreatedCount());
+    assertEquals(1, jobRunEvent.highRiskRowCount());
+    assertEquals(0, jobRunEvent.mediumRiskRowCount());
+    assertEquals(1, jobRunEvent.totalRowsProcessed());
+    assertEquals(0, jobRunEvent.amlChecksCreatedCount());
   }
 
   @Test
@@ -486,9 +486,9 @@ class RiskLevelServiceTest {
         ArgumentCaptor.forClass(AmlRiskLevelJobRunEvent.class);
     verify(eventPublisher).publishEvent(jobEventCaptor.capture());
     AmlRiskLevelJobRunEvent jobRunEvent = jobEventCaptor.getValue();
-    assertEquals(1, jobRunEvent.getHighRiskRowCount());
-    assertEquals(0, jobRunEvent.getMediumRiskRowCount());
-    assertEquals(1, jobRunEvent.getTotalRowsProcessed());
-    assertEquals(1, jobRunEvent.getAmlChecksCreatedCount());
+    assertEquals(1, jobRunEvent.highRiskRowCount());
+    assertEquals(0, jobRunEvent.mediumRiskRowCount());
+    assertEquals(1, jobRunEvent.totalRowsProcessed());
+    assertEquals(1, jobRunEvent.amlChecksCreatedCount());
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/auth/partner/HandoverTokenLoginEventTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/auth/partner/HandoverTokenLoginEventTest.java
@@ -156,7 +156,7 @@ public class HandoverTokenLoginEventTest {
 
     AuthenticationTokens tokens = new AuthenticationTokens("mock-access", "mock-refresh");
     AfterTokenGrantedEvent afterTokenEvent =
-        new AfterTokenGrantedEvent(this, authenticatedPerson, PARTNER, tokens);
+        new AfterTokenGrantedEvent(authenticatedPerson, PARTNER, tokens);
     loginEventBroadcaster.onAfterTokenGrantedEvent(afterTokenEvent);
 
     // Then
@@ -223,7 +223,7 @@ public class HandoverTokenLoginEventTest {
 
     AuthenticationTokens tokens = new AuthenticationTokens("mock-access", "mock-refresh");
     AfterTokenGrantedEvent afterTokenEvent =
-        new AfterTokenGrantedEvent(this, authenticatedPerson, PARTNER, tokens);
+        new AfterTokenGrantedEvent(authenticatedPerson, PARTNER, tokens);
     loginEventBroadcaster.onAfterTokenGrantedEvent(afterTokenEvent);
 
     // Then
@@ -283,7 +283,7 @@ public class HandoverTokenLoginEventTest {
 
     AuthenticationTokens tokens = new AuthenticationTokens("mock-access", "mock-refresh");
     AfterTokenGrantedEvent afterTokenEvent =
-        new AfterTokenGrantedEvent(this, authenticatedPerson, PARTNER, tokens);
+        new AfterTokenGrantedEvent(authenticatedPerson, PARTNER, tokens);
     loginEventBroadcaster.onAfterTokenGrantedEvent(afterTokenEvent);
 
     // Then

--- a/src/test/groovy/ee/tuleva/onboarding/epis/contact/ContactDetailsUpdaterSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/epis/contact/ContactDetailsUpdaterSpec.groovy
@@ -17,7 +17,7 @@ class ContactDetailsUpdaterSpec extends Specification {
         def user = sampleUser().build()
         def mandate = sampleMandate()
         def locale = ENGLISH
-        def event = AfterMandateSignedEvent.newInstance(this, user, mandate, locale)
+        def event = new AfterMandateSignedEvent(user, mandate, locale)
 
         when:
         contactDetailsUpdater.updateAddress(event)

--- a/src/test/groovy/ee/tuleva/onboarding/event/broadcasting/LoginEventBroadcasterSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/event/broadcasting/LoginEventBroadcasterSpec.groovy
@@ -44,7 +44,7 @@ class LoginEventBroadcasterSpec extends Specification {
     samplePerson = samplePerson.build()
     def tokens = sampleAuthenticationTokens()
 
-    def event = new AfterTokenGrantedEvent(this, samplePerson, grantType, tokens)
+    def event = new AfterTokenGrantedEvent(samplePerson, grantType, tokens)
 
     when:
     service.onAfterTokenGrantedEvent(event)
@@ -73,7 +73,7 @@ class LoginEventBroadcasterSpec extends Specification {
     def contactDetails = contactDetailsFixture()
     def conversion = fullyConverted()
 
-    def event = new AfterTokenGrantedEvent(this, samplePerson, SMART_ID, tokens)
+    def event = new AfterTokenGrantedEvent(samplePerson, SMART_ID, tokens)
 
     1 * conversionService.getConversion(samplePerson) >> conversion
     1 * contactDetailsService.getContactDetails(samplePerson) >> contactDetails

--- a/src/test/groovy/ee/tuleva/onboarding/event/broadcasting/MandateSuccessfulEventBroadcasterSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/event/broadcasting/MandateSuccessfulEventBroadcasterSpec.groovy
@@ -20,7 +20,7 @@ class MandateSuccessfulEventBroadcasterSpec extends Specification {
     given:
     User user = sampleUser
     Mandate mandate = sampleMandate().tap { it.pillar = pillar }
-    def event = new AfterMandateSignedEvent(this, user, mandate, Locale.ENGLISH)
+    def event = new AfterMandateSignedEvent(user, mandate, Locale.ENGLISH)
 
     when:
     service.publishMandateSuccessfulEvent(event)

--- a/src/test/groovy/ee/tuleva/onboarding/kyc/survey/KycSurveyControllerIntegrationTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyc/survey/KycSurveyControllerIntegrationTest.java
@@ -149,7 +149,7 @@ class KycSurveyControllerIntegrationTest {
     assertThat(events).hasSize(1);
 
     var event = events.getFirst();
-    assertThat(event.getPersonalCode()).isEqualTo(user.getPersonalCode());
-    assertThat(event.getKycCheck()).isEqualTo(new KycCheck(99, HIGH));
+    assertThat(event.personalCode()).isEqualTo(user.getPersonalCode());
+    assertThat(event.kycCheck()).isEqualTo(new KycCheck(99, HIGH));
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/mandate/batch/poller/MandateBatchProcessingPollerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/mandate/batch/poller/MandateBatchProcessingPollerTest.java
@@ -188,10 +188,10 @@ class MandateBatchProcessingPollerTest {
     verify(applicationEventPublisher, times(1))
         .publishEvent(
             argThat(
-                event ->
+                (Object event) ->
                     event instanceof AfterMandateBatchSignedEvent
                         && ((AfterMandateBatchSignedEvent) event)
-                            .getMandateBatch()
+                            .mandateBatch()
                             .equals(mandateBatch)));
     verify(applicationEventPublisher, times(2)).publishEvent(any(AfterMandateSignedEvent.class));
   }
@@ -254,10 +254,10 @@ class MandateBatchProcessingPollerTest {
     verify(applicationEventPublisher, times(1))
         .publishEvent(
             argThat(
-                event ->
+                (Object event) ->
                     event instanceof OnMandateBatchFailedEvent
                         && ((OnMandateBatchFailedEvent) event)
-                            .getMandateBatch()
+                            .mandateBatch()
                             .equals(mandateBatch)));
     verify(applicationEventPublisher, times(0))
         .publishEvent(any(AfterMandateBatchSignedEvent.class));

--- a/src/test/groovy/ee/tuleva/onboarding/mandate/email/MandateEmailSenderSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/mandate/email/MandateEmailSenderSpec.groovy
@@ -45,7 +45,7 @@ class MandateEmailSenderSpec extends Specification {
     PaymentRates paymentRates = samplePaymentRates()
     PillarSuggestion pillarSuggestion = new PillarSuggestion(user, contactDetails, conversion, paymentRates)
 
-    AfterMandateSignedEvent event = new AfterMandateSignedEvent(this, user, mandate, Locale.ENGLISH)
+    AfterMandateSignedEvent event = new AfterMandateSignedEvent(user, mandate, Locale.ENGLISH)
 
     1 * episService.getContactDetails(_) >> contactDetails
     1 * conversionService.getConversion(user) >> conversion
@@ -67,11 +67,11 @@ class MandateEmailSenderSpec extends Specification {
     PaymentRates paymentRates = samplePaymentRates()
     PillarSuggestion pillarSuggestion = new PillarSuggestion(user, contactDetails, conversion, paymentRates)
 
-    AfterMandateSignedEvent event = new AfterMandateSignedEvent(this, user, mandate, Locale.ENGLISH)
+    AfterMandateSignedEvent event = new AfterMandateSignedEvent(user, mandate, Locale.ENGLISH)
 
     1 * episService.getContactDetails(_) >> contactDetails
-    1 * conversionService.getConversion(event.getUser()) >> conversion
-    1 * paymentRateService.getPaymentRates(event.getUser()) >> paymentRates
+    1 * conversionService.getConversion(event.user()) >> conversion
+    1 * paymentRateService.getPaymentRates(event.user()) >> paymentRates
 
     when:
     mandateEmailSender.sendEmail(event)
@@ -94,7 +94,7 @@ class MandateEmailSenderSpec extends Specification {
     PaymentRates paymentRates = samplePaymentRates()
     PillarSuggestion pillarSuggestion = new PillarSuggestion(user, contactDetails, conversion, paymentRates)
 
-    AfterMandateBatchSignedEvent event = new AfterMandateBatchSignedEvent(this, user, mandateBatch, Locale.ENGLISH)
+    AfterMandateBatchSignedEvent event = new AfterMandateBatchSignedEvent(user, mandateBatch, Locale.ENGLISH)
 
     1 * episService.getContactDetails(_) >> contactDetails
     1 * conversionService.getConversion(user) >> conversion

--- a/src/test/groovy/ee/tuleva/onboarding/mandate/email/persistence/ScheduledEmailCancellerSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/mandate/email/persistence/ScheduledEmailCancellerSpec.groovy
@@ -14,7 +14,7 @@ class ScheduledEmailCancellerSpec extends Specification {
     given:
     User user = Mock()
     Mandate mandate = new Mandate(pillar: pillar)
-    AfterMandateSignedEvent event = new AfterMandateSignedEvent(new Object(), user, mandate, Locale.ENGLISH)
+    AfterMandateSignedEvent event = new AfterMandateSignedEvent(user, mandate, Locale.ENGLISH)
 
     when:
     scheduledEmailCanceller.cancelEmail(event)

--- a/src/test/groovy/ee/tuleva/onboarding/payment/email/PaymentEmailSenderSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/payment/email/PaymentEmailSenderSpec.groovy
@@ -45,7 +45,7 @@ class PaymentEmailSenderSpec extends Specification {
     def paymentRates = samplePaymentRates()
     def pillarSuggestion = new PillarSuggestion(user, contactDetails, conversion, paymentRates)
 
-    def paymentCreatedEvent = new PaymentCreatedEvent(this, user, payment, locale)
+    def paymentCreatedEvent = new PaymentCreatedEvent(user, payment, locale)
 
     1 * contactDetailsService.getContactDetails(user) >> contactDetails
     1 * conversionService.getConversion(user) >> conversion
@@ -64,7 +64,7 @@ class PaymentEmailSenderSpec extends Specification {
     def payment = aNewSinglePayment()
     payment.paymentType = MEMBER_FEE
     def locale = ENGLISH
-    def paymentCreatedEvent = new PaymentCreatedEvent(this, user, payment, locale)
+    def paymentCreatedEvent = new PaymentCreatedEvent(user, payment, locale)
 
     when:
     paymentEmailSender.sendEmails(paymentCreatedEvent)
@@ -78,7 +78,7 @@ class PaymentEmailSenderSpec extends Specification {
     def user = sampleUser().build()
     def locale = ENGLISH
 
-    def savingsPaymentCreatedEvent = new SavingsPaymentCreatedEvent(this, user, locale)
+    def savingsPaymentCreatedEvent = new SavingsPaymentCreatedEvent(user, locale)
 
     when:
     paymentEmailSender.sendEmails(savingsPaymentCreatedEvent)
@@ -92,7 +92,7 @@ class PaymentEmailSenderSpec extends Specification {
     def user = sampleUser().build()
     def locale = ENGLISH
 
-    def savingsPaymentCancelledEvent = new SavingsPaymentCancelledEvent(this, user, locale)
+    def savingsPaymentCancelledEvent = new SavingsPaymentCancelledEvent(user, locale)
 
     when:
     paymentEmailSender.sendEmails(savingsPaymentCancelledEvent)
@@ -106,7 +106,7 @@ class PaymentEmailSenderSpec extends Specification {
     def user = sampleUser().build()
     def locale = ENGLISH
 
-    def savingsPaymentFailedEvent = new SavingsPaymentFailedEvent(this, user, locale)
+    def savingsPaymentFailedEvent = new SavingsPaymentFailedEvent(user, locale)
 
     when:
     paymentEmailSender.sendEmails(savingsPaymentFailedEvent)

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/SavingsFundOnboardingIntegrationTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/SavingsFundOnboardingIntegrationTest.java
@@ -42,7 +42,7 @@ class SavingsFundOnboardingIntegrationTest {
   @Test
   @DisplayName("KycCheckPerformedEvent with LOW risk sets status to COMPLETED")
   void onKycCheckPerformed_mapsLowRiskToCompleted() {
-    var event = new KycCheckPerformedEvent(this, user.getPersonalCode(), new KycCheck(10, LOW));
+    var event = new KycCheckPerformedEvent(user.getPersonalCode(), new KycCheck(10, LOW));
 
     eventPublisher.publishEvent(event);
 
@@ -52,7 +52,7 @@ class SavingsFundOnboardingIntegrationTest {
   @Test
   @DisplayName("KycCheckPerformedEvent with MEDIUM risk sets status to PENDING")
   void onKycCheckPerformed_mapsMediumRiskToPending() {
-    var event = new KycCheckPerformedEvent(this, user.getPersonalCode(), new KycCheck(50, MEDIUM));
+    var event = new KycCheckPerformedEvent(user.getPersonalCode(), new KycCheck(50, MEDIUM));
 
     eventPublisher.publishEvent(event);
 
@@ -62,7 +62,7 @@ class SavingsFundOnboardingIntegrationTest {
   @Test
   @DisplayName("KycCheckPerformedEvent with HIGH risk sets status to REJECTED")
   void onKycCheckPerformed_mapsHighRiskToRejected() {
-    var event = new KycCheckPerformedEvent(this, user.getPersonalCode(), new KycCheck(99, HIGH));
+    var event = new KycCheckPerformedEvent(user.getPersonalCode(), new KycCheck(99, HIGH));
 
     eventPublisher.publishEvent(event);
 
@@ -73,7 +73,7 @@ class SavingsFundOnboardingIntegrationTest {
   @DisplayName("KycCheckPerformedEvent does not update status if already COMPLETED")
   void onKycCheckPerformed_doesNotUpdateIfAlreadyCompleted() {
     repository.saveOnboardingStatus(user.getId(), COMPLETED);
-    var event = new KycCheckPerformedEvent(this, user.getPersonalCode(), new KycCheck(99, HIGH));
+    var event = new KycCheckPerformedEvent(user.getPersonalCode(), new KycCheck(99, HIGH));
 
     eventPublisher.publishEvent(event);
 
@@ -83,7 +83,7 @@ class SavingsFundOnboardingIntegrationTest {
   @Test
   @DisplayName("KycCheckPerformedEvent publishes TrackableEvent when status changes")
   void onKycCheckPerformed_publishesTrackableEventOnStatusChange() {
-    var event = new KycCheckPerformedEvent(this, user.getPersonalCode(), new KycCheck(10, LOW));
+    var event = new KycCheckPerformedEvent(user.getPersonalCode(), new KycCheck(10, LOW));
 
     eventPublisher.publishEvent(event);
 

--- a/src/test/groovy/ee/tuleva/onboarding/user/UserDetailsUpdaterSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/user/UserDetailsUpdaterSpec.groovy
@@ -30,7 +30,7 @@ class UserDetailsUpdaterSpec extends Specification {
     1 * contactDetailsService.getContactDetails(person, tokens.accessToken()) >> contactDetails
 
     when:
-    service.onAfterTokenGrantedEvent(new AfterTokenGrantedEvent(this, person, grantType, tokens))
+    service.onAfterTokenGrantedEvent(new AfterTokenGrantedEvent(person, grantType, tokens))
 
     then:
     1 * userService.updateUser(user.personalCode, Optional.of(contactDetails.email), contactDetails.phoneNumber)


### PR DESCRIPTION
This was needed at one point, but no longer is.

Allows for events to be records.
