### PR TITLE
Move Smart-ID auth state from LRUMap to HttpSession

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/auth/AuthController.java
+++ b/src/main/java/ee/tuleva/onboarding/auth/AuthController.java
@@ -19,6 +19,7 @@ import ee.tuleva.onboarding.auth.webeid.WebEidAuthService;
 import ee.tuleva.onboarding.error.ValidationErrorsException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import java.net.URLDecoder;
@@ -49,7 +50,9 @@ public class AuthController {
   @Operation(summary = "Initiate authentication")
   @PostMapping(value = "/authenticate", consumes = MediaType.APPLICATION_JSON_VALUE)
   public AuthenticateResponse authenticate(
-      @Valid @RequestBody AuthenticateCommand command, @Parameter(hidden = true) Errors errors) {
+      @Valid @RequestBody AuthenticateCommand command,
+      @Parameter(hidden = true) Errors errors,
+      @Parameter(hidden = true) HttpServletRequest request) {
     if (errors != null && errors.hasErrors()) {
       throw new ValidationErrorsException(errors);
     }
@@ -59,7 +62,9 @@ public class AuthController {
         yield AuthenticateResponse.fromWebEidChallenge(challengeNonce);
       }
       case SmartIdAuthenticateCommand cmd -> {
-        var loginSession = smartIdAuthService.startLogin(cmd.personalCode());
+        var httpSessionId = request.getSession(true).getId();
+        var loginSession = smartIdAuthService.startLogin(cmd.personalCode(), httpSessionId);
+        genericSessionStore.save(loginSession);
         yield AuthenticateResponse.fromSmartIdSession(loginSession);
       }
       case MobileIdAuthenticateCommand cmd -> {

--- a/src/main/java/ee/tuleva/onboarding/auth/session/GenericSessionStore.java
+++ b/src/main/java/ee/tuleva/onboarding/auth/session/GenericSessionStore.java
@@ -2,12 +2,19 @@ package ee.tuleva.onboarding.auth.session;
 
 import jakarta.servlet.http.HttpSession;
 import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.session.FindByIndexNameSessionRepository;
+import org.springframework.session.Session;
+import org.springframework.session.SessionRepository;
 import org.springframework.stereotype.Component;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
 @Component
+@RequiredArgsConstructor
 public class GenericSessionStore {
+
+  private final FindByIndexNameSessionRepository<? extends Session> sessionRepository;
 
   public <T> void save(T sessionAttribute) {
     HttpSession session = getSession();
@@ -19,6 +26,30 @@ public class GenericSessionStore {
     @SuppressWarnings("unchecked")
     T sessionAttribute = (T) session.getAttribute(clazz.getName());
     return Optional.ofNullable(sessionAttribute);
+  }
+
+  // For background threads with no HttpServletRequest. Bounded retry handles the race where
+  // a fast SDK response writes back before the originating request commits the session row.
+  public <T> void saveBySessionId(String sessionId, T attribute) {
+    saveAttribute(sessionRepository, sessionId, attribute);
+  }
+
+  private static <S extends Session> void saveAttribute(
+      SessionRepository<S> repository, String sessionId, Object attribute) {
+    for (int attempt = 0; attempt < 3; attempt++) {
+      S session = repository.findById(sessionId);
+      if (session != null) {
+        session.setAttribute(attribute.getClass().getName(), attribute);
+        repository.save(session);
+        return;
+      }
+      try {
+        Thread.sleep(100);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        return;
+      }
+    }
   }
 
   private static HttpSession getSession() {

--- a/src/main/java/ee/tuleva/onboarding/auth/session/GenericSessionStore.java
+++ b/src/main/java/ee/tuleva/onboarding/auth/session/GenericSessionStore.java
@@ -3,6 +3,7 @@ package ee.tuleva.onboarding.auth.session;
 import jakarta.servlet.http.HttpSession;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.session.FindByIndexNameSessionRepository;
 import org.springframework.session.Session;
 import org.springframework.session.SessionRepository;
@@ -12,6 +13,7 @@ import org.springframework.web.context.request.ServletRequestAttributes;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class GenericSessionStore {
 
   private final FindByIndexNameSessionRepository<? extends Session> sessionRepository;
@@ -50,6 +52,10 @@ public class GenericSessionStore {
         return;
       }
     }
+    log.error(
+        "Session not found after retries; dropping attribute: sessionId={}, attribute={}",
+        sessionId,
+        attribute.getClass().getName());
   }
 
   private static HttpSession getSession() {

--- a/src/main/java/ee/tuleva/onboarding/auth/session/GenericSessionStore.java
+++ b/src/main/java/ee/tuleva/onboarding/auth/session/GenericSessionStore.java
@@ -1,5 +1,6 @@
 package ee.tuleva.onboarding.auth.session;
 
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -19,12 +20,15 @@ public class GenericSessionStore {
   private final FindByIndexNameSessionRepository<? extends Session> sessionRepository;
 
   public <T> void save(T sessionAttribute) {
-    HttpSession session = getSession();
+    HttpSession session = currentRequest().getSession(true);
     session.setAttribute(sessionAttribute.getClass().getName(), sessionAttribute);
   }
 
   public <T> Optional<T> get(Class<T> clazz) {
-    HttpSession session = getSession();
+    HttpSession session = currentRequest().getSession(false);
+    if (session == null) {
+      return Optional.empty();
+    }
     @SuppressWarnings("unchecked")
     T sessionAttribute = (T) session.getAttribute(clazz.getName());
     return Optional.ofNullable(sessionAttribute);
@@ -49,6 +53,10 @@ public class GenericSessionStore {
         Thread.sleep(100);
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
+        log.error(
+            "Interrupted while waiting for session; dropping attribute: sessionId={}, attribute={}",
+            sessionId,
+            attribute.getClass().getName());
         return;
       }
     }
@@ -58,9 +66,8 @@ public class GenericSessionStore {
         attribute.getClass().getName());
   }
 
-  private static HttpSession getSession() {
-    ServletRequestAttributes attr =
-        (ServletRequestAttributes) RequestContextHolder.currentRequestAttributes();
-    return attr.getRequest().getSession(true);
+  private static HttpServletRequest currentRequest() {
+    return ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes())
+        .getRequest();
   }
 }

--- a/src/main/java/ee/tuleva/onboarding/auth/smartid/SmartIdAuthProvider.java
+++ b/src/main/java/ee/tuleva/onboarding/auth/smartid/SmartIdAuthProvider.java
@@ -21,9 +21,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class SmartIdAuthProvider implements AuthProvider {
 
-  // Smart-ID's own server-side session TTL is ~90 s (the app warns the user at ~60 s
-  // that 30 s remain). We give 120 s here to cover SK's window + the poll/write-back
-  // roundtrip; anything shorter would reject users SK still accepts.
+  // SK accepts up to ~90s of user idle; 120s covers that plus poll/write-back roundtrip.
   private static final Duration GRANT_TTL = Duration.ofSeconds(120);
 
   private final GenericSessionStore genericSessionStore;

--- a/src/main/java/ee/tuleva/onboarding/auth/smartid/SmartIdAuthProvider.java
+++ b/src/main/java/ee/tuleva/onboarding/auth/smartid/SmartIdAuthProvider.java
@@ -2,12 +2,17 @@ package ee.tuleva.onboarding.auth.smartid;
 
 import static ee.tuleva.onboarding.auth.GrantType.GRANT_TYPE;
 import static ee.tuleva.onboarding.auth.GrantType.SMART_ID;
+import static ee.tuleva.onboarding.error.response.ErrorsResponse.ofSingleError;
 
 import ee.tuleva.onboarding.auth.AuthProvider;
 import ee.tuleva.onboarding.auth.GrantType;
 import ee.tuleva.onboarding.auth.principal.AuthenticatedPerson;
 import ee.tuleva.onboarding.auth.principal.PrincipalService;
 import ee.tuleva.onboarding.auth.response.AuthNotCompleteException;
+import ee.tuleva.onboarding.auth.session.GenericSessionStore;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -15,8 +20,15 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 public class SmartIdAuthProvider implements AuthProvider {
-  private final SmartIdAuthService smartIdAuthService;
+
+  // Smart-ID's own server-side session TTL is ~90 s (the app warns the user at ~60 s
+  // that 30 s remain). We give 120 s here to cover SK's window + the poll/write-back
+  // roundtrip; anything shorter would reject users SK still accepts.
+  private static final Duration GRANT_TTL = Duration.ofSeconds(120);
+
+  private final GenericSessionStore genericSessionStore;
   private final PrincipalService principalService;
+  private final Clock clock;
 
   @Override
   public boolean supports(GrantType grantType) {
@@ -25,15 +37,27 @@ public class SmartIdAuthProvider implements AuthProvider {
 
   @Override
   public AuthenticatedPerson authenticate(String authenticationHash) {
-    if (authenticationHash == null) {
+    var session =
+        genericSessionStore
+            .get(SmartIdSession.class)
+            .orElseThrow(SmartIdSessionNotFoundException::new);
+
+    if (!session.getAuthenticationHash().getHashInBase64().equals(authenticationHash)) {
       throw new SmartIdSessionNotFoundException();
     }
 
-    var identity = smartIdAuthService.getAuthenticationIdentity(authenticationHash);
-    if (identity.isEmpty()) {
+    if (Instant.now(clock).isAfter(session.getCreatedAt().plus(GRANT_TTL))) {
+      throw new SmartIdSessionNotFoundException();
+    }
+
+    if (session.getErrorCode() != null) {
+      throw new SmartIdException(ofSingleError(session.getErrorCode(), session.getErrorMessage()));
+    }
+
+    if (session.getPerson() == null) {
       throw new AuthNotCompleteException();
     }
-    var smartIdPerson = new SmartIdPerson(identity.get());
-    return principalService.getFrom(smartIdPerson, Map.of(GRANT_TYPE, SMART_ID.name()));
+
+    return principalService.getFrom(session.getPerson(), Map.of(GRANT_TYPE, SMART_ID.name()));
   }
 }

--- a/src/main/java/ee/tuleva/onboarding/auth/smartid/SmartIdAuthService.java
+++ b/src/main/java/ee/tuleva/onboarding/auth/smartid/SmartIdAuthService.java
@@ -50,6 +50,7 @@ public class SmartIdAuthService {
       }
     } catch (InterruptedException e) {
       poller.shutdownNow();
+      Thread.currentThread().interrupt();
     }
   }
 

--- a/src/main/java/ee/tuleva/onboarding/auth/smartid/SmartIdAuthService.java
+++ b/src/main/java/ee/tuleva/onboarding/auth/smartid/SmartIdAuthService.java
@@ -1,6 +1,6 @@
 package ee.tuleva.onboarding.auth.smartid;
 
-import static java.util.concurrent.Executors.newFixedThreadPool;
+import static java.util.concurrent.Executors.newVirtualThreadPerTaskExecutor;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 import ee.sk.smartid.AuthenticationHash;
@@ -32,7 +32,7 @@ import org.springframework.stereotype.Service;
 @Slf4j
 public class SmartIdAuthService {
 
-  private final ExecutorService poller = newFixedThreadPool(20);
+  private final ExecutorService poller = newVirtualThreadPerTaskExecutor();
 
   private final SmartIdClient smartIdClient;
   private final SmartIdAuthenticationHashGenerator hashGenerator;

--- a/src/main/java/ee/tuleva/onboarding/auth/smartid/SmartIdAuthService.java
+++ b/src/main/java/ee/tuleva/onboarding/auth/smartid/SmartIdAuthService.java
@@ -1,6 +1,7 @@
 package ee.tuleva.onboarding.auth.smartid;
 
 import static java.util.concurrent.Executors.newFixedThreadPool;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 import ee.sk.smartid.AuthenticationHash;
 import ee.sk.smartid.AuthenticationIdentity;
@@ -21,7 +22,6 @@ import java.time.Clock;
 import java.time.Instant;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
@@ -45,7 +45,7 @@ public class SmartIdAuthService {
   public void stop() {
     poller.shutdown();
     try {
-      if (!poller.awaitTermination(800, TimeUnit.MILLISECONDS)) {
+      if (!poller.awaitTermination(800, MILLISECONDS)) {
         poller.shutdownNow();
       }
     } catch (InterruptedException e) {

--- a/src/main/java/ee/tuleva/onboarding/auth/smartid/SmartIdAuthService.java
+++ b/src/main/java/ee/tuleva/onboarding/auth/smartid/SmartIdAuthService.java
@@ -1,10 +1,13 @@
 package ee.tuleva.onboarding.auth.smartid;
 
-import static ee.tuleva.onboarding.error.response.ErrorsResponse.ofSingleError;
-import static java.util.Collections.*;
-import static java.util.concurrent.Executors.*;
+import static java.util.concurrent.Executors.newFixedThreadPool;
 
-import ee.sk.smartid.*;
+import ee.sk.smartid.AuthenticationHash;
+import ee.sk.smartid.AuthenticationIdentity;
+import ee.sk.smartid.AuthenticationRequestBuilder;
+import ee.sk.smartid.AuthenticationResponseValidator;
+import ee.sk.smartid.SmartIdAuthenticationResponse;
+import ee.sk.smartid.SmartIdClient;
 import ee.sk.smartid.exception.UnprocessableSmartIdResponseException;
 import ee.sk.smartid.exception.useraccount.UserAccountNotFoundException;
 import ee.sk.smartid.exception.useraction.UserRefusedException;
@@ -12,21 +15,16 @@ import ee.sk.smartid.rest.dao.Interaction;
 import ee.sk.smartid.rest.dao.SemanticsIdentifier;
 import ee.sk.smartid.rest.dao.SemanticsIdentifier.CountryCode;
 import ee.sk.smartid.rest.dao.SemanticsIdentifier.IdentityType;
+import ee.tuleva.onboarding.auth.session.GenericSessionStore;
 import jakarta.annotation.PreDestroy;
 import java.time.Clock;
-import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
-import lombok.Builder;
-import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.collections4.map.LRUMap;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -34,23 +32,12 @@ import org.springframework.stereotype.Service;
 @Slf4j
 public class SmartIdAuthService {
 
-  @Builder
-  @Data
-  static class SmartIdResult {
-
-    private AuthenticationIdentity authenticationIdentity;
-    private SmartIdException error;
-    private Instant createdAt;
-  }
-
-  private static final Duration TTL = Duration.ofSeconds(60);
-
-  private final Map<String, SmartIdResult> smartIdResults = synchronizedMap(new LRUMap<>());
   private final ExecutorService poller = newFixedThreadPool(20);
 
   private final SmartIdClient smartIdClient;
   private final SmartIdAuthenticationHashGenerator hashGenerator;
   private final AuthenticationResponseValidator authenticationResponseValidator;
+  private final GenericSessionStore genericSessionStore;
   private final Clock clock;
 
   @SneakyThrows
@@ -66,70 +53,44 @@ public class SmartIdAuthService {
     }
   }
 
-  public SmartIdSession startLogin(String personalCode) {
+  public SmartIdSession startLogin(String personalCode, String httpSessionId) {
     var authenticationHash = hashGenerator.generateHash();
-    String verificationCode = authenticationHash.calculateVerificationCode();
-    SmartIdSession session = new SmartIdSession(verificationCode, personalCode, authenticationHash);
-    poll(session);
+    var verificationCode = authenticationHash.calculateVerificationCode();
+    var session =
+        new SmartIdSession(verificationCode, personalCode, authenticationHash, Instant.now(clock));
+    poll(session, httpSessionId);
     return session;
   }
 
-  public Optional<AuthenticationIdentity> getAuthenticationIdentity(String authenticationHash) {
-    var result =
-        smartIdResults.computeIfPresent(
-            authenticationHash,
-            (key, value) -> {
-              if (Instant.now(clock).isAfter(value.getCreatedAt().plus(TTL))) {
-                return null; // Remove the entry
-              }
-              return value; // Keep the entry
-            });
-    if (result == null) {
-      return Optional.empty();
-    }
-    if (result.error != null) {
-      throw result.error;
-    }
-    return Optional.ofNullable(result.getAuthenticationIdentity());
-  }
-
-  private void poll(SmartIdSession session) {
+  private void poll(SmartIdSession session, String httpSessionId) {
     log.info("Starting to poll");
     poller.submit(
         () -> {
-          final var resultBuilder = SmartIdResult.builder().createdAt(Instant.now(clock));
           try {
             SmartIdAuthenticationResponse response =
                 requestBuilder(session.getPersonalCode(), session.getAuthenticationHash())
                     .authenticate();
-            AuthenticationIdentity authenticationIdentity =
-                authenticationResponseValidator.validate(response);
-            resultBuilder.authenticationIdentity(authenticationIdentity);
+            AuthenticationIdentity identity = authenticationResponseValidator.validate(response);
+            session.setPerson(new SmartIdPerson(identity));
           } catch (UnprocessableSmartIdResponseException e) {
             log.info("Smart ID validation failed: personalCode=" + session.getPersonalCode(), e);
-            resultBuilder.error(
-                new SmartIdException(
-                    ofSingleError("smart.id.validation.failed", "Smart ID validation failed")));
+            session.setErrorCode("smart.id.validation.failed");
+            session.setErrorMessage("Smart ID validation failed");
           } catch (UserAccountNotFoundException e) {
             log.info(
                 "Smart ID User account not found: personalCode=" + session.getPersonalCode(), e);
-            resultBuilder.error(
-                new SmartIdException(
-                    ofSingleError(
-                        "smart.id.account.not.found", "Smart ID user account not found")));
+            session.setErrorCode("smart.id.account.not.found");
+            session.setErrorMessage("Smart ID user account not found");
           } catch (UserRefusedException e) {
-            resultBuilder.error(
-                new SmartIdException(
-                    ofSingleError("smart.id.user.refused", "Smart ID User refused")));
+            session.setErrorCode("smart.id.user.refused");
+            session.setErrorMessage("Smart ID User refused");
           } catch (Exception e) {
             log.error("Smart ID technical error", e);
-            resultBuilder.error(
-                new SmartIdException(
-                    ofSingleError("smart.id.technical.error", "Smart ID technical error")));
+            session.setErrorCode("smart.id.technical.error");
+            session.setErrorMessage("Smart ID technical error");
           } finally {
             log.info("Smart ID authentication ended");
-            smartIdResults.put(
-                session.getAuthenticationHash().getHashInBase64(), resultBuilder.build());
+            genericSessionStore.saveBySessionId(httpSessionId, session);
           }
         });
   }

--- a/src/main/java/ee/tuleva/onboarding/auth/smartid/SmartIdSession.java
+++ b/src/main/java/ee/tuleva/onboarding/auth/smartid/SmartIdSession.java
@@ -3,14 +3,19 @@ package ee.tuleva.onboarding.auth.smartid;
 import ee.sk.smartid.AuthenticationHash;
 import java.io.Serial;
 import java.io.Serializable;
+import java.time.Instant;
 import lombok.Data;
 
 @Data
 public class SmartIdSession implements Serializable {
 
-  @Serial private static final long serialVersionUID = 6326478770346040900L;
+  @Serial private static final long serialVersionUID = 7445120994281540801L;
 
   private final String verificationCode;
   private final String personalCode;
   private final AuthenticationHash authenticationHash;
+  private final Instant createdAt;
+  private SmartIdPerson person;
+  private String errorCode;
+  private String errorMessage;
 }

--- a/src/main/java/ee/tuleva/onboarding/config/SmartIdClientConfiguration.java
+++ b/src/main/java/ee/tuleva/onboarding/config/SmartIdClientConfiguration.java
@@ -1,5 +1,7 @@
 package ee.tuleva.onboarding.config;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 import ee.sk.smartid.AuthenticationResponseValidator;
 import ee.sk.smartid.SmartIdClient;
 import ee.sk.smartid.exception.permanent.SmartIdClientException;
@@ -12,7 +14,6 @@ import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.Enumeration;
-import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -32,7 +33,7 @@ public class SmartIdClientConfiguration {
   @ConfigurationProperties(prefix = "smartid")
   public SmartIdClient smartIdClient(KeyStore trustStore) {
     SmartIdClient smartIdClient = new SmartIdClient();
-    smartIdClient.setSessionStatusResponseSocketOpenTime(TimeUnit.SECONDS, 1L);
+    smartIdClient.setSessionStatusResponseSocketOpenTime(SECONDS, 1L);
     smartIdClient.setTrustStore(trustStore);
     return smartIdClient;
   }

--- a/src/main/java/ee/tuleva/onboarding/error/ErrorHandlingControllerAdvice.java
+++ b/src/main/java/ee/tuleva/onboarding/error/ErrorHandlingControllerAdvice.java
@@ -6,8 +6,10 @@ import ee.tuleva.onboarding.account.PensionRegistryAccountStatementConnectionExc
 import ee.tuleva.onboarding.auth.ExpiredRefreshJwtException;
 import ee.tuleva.onboarding.auth.idcard.exception.IdCardSessionNotFoundException;
 import ee.tuleva.onboarding.auth.jwt.JwtTokenUtil;
+import ee.tuleva.onboarding.auth.mobileid.MobileIdSessionNotFoundException;
 import ee.tuleva.onboarding.auth.response.AuthNotCompleteException;
 import ee.tuleva.onboarding.auth.role.RoleSwitchAccessDeniedException;
+import ee.tuleva.onboarding.auth.smartid.SmartIdSessionNotFoundException;
 import ee.tuleva.onboarding.auth.webeid.WebEidAuthException;
 import ee.tuleva.onboarding.company.CompanyNotFoundException;
 import ee.tuleva.onboarding.error.exception.ErrorsResponseException;
@@ -47,6 +49,14 @@ public class ErrorHandlingControllerAdvice {
   public ResponseEntity<ErrorsResponse> handleErrors(IdSessionException exception) {
     log.warn("IdSessionException {}", exception.toString());
     return new ResponseEntity<>(exception.getErrorsResponse(), UNAUTHORIZED);
+  }
+
+  @ExceptionHandler({SmartIdSessionNotFoundException.class, MobileIdSessionNotFoundException.class})
+  public ResponseEntity<ErrorsResponse> handleAuthSessionNotFound(RuntimeException exception) {
+    log.error("Auth session not found: {}", exception.getMessage());
+    return new ResponseEntity<>(
+        ErrorsResponse.ofSingleError("auth.session.not.found", exception.getMessage()),
+        UNAUTHORIZED);
   }
 
   @ExceptionHandler(PensionRegistryAccountStatementConnectionException.class)

--- a/src/test/groovy/ee/tuleva/onboarding/auth/AuthControllerSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/auth/AuthControllerSpec.groovy
@@ -9,6 +9,7 @@ import ee.tuleva.onboarding.auth.mobileid.MobileIdFixture
 import ee.tuleva.onboarding.auth.session.GenericSessionStore
 import ee.tuleva.onboarding.auth.smartid.SmartIdAuthService
 import ee.tuleva.onboarding.auth.smartid.SmartIdFixture
+import ee.tuleva.onboarding.auth.smartid.SmartIdSession
 import ee.tuleva.onboarding.auth.webeid.WebEidAuthService
 import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.MockMvc
@@ -48,7 +49,8 @@ class AuthControllerSpec extends BaseControllerSpec {
 
   def "Authenticate: Initiate smart id authentication"() {
     given:
-    1 * smartIdAuthService.startLogin(SmartIdFixture.personalCode) >> SmartIdFixture.sampleSmartIdSession
+    1 * smartIdAuthService.startLogin(SmartIdFixture.personalCode, _ as String) >> SmartIdFixture.sampleSmartIdSession
+    1 * sessionStore.save(_ as SmartIdSession)
     when:
     def result = mockMvc.perform(post("/authenticate")
         .contentType(MediaType.APPLICATION_JSON)

--- a/src/test/groovy/ee/tuleva/onboarding/auth/session/GenericSessionStoreSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/auth/session/GenericSessionStoreSpec.groovy
@@ -1,35 +1,74 @@
 package ee.tuleva.onboarding.auth.session
 
-import org.springframework.session.FindByIndexNameSessionRepository
-import spock.lang.Specification
 import org.springframework.mock.web.MockHttpServletRequest
 import org.springframework.mock.web.MockHttpSession
-import org.springframework.web.context.request.ServletRequestAttributes
+import org.springframework.session.FindByIndexNameSessionRepository
+import org.springframework.session.MapSession
+import org.springframework.session.Session
 import org.springframework.web.context.request.RequestContextHolder
+import org.springframework.web.context.request.ServletRequestAttributes
+import spock.lang.Specification
 
 class GenericSessionStoreSpec extends Specification {
 
-  def "ensure serializable attribute round-trip works"() {
-    given: "A mock HTTP session and a GenericSessionStore instance"
-        MockHttpServletRequest request = new MockHttpServletRequest()
-        MockHttpSession session = new MockHttpSession()
-        request.setSession(session)
-        ServletRequestAttributes attributes = new ServletRequestAttributes(request)
-        RequestContextHolder.setRequestAttributes(attributes)
-        GenericSessionStore sessionStore = new GenericSessionStore(Mock(FindByIndexNameSessionRepository))
+  FindByIndexNameSessionRepository<Session> sessionRepository = Mock()
+  GenericSessionStore sessionStore = new GenericSessionStore(sessionRepository)
 
-    and: "A serializable session attribute"
-        String testAttribute = "TestAttribute"
+  def "save and get round-trip works through HttpSession"() {
+    given:
+    MockHttpServletRequest request = new MockHttpServletRequest()
+    request.setSession(new MockHttpSession())
+    RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request))
 
-    when: "save is called with the session attribute"
-        sessionStore.save(testAttribute)
+    when:
+    sessionStore.save("TestAttribute")
 
-    then: "The attribute can be retrieved using its class"
-        Optional<String> retrievedAttribute = sessionStore.get(String.class)
-        assert retrievedAttribute.isPresent()
-        assert retrievedAttribute.get() == testAttribute
+    then:
+    sessionStore.get(String.class) == Optional.of("TestAttribute")
 
-    cleanup: "Clear the request attributes after test"
-        RequestContextHolder.resetRequestAttributes()
+    cleanup:
+    RequestContextHolder.resetRequestAttributes()
+  }
+
+  def "saveBySessionId stores the attribute on the looked-up session"() {
+    given:
+    Session session = new MapSession("session-42")
+    sessionRepository.findById("session-42") >> session
+
+    when:
+    sessionStore.saveBySessionId("session-42", "stored-value")
+
+    then:
+    session.getAttribute(String.class.getName()) == "stored-value"
+    1 * sessionRepository.save(session)
+  }
+
+  def "saveBySessionId retries when the session is not yet available"() {
+    given:
+    Session session = new MapSession("session-42")
+    int callCount = 0
+    sessionRepository.findById("session-42") >> {
+      callCount++
+      callCount < 3 ? null : session
+    }
+
+    when:
+    sessionStore.saveBySessionId("session-42", "stored-value")
+
+    then:
+    callCount == 3
+    session.getAttribute(String.class.getName()) == "stored-value"
+    1 * sessionRepository.save(session)
+  }
+
+  def "saveBySessionId drops the attribute when retries exhaust"() {
+    given:
+    sessionRepository.findById("missing-session") >> null
+
+    when:
+    sessionStore.saveBySessionId("missing-session", "stored-value")
+
+    then:
+    0 * sessionRepository.save(_)
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/auth/session/GenericSessionStoreSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/auth/session/GenericSessionStoreSpec.groovy
@@ -1,5 +1,6 @@
 package ee.tuleva.onboarding.auth.session
 
+import org.springframework.session.FindByIndexNameSessionRepository
 import spock.lang.Specification
 import org.springframework.mock.web.MockHttpServletRequest
 import org.springframework.mock.web.MockHttpSession
@@ -15,7 +16,7 @@ class GenericSessionStoreSpec extends Specification {
         request.setSession(session)
         ServletRequestAttributes attributes = new ServletRequestAttributes(request)
         RequestContextHolder.setRequestAttributes(attributes)
-        GenericSessionStore sessionStore = new GenericSessionStore()
+        GenericSessionStore sessionStore = new GenericSessionStore(Mock(FindByIndexNameSessionRepository))
 
     and: "A serializable session attribute"
         String testAttribute = "TestAttribute"

--- a/src/test/groovy/ee/tuleva/onboarding/auth/smartid/SmartIdAuthIntegrationTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/auth/smartid/SmartIdAuthIntegrationTest.java
@@ -1,0 +1,159 @@
+package ee.tuleva.onboarding.auth.smartid;
+
+import static ee.tuleva.onboarding.auth.smartid.SmartIdFixture.firstName;
+import static ee.tuleva.onboarding.auth.smartid.SmartIdFixture.lastName;
+import static ee.tuleva.onboarding.auth.smartid.SmartIdFixture.personalCode;
+import static java.time.Duration.ofSeconds;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import ee.sk.smartid.AuthenticationHash;
+import ee.sk.smartid.AuthenticationIdentity;
+import ee.sk.smartid.AuthenticationResponseValidator;
+import ee.sk.smartid.SmartIdClient;
+import ee.sk.smartid.rest.SmartIdConnector;
+import ee.sk.smartid.rest.dao.AuthenticationSessionResponse;
+import ee.sk.smartid.rest.dao.SemanticsIdentifier;
+import ee.sk.smartid.rest.dao.SessionCertificate;
+import ee.sk.smartid.rest.dao.SessionResult;
+import ee.sk.smartid.rest.dao.SessionSignature;
+import ee.sk.smartid.rest.dao.SessionStatus;
+import java.security.KeyStore;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import tools.jackson.databind.json.JsonMapper;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles({"test", "mock"})
+@Import(SmartIdAuthIntegrationTest.SmartIdTestConfig.class)
+class SmartIdAuthIntegrationTest {
+
+  @Autowired private MockMvc mockMvc;
+  @Autowired private JsonMapper objectMapper;
+
+  @MockitoBean private SmartIdConnector smartIdConnector;
+  @MockitoBean private AuthenticationResponseValidator authenticationResponseValidator;
+  @MockitoBean private SmartIdAuthenticationHashGenerator hashGenerator;
+
+  // SK demo CA test certificate (PNOEE-31111111111). Used only so the SDK's internal
+  // X509 parsing succeeds; the AuthenticationResponseValidator is mocked to bypass real
+  // signature/chain verification.
+  private static final String SAMPLE_TEST_CERT =
+      "MIIHhjCCBW6gAwIBAgIQDNYLtVwrKURYStrYApYViTANBgkqhkiG9w0BAQsFADBoMQswCQYDVQQGEwJFRTEiMCAGA1UECgwZQVMgU2VydGlmaXRzZWVyaW1pc2tlc2t1czEXMBUGA1UEYQwOTlRSRUUtMTA3NDcwMTMxHDAaBgNVBAMME1RFU1Qgb2YgRUlELVNLIDIwMTYwHhcNMTYxMjA5MTYyNDU2WhcNMTkxMjA5MTYyNDU2WjCBvzELMAkGA1UEBhMCRUUxIjAgBgNVBAoMGUFTIFNlcnRpZml0c2VlcmltaXNrZXNrdXMxGjAYBgNVBAsMEWRpZ2l0YWwgc2lnbmF0dXJlMS0wKwYDVQQDDCRFTEZSSUlEQSxNQU5JVkFMREUsUE5PRUUtMzExMTExMTExMTExETAPBgNVBAQMCEVMRlJJSURBMRIwEAYDVQQqDAlNQU5JVkFMREUxGjAYBgNVBAUTEVBOT0VFLTMxMTExMTExMTExMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAgcfk+eY6dvVyDDPpJPkoKpQ08pQx5Jpfjgq+G31lRSsx03y4WYWQhILu5R4isI6DGzQ1MK2dEsW9Dl+S39y7mDDqGlviVpxCtgz14H7NG84ew8vd+sBeaYCvEhKS4+FxRWCmg5VCozr3s2Evi/ao3Wj51ThtecVmAY7PoE27Zckr0GJ/0I+JqEQx19POBr/lNkZN1AxBy8O9gvDzdpCa2Vn9qahY9eZnDGScrP2KsR34UlXa5PjEMVPtSB4btPi9VOQuRoZImGchfUyf1A2uyIPhV5aC+Zgl60B65WxZ+/nEsVN4NoSgBUv+HlwuRxJPelQKeA9tPwKroqO9PGc5/ee2C1HLH7loD+SwahSPMOY2e8CQd6pLmRF1a/H+ZPWZBW+U7Ekm3YeNNJToUkuonAQB/JbwBvHkZXwsH4/kMHyMPiws5G3nr/jyqF2595KKghIgjGHR1WhGljQzdgO5LT4uuOhesGDRYeMUanvClWSb/mt0SdS8njziY7WoYPYFFFgjRvIIK5FgOd8d2W88I5pj2/SjcXb6GMqEqI3HkCBGPDSo57nSJZzJD8KjJs/4jvzZnGwCFZ8+jeyh562B01mkFfwFaoFOYfqRG3g5sGdZUdY9Nk3FZ8dgEwylUMSxmaL0R2/mzNVasFWp482eHwlK2rae3v+QtCHGfOKn+vsCAwEAAaOCAdIwggHOMAkGA1UdEwQCMAAwDgYDVR0PAQH/BAQDAgZAMFYGA1UdIARPME0wQAYKKwYBBAHOHwMRAjAyMDAGCCsGAQUFBwIBFiRodHRwczovL3d3dy5zay5lZS9lbi9yZXBvc2l0b3J5L0NQUy8wCQYHBACL7EABATAdBgNVHQ4EFgQUNxW1gjoB4+Qh46Rj3SuULubhtUMwgZkGCCsGAQUFBwEDBIGMMIGJMAgGBgQAjkYBATAVBggrBgEFBQcLAjAJBgcEAIvsSQEBMBMGBgQAjkYBBjAJBgcEAI5GAQYBMFEGBgQAjkYBBTBHMEUWP2h0dHBzOi8vc2suZWUvZW4vcmVwb3NpdG9yeS9jb25kaXRpb25zLWZvci11c2Utb2YtY2VydGlmaWNhdGVzLxMCRU4wHwYDVR0jBBgwFoAUrrDq4Tb4JqulzAtmVf46HQK/ErQwfQYIKwYBBQUHAQEEcTBvMCkGCCsGAQUFBzABhh1odHRwOi8vYWlhLmRlbW8uc2suZWUvZWlkMjAxNjBCBggrBgEFBQcwAoY2aHR0cHM6Ly9zay5lZS91cGxvYWQvZmlsZXMvVEVTVF9vZl9FSUQtU0tfMjAxNi5kZXIuY3J0MA0GCSqGSIb3DQEBCwUAA4ICAQCH+SY8KKgw5UDlVL99ToRWPpcloyfOM64UTnNgEDXDDI5r1CNNA0OlggzoEZfakNQJamHjIT287LV7nXFsB4Q9VzyI3H1J5mzVIZrMUiE68wf25BDuA3Zwpri+f8Me78f3nowO2cJ2AiMJ83vQFKKy1LFOixWguuxioKlda2Jq7B57ty5cN+jZwLO7Vrv4Tryg9QeOaxnFvHvuZaxMnE55of7cLpfyAH/5DKvlXx4cdmh7kNO4F/o2LT7om4Cf+Sq6tFS3cUn4zcQbFKT5lw+7vfewzG6X0qYnHbe7Ts/zhh7IJpHnPF1p23ND0+jHgbcDVTFjV4pN1PhVthYHOMeDW461okw2OA/jfuQetUlDwqT5yCdjrOTMDkjZCjTMhcVPzw+7hSUUnewKiR0smuyZbKpE/ZGZWUA6K0sieGCpHGKJo99zD3zmEWmOmq++D0TmVvEiXVJs8fuNWl+VmXSStkMeNR4noHAL1PFUebXVS0lPpQZzBKgqhMGAgbwvYajZnOlvXVll6QashxFZmOVNy88O67s+a2p1SmQTtqNrlodszqkKsc28nDbbvBUd4PUD5tmVgPe29Zwnm1TxFuhl0gqvVc+qZme8zq6yd3nCKNrY6qron4Xcc1rxCWS7NcyO5JiF+qXgAuDOkSFJaaEnQh83ZJsNneXD/nyBH8kSiQ==";
+
+  @TestConfiguration
+  static class SmartIdTestConfig {
+    @Bean
+    @Primary
+    SmartIdClient testSmartIdClient(
+        SmartIdConnector connector, @Qualifier("trustStore") KeyStore trustStore) {
+      var client = new SmartIdClient();
+      client.setSmartIdConnector(connector);
+      client.setTrustStore(trustStore);
+      client.setRelyingPartyUUID("00000000-0000-0000-0000-000000000000");
+      client.setRelyingPartyName("Test");
+      return client;
+    }
+  }
+
+  @Test
+  void smartIdLoginCompletesEndToEnd() throws Exception {
+    var hash = AuthenticationHash.generateRandomHash();
+    given(hashGenerator.generateHash()).willReturn(hash);
+    given(smartIdConnector.authenticate(any(SemanticsIdentifier.class), any()))
+        .willReturn(authenticationSessionResponse("test-session-id"));
+    given(smartIdConnector.getSessionStatus(eq("test-session-id")))
+        .willReturn(completeSessionStatus());
+    given(authenticationResponseValidator.validate(any())).willReturn(validIdentity());
+
+    var authResult =
+        mockMvc
+            .perform(
+                post("/authenticate")
+                    .contentType(APPLICATION_JSON)
+                    .content("{\"type\":\"SMART_ID\",\"personalCode\":\"" + personalCode + "\"}"))
+            .andExpect(status().isOk())
+            .andExpect(cookie().exists("SESSION"))
+            .andReturn();
+
+    var sessionCookie = authResult.getResponse().getCookie("SESSION");
+    assertThat(sessionCookie).isNotNull();
+    var authHash =
+        objectMapper
+            .readTree(authResult.getResponse().getContentAsString())
+            .get("authenticationHash")
+            .asText();
+
+    // Background poll runs in a fixed-thread-pool, writes the result via Spring Session JDBC,
+    // and the next /oauth/token request reads it back through the SESSION cookie. If the
+    // SmartIdSession were still kept in a per-JVM map (the original bug), this would fail
+    // when ECS handed the next request to a different task.
+    await()
+        .atMost(ofSeconds(5))
+        .untilAsserted(
+            () ->
+                mockMvc
+                    .perform(
+                        post("/oauth/token")
+                            .cookie(sessionCookie)
+                            .param("grant_type", "SMART_ID")
+                            .param("authenticationHash", authHash))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.access_token").isNotEmpty()));
+  }
+
+  private static AuthenticationSessionResponse authenticationSessionResponse(String sessionId) {
+    var response = new AuthenticationSessionResponse();
+    response.setSessionID(sessionId);
+    return response;
+  }
+
+  private static AuthenticationIdentity validIdentity() {
+    var identity = new AuthenticationIdentity();
+    identity.setIdentityCode(personalCode);
+    identity.setGivenName(firstName);
+    identity.setSurname(lastName);
+    identity.setCountry("EE");
+    return identity;
+  }
+
+  private static SessionStatus completeSessionStatus() {
+    var result = new SessionResult();
+    result.setEndResult("OK");
+    result.setDocumentNumber("PNOEE-372123456");
+
+    var signature = new SessionSignature();
+    signature.setAlgorithm("sha256WithRSAEncryption");
+    signature.setValue("dummy-signature");
+
+    var certificate = new SessionCertificate();
+    certificate.setCertificateLevel("QUALIFIED");
+    certificate.setValue(SAMPLE_TEST_CERT);
+
+    var status = new SessionStatus();
+    status.setState("COMPLETE");
+    status.setResult(result);
+    status.setSignature(signature);
+    status.setCert(certificate);
+    return status;
+  }
+}

--- a/src/test/groovy/ee/tuleva/onboarding/auth/smartid/SmartIdAuthIntegrationTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/auth/smartid/SmartIdAuthIntegrationTest.java
@@ -39,12 +39,14 @@ import org.springframework.context.annotation.Primary;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
 import tools.jackson.databind.json.JsonMapper;
 
 @SpringBootTest
 @AutoConfigureMockMvc
 @ActiveProfiles({"test", "mock"})
 @Import(SmartIdAuthIntegrationTest.SmartIdTestConfig.class)
+@Transactional
 class SmartIdAuthIntegrationTest {
 
   @Autowired private MockMvc mockMvc;
@@ -104,6 +106,7 @@ class SmartIdAuthIntegrationTest {
             .asText();
 
     await()
+        .pollInSameThread() // keep test transaction visible to /oauth/token's MockMvc call
         .atMost(ofSeconds(5))
         .untilAsserted(
             () ->

--- a/src/test/groovy/ee/tuleva/onboarding/auth/smartid/SmartIdAuthIntegrationTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/auth/smartid/SmartIdAuthIntegrationTest.java
@@ -103,10 +103,6 @@ class SmartIdAuthIntegrationTest {
             .get("authenticationHash")
             .asText();
 
-    // Background poll runs in a fixed-thread-pool, writes the result via Spring Session JDBC,
-    // and the next /oauth/token request reads it back through the SESSION cookie. If the
-    // SmartIdSession were still kept in a per-JVM map (the original bug), this would fail
-    // when ECS handed the next request to a different task.
     await()
         .atMost(ofSeconds(5))
         .untilAsserted(

--- a/src/test/groovy/ee/tuleva/onboarding/auth/smartid/SmartIdAuthProviderSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/auth/smartid/SmartIdAuthProviderSpec.groovy
@@ -1,23 +1,33 @@
 package ee.tuleva.onboarding.auth.smartid
 
+import ee.sk.smartid.AuthenticationHash
 import ee.sk.smartid.AuthenticationIdentity
 import ee.tuleva.onboarding.auth.GrantType
 import ee.tuleva.onboarding.auth.principal.AuthenticatedPerson
-import ee.tuleva.onboarding.auth.principal.Person
 import ee.tuleva.onboarding.auth.principal.PrincipalService
 import ee.tuleva.onboarding.auth.response.AuthNotCompleteException
+import ee.tuleva.onboarding.auth.session.GenericSessionStore
+import ee.tuleva.onboarding.time.MutableClock
 import spock.lang.Specification
+
+import java.time.Clock
+import java.time.Instant
 
 import static ee.tuleva.onboarding.auth.AuthenticatedPersonFixture.sampleAuthenticatedPersonAndMember
 import static ee.tuleva.onboarding.auth.GrantType.GRANT_TYPE
 import static ee.tuleva.onboarding.auth.GrantType.SMART_ID
+import static ee.tuleva.onboarding.auth.smartid.SmartIdFixture.firstName
+import static ee.tuleva.onboarding.auth.smartid.SmartIdFixture.lastName
+import static ee.tuleva.onboarding.auth.smartid.SmartIdFixture.personalCode
 
 class SmartIdAuthProviderSpec extends Specification {
-  private final SmartIdAuthService smartIdAuthService = Mock()
+  private final GenericSessionStore genericSessionStore = Mock()
   private final PrincipalService principalService = Mock()
+  private final MutableClock clock = new MutableClock()
   private final SmartIdAuthProvider smartIdAuthProvider = new SmartIdAuthProvider(
-      smartIdAuthService,
-      principalService
+      genericSessionStore,
+      principalService,
+      clock
   )
 
   def "supports smartid"() {
@@ -27,34 +37,84 @@ class SmartIdAuthProviderSpec extends Specification {
     !smartIdAuthProvider.supports(GrantType.MOBILE_ID)
   }
 
-  def "throws when hash is missing"() {
+  def "throws when no SmartIdSession is in HttpSession"() {
+    given:
+    genericSessionStore.get(SmartIdSession) >> Optional.empty()
     when:
-    smartIdAuthProvider.authenticate(null)
+    smartIdAuthProvider.authenticate("any-hash")
     then:
     thrown(SmartIdSessionNotFoundException)
   }
 
-  def "throws when identity is missing"() {
+  def "throws when the polled hash does not match the session hash"() {
     given:
-    String authenticationHash = "dummy"
-    smartIdAuthService.getAuthenticationIdentity(authenticationHash) >> Optional.empty()
+    SmartIdSession session = sessionWithHash()
+    genericSessionStore.get(SmartIdSession) >> Optional.of(session)
     when:
-    smartIdAuthProvider.authenticate(authenticationHash)
+    smartIdAuthProvider.authenticate("different-hash")
+    then:
+    thrown(SmartIdSessionNotFoundException)
+  }
+
+  def "throws SmartIdException when the session has an error recorded"() {
+    given:
+    SmartIdSession session = sessionWithHash()
+    session.errorCode = "smart.id.user.refused"
+    session.errorMessage = "Smart ID User refused"
+    genericSessionStore.get(SmartIdSession) >> Optional.of(session)
+    when:
+    smartIdAuthProvider.authenticate(session.authenticationHash.hashInBase64)
+    then:
+    SmartIdException e = thrown()
+    e.errorsResponse.errors[0].code == "smart.id.user.refused"
+  }
+
+  def "throws AuthNotCompleteException when person is not yet recorded"() {
+    given:
+    SmartIdSession session = sessionWithHash()
+    genericSessionStore.get(SmartIdSession) >> Optional.of(session)
+    when:
+    smartIdAuthProvider.authenticate(session.authenticationHash.hashInBase64)
     then:
     thrown(AuthNotCompleteException)
   }
 
-  def "returns person when identity is present"() {
+  def "throws when grant is older than 120 seconds (replay protection)"() {
+    given:
+    SmartIdSession session = sessionWithHash()
+    AuthenticationIdentity identity = new AuthenticationIdentity()
+    identity.identityCode = personalCode
+    identity.givenName = firstName
+    identity.surname = lastName
+    identity.country = "EE"
+    session.person = new SmartIdPerson(identity)
+    genericSessionStore.get(SmartIdSession) >> Optional.of(session)
+    clock.tick(121, java.time.temporal.ChronoUnit.SECONDS)
+    when:
+    smartIdAuthProvider.authenticate(session.authenticationHash.hashInBase64)
+    then:
+    thrown(SmartIdSessionNotFoundException)
+  }
+
+  def "returns the authenticated person when polled hash matches and person is set"() {
     given:
     AuthenticatedPerson person = sampleAuthenticatedPersonAndMember().build()
-    String authenticationHash = "dummy"
-    smartIdAuthService.getAuthenticationIdentity(authenticationHash) >> Optional.of(new AuthenticationIdentity())
-    principalService.getFrom(_ as Person, [
-        (GRANT_TYPE): SMART_ID.name()
-    ]) >> person
+    SmartIdSession session = sessionWithHash()
+    AuthenticationIdentity identity = new AuthenticationIdentity()
+    identity.identityCode = personalCode
+    identity.givenName = firstName
+    identity.surname = lastName
+    identity.country = "EE"
+    session.person = new SmartIdPerson(identity)
+    genericSessionStore.get(SmartIdSession) >> Optional.of(session)
+    principalService.getFrom(session.person, [(GRANT_TYPE): SMART_ID.name()]) >> person
     when:
-    AuthenticatedPerson result = smartIdAuthProvider.authenticate(authenticationHash)
+    AuthenticatedPerson result = smartIdAuthProvider.authenticate(session.authenticationHash.hashInBase64)
     then:
     result == person
+  }
+
+  private SmartIdSession sessionWithHash() {
+    return new SmartIdSession("12345", personalCode, AuthenticationHash.generateRandomHash(), Instant.now(clock))
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/auth/smartid/SmartIdAuthServiceSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/auth/smartid/SmartIdAuthServiceSpec.groovy
@@ -19,6 +19,7 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
 
 import static ee.tuleva.onboarding.auth.smartid.SmartIdFixture.*
+import static java.util.concurrent.TimeUnit.SECONDS
 
 class SmartIdAuthServiceSpec extends Specification {
 
@@ -44,6 +45,10 @@ class SmartIdAuthServiceSpec extends Specification {
     saveBySessionIdCalled = new CountDownLatch(1)
 
     smartIdAuthService = new SmartIdAuthService(smartIdClient, hashGenerator, validator, genericSessionStore, clock)
+  }
+
+  def cleanup() {
+    smartIdAuthService.stop()
   }
 
   def "StartLogin: returns a session with hash, verification code and personal code"() {
@@ -122,7 +127,7 @@ class SmartIdAuthServiceSpec extends Specification {
   }
 
   private void waitForPollComplete() {
-    if (!saveBySessionIdCalled.await(2, TimeUnit.SECONDS)) {
+    if (!saveBySessionIdCalled.await(2, SECONDS)) {
       throw new TimeoutException('Polling timed out')
     }
   }

--- a/src/test/groovy/ee/tuleva/onboarding/auth/smartid/SmartIdAuthServiceSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/auth/smartid/SmartIdAuthServiceSpec.groovy
@@ -9,6 +9,7 @@ import ee.sk.smartid.exception.useraccount.UserAccountNotFoundException
 import ee.sk.smartid.exception.useraction.UserRefusedException
 import ee.sk.smartid.rest.SmartIdConnector
 import ee.sk.smartid.rest.dao.*
+import ee.tuleva.onboarding.auth.session.GenericSessionStore
 import ee.tuleva.onboarding.time.MutableClock
 import spock.lang.Specification
 
@@ -17,14 +18,16 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
 
 import static ee.tuleva.onboarding.auth.smartid.SmartIdFixture.*
-import static java.time.temporal.ChronoUnit.SECONDS
 
 class SmartIdAuthServiceSpec extends Specification {
+
+  static final String httpSessionId = "test-http-session"
 
   SmartIdAuthService smartIdAuthService
   SmartIdAuthenticationHashGenerator hashGenerator = Mock(SmartIdAuthenticationHashGenerator)
   AuthenticationResponseValidator validator = Mock(AuthenticationResponseValidator)
   SmartIdConnector connector = Mock(SmartIdConnector)
+  GenericSessionStore genericSessionStore = Mock(GenericSessionStore)
   Clock clock = new MutableClock()
   AuthenticationHash hash
 
@@ -37,141 +40,100 @@ class SmartIdAuthServiceSpec extends Specification {
     hash = AuthenticationHash.generateRandomHash()
     hashGenerator.generateHash() >> hash
 
-    smartIdAuthService = new SmartIdAuthService(smartIdClient, hashGenerator, validator, clock)
+    smartIdAuthService = new SmartIdAuthService(smartIdClient, hashGenerator, validator, genericSessionStore, clock)
   }
 
-  def "StartLogin: Start smart id login generates hash"() {
+  def "StartLogin: returns a session with hash, verification code and personal code"() {
     when:
-    SmartIdSession session = smartIdAuthService.startLogin(personalCode)
+    SmartIdSession session = smartIdAuthService.startLogin(personalCode, httpSessionId)
     then:
     session.verificationCode == hash.calculateVerificationCode()
     session.personalCode == personalCode
     session.authenticationHash == hash
   }
 
-  def "IsLoginComplete: Login is not complete when result is not valid"() {
+  def "Polling: invalid SK response records error code and stores session"() {
     given:
     1 * connector.authenticate(_ as SemanticsIdentifier, _) >> response(aSessionId)
     1 * connector.getSessionStatus(aSessionId) >> sessionStatus("COMPLETE", "DOCUMENT_UNUSABLE")
+    1 * genericSessionStore.saveBySessionId(httpSessionId, _ as SmartIdSession)
     when:
-    SmartIdSession session = smartIdAuthService.startLogin(personalCode)
-    waitForLoginComplete(session)
+    SmartIdSession session = smartIdAuthService.startLogin(personalCode, httpSessionId)
+    waitForPollComplete(session)
     then:
-    thrown(SmartIdException)
+    session.errorCode == "smart.id.technical.error"
   }
 
-  def "IsLoginComplete: Login is not complete when user account not found"() {
+  def "Polling: user account not found records the corresponding error and stores session"() {
     given:
     1 * connector.authenticate(_ as SemanticsIdentifier, _) >> response(aSessionId)
-    1 * connector.getSessionStatus(aSessionId) >> {
-      throw new UserAccountNotFoundException()
-    }
+    1 * connector.getSessionStatus(aSessionId) >> { throw new UserAccountNotFoundException() }
+    1 * genericSessionStore.saveBySessionId(httpSessionId, _ as SmartIdSession)
     when:
-    SmartIdSession session = smartIdAuthService.startLogin(personalCode)
-    waitForLoginComplete(session)
+    SmartIdSession session = smartIdAuthService.startLogin(personalCode, httpSessionId)
+    waitForPollComplete(session)
     then:
-    thrown(SmartIdException)
+    session.errorCode == "smart.id.account.not.found"
   }
 
-  def "IsLoginComplete: Login is not complete when user refused authentication"() {
+  def "Polling: user refused records the corresponding error and stores session"() {
     given:
     1 * connector.authenticate(_ as SemanticsIdentifier, _) >> response(aSessionId)
-    1 * connector.getSessionStatus(aSessionId) >> {
-      throw new UserRefusedException()
-    }
+    1 * connector.getSessionStatus(aSessionId) >> { throw new UserRefusedException() }
+    1 * genericSessionStore.saveBySessionId(httpSessionId, _ as SmartIdSession)
     when:
-    SmartIdSession session = smartIdAuthService.startLogin(personalCode)
-    waitForLoginComplete(session)
+    SmartIdSession session = smartIdAuthService.startLogin(personalCode, httpSessionId)
+    waitForPollComplete(session)
     then:
-    thrown(SmartIdException)
+    session.errorCode == "smart.id.user.refused"
   }
 
-  def "IsLoginComplete: Fetch state of smart id login"() {
-    given:
-    1 * connector.authenticate(_ as SemanticsIdentifier, _) >> response(aSessionId)
-    1 * connector.getSessionStatus(aSessionId) >> sessionStatus("COMPLETE", "OK", "sessionSignature")
-    1 * validator.validate(_) >> validAuthIdentity()
-    when:
-    SmartIdSession session = smartIdAuthService.startLogin(personalCode)
-    boolean isLoginComplete = waitForLoginComplete(session)
-    then:
-    isLoginComplete
-  }
-
-  def "IsLoginComplete: Error with authentication result"() {
+  def "Polling: validator failure records technical error and stores session"() {
     given:
     1 * connector.authenticate(_ as SemanticsIdentifier, _) >> response(aSessionId)
     1 * connector.getSessionStatus(aSessionId) >> sessionStatus("COMPLETE", "OK", "signature")
-    1 * validator.validate(_) >> {
-      throw new UnprocessableSmartIdResponseException("Something went wrong")
-    }
+    1 * validator.validate(_) >> { throw new UnprocessableSmartIdResponseException("Something went wrong") }
+    1 * genericSessionStore.saveBySessionId(httpSessionId, _ as SmartIdSession)
     when:
-    SmartIdSession session = smartIdAuthService.startLogin(personalCode)
-    waitForLoginComplete(session)
+    SmartIdSession session = smartIdAuthService.startLogin(personalCode, httpSessionId)
+    waitForPollComplete(session)
     then:
-    thrown(SmartIdException)
+    session.errorCode == "smart.id.validation.failed"
   }
 
-  def "Idempotent: authentication result can be fetched twice within TTL"() {
+  def "Polling: successful authentication records person and stores session"() {
     given:
     1 * connector.authenticate(_ as SemanticsIdentifier, _) >> response(aSessionId)
     1 * connector.getSessionStatus(aSessionId) >> sessionStatus("COMPLETE", "OK", "sessionSignature")
     1 * validator.validate(_) >> validAuthIdentity()
-
+    1 * genericSessionStore.saveBySessionId(httpSessionId, _ as SmartIdSession)
     when:
-    SmartIdSession session = smartIdAuthService.startLogin(personalCode)
-    waitForLoginComplete(session)
-
-    and:
-    def first = smartIdAuthService.getAuthenticationIdentity(session.authenticationHash.hashInBase64)
-    def second = smartIdAuthService.getAuthenticationIdentity(session.authenticationHash.hashInBase64)
-
+    SmartIdSession session = smartIdAuthService.startLogin(personalCode, httpSessionId)
+    waitForPollComplete(session)
     then:
-    first == second
+    session.person != null
+    session.person.firstName == firstName
+    session.person.lastName == lastName
+    session.person.personalCode == personalCode
+    session.errorCode == null
   }
 
-  def "TTL expiry: authentication result is purged after 60 seconds"() {
-    given:
-    1 * connector.authenticate(_ as SemanticsIdentifier, _) >> response(aSessionId)
-    1 * connector.getSessionStatus(aSessionId) >> sessionStatus("COMPLETE", "OK", "sessionSignature")
-    1 * validator.validate(_) >> validAuthIdentity()
-
-    when:
-    SmartIdSession session = smartIdAuthService.startLogin(personalCode)
-    waitForLoginComplete(session)
-
-    and:
-    def first = smartIdAuthService.getAuthenticationIdentity(session.authenticationHash.hashInBase64)
-
-    then:
-    first.present
-
-    when:
-    clock.tick(61, SECONDS)
-
-    and:
-    def second = smartIdAuthService.getAuthenticationIdentity(session.authenticationHash.hashInBase64)
-
-    then:
-    second.empty
-  }
-
-  private boolean waitForLoginComplete(SmartIdSession session) {
+  private static void waitForPollComplete(SmartIdSession session) {
     int pollCount = 0
-    while (true) {
-      if (smartIdAuthService.getAuthenticationIdentity(session.authenticationHash.hashInBase64).isPresent()) {
-        return true
-      }
+    while (session.person == null && session.errorCode == null) {
       pollCount++
-      if (pollCount > 10) {
+      if (pollCount > 50) {
         throw new TimeoutException('Polling timed out')
       }
       TimeUnit.MILLISECONDS.sleep(20)
     }
+    // give the finally block a moment to call saveBySessionId
+    TimeUnit.MILLISECONDS.sleep(40)
   }
 
   private static AuthenticationIdentity validAuthIdentity() {
     AuthenticationIdentity identity = new AuthenticationIdentity()
+    identity.identityCode = personalCode
     identity.givenName = firstName
     identity.surname = lastName
     return identity

--- a/src/test/groovy/ee/tuleva/onboarding/auth/smartid/SmartIdAuthServiceSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/auth/smartid/SmartIdAuthServiceSpec.groovy
@@ -14,6 +14,7 @@ import ee.tuleva.onboarding.time.MutableClock
 import spock.lang.Specification
 
 import java.time.Clock
+import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
 
@@ -30,6 +31,7 @@ class SmartIdAuthServiceSpec extends Specification {
   GenericSessionStore genericSessionStore = Mock(GenericSessionStore)
   Clock clock = new MutableClock()
   AuthenticationHash hash
+  CountDownLatch saveBySessionIdCalled
 
   def setup() {
     SmartIdClient smartIdClient = new SmartIdClient()
@@ -39,6 +41,7 @@ class SmartIdAuthServiceSpec extends Specification {
 
     hash = AuthenticationHash.generateRandomHash()
     hashGenerator.generateHash() >> hash
+    saveBySessionIdCalled = new CountDownLatch(1)
 
     smartIdAuthService = new SmartIdAuthService(smartIdClient, hashGenerator, validator, genericSessionStore, clock)
   }
@@ -56,10 +59,10 @@ class SmartIdAuthServiceSpec extends Specification {
     given:
     1 * connector.authenticate(_ as SemanticsIdentifier, _) >> response(aSessionId)
     1 * connector.getSessionStatus(aSessionId) >> sessionStatus("COMPLETE", "DOCUMENT_UNUSABLE")
-    1 * genericSessionStore.saveBySessionId(httpSessionId, _ as SmartIdSession)
+    1 * genericSessionStore.saveBySessionId(httpSessionId, _ as SmartIdSession) >> { saveBySessionIdCalled.countDown() }
     when:
     SmartIdSession session = smartIdAuthService.startLogin(personalCode, httpSessionId)
-    waitForPollComplete(session)
+    waitForPollComplete()
     then:
     session.errorCode == "smart.id.technical.error"
   }
@@ -68,10 +71,10 @@ class SmartIdAuthServiceSpec extends Specification {
     given:
     1 * connector.authenticate(_ as SemanticsIdentifier, _) >> response(aSessionId)
     1 * connector.getSessionStatus(aSessionId) >> { throw new UserAccountNotFoundException() }
-    1 * genericSessionStore.saveBySessionId(httpSessionId, _ as SmartIdSession)
+    1 * genericSessionStore.saveBySessionId(httpSessionId, _ as SmartIdSession) >> { saveBySessionIdCalled.countDown() }
     when:
     SmartIdSession session = smartIdAuthService.startLogin(personalCode, httpSessionId)
-    waitForPollComplete(session)
+    waitForPollComplete()
     then:
     session.errorCode == "smart.id.account.not.found"
   }
@@ -80,10 +83,10 @@ class SmartIdAuthServiceSpec extends Specification {
     given:
     1 * connector.authenticate(_ as SemanticsIdentifier, _) >> response(aSessionId)
     1 * connector.getSessionStatus(aSessionId) >> { throw new UserRefusedException() }
-    1 * genericSessionStore.saveBySessionId(httpSessionId, _ as SmartIdSession)
+    1 * genericSessionStore.saveBySessionId(httpSessionId, _ as SmartIdSession) >> { saveBySessionIdCalled.countDown() }
     when:
     SmartIdSession session = smartIdAuthService.startLogin(personalCode, httpSessionId)
-    waitForPollComplete(session)
+    waitForPollComplete()
     then:
     session.errorCode == "smart.id.user.refused"
   }
@@ -93,10 +96,10 @@ class SmartIdAuthServiceSpec extends Specification {
     1 * connector.authenticate(_ as SemanticsIdentifier, _) >> response(aSessionId)
     1 * connector.getSessionStatus(aSessionId) >> sessionStatus("COMPLETE", "OK", "signature")
     1 * validator.validate(_) >> { throw new UnprocessableSmartIdResponseException("Something went wrong") }
-    1 * genericSessionStore.saveBySessionId(httpSessionId, _ as SmartIdSession)
+    1 * genericSessionStore.saveBySessionId(httpSessionId, _ as SmartIdSession) >> { saveBySessionIdCalled.countDown() }
     when:
     SmartIdSession session = smartIdAuthService.startLogin(personalCode, httpSessionId)
-    waitForPollComplete(session)
+    waitForPollComplete()
     then:
     session.errorCode == "smart.id.validation.failed"
   }
@@ -106,10 +109,10 @@ class SmartIdAuthServiceSpec extends Specification {
     1 * connector.authenticate(_ as SemanticsIdentifier, _) >> response(aSessionId)
     1 * connector.getSessionStatus(aSessionId) >> sessionStatus("COMPLETE", "OK", "sessionSignature")
     1 * validator.validate(_) >> validAuthIdentity()
-    1 * genericSessionStore.saveBySessionId(httpSessionId, _ as SmartIdSession)
+    1 * genericSessionStore.saveBySessionId(httpSessionId, _ as SmartIdSession) >> { saveBySessionIdCalled.countDown() }
     when:
     SmartIdSession session = smartIdAuthService.startLogin(personalCode, httpSessionId)
-    waitForPollComplete(session)
+    waitForPollComplete()
     then:
     session.person != null
     session.person.firstName == firstName
@@ -118,17 +121,10 @@ class SmartIdAuthServiceSpec extends Specification {
     session.errorCode == null
   }
 
-  private static void waitForPollComplete(SmartIdSession session) {
-    int pollCount = 0
-    while (session.person == null && session.errorCode == null) {
-      pollCount++
-      if (pollCount > 50) {
-        throw new TimeoutException('Polling timed out')
-      }
-      TimeUnit.MILLISECONDS.sleep(20)
+  private void waitForPollComplete() {
+    if (!saveBySessionIdCalled.await(2, TimeUnit.SECONDS)) {
+      throw new TimeoutException('Polling timed out')
     }
-    // give the finally block a moment to call saveBySessionId
-    TimeUnit.MILLISECONDS.sleep(40)
   }
 
   private static AuthenticationIdentity validAuthIdentity() {

--- a/src/test/groovy/ee/tuleva/onboarding/auth/smartid/SmartIdFixture.java
+++ b/src/test/groovy/ee/tuleva/onboarding/auth/smartid/SmartIdFixture.java
@@ -5,6 +5,7 @@ import ee.sk.smartid.AuthenticationIdentity;
 import ee.sk.smartid.rest.dao.SemanticsIdentifier;
 import ee.sk.smartid.rest.dao.SemanticsIdentifier.CountryCode;
 import ee.sk.smartid.rest.dao.SemanticsIdentifier.IdentityType;
+import java.time.Instant;
 
 public class SmartIdFixture {
 
@@ -14,9 +15,11 @@ public class SmartIdFixture {
   private static final String verificationCode = "12345";
   public static final String aSessionId = "someSessionId";
   public static SmartIdSession sampleSmartIdSession =
-      new SmartIdSession(verificationCode, personalCode, AuthenticationHash.generateRandomHash());
+      new SmartIdSession(
+          verificationCode, personalCode, AuthenticationHash.generateRandomHash(), Instant.now());
   public static SmartIdSession sampleFinalSmartIdSession =
-      new SmartIdSession(verificationCode, personalCode, AuthenticationHash.generateRandomHash());
+      new SmartIdSession(
+          verificationCode, personalCode, AuthenticationHash.generateRandomHash(), Instant.now());
 
   public static AuthenticationIdentity anAuthenticationIdentity = new AuthenticationIdentity();
   public static SemanticsIdentifier aSemanticsIdentifier =

--- a/src/test/groovy/ee/tuleva/onboarding/epis/EpisServiceIntegrationSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/epis/EpisServiceIntegrationSpec.groovy
@@ -35,6 +35,8 @@ import static ee.tuleva.onboarding.epis.cancellation.CancellationFixture.*
 import static ee.tuleva.onboarding.mandate.application.ApplicationType.TRANSFER
 import static ee.tuleva.onboarding.pillar.Pillar.SECOND
 import static ee.tuleva.onboarding.country.CountryFixture.countryFixture
+import static java.util.concurrent.TimeUnit.MILLISECONDS
+import static java.util.concurrent.TimeUnit.SECONDS
 import static org.mockserver.model.HttpRequest.request
 import static org.mockserver.model.HttpResponse.response
 import static org.mockserver.model.JsonBody.json
@@ -101,7 +103,7 @@ class EpisServiceIntegrationSpec extends Specification {
         .when(request("/applications")
             .withHeader("Authorization", "Bearer dummy"))
         .respond(response()
-            .withDelay(TimeUnit.MILLISECONDS, 500)
+            .withDelay(MILLISECONDS, 500)
             .withContentType(MediaType.APPLICATION_JSON)
             .withBody(json("""
                         [{
@@ -127,7 +129,7 @@ class EpisServiceIntegrationSpec extends Specification {
         SecurityContextHolder.clearContext()
       })
       shutdown()
-      awaitTermination(5, TimeUnit.SECONDS)
+      awaitTermination(5, SECONDS)
     }
     then:
     mockServerClient.verify(request().withPath("/applications"), VerificationTimes.exactly(1))
@@ -139,7 +141,7 @@ class EpisServiceIntegrationSpec extends Specification {
         .when(request("/account-cash-flow-statement")
             .withHeader("Authorization", "Bearer dummy"))
         .respond(response()
-            .withDelay(TimeUnit.MILLISECONDS, 500)
+            .withDelay(MILLISECONDS, 500)
             .withContentType(MediaType.APPLICATION_JSON)
             .withBody(json("""
                         {"startBalance": {}, "endBalance": {}, "transactions": []}
@@ -158,7 +160,7 @@ class EpisServiceIntegrationSpec extends Specification {
         SecurityContextHolder.clearContext()
       })
       shutdown()
-      awaitTermination(5, TimeUnit.SECONDS)
+      awaitTermination(5, SECONDS)
     }
     then:
     mockServerClient.verify(request().withPath("/account-cash-flow-statement"), VerificationTimes.exactly(1))

--- a/src/test/groovy/ee/tuleva/onboarding/mandate/batch/poller/MandateBatchProcessingPollerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/mandate/batch/poller/MandateBatchProcessingPollerTest.java
@@ -23,6 +23,7 @@ import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutorService;
 import lombok.SneakyThrows;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -39,6 +40,11 @@ class MandateBatchProcessingPollerTest {
   @Mock private EpisService episService;
 
   @InjectMocks private MandateBatchProcessingPoller mandateBatchProcessingPoller;
+
+  @AfterEach
+  void tearDown() {
+    mandateBatchProcessingPoller.stop();
+  }
 
   @SneakyThrows
   @SuppressWarnings("unchecked")


### PR DESCRIPTION
Smart-ID previously stored poll results in a per-JVM LRUMap, which broke when ECS scaled to 2+ tasks (same incident driver as M1). The result now lands in HttpSession (Spring Session JDBC), mirroring Mobile-ID.

GenericSessionStore gains saveBySessionId(...) for the background poller that has no HttpServletRequest context. SmartIdAuthProvider reads the session via the SESSION cookie, validates the auth hash matches, and enforces a 120 s grant TTL (covers SK's ~90 s server-side window plus poll/write-back roundtrip; replay protection).

End-to-end coverage via SmartIdAuthIntegrationTest: /authenticate → background poll → /oauth/token with the SESSION cookie returns a JWT. The test mocks SmartIdConnector + AuthenticationResponseValidator.