### PR TITLE
Add CSV format support to NAV history endpoint

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/fund/FundController.java
+++ b/src/main/java/ee/tuleva/onboarding/fund/FundController.java
@@ -1,10 +1,18 @@
 package ee.tuleva.onboarding.fund;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVPrinter;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -25,12 +33,40 @@ public class FundController {
     return fundService.getFunds(fundManagerName);
   }
 
+  private static final DateTimeFormatter ESTONIAN_DATE = DateTimeFormatter.ofPattern("dd.MM.yyyy");
+
   @Operation(summary = "Get NAV history for a fund")
   @GetMapping("/funds/{isin}/nav")
-  public List<NavValueResponse> getNavHistory(
+  public Object getNavHistory(
       @PathVariable String isin,
       @RequestParam(required = false) LocalDate startDate,
-      @RequestParam(required = false) LocalDate endDate) {
-    return fundService.getNavHistory(isin, startDate, endDate);
+      @RequestParam(required = false) LocalDate endDate,
+      @RequestParam(required = false) String format,
+      HttpServletResponse response)
+      throws IOException {
+    List<NavValueResponse> navHistory = fundService.getNavHistory(isin, startDate, endDate);
+    if ("csv".equals(format)) {
+      writeCsvResponse(response, isin, navHistory);
+      return null;
+    }
+    return navHistory;
+  }
+
+  private static final byte[] UTF8_BOM = {(byte) 0xEF, (byte) 0xBB, (byte) 0xBF};
+
+  private void writeCsvResponse(
+      HttpServletResponse response, String isin, List<NavValueResponse> navHistory)
+      throws IOException {
+    response.setContentType("text/csv;charset=UTF-8");
+    response.setHeader("Content-Disposition", "attachment; filename=\"nav-" + isin + ".csv\"");
+    var outputStream = response.getOutputStream();
+    outputStream.write(UTF8_BOM);
+    var format =
+        CSVFormat.DEFAULT.builder().setDelimiter(';').setHeader("Kuupäev", "NAV (EUR)").get();
+    try (var printer = new CSVPrinter(new OutputStreamWriter(outputStream, UTF_8), format)) {
+      for (var row : navHistory) {
+        printer.printRecord(ESTONIAN_DATE.format(row.date()), row.value().toPlainString());
+      }
+    }
   }
 }

--- a/src/main/java/ee/tuleva/onboarding/fund/FundController.java
+++ b/src/main/java/ee/tuleva/onboarding/fund/FundController.java
@@ -1,12 +1,13 @@
 package ee.tuleva.onboarding.fund;
 
 import io.swagger.v3.oas.annotations.Operation;
-import jakarta.servlet.http.HttpServletResponse;
-import java.io.IOException;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -29,23 +30,20 @@ public class FundController {
 
   @Operation(summary = "Get NAV history for a fund")
   @GetMapping("/funds/{isin}/nav")
-  public Object getNavHistory(
+  public ResponseEntity<?> getNavHistory(
       @PathVariable String isin,
       @RequestParam(required = false) LocalDate startDate,
       @RequestParam(required = false) LocalDate endDate,
-      @RequestParam(required = false) String format,
-      HttpServletResponse response)
-      throws IOException {
-    if ("csv".equals(format)) {
+      @RequestParam(required = false) String format) {
+    if ("csv".equalsIgnoreCase(format)) {
       byte[] csv = fundService.getNavHistoryCsv(isin, startDate, endDate);
-      response.setContentType("text/csv;charset=UTF-8");
-      response.setHeader(
-          "Content-Disposition",
-          "attachment; filename=\"nav-" + isin.replaceAll("[^A-Za-z0-9]", "") + ".csv\"");
-      response.getOutputStream().write(csv);
-      response.flushBuffer();
-      return null;
+      return ResponseEntity.ok()
+          .contentType(MediaType.parseMediaType("text/csv;charset=UTF-8"))
+          .header(
+              HttpHeaders.CONTENT_DISPOSITION,
+              "attachment; filename=\"nav-" + isin.replaceAll("[^A-Za-z0-9]", "") + ".csv\"")
+          .body(csv);
     }
-    return fundService.getNavHistory(isin, startDate, endDate);
+    return ResponseEntity.ok(fundService.getNavHistory(isin, startDate, endDate));
   }
 }

--- a/src/main/java/ee/tuleva/onboarding/fund/FundController.java
+++ b/src/main/java/ee/tuleva/onboarding/fund/FundController.java
@@ -1,18 +1,12 @@
 package ee.tuleva.onboarding.fund;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.io.OutputStreamWriter;
 import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
-import org.apache.commons.csv.CSVFormat;
-import org.apache.commons.csv.CSVPrinter;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -33,8 +27,6 @@ public class FundController {
     return fundService.getFunds(fundManagerName);
   }
 
-  private static final DateTimeFormatter ESTONIAN_DATE = DateTimeFormatter.ofPattern("dd.MM.yyyy");
-
   @Operation(summary = "Get NAV history for a fund")
   @GetMapping("/funds/{isin}/nav")
   public Object getNavHistory(
@@ -44,29 +36,16 @@ public class FundController {
       @RequestParam(required = false) String format,
       HttpServletResponse response)
       throws IOException {
-    List<NavValueResponse> navHistory = fundService.getNavHistory(isin, startDate, endDate);
     if ("csv".equals(format)) {
-      writeCsvResponse(response, isin, navHistory);
+      byte[] csv = fundService.getNavHistoryCsv(isin, startDate, endDate);
+      response.setContentType("text/csv;charset=UTF-8");
+      response.setHeader(
+          "Content-Disposition",
+          "attachment; filename=\"nav-" + isin.replaceAll("[^A-Za-z0-9]", "") + ".csv\"");
+      response.getOutputStream().write(csv);
+      response.flushBuffer();
       return null;
     }
-    return navHistory;
-  }
-
-  private static final byte[] UTF8_BOM = {(byte) 0xEF, (byte) 0xBB, (byte) 0xBF};
-
-  private void writeCsvResponse(
-      HttpServletResponse response, String isin, List<NavValueResponse> navHistory)
-      throws IOException {
-    response.setContentType("text/csv;charset=UTF-8");
-    response.setHeader("Content-Disposition", "attachment; filename=\"nav-" + isin + ".csv\"");
-    var outputStream = response.getOutputStream();
-    outputStream.write(UTF8_BOM);
-    var format =
-        CSVFormat.DEFAULT.builder().setDelimiter(';').setHeader("Kuupäev", "NAV (EUR)").get();
-    try (var printer = new CSVPrinter(new OutputStreamWriter(outputStream, UTF_8), format)) {
-      for (var row : navHistory) {
-        printer.printRecord(ESTONIAN_DATE.format(row.date()), row.value().toPlainString());
-      }
-    }
+    return fundService.getNavHistory(isin, startDate, endDate);
   }
 }

--- a/src/main/java/ee/tuleva/onboarding/fund/FundService.java
+++ b/src/main/java/ee/tuleva/onboarding/fund/FundService.java
@@ -4,6 +4,7 @@ import static ee.tuleva.onboarding.fund.TulevaFund.TKF100;
 import static ee.tuleva.onboarding.ledger.SystemAccount.FUND_UNITS_OUTSTANDING;
 import static ee.tuleva.onboarding.ledger.UserAccount.FUND_UNITS;
 import static java.math.RoundingMode.HALF_UP;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.stream.StreamSupport.stream;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 
@@ -15,14 +16,20 @@ import ee.tuleva.onboarding.ledger.LedgerService;
 import ee.tuleva.onboarding.locale.LocaleService;
 import ee.tuleva.onboarding.savings.fund.SavingsFundConfiguration;
 import ee.tuleva.onboarding.savings.fund.nav.FundNavProvider;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVPrinter;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
 
@@ -109,6 +116,9 @@ class FundService {
     return nav.setScale(TKF100.getNavScale());
   }
 
+  private static final DateTimeFormatter ESTONIAN_DATE = DateTimeFormatter.ofPattern("dd.MM.yyyy");
+  private static final byte[] UTF8_BOM = {(byte) 0xEF, (byte) 0xBB, (byte) 0xBF};
+
   List<NavValueResponse> getNavHistory(String isin, LocalDate startDate, LocalDate endDate) {
     if (fundRepository.findByIsin(isin) == null) {
       throw new ResponseStatusException(NOT_FOUND);
@@ -118,6 +128,24 @@ class FundService {
     return fundValueRepository.findValuesBetweenDates(isin, start, end).stream()
         .map(fv -> new NavValueResponse(fv.date(), fv.value()))
         .toList();
+  }
+
+  byte[] getNavHistoryCsv(String isin, LocalDate startDate, LocalDate endDate) {
+    List<NavValueResponse> navHistory = getNavHistory(isin, startDate, endDate);
+    try (var outputStream = new ByteArrayOutputStream();
+        var writer = new OutputStreamWriter(outputStream, UTF_8)) {
+      outputStream.write(UTF8_BOM);
+      var csvFormat =
+          CSVFormat.DEFAULT.builder().setDelimiter(';').setHeader("Kuupäev", "NAV (EUR)").get();
+      try (var printer = new CSVPrinter(writer, csvFormat)) {
+        for (var row : navHistory) {
+          printer.printRecord(ESTONIAN_DATE.format(row.date()), row.value().toPlainString());
+        }
+      }
+      return outputStream.toByteArray();
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to generate NAV history CSV: isin=" + isin, e);
+    }
   }
 
   private Iterable<Fund> fundsBy(Optional<String> fundManagerName) {

--- a/src/test/groovy/ee/tuleva/onboarding/fund/FundControllerSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/fund/FundControllerSpec.groovy
@@ -94,11 +94,8 @@ class FundControllerSpec extends BaseControllerSpec {
     def "get: Get NAV history as CSV"() {
         given:
         def isin = "EE0000003283"
-        def navValues = [
-            new NavValueResponse(LocalDate.of(2026, 2, 3), 1.0000G),
-            new NavValueResponse(LocalDate.of(2026, 2, 4), 1.0012G),
-        ]
-        1 * fundService.getNavHistory(isin, null, null) >> navValues
+        def csvBytes = "Kuupäev;NAV (EUR)\r\n03.02.2026;1.0000\r\n".getBytes("UTF-8")
+        1 * fundService.getNavHistoryCsv(isin, null, null) >> csvBytes
         expect:
         def result = mockMvc
                 .perform(get("/v1/funds/${isin}/nav?format=csv"))
@@ -106,10 +103,7 @@ class FundControllerSpec extends BaseControllerSpec {
                 .andExpect(header().string("Content-Type", "text/csv;charset=UTF-8"))
                 .andExpect(header().string("Content-Disposition", 'attachment; filename="nav-EE0000003283.csv"'))
                 .andReturn()
-        def csv = result.response.contentAsString
-        csv.contains("Kuupäev;NAV (EUR)")
-        csv.contains("03.02.2026;1.0000")
-        csv.contains("04.02.2026;1.0012")
+        result.response.contentAsByteArray == csvBytes
     }
 
     def "get: Get NAV history for unknown fund returns 404"() {
@@ -118,6 +112,15 @@ class FundControllerSpec extends BaseControllerSpec {
         expect:
         mockMvc
                 .perform(get("/v1/funds/UNKNOWN/nav"))
+                .andExpect(status().isNotFound())
+    }
+
+    def "get: Get NAV history as CSV for unknown fund returns 404"() {
+        given:
+        1 * fundService.getNavHistoryCsv("UNKNOWN", null, null) >> { throw new ResponseStatusException(NOT_FOUND) }
+        expect:
+        mockMvc
+                .perform(get("/v1/funds/UNKNOWN/nav?format=csv"))
                 .andExpect(status().isNotFound())
     }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/fund/FundControllerSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/fund/FundControllerSpec.groovy
@@ -3,6 +3,7 @@ package ee.tuleva.onboarding.fund
 import ee.tuleva.onboarding.BaseControllerSpec
 import ee.tuleva.onboarding.mandate.MandateFixture
 import org.springframework.http.MediaType
+import org.springframework.http.converter.ByteArrayHttpMessageConverter
 import org.springframework.test.web.servlet.MockMvc
 
 import org.springframework.web.server.ResponseStatusException
@@ -29,7 +30,37 @@ class FundControllerSpec extends BaseControllerSpec {
     private MockMvc mockMvc
 
     def setup() {
-        mockMvc = mockMvc(controller)
+        mockMvc = mockMvcWithByteArray(controller)
+    }
+
+    private MockMvc mockMvcWithByteArray(Object... controllers) {
+        return org.springframework.test.web.servlet.setup.MockMvcBuilders
+                .standaloneSetup(controllers)
+                .setMessageConverters(jacksonConverter(), new ByteArrayHttpMessageConverter())
+                .setControllerAdvice(new ee.tuleva.onboarding.error.ErrorHandlingControllerAdvice())
+                .setCustomArgumentResolvers(authResolver())
+                .build()
+    }
+
+    private org.springframework.http.converter.json.JacksonJsonHttpMessageConverter jacksonConverter() {
+        def objectMapper = tools.jackson.databind.json.JsonMapper.builder()
+                .enable(tools.jackson.core.StreamWriteFeature.WRITE_BIGDECIMAL_AS_PLAIN)
+                .build()
+        return new org.springframework.http.converter.json.JacksonJsonHttpMessageConverter(objectMapper)
+    }
+
+    private org.springframework.web.method.support.HandlerMethodArgumentResolver authResolver() {
+        return new org.springframework.web.method.support.HandlerMethodArgumentResolver() {
+            boolean supportsParameter(org.springframework.core.MethodParameter parameter) {
+                return parameter.parameterType == ee.tuleva.onboarding.auth.principal.AuthenticatedPerson
+            }
+            Object resolveArgument(org.springframework.core.MethodParameter parameter,
+                    org.springframework.web.method.support.ModelAndViewContainer mavContainer,
+                    org.springframework.web.context.request.NativeWebRequest webRequest,
+                    org.springframework.web.bind.support.WebDataBinderFactory binderFactory) {
+                return ee.tuleva.onboarding.auth.principal.AuthenticatedPerson.builder().userId(1L).build()
+            }
+        }
     }
 
     def "get: Get all funds"() {

--- a/src/test/groovy/ee/tuleva/onboarding/fund/FundControllerSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/fund/FundControllerSpec.groovy
@@ -17,6 +17,7 @@ import static org.hamcrest.Matchers.hasSize
 import static org.hamcrest.Matchers.is
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
@@ -88,6 +89,27 @@ class FundControllerSpec extends BaseControllerSpec {
                 .andExpect(jsonPath('$[0].value', is(1.0d)))
                 .andExpect(jsonPath('$[1].date', is("2026-02-04")))
                 .andExpect(jsonPath('$[1].value', is(1.0012d)))
+    }
+
+    def "get: Get NAV history as CSV"() {
+        given:
+        def isin = "EE0000003283"
+        def navValues = [
+            new NavValueResponse(LocalDate.of(2026, 2, 3), 1.0000G),
+            new NavValueResponse(LocalDate.of(2026, 2, 4), 1.0012G),
+        ]
+        1 * fundService.getNavHistory(isin, null, null) >> navValues
+        expect:
+        def result = mockMvc
+                .perform(get("/v1/funds/${isin}/nav?format=csv"))
+                .andExpect(status().isOk())
+                .andExpect(header().string("Content-Type", "text/csv;charset=UTF-8"))
+                .andExpect(header().string("Content-Disposition", 'attachment; filename="nav-EE0000003283.csv"'))
+                .andReturn()
+        def csv = result.response.contentAsString
+        csv.contains("Kuupäev;NAV (EUR)")
+        csv.contains("03.02.2026;1.0000")
+        csv.contains("04.02.2026;1.0012")
     }
 
     def "get: Get NAV history for unknown fund returns 404"() {

--- a/src/test/groovy/ee/tuleva/onboarding/fund/FundServiceSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/fund/FundServiceSpec.groovy
@@ -444,6 +444,32 @@ class FundServiceSpec extends Specification {
     thrown(ResponseStatusException)
   }
 
+  def "getNavHistoryCsv returns semicolon-delimited CSV with BOM"() {
+    given:
+    def isin = "EE0000003283"
+    def startDate = LocalDate.of(2026, 2, 2)
+    def endDate = LocalDate.of(2026, 4, 14)
+    fundRepository.findByIsin(isin) >> additionalSavingsFund()
+    fundValueRepository.findValuesBetweenDates(isin, startDate, endDate) >> [
+        aFundValue(isin, LocalDate.of(2026, 2, 3), 1.0000),
+        aFundValue(isin, LocalDate.of(2026, 2, 4), 1.0012),
+    ]
+
+    when:
+    def bytes = fundService.getNavHistoryCsv(isin, startDate, endDate)
+
+    then:
+    bytes[0] == (byte) 0xEF
+    bytes[1] == (byte) 0xBB
+    bytes[2] == (byte) 0xBF
+    def csv = new String(bytes, "UTF-8")
+    def lines = csv.trim().split("\r\n")
+    lines.length == 3
+    lines[0].endsWith("Kuupäev;NAV (EUR)")
+    lines[1] == "03.02.2026;1.0000"
+    lines[2] == "04.02.2026;1.0012"
+  }
+
   def "non-savings fund returns null volume"() {
     given:
     String fundManagerName = "Tuleva"


### PR DESCRIPTION
## Summary
- `GET /v1/funds/{isin}/nav?format=csv` returns semicolon-delimited CSV with UTF-8 BOM
- Uses Apache Commons CSV (same pattern as `NavReportCsvGenerator`) with Estonian date format
- Builds on the NAV history endpoint merged in #1557

## Test plan
- [x] CircleCI build passes
- [x] 100% patch coverage
- [ ] `curl "https://onboarding-service.tuleva.ee/v1/funds/EE0000003283/nav?format=csv"` → downloads CSV
- [ ] Open in Excel → columns parse correctly with semicolons

🤖 Generated with [Claude Code](https://claude.com/claude-code)