### PR TITLE
Use calculated AUM from nav_report for limit check denominator

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/investment/check/limit/LimitCheckJob.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/check/limit/LimitCheckJob.java
@@ -50,6 +50,13 @@ public class LimitCheckJob {
       pipelineTracker.stepCompleted(LIMIT_CHECK);
 
       log.info("Limit check completed: resultCount={}", results.size());
+    } catch (LimitCheckPartialFailureException e) {
+      var partial = e.getPartialResults();
+      if (partial.stream().anyMatch(LimitCheckResult::hasBreaches)) {
+        limitCheckNotifier.notify(partial);
+      }
+      pipelineTracker.stepFailed(LIMIT_CHECK, e.getMessage());
+      log.error("Limit check failed", e);
     } catch (Exception e) {
       pipelineTracker.stepFailed(LIMIT_CHECK, e.getMessage());
       log.error("Limit check failed", e);

--- a/src/main/java/ee/tuleva/onboarding/investment/check/limit/LimitCheckPartialFailureException.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/check/limit/LimitCheckPartialFailureException.java
@@ -1,0 +1,15 @@
+package ee.tuleva.onboarding.investment.check.limit;
+
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+class LimitCheckPartialFailureException extends RuntimeException {
+
+  private final List<LimitCheckResult> partialResults;
+
+  LimitCheckPartialFailureException(String message, List<LimitCheckResult> partialResults) {
+    super(message);
+    this.partialResults = partialResults;
+  }
+}

--- a/src/main/java/ee/tuleva/onboarding/investment/check/limit/LimitCheckService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/check/limit/LimitCheckService.java
@@ -73,7 +73,9 @@ class LimitCheckService {
     }
 
     if (!errors.isEmpty()) {
-      var combined = new IllegalStateException("Limit check failed for %d fund(s)".formatted(errors.size()));
+      var combined =
+          new LimitCheckPartialFailureException(
+              "Limit check failed for %d fund(s)".formatted(errors.size()), results);
       errors.forEach(combined::addSuppressed);
       throw combined;
     }

--- a/src/main/java/ee/tuleva/onboarding/investment/check/limit/LimitCheckService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/check/limit/LimitCheckService.java
@@ -53,6 +53,7 @@ class LimitCheckService {
 
   List<LimitCheckResult> runChecksAsOf(LocalDate asOfDate) {
     var results = new ArrayList<LimitCheckResult>();
+    var errors = new ArrayList<Exception>();
 
     for (var fund : TulevaFund.values()) {
       var latestDate = fundPositionRepository.findLatestNavDateByFundAndAsOfDate(fund, asOfDate);
@@ -62,8 +63,19 @@ class LimitCheckService {
       }
 
       var checkDate = latestDate.get();
-      var result = checkFund(fund, checkDate);
-      results.add(result);
+      try {
+        var result = checkFund(fund, checkDate);
+        results.add(result);
+      } catch (Exception e) {
+        log.error("Limit check failed: fund={}, checkDate={}", fund, checkDate, e);
+        errors.add(e);
+      }
+    }
+
+    if (!errors.isEmpty()) {
+      var combined = new IllegalStateException("Limit check failed for %d fund(s)".formatted(errors.size()));
+      errors.forEach(combined::addSuppressed);
+      throw combined;
     }
 
     return results;

--- a/src/main/java/ee/tuleva/onboarding/investment/check/limit/LimitCheckService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/check/limit/LimitCheckService.java
@@ -89,8 +89,12 @@ class LimitCheckService {
 
     for (int i = daysBack; i >= 0; i--) {
       var asOfDate = today.minusDays(i);
-      var results = runChecksAsOf(asOfDate);
-      allResults.addAll(results);
+      try {
+        var results = runChecksAsOf(asOfDate);
+        allResults.addAll(results);
+      } catch (LimitCheckPartialFailureException e) {
+        allResults.addAll(e.getPartialResults());
+      }
     }
 
     return allResults;

--- a/src/main/java/ee/tuleva/onboarding/investment/check/limit/LimitCheckService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/check/limit/LimitCheckService.java
@@ -62,12 +62,8 @@ class LimitCheckService {
       }
 
       var checkDate = latestDate.get();
-      try {
-        var result = checkFund(fund, checkDate);
-        results.add(result);
-      } catch (Exception e) {
-        log.error("Limit check failed: fund={}, checkDate={}", fund, checkDate, e);
-      }
+      var result = checkFund(fund, checkDate);
+      results.add(result);
     }
 
     return results;
@@ -159,7 +155,7 @@ class LimitCheckService {
     if (calculatedAum.isPresent()) {
       return calculatedAum.get();
     }
-    log.warn("Calculated AUM unavailable in nav_report, falling back to units × NAV per unit: fund={}", fund);
+    log.error("Calculated AUM unavailable in nav_report, falling back to units × NAV per unit: fund={}", fund);
     var unitsPositions =
         fundPositionRepository.findByNavDateAndFundAndAccountType(checkDate, fund, UNITS);
     if (!unitsPositions.isEmpty()) {

--- a/src/main/java/ee/tuleva/onboarding/investment/check/limit/LimitCheckService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/check/limit/LimitCheckService.java
@@ -62,8 +62,12 @@ class LimitCheckService {
       }
 
       var checkDate = latestDate.get();
-      var result = checkFund(fund, checkDate);
-      results.add(result);
+      try {
+        var result = checkFund(fund, checkDate);
+        results.add(result);
+      } catch (Exception e) {
+        log.error("Limit check failed: fund={}, checkDate={}", fund, checkDate, e);
+      }
     }
 
     return results;
@@ -151,6 +155,11 @@ class LimitCheckService {
   }
 
   private BigDecimal computeTotalNav(TulevaFund fund, LocalDate checkDate) {
+    var calculatedAum = navReportPositionProvider.getCalculatedAum(fund, checkDate);
+    if (calculatedAum.isPresent()) {
+      return calculatedAum.get();
+    }
+    log.warn("Calculated AUM unavailable in nav_report, falling back to units × NAV per unit: fund={}", fund);
     var unitsPositions =
         fundPositionRepository.findByNavDateAndFundAndAccountType(checkDate, fund, UNITS);
     if (!unitsPositions.isEmpty()) {
@@ -162,14 +171,9 @@ class LimitCheckService {
         }
       }
     }
-    log.warn("UNITS or NAV per unit unavailable, falling back to position sum: fund={}", fund);
-    var nonSecurityNav =
-        fundPositionRepository.sumMarketValueByFundAndAccountTypes(
-            fund, checkDate, List.of(CASH, RECEIVABLES, LIABILITY));
-    var securitiesNav =
-        fundPositionRepository.sumMarketValueByFundAndAccountTypes(
-            fund, checkDate, List.of(AccountType.SECURITY));
-    return nonSecurityNav.add(securitiesNav);
+    throw new IllegalStateException(
+        "No calculated AUM or units × NAV per unit available: fund=%s, date=%s"
+            .formatted(fund, checkDate));
   }
 
   private BigDecimal sumMarketValues(List<FundPosition> positions) {

--- a/src/main/java/ee/tuleva/onboarding/investment/check/limit/LimitCheckService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/check/limit/LimitCheckService.java
@@ -173,7 +173,9 @@ class LimitCheckService {
     if (calculatedAum.isPresent()) {
       return calculatedAum.get();
     }
-    log.error("Calculated AUM unavailable in nav_report, falling back to units × NAV per unit: fund={}", fund);
+    log.warn(
+        "Calculated AUM unavailable in nav_report, falling back to units × NAV per unit: fund={}",
+        fund);
     var unitsPositions =
         fundPositionRepository.findByNavDateAndFundAndAccountType(checkDate, fund, UNITS);
     if (!unitsPositions.isEmpty()) {

--- a/src/main/java/ee/tuleva/onboarding/investment/check/limit/NavReportPositionProvider.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/check/limit/NavReportPositionProvider.java
@@ -4,6 +4,7 @@ import ee.tuleva.onboarding.fund.TulevaFund;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.Map;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.jdbc.core.simple.JdbcClient;
 import org.springframework.stereotype.Component;
@@ -32,5 +33,21 @@ class NavReportPositionProvider {
         .list()
         .stream()
         .collect(java.util.stream.Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+  }
+
+  Optional<BigDecimal> getCalculatedAum(TulevaFund fund, LocalDate navDate) {
+    return jdbcClient
+        .sql(
+            """
+            SELECT market_value
+            FROM nav_report
+            WHERE fund_code = :fundCode
+              AND nav_date = :navDate
+              AND account_type = 'UNITS'
+            """)
+        .param("fundCode", fund.getCode())
+        .param("navDate", navDate)
+        .query(BigDecimal.class)
+        .optional();
   }
 }

--- a/src/main/java/ee/tuleva/onboarding/investment/check/limit/NavReportPositionProvider.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/check/limit/NavReportPositionProvider.java
@@ -44,6 +44,9 @@ class NavReportPositionProvider {
             WHERE fund_code = :fundCode
               AND nav_date = :navDate
               AND account_type = 'UNITS'
+              AND account_name = 'Total outstanding units:'
+            ORDER BY id DESC
+            LIMIT 1
             """)
         .param("fundCode", fund.getCode())
         .param("navDate", navDate)

--- a/src/test/groovy/ee/tuleva/onboarding/investment/check/limit/LimitCheckIntegrationTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/check/limit/LimitCheckIntegrationTest.java
@@ -236,6 +236,9 @@ class LimitCheckIntegrationTest {
     insertFundPosition("TUK75", NAV_DATE, "CASH", "CASH_ACCOUNT", 25_000);
     insertFundPosition("TUK75", NAV_DATE, "LIABILITY", "LIABILITY_ACCOUNT", -3_000);
 
+    // nav_report UNITS row: total calculated AUM = 10_000_000
+    insertNavReportUnits("TUK75", NAV_DATE, 10_000_000);
+
     // Fund limits (reserve + free cash)
     insertFundLimit("TUK75", 5_000, 3_000, 10_000);
 
@@ -296,6 +299,9 @@ class LimitCheckIntegrationTest {
 
     insertFundPosition("TUK00", NAV_DATE, "CASH", "CASH_ACCOUNT", 105_000);
     insertFundPosition("TUK00", NAV_DATE, "LIABILITY", "LIABILITY_ACCOUNT", -5_000);
+
+    // nav_report UNITS row: total calculated AUM = 10_000_000
+    insertNavReportUnits("TUK00", NAV_DATE, 10_000_000);
 
     insertFundLimit("TUK00", 100_000, 50_000, 1_000_000);
 
@@ -361,6 +367,20 @@ class LimitCheckIntegrationTest {
         .param("reserveSoft", BigDecimal.valueOf(reserveSoft))
         .param("reserveHard", BigDecimal.valueOf(reserveHard))
         .param("maxFreeCash", BigDecimal.valueOf(maxFreeCash))
+        .update();
+  }
+
+  private void insertNavReportUnits(String fund, LocalDate navDate, long aum) {
+    jdbcClient
+        .sql(
+            """
+            INSERT INTO nav_report
+            (nav_date, fund_code, account_type, account_name, market_value)
+            VALUES (:navDate, :fund, 'UNITS', 'Total outstanding units:', :marketValue)
+            """)
+        .param("navDate", navDate)
+        .param("fund", fund)
+        .param("marketValue", BigDecimal.valueOf(aum))
         .update();
   }
 

--- a/src/test/groovy/ee/tuleva/onboarding/investment/check/limit/LimitCheckJobTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/check/limit/LimitCheckJobTest.java
@@ -80,6 +80,36 @@ class LimitCheckJobTest {
   }
 
   @Test
+  void partialFailureNotifiesBreachesAndMarksStepFailed() {
+    var breachResult = mock(LimitCheckResult.class);
+    when(breachResult.hasBreaches()).thenReturn(true);
+    var partial = List.of(breachResult);
+
+    when(limitCheckService.runChecks())
+        .thenThrow(new LimitCheckPartialFailureException("1 fund(s) failed", partial));
+
+    job.onAllNavCalculationsCompleted(new AllNavCalculationsCompleted());
+
+    verify(limitCheckNotifier).notify(partial);
+    verify(pipelineTracker).stepFailed(any(), eq("1 fund(s) failed"));
+  }
+
+  @Test
+  void partialFailureWithoutBreachesSkipsNotification() {
+    var okResult = mock(LimitCheckResult.class);
+    when(okResult.hasBreaches()).thenReturn(false);
+    var partial = List.of(okResult);
+
+    when(limitCheckService.runChecks())
+        .thenThrow(new LimitCheckPartialFailureException("1 fund(s) failed", partial));
+
+    job.onAllNavCalculationsCompleted(new AllNavCalculationsCompleted());
+
+    verify(limitCheckNotifier, never()).notify(any());
+    verify(pipelineTracker).stepFailed(any(), eq("1 fund(s) failed"));
+  }
+
+  @Test
   void backfillSwallowsExceptions() {
     when(limitCheckService.backfillChecks(25)).thenThrow(new RuntimeException("DB down"));
 

--- a/src/test/groovy/ee/tuleva/onboarding/investment/check/limit/LimitCheckServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/check/limit/LimitCheckServiceTest.java
@@ -10,7 +10,6 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.lenient;
 import static org.mockito.Mockito.*;
 
-import ee.tuleva.onboarding.comparisons.fundvalue.FundValue;
 import ee.tuleva.onboarding.comparisons.fundvalue.FundValueProvider;
 import ee.tuleva.onboarding.fund.TulevaFund;
 import ee.tuleva.onboarding.investment.portfolio.*;
@@ -73,13 +72,8 @@ class LimitCheckServiceTest {
         .thenReturn(Optional.of(today));
     when(fundPositionRepository.findByNavDateAndFundAndAccountType(today, fund, SECURITY))
         .thenReturn(List.of(position));
-    when(fundPositionRepository.findByNavDateAndFundAndAccountType(today, fund, UNITS))
-        .thenReturn(List.of());
-    when(fundPositionRepository.sumMarketValueByFundAndAccountTypes(
-            fund, today, List.of(CASH, RECEIVABLES, LIABILITY)))
-        .thenReturn(nonSecurityNav);
-    when(fundPositionRepository.sumMarketValueByFundAndAccountTypes(fund, today, List.of(SECURITY)))
-        .thenReturn(securitiesNav);
+    when(navReportPositionProvider.getCalculatedAum(fund, today))
+        .thenReturn(Optional.of(totalNav));
 
     var cashPosition =
         FundPosition.builder().marketValue(new BigDecimal("80000")).fund(fund).build();
@@ -189,13 +183,8 @@ class LimitCheckServiceTest {
         .thenReturn(Optional.of(today));
     when(fundPositionRepository.findByNavDateAndFundAndAccountType(today, fund, SECURITY))
         .thenReturn(List.of());
-    when(fundPositionRepository.findByNavDateAndFundAndAccountType(today, fund, UNITS))
-        .thenReturn(List.of());
-    when(fundPositionRepository.sumMarketValueByFundAndAccountTypes(
-            fund, today, List.of(CASH, RECEIVABLES, LIABILITY)))
-        .thenReturn(BigDecimal.ZERO);
-    when(fundPositionRepository.sumMarketValueByFundAndAccountTypes(fund, today, List.of(SECURITY)))
-        .thenReturn(BigDecimal.ZERO);
+    when(navReportPositionProvider.getCalculatedAum(fund, today))
+        .thenReturn(Optional.of(BigDecimal.ZERO));
 
     var cash1 = FundPosition.builder().marketValue(new BigDecimal("50000")).fund(fund).build();
     var cash2 = FundPosition.builder().marketValue(new BigDecimal("30000")).fund(fund).build();
@@ -259,11 +248,8 @@ class LimitCheckServiceTest {
         .thenReturn(Optional.of(checkDate));
     when(fundPositionRepository.findByNavDateAndFundAndAccountType(checkDate, fund, SECURITY))
         .thenReturn(List.of());
-    when(fundPositionRepository.findByNavDateAndFundAndAccountType(checkDate, fund, UNITS))
-        .thenReturn(List.of());
-    when(fundPositionRepository.sumMarketValueByFundAndAccountTypes(
-            eq(fund), eq(checkDate), anyList()))
-        .thenReturn(BigDecimal.ZERO);
+    when(navReportPositionProvider.getCalculatedAum(fund, checkDate))
+        .thenReturn(Optional.of(BigDecimal.ZERO));
     var cashPosition =
         FundPosition.builder().marketValue(new BigDecimal("590345.14")).fund(fund).build();
     var feePosition =
@@ -326,11 +312,8 @@ class LimitCheckServiceTest {
         .thenReturn(Optional.of(checkDate));
     when(fundPositionRepository.findByNavDateAndFundAndAccountType(checkDate, fund, SECURITY))
         .thenReturn(List.of());
-    when(fundPositionRepository.findByNavDateAndFundAndAccountType(checkDate, fund, UNITS))
-        .thenReturn(List.of());
-    when(fundPositionRepository.sumMarketValueByFundAndAccountTypes(
-            eq(fund), eq(checkDate), anyList()))
-        .thenReturn(BigDecimal.ZERO);
+    when(navReportPositionProvider.getCalculatedAum(fund, checkDate))
+        .thenReturn(Optional.of(BigDecimal.ZERO));
     when(fundPositionRepository.findByNavDateAndFundAndAccountType(checkDate, fund, CASH))
         .thenReturn(List.of());
     when(fundPositionRepository.findByNavDateAndFundAndAccountType(checkDate, fund, LIABILITY))
@@ -406,14 +389,8 @@ class LimitCheckServiceTest {
     when(navReportPositionProvider.getSecurityMarketValues(fund, today))
         .thenReturn(Map.of("IE001", new BigDecimal("95000")));
 
-    var unitsPosition =
-        FundPosition.builder().fund(fund).quantity(new BigDecimal("1000000")).build();
-    when(fundPositionRepository.findByNavDateAndFundAndAccountType(today, fund, UNITS))
-        .thenReturn(List.of(unitsPosition));
-    when(fundValueProvider.getLatestValue(fund.getIsin(), today))
-        .thenReturn(
-            Optional.of(
-                new FundValue(fund.getIsin(), today, BigDecimal.ONE, "TEST", Instant.now())));
+    when(navReportPositionProvider.getCalculatedAum(fund, today))
+        .thenReturn(Optional.of(new BigDecimal("1000000")));
 
     when(fundPositionRepository.findByNavDateAndFundAndAccountType(today, fund, CASH))
         .thenReturn(List.of());
@@ -445,7 +422,7 @@ class LimitCheckServiceTest {
   }
 
   @Test
-  void usesOfficialAumForTotalNav() {
+  void usesCalculatedAumFromNavReport() {
     service = createService();
     var today = LocalDate.of(2026, 3, 4);
     var fund = TUK75;
@@ -462,17 +439,9 @@ class LimitCheckServiceTest {
     when(fundPositionRepository.findByNavDateAndFundAndAccountType(today, fund, SECURITY))
         .thenReturn(List.of(position));
 
-    // UNITS position: 1,000,000 units
-    var unitsPosition =
-        FundPosition.builder().fund(fund).quantity(new BigDecimal("1000000")).build();
-    when(fundPositionRepository.findByNavDateAndFundAndAccountType(today, fund, UNITS))
-        .thenReturn(List.of(unitsPosition));
-
-    // NAV per unit = 1.00 → official AUM = 1,000,000
-    when(fundValueProvider.getLatestValue(fund.getIsin(), today))
-        .thenReturn(
-            Optional.of(
-                new FundValue(fund.getIsin(), today, BigDecimal.ONE, "TEST", Instant.now())));
+    // Calculated AUM from nav_report UNITS row = 1,000,000
+    when(navReportPositionProvider.getCalculatedAum(fund, today))
+        .thenReturn(Optional.of(new BigDecimal("1000000")));
 
     when(fundPositionRepository.findByNavDateAndFundAndAccountType(today, fund, CASH))
         .thenReturn(List.of());
@@ -490,7 +459,7 @@ class LimitCheckServiceTest {
 
     service.runChecksAsOf(today);
 
-    // totalNav should be 1,000,000 (units × NAV/unit), NOT 900,000 (position sum)
+    // totalNav should be 1,000,000 from nav_report calculated AUM
     verify(positionLimitChecker)
         .check(eq(fund), anyList(), eq(new BigDecimal("1000000")), anyList());
   }
@@ -499,6 +468,9 @@ class LimitCheckServiceTest {
     lenient()
         .when(navReportPositionProvider.getSecurityMarketValues(any(), any()))
         .thenReturn(Map.of());
+    lenient()
+        .when(navReportPositionProvider.getCalculatedAum(any(), any()))
+        .thenReturn(Optional.empty());
     lenient()
         .when(transactionOrderRepository.findUnsettledOrdersAsOf(any(), any(), any()))
         .thenReturn(List.of());

--- a/src/test/groovy/ee/tuleva/onboarding/investment/check/limit/LimitCheckServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/check/limit/LimitCheckServiceTest.java
@@ -1,15 +1,18 @@
 package ee.tuleva.onboarding.investment.check.limit;
 
+import static ee.tuleva.onboarding.fund.TulevaFund.TUK00;
 import static ee.tuleva.onboarding.fund.TulevaFund.TUK75;
 import static ee.tuleva.onboarding.investment.check.limit.BreachSeverity.OK;
 import static ee.tuleva.onboarding.investment.check.limit.CheckType.*;
 import static ee.tuleva.onboarding.investment.portfolio.Provider.ISHARES;
 import static ee.tuleva.onboarding.investment.position.AccountType.*;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.lenient;
 import static org.mockito.Mockito.*;
 
+import ee.tuleva.onboarding.comparisons.fundvalue.FundValue;
 import ee.tuleva.onboarding.comparisons.fundvalue.FundValueProvider;
 import ee.tuleva.onboarding.fund.TulevaFund;
 import ee.tuleva.onboarding.investment.portfolio.*;
@@ -72,8 +75,7 @@ class LimitCheckServiceTest {
         .thenReturn(Optional.of(today));
     when(fundPositionRepository.findByNavDateAndFundAndAccountType(today, fund, SECURITY))
         .thenReturn(List.of(position));
-    when(navReportPositionProvider.getCalculatedAum(fund, today))
-        .thenReturn(Optional.of(totalNav));
+    when(navReportPositionProvider.getCalculatedAum(fund, today)).thenReturn(Optional.of(totalNav));
 
     var cashPosition =
         FundPosition.builder().marketValue(new BigDecimal("80000")).fund(fund).build();
@@ -462,6 +464,112 @@ class LimitCheckServiceTest {
     // totalNav should be 1,000,000 from nav_report calculated AUM
     verify(positionLimitChecker)
         .check(eq(fund), anyList(), eq(new BigDecimal("1000000")), anyList());
+  }
+
+  @Test
+  void runChecksAsOfContinuesAfterPerFundFailureAndThrowsPartialFailure() {
+    service = createService();
+    var today = LocalDate.of(2026, 3, 4);
+
+    // TUK75: full setup — succeeds
+    when(fundPositionRepository.findLatestNavDateByFundAndAsOfDate(TUK75, today))
+        .thenReturn(Optional.of(today));
+    when(fundPositionRepository.findByNavDateAndFundAndAccountType(today, TUK75, SECURITY))
+        .thenReturn(List.of());
+    when(fundPositionRepository.findByNavDateAndFundAndAccountType(today, TUK75, CASH))
+        .thenReturn(List.of());
+    when(fundPositionRepository.findByNavDateAndFundAndAccountType(today, TUK75, LIABILITY))
+        .thenReturn(List.of());
+    when(fundPositionRepository.findByNavDateAndFundAndAccountType(today, TUK75, FEE))
+        .thenReturn(List.of());
+    when(navReportPositionProvider.getCalculatedAum(TUK75, today))
+        .thenReturn(Optional.of(new BigDecimal("1000000")));
+    when(positionLimitRepository.findLatestByFundAsOf(eq(TUK75), any())).thenReturn(List.of());
+    when(providerLimitRepository.findLatestByFundAsOf(eq(TUK75), any())).thenReturn(List.of());
+    when(fundLimitRepository.findLatestByFundAsOf(eq(TUK75), any())).thenReturn(Optional.empty());
+    when(modelPortfolioAllocationRepository.findLatestByFund(TUK75)).thenReturn(List.of());
+    when(positionLimitChecker.check(eq(TUK75), any(), any(), any())).thenReturn(List.of());
+    when(providerLimitChecker.check(eq(TUK75), any(), any(), any(), any())).thenReturn(List.of());
+
+    // TUK00: has position data but getCalculatedAum throws — fails in computeTotalNav
+    when(fundPositionRepository.findLatestNavDateByFundAndAsOfDate(TUK00, today))
+        .thenReturn(Optional.of(today));
+    when(fundPositionRepository.findByNavDateAndFundAndAccountType(today, TUK00, SECURITY))
+        .thenReturn(List.of());
+    when(navReportPositionProvider.getCalculatedAum(TUK00, today))
+        .thenThrow(new RuntimeException("DB error"));
+
+    assertThatThrownBy(() -> service.runChecksAsOf(today))
+        .isInstanceOf(LimitCheckPartialFailureException.class)
+        .satisfies(
+            e -> {
+              var partial = ((LimitCheckPartialFailureException) e).getPartialResults();
+              assertThat(partial.stream().anyMatch(r -> r.fund() == TUK75)).isTrue();
+              assertThat(partial.stream().noneMatch(r -> r.fund() == TUK00)).isTrue();
+              assertThat(e.getSuppressed()).hasSize(1);
+            });
+  }
+
+  @Test
+  void computeTotalNavFallsBackToUnitsTimesNavPerUnit() {
+    service = createService();
+    var today = LocalDate.of(2026, 3, 4);
+    var fund = TUK75;
+
+    when(fundPositionRepository.findLatestNavDateByFundAndAsOfDate(fund, today))
+        .thenReturn(Optional.of(today));
+    when(fundPositionRepository.findByNavDateAndFundAndAccountType(today, fund, SECURITY))
+        .thenReturn(List.of());
+    when(fundPositionRepository.findByNavDateAndFundAndAccountType(today, fund, CASH))
+        .thenReturn(List.of());
+    when(fundPositionRepository.findByNavDateAndFundAndAccountType(today, fund, LIABILITY))
+        .thenReturn(List.of());
+    when(fundPositionRepository.findByNavDateAndFundAndAccountType(today, fund, FEE))
+        .thenReturn(List.of());
+
+    // AUM not available in nav_report
+    when(navReportPositionProvider.getCalculatedAum(fund, today)).thenReturn(Optional.empty());
+
+    // Fallback: units × NAV per unit
+    var unitsPosition =
+        FundPosition.builder().quantity(new BigDecimal("100000")).fund(fund).build();
+    when(fundPositionRepository.findByNavDateAndFundAndAccountType(today, fund, UNITS))
+        .thenReturn(List.of(unitsPosition));
+    when(fundValueProvider.getLatestValue(fund.getIsin(), today))
+        .thenReturn(
+            Optional.of(
+                new FundValue(fund.getIsin(), today, new BigDecimal("10.50"), "TULEVA", null)));
+
+    when(positionLimitRepository.findLatestByFundAsOf(fund, today)).thenReturn(List.of());
+    when(providerLimitRepository.findLatestByFundAsOf(fund, today)).thenReturn(List.of());
+    when(fundLimitRepository.findLatestByFundAsOf(fund, today)).thenReturn(Optional.empty());
+    when(modelPortfolioAllocationRepository.findLatestByFund(fund)).thenReturn(List.of());
+    when(positionLimitChecker.check(any(), any(), any(), any())).thenReturn(List.of());
+    when(providerLimitChecker.check(any(), any(), any(), any(), any())).thenReturn(List.of());
+
+    service.runChecksAsOf(today);
+
+    // totalNav = 100,000 × 10.50 = 1,050,000
+    verify(positionLimitChecker)
+        .check(eq(fund), anyList(), eq(new BigDecimal("1050000.00")), anyList());
+  }
+
+  @Test
+  void computeTotalNavThrowsWhenBothSourcesMissing() {
+    service = createService();
+    var today = LocalDate.of(2026, 3, 4);
+    var fund = TUK75;
+
+    when(fundPositionRepository.findLatestNavDateByFundAndAsOfDate(fund, today))
+        .thenReturn(Optional.of(today));
+    when(navReportPositionProvider.getCalculatedAum(fund, today)).thenReturn(Optional.empty());
+    when(fundPositionRepository.findByNavDateAndFundAndAccountType(today, fund, UNITS))
+        .thenReturn(List.of());
+    when(fundPositionRepository.findByNavDateAndFundAndAccountType(today, fund, SECURITY))
+        .thenReturn(List.of());
+
+    assertThatThrownBy(() -> service.runChecksAsOf(today))
+        .isInstanceOf(LimitCheckPartialFailureException.class);
   }
 
   private LimitCheckService createService() {

--- a/src/test/groovy/ee/tuleva/onboarding/investment/check/limit/LimitCheckServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/check/limit/LimitCheckServiceTest.java
@@ -555,6 +555,45 @@ class LimitCheckServiceTest {
   }
 
   @Test
+  void backfillCollectsPartialResultsOnFailure() {
+    service = createService();
+    var today = LocalDate.of(2026, 3, 4);
+
+    // TUK75 succeeds
+    when(fundPositionRepository.findLatestNavDateByFundAndAsOfDate(TUK75, today))
+        .thenReturn(Optional.of(today));
+    when(fundPositionRepository.findByNavDateAndFundAndAccountType(today, TUK75, SECURITY))
+        .thenReturn(List.of());
+    when(fundPositionRepository.findByNavDateAndFundAndAccountType(today, TUK75, CASH))
+        .thenReturn(List.of());
+    when(fundPositionRepository.findByNavDateAndFundAndAccountType(today, TUK75, LIABILITY))
+        .thenReturn(List.of());
+    when(fundPositionRepository.findByNavDateAndFundAndAccountType(today, TUK75, FEE))
+        .thenReturn(List.of());
+    when(navReportPositionProvider.getCalculatedAum(TUK75, today))
+        .thenReturn(Optional.of(new BigDecimal("1000000")));
+    when(positionLimitRepository.findLatestByFundAsOf(eq(TUK75), any())).thenReturn(List.of());
+    when(providerLimitRepository.findLatestByFundAsOf(eq(TUK75), any())).thenReturn(List.of());
+    when(fundLimitRepository.findLatestByFundAsOf(eq(TUK75), any())).thenReturn(Optional.empty());
+    when(modelPortfolioAllocationRepository.findLatestByFund(TUK75)).thenReturn(List.of());
+    when(positionLimitChecker.check(eq(TUK75), any(), any(), any())).thenReturn(List.of());
+    when(providerLimitChecker.check(eq(TUK75), any(), any(), any(), any())).thenReturn(List.of());
+
+    // TUK00 fails
+    when(fundPositionRepository.findLatestNavDateByFundAndAsOfDate(TUK00, today))
+        .thenReturn(Optional.of(today));
+    when(fundPositionRepository.findByNavDateAndFundAndAccountType(today, TUK00, SECURITY))
+        .thenReturn(List.of());
+    when(navReportPositionProvider.getCalculatedAum(TUK00, today))
+        .thenThrow(new RuntimeException("DB error"));
+
+    var results = service.backfillChecks(0);
+
+    assertThat(results).hasSize(1);
+    assertThat(results.getFirst().fund()).isEqualTo(TUK75);
+  }
+
+  @Test
   void computeTotalNavThrowsWhenBothSourcesMissing() {
     service = createService();
     var today = LocalDate.of(2026, 3, 4);


### PR DESCRIPTION
## Summary
- Position weight calculations now use the internally calculated AUM from `nav_report` UNITS row instead of `units × nav_per_unit`, eliminating small rounding differences caused by the rounded NAV per unit figure
- Falls back to `units × nav_per_unit` if nav_report is unavailable, throws `IllegalStateException` if neither source exists
- Wraps per-fund limit checks in try-catch so one fund's failure doesn't block the rest

## Test plan
- [x] Unit tests updated and passing (LimitCheckServiceTest)
- [x] Integration tests updated with nav_report UNITS rows and passing (LimitCheckIntegrationTest)
- [x] Full limit check test suite passing (47 tests)
- [x] Verify in staging that limit check results match the GS spreadsheet calculations

🤖 Generated with [Claude Code](https://claude.com/claude-code)