### PR TITLE
Add public NAV history endpoint for TKF

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/config/SecurityConfiguration.java
+++ b/src/main/java/ee/tuleva/onboarding/config/SecurityConfiguration.java
@@ -54,6 +54,8 @@ public class SecurityConfiguration {
                     .hasAuthority(MEMBER)
                     .requestMatchers(GET, "/v1/funds")
                     .permitAll()
+                    .requestMatchers(GET, "/v1/funds/*/nav")
+                    .permitAll()
                     .requestMatchers(HEAD, "/v1/members")
                     .permitAll()
                     .requestMatchers(GET, "/v1/members/lookup")

--- a/src/main/java/ee/tuleva/onboarding/fund/FundController.java
+++ b/src/main/java/ee/tuleva/onboarding/fund/FundController.java
@@ -1,10 +1,12 @@
 package ee.tuleva.onboarding.fund;
 
 import io.swagger.v3.oas.annotations.Operation;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -21,5 +23,14 @@ public class FundController {
   public List<ExtendedApiFundResponse> get(
       @RequestParam("fundManager.name") Optional<String> fundManagerName) {
     return fundService.getFunds(fundManagerName);
+  }
+
+  @Operation(summary = "Get NAV history for a fund")
+  @GetMapping("/funds/{isin}/nav")
+  public List<NavValueResponse> getNavHistory(
+      @PathVariable String isin,
+      @RequestParam(required = false) LocalDate startDate,
+      @RequestParam(required = false) LocalDate endDate) {
+    return fundService.getNavHistory(isin, startDate, endDate);
   }
 }

--- a/src/main/java/ee/tuleva/onboarding/fund/FundService.java
+++ b/src/main/java/ee/tuleva/onboarding/fund/FundService.java
@@ -5,6 +5,7 @@ import static ee.tuleva.onboarding.ledger.SystemAccount.FUND_UNITS_OUTSTANDING;
 import static ee.tuleva.onboarding.ledger.UserAccount.FUND_UNITS;
 import static java.math.RoundingMode.HALF_UP;
 import static java.util.stream.StreamSupport.stream;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 import ee.tuleva.onboarding.comparisons.fundvalue.FundValue;
 import ee.tuleva.onboarding.comparisons.fundvalue.persistence.FundValueRepository;
@@ -15,6 +16,7 @@ import ee.tuleva.onboarding.locale.LocaleService;
 import ee.tuleva.onboarding.savings.fund.SavingsFundConfiguration;
 import ee.tuleva.onboarding.savings.fund.nav.FundNavProvider;
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.List;
 import java.util.Objects;
@@ -22,6 +24,7 @@ import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
 
 @Service
 @Slf4j
@@ -104,6 +107,17 @@ class FundService {
 
   private BigDecimal toNavScale(BigDecimal nav) {
     return nav.setScale(TKF100.getNavScale());
+  }
+
+  List<NavValueResponse> getNavHistory(String isin, LocalDate startDate, LocalDate endDate) {
+    if (fundRepository.findByIsin(isin) == null) {
+      throw new ResponseStatusException(NOT_FOUND);
+    }
+    LocalDate start = startDate != null ? startDate : LocalDate.EPOCH;
+    LocalDate end = endDate != null ? endDate : LocalDate.of(9999, 12, 31);
+    return fundValueRepository.findValuesBetweenDates(isin, start, end).stream()
+        .map(fv -> new NavValueResponse(fv.date(), fv.value()))
+        .toList();
   }
 
   private Iterable<Fund> fundsBy(Optional<String> fundManagerName) {

--- a/src/main/java/ee/tuleva/onboarding/fund/NavValueResponse.java
+++ b/src/main/java/ee/tuleva/onboarding/fund/NavValueResponse.java
@@ -1,0 +1,6 @@
+package ee.tuleva.onboarding.fund;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+public record NavValueResponse(LocalDate date, BigDecimal value) {}

--- a/src/test/groovy/ee/tuleva/onboarding/fund/FundControllerSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/fund/FundControllerSpec.groovy
@@ -5,7 +5,12 @@ import ee.tuleva.onboarding.mandate.MandateFixture
 import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.MockMvc
 
+import org.springframework.web.server.ResponseStatusException
+
+import java.time.LocalDate
 import java.util.stream.Collectors
+
+import static org.springframework.http.HttpStatus.NOT_FOUND
 
 import static ee.tuleva.onboarding.mandate.MandateFixture.sampleFunds
 import static org.hamcrest.Matchers.hasSize
@@ -63,5 +68,34 @@ class FundControllerSpec extends BaseControllerSpec {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath('$', hasSize(funds.size())))
                 .andExpect(jsonPath('$[0].fundManager.name', is(fundManagerName)))
+    }
+
+    def "get: Get NAV history for fund"() {
+        given:
+        def isin = "EE0000003283"
+        def navValues = [
+            new NavValueResponse(LocalDate.of(2026, 2, 3), 1.0000G),
+            new NavValueResponse(LocalDate.of(2026, 2, 4), 1.0012G),
+        ]
+        1 * fundService.getNavHistory(isin, null, null) >> navValues
+        expect:
+        mockMvc
+                .perform(get("/v1/funds/${isin}/nav"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath('$', hasSize(2)))
+                .andExpect(jsonPath('$[0].date', is("2026-02-03")))
+                .andExpect(jsonPath('$[0].value', is(1.0d)))
+                .andExpect(jsonPath('$[1].date', is("2026-02-04")))
+                .andExpect(jsonPath('$[1].value', is(1.0012d)))
+    }
+
+    def "get: Get NAV history for unknown fund returns 404"() {
+        given:
+        1 * fundService.getNavHistory("UNKNOWN", null, null) >> { throw new ResponseStatusException(NOT_FOUND) }
+        expect:
+        mockMvc
+                .perform(get("/v1/funds/UNKNOWN/nav"))
+                .andExpect(status().isNotFound())
     }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/fund/FundServiceSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/fund/FundServiceSpec.groovy
@@ -10,6 +10,7 @@ import ee.tuleva.onboarding.ledger.LedgerService
 import ee.tuleva.onboarding.locale.LocaleService
 import ee.tuleva.onboarding.savings.fund.SavingsFundConfiguration
 import ee.tuleva.onboarding.savings.fund.nav.FundNavProvider
+import org.springframework.web.server.ResponseStatusException
 import spock.lang.Specification
 
 import java.time.LocalDate
@@ -397,6 +398,50 @@ class FundServiceSpec extends Specification {
     def fund = response.first()
     fund.nav == safeNav
     0 * fundValueRepository.findLastValueForFund(savingsFund.isin)
+  }
+
+  def "getNavHistory returns mapped fund values"() {
+    given:
+    def isin = "EE0000003283"
+    def startDate = LocalDate.of(2026, 2, 2)
+    def endDate = LocalDate.of(2026, 4, 14)
+    fundRepository.findByIsin(isin) >> additionalSavingsFund()
+    fundValueRepository.findValuesBetweenDates(isin, startDate, endDate) >> [
+        aFundValue(isin, LocalDate.of(2026, 2, 3), 1.0000),
+        aFundValue(isin, LocalDate.of(2026, 2, 4), 1.0012),
+    ]
+
+    when:
+    def result = fundService.getNavHistory(isin, startDate, endDate)
+
+    then:
+    result.size() == 2
+    result[0] == new NavValueResponse(LocalDate.of(2026, 2, 3), 1.0000G)
+    result[1] == new NavValueResponse(LocalDate.of(2026, 2, 4), 1.0012G)
+  }
+
+  def "getNavHistory defaults null dates to full range"() {
+    given:
+    def isin = "EE0000003283"
+    fundRepository.findByIsin(isin) >> additionalSavingsFund()
+    fundValueRepository.findValuesBetweenDates(isin, LocalDate.EPOCH, LocalDate.of(9999, 12, 31)) >> []
+
+    when:
+    def result = fundService.getNavHistory(isin, null, null)
+
+    then:
+    result.isEmpty()
+  }
+
+  def "getNavHistory throws 404 for unknown ISIN"() {
+    given:
+    fundRepository.findByIsin("UNKNOWN") >> null
+
+    when:
+    fundService.getNavHistory("UNKNOWN", null, null)
+
+    then:
+    thrown(ResponseStatusException)
   }
 
   def "non-savings fund returns null volume"() {


### PR DESCRIPTION
## Summary
- New `GET /v1/funds/{isin}/nav` endpoint returning historical NAV values from `index_values` table
- Optional `startDate`/`endDate` query params, defaults to full history
- Returns 404 for unknown ISINs
- Enables NAV history CSV download from tuleva.ee

## Test plan
- [x] CircleCI build passes
- [x] Codecov patch coverage passes
- [ ] Deploy to staging and verify `curl /v1/funds/EE0000003283/nav` returns JSON array

🤖 Generated with [Claude Code](https://claude.com/claude-code)