### PR TITLE
Fix KYC check not saved when person retries after rejection

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/aml/AmlService.java
+++ b/src/main/java/ee/tuleva/onboarding/aml/AmlService.java
@@ -212,7 +212,7 @@ public class AmlService {
     return addCheckIfMissing(pensionRegistryNameCheck);
   }
 
-  public Optional<AmlCheck> addKycCheck(String personalCode, KycCheck kycCheck) {
+  public AmlCheck addKycCheck(String personalCode, KycCheck kycCheck) {
     AmlCheck check =
         AmlCheck.builder()
             .personalCode(personalCode)
@@ -220,7 +220,7 @@ public class AmlService {
             .success(kycCheck.riskLevel() == LOW || kycCheck.riskLevel() == NONE)
             .metadata(kycCheck.metadata())
             .build();
-    return addCheckIfMissing(check);
+    return addCheck(check);
   }
 
   private boolean personDataMatches(Person person1, Person person2) {

--- a/src/test/groovy/ee/tuleva/onboarding/aml/AmlServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/aml/AmlServiceTest.java
@@ -24,6 +24,7 @@ import ee.tuleva.onboarding.conversion.UserConversionService;
 import ee.tuleva.onboarding.country.Country;
 import ee.tuleva.onboarding.epis.contact.ContactDetails;
 import ee.tuleva.onboarding.event.TrackableEvent;
+import ee.tuleva.onboarding.kyc.KycCheck;
 import ee.tuleva.onboarding.mandate.Mandate;
 import ee.tuleva.onboarding.time.ClockHolder;
 import ee.tuleva.onboarding.user.User;
@@ -709,5 +710,20 @@ class AmlServiceTest {
     return stream(checkTypes)
         .map(type -> AmlCheck.builder().type(type).success(false).build())
         .toList();
+  }
+
+  @Test
+  void addKycCheckAlwaysSavesEvenWhenPreviousCheckExists() {
+    when(amlCheckRepository.existsByPersonalCodeAndTypeAndCreatedTimeAfter(
+            "39107050268", KYC_CHECK, aYearAgoFromTestClock))
+        .thenReturn(true);
+
+    var kycCheck = new KycCheck(KycCheck.RiskLevel.LOW, Map.of());
+
+    amlService.addKycCheck("39107050268", kycCheck);
+
+    verify(amlCheckRepository).save(amlCheckCaptor.capture());
+    assertThat(amlCheckCaptor.getValue().getType()).isEqualTo(KYC_CHECK);
+    assertThat(amlCheckCaptor.getValue().isSuccess()).isTrue();
   }
 }


### PR DESCRIPTION
## Summary
- `AmlService.addKycCheck()` used `addCheckIfMissing()`, which checks if **any** `KYC_CHECK` exists for the person in the last year — regardless of success/failure
- When a person first failed KYC and then passed, the successful result was silently discarded because a check of that type already existed
- This caused `KYB_RELATED_PERSONS_KYC` to show `REJECTED` for person `39107050268` even though they had passed KYC
- Fix: `addKycCheck()` now uses `addCheck()` (always saves) since KYC is retriable

## Test plan
- [x] New test: `addKycCheckAlwaysSavesEvenWhenPreviousCheckExists`
- [x] All existing `AmlServiceTest` tests pass
- [x] Full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)