### PR TITLE
Handle in-runoff instruments across tracking, limits, and transactions

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/investment/check/limit/LimitCheckService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/check/limit/LimitCheckService.java
@@ -19,6 +19,7 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -208,11 +209,19 @@ class LimitCheckService {
   }
 
   private Map<String, Provider> buildIsinToProviderMap(TulevaFund fund) {
-    return modelPortfolioAllocationRepository.findLatestByFund(fund).stream()
+    var merged =
+        new HashMap<>(
+            modelPortfolioAllocationRepository.findPreviousByFund(fund).stream()
+                .filter(a -> a.getIsin() != null && a.getProvider() != null)
+                .collect(
+                    Collectors.toMap(
+                        ModelPortfolioAllocation::getIsin,
+                        ModelPortfolioAllocation::getProvider,
+                        (a, b) -> b)));
+    modelPortfolioAllocationRepository.findLatestByFund(fund).stream()
         .filter(a -> a.getIsin() != null && a.getProvider() != null)
-        .collect(
-            Collectors.toMap(
-                ModelPortfolioAllocation::getIsin, ModelPortfolioAllocation::getProvider));
+        .forEach(a -> merged.put(a.getIsin(), a.getProvider()));
+    return merged;
   }
 
   private void saveEvent(

--- a/src/main/java/ee/tuleva/onboarding/investment/check/tracking/TrackingDifferenceService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/check/tracking/TrackingDifferenceService.java
@@ -164,6 +164,7 @@ class TrackingDifferenceService {
       log.warn("No model portfolio for fund: fund={}", fund);
       return results;
     }
+    var previousAllocations = modelPortfolioAllocationRepository.findPreviousByFund(fund);
 
     var positions =
         fundPositionRepository.findByNavDateAndFundAndAccountType(checkDate, fund, SECURITY);
@@ -183,10 +184,12 @@ class TrackingDifferenceService {
             .orElse(ZERO);
 
     var securities =
-        buildSecurityData(fund, allocations, positions, totalNav, checkDate, previousDate);
+        buildSecurityData(
+            fund, allocations, previousAllocations, positions, totalNav, checkDate, previousDate);
 
     var missingPrices =
         securities.stream()
+            .filter(s -> s.modelWeight().signum() > 0)
             .filter(s -> s.today().price() == null || s.previous().price() == null)
             .map(SecurityData::isin)
             .toList();
@@ -440,6 +443,7 @@ class TrackingDifferenceService {
   private List<SecurityData> buildSecurityData(
       TulevaFund fund,
       List<ModelPortfolioAllocation> allocations,
+      List<ModelPortfolioAllocation> previousAllocations,
       List<FundPosition> todayPositions,
       BigDecimal totalNav,
       LocalDate checkDate,
@@ -453,40 +457,85 @@ class TrackingDifferenceService {
     var todayCutoff = computePriceCutoff(fund, checkDate);
     var yesterdayCutoff = computePriceCutoff(fund, previousDate);
 
-    return allocations.stream()
+    var currentIsins =
+        allocations.stream()
+            .map(ModelPortfolioAllocation::getIsin)
+            .filter(Objects::nonNull)
+            .collect(Collectors.toSet());
+
+    var result =
+        new ArrayList<>(
+            allocations.stream()
+                .filter(a -> a.getIsin() != null)
+                .map(
+                    a ->
+                        buildOneSecurityData(
+                            a.getIsin(),
+                            a.getWeight(),
+                            todayByIsin,
+                            totalNav,
+                            checkDate,
+                            previousDate,
+                            todayCutoff,
+                            yesterdayCutoff))
+                .toList());
+
+    previousAllocations.stream()
         .filter(a -> a.getIsin() != null)
+        .filter(a -> !currentIsins.contains(a.getIsin()))
+        .filter(a -> todayByIsin.containsKey(a.getIsin()))
         .map(
-            a -> {
-              var todayResolved =
-                  positionPriceResolver
-                      .resolve(a.getIsin(), checkDate, todayCutoff)
-                      .filter(rp -> rp.validationStatus() == ValidationStatus.OK)
-                      .orElse(null);
-              var yesterdayResolved =
-                  positionPriceResolver
-                      .resolve(a.getIsin(), previousDate, yesterdayCutoff)
-                      .filter(rp -> rp.validationStatus() == ValidationStatus.OK)
-                      .orElse(null);
+            a ->
+                buildOneSecurityData(
+                    a.getIsin(),
+                    ZERO,
+                    todayByIsin,
+                    totalNav,
+                    checkDate,
+                    previousDate,
+                    todayCutoff,
+                    yesterdayCutoff))
+        .forEach(result::add);
 
-              var todayPos = todayByIsin.get(a.getIsin());
-              var actualMarketValue = todayPos != null ? todayPos.getMarketValue() : ZERO;
-              var actualWeight =
-                  totalNav.signum() != 0
-                      ? actualMarketValue.divide(totalNav, 6, RoundingMode.HALF_UP)
-                      : ZERO;
+    return result;
+  }
 
-              var today =
-                  new PriceSnapshot(
-                      todayResolved != null ? todayResolved.usedPrice() : null,
-                      todayResolved != null ? todayResolved.priceDate() : null);
-              var previous =
-                  new PriceSnapshot(
-                      yesterdayResolved != null ? yesterdayResolved.usedPrice() : null,
-                      yesterdayResolved != null ? yesterdayResolved.priceDate() : null);
+  private SecurityData buildOneSecurityData(
+      String isin,
+      BigDecimal modelWeight,
+      Map<String, FundPosition> todayByIsin,
+      BigDecimal totalNav,
+      LocalDate checkDate,
+      LocalDate previousDate,
+      Instant todayCutoff,
+      Instant yesterdayCutoff) {
 
-              return new SecurityData(a.getIsin(), a.getWeight(), actualWeight, today, previous);
-            })
-        .toList();
+    var todayResolved =
+        positionPriceResolver
+            .resolve(isin, checkDate, todayCutoff)
+            .filter(rp -> rp.validationStatus() == ValidationStatus.OK)
+            .orElse(null);
+    var yesterdayResolved =
+        positionPriceResolver
+            .resolve(isin, previousDate, yesterdayCutoff)
+            .filter(rp -> rp.validationStatus() == ValidationStatus.OK)
+            .orElse(null);
+
+    var todayPos = todayByIsin.get(isin);
+    var actualMarketValue = todayPos != null ? todayPos.getMarketValue() : ZERO;
+    var actualWeight =
+        totalNav.signum() != 0 ? actualMarketValue.divide(totalNav, 6, RoundingMode.HALF_UP) : ZERO;
+
+    var today =
+        new PriceSnapshot(
+            todayResolved != null ? todayResolved.usedPrice() : null,
+            todayResolved != null ? todayResolved.priceDate() : null);
+    var previous =
+        new PriceSnapshot(
+            yesterdayResolved != null ? yesterdayResolved.usedPrice() : null,
+            yesterdayResolved != null ? yesterdayResolved.priceDate() : null);
+
+    return new SecurityData(isin, modelWeight, actualWeight, today, previous);
   }
 
   private Instant computePriceCutoff(TulevaFund fund, LocalDate navDate) {

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionInputService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionInputService.java
@@ -21,6 +21,7 @@ import ee.tuleva.onboarding.investment.position.FundPositionRepository;
 import ee.tuleva.onboarding.ledger.NavLedgerRepository;
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -65,13 +66,18 @@ public class TransactionInputService {
     BigDecimal cash = getCashBalance(fund, positionDate);
     BigDecimal accruedFees = getAccruedFees(fund, asOfDate);
     List<ModelPortfolioAllocation> allocations = getModelAllocations(fund);
+    List<ModelPortfolioAllocation> previousAllocations =
+        modelPortfolioAllocationRepository.findPreviousByFund(fund).stream()
+            .filter(a -> a.getIsin() != null)
+            .toList();
     List<ModelWeight> modelWeights = toModelWeights(allocations);
     BigDecimal cashBuffer = getCashBuffer(fund);
     BigDecimal minTransaction = getMinTransaction(fund);
     Map<String, PositionLimitSnapshot> positionLimits = getPositionLimits(fund);
     Set<String> fastSellIsins = getFastSellIsins(allocations);
-    Map<String, InstrumentType> instrumentTypes = getInstrumentTypes(allocations);
-    Map<String, OrderVenue> orderVenues = getOrderVenues(allocations);
+    Map<String, InstrumentType> instrumentTypes =
+        getInstrumentTypes(allocations, previousAllocations);
+    Map<String, OrderVenue> orderVenues = getOrderVenues(allocations, previousAllocations);
 
     BigDecimal securityValue =
         positions.stream()
@@ -190,14 +196,20 @@ public class TransactionInputService {
   }
 
   private Map<String, InstrumentType> getInstrumentTypes(
-      List<ModelPortfolioAllocation> allocations) {
-    return allocations.stream()
-        .filter(allocation -> allocation.getInstrumentType() != null)
-        .collect(
-            Collectors.toMap(
-                ModelPortfolioAllocation::getIsin,
-                ModelPortfolioAllocation::getInstrumentType,
-                (a, b) -> b));
+      List<ModelPortfolioAllocation> current, List<ModelPortfolioAllocation> previous) {
+    var merged =
+        new HashMap<>(
+            previous.stream()
+                .filter(a -> a.getInstrumentType() != null)
+                .collect(
+                    Collectors.toMap(
+                        ModelPortfolioAllocation::getIsin,
+                        ModelPortfolioAllocation::getInstrumentType,
+                        (a, b) -> b)));
+    current.stream()
+        .filter(a -> a.getInstrumentType() != null)
+        .forEach(a -> merged.put(a.getIsin(), a.getInstrumentType()));
+    return merged;
   }
 
   private BigDecimal getFundUnitsReservedValue() {
@@ -226,14 +238,21 @@ public class TransactionInputService {
     }
   }
 
-  private Map<String, OrderVenue> getOrderVenues(List<ModelPortfolioAllocation> allocations) {
-    return allocations.stream()
-        .filter(allocation -> allocation.getOrderVenue() != null)
-        .collect(
-            Collectors.toMap(
-                ModelPortfolioAllocation::getIsin,
-                ModelPortfolioAllocation::getOrderVenue,
-                (a, b) -> b));
+  private Map<String, OrderVenue> getOrderVenues(
+      List<ModelPortfolioAllocation> current, List<ModelPortfolioAllocation> previous) {
+    var merged =
+        new HashMap<>(
+            previous.stream()
+                .filter(a -> a.getOrderVenue() != null)
+                .collect(
+                    Collectors.toMap(
+                        ModelPortfolioAllocation::getIsin,
+                        ModelPortfolioAllocation::getOrderVenue,
+                        (a, b) -> b)));
+    current.stream()
+        .filter(a -> a.getOrderVenue() != null)
+        .forEach(a -> merged.put(a.getIsin(), a.getOrderVenue()));
+    return merged;
   }
 
   private BigDecimal getPendingCashImpact(TulevaFund fund, LocalDate asOfDate) {

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionPreparationService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionPreparationService.java
@@ -12,6 +12,7 @@ import ee.tuleva.onboarding.investment.transaction.export.TransactionExportUploa
 import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
@@ -129,14 +130,18 @@ public class TransactionPreparationService {
         });
     orderRepository.saveAll(orders);
 
-    List<ModelPortfolioAllocation> allocations =
+    List<ModelPortfolioAllocation> currentAllocations =
         modelPortfolioAllocationRepository.findLatestByFund(batch.getFund());
+    List<ModelPortfolioAllocation> previousAllocations =
+        modelPortfolioAllocationRepository.findPreviousByFund(batch.getFund());
+    var mergedAllocations = new ArrayList<>(previousAllocations);
+    mergedAllocations.addAll(currentAllocations);
     Map<String, String> labelsByIsin =
-        buildLookupMap(allocations, ModelPortfolioAllocation::getLabel);
+        buildLookupMap(mergedAllocations, ModelPortfolioAllocation::getLabel);
     Map<String, String> ricByIsin =
-        buildLookupMap(allocations, ModelPortfolioAllocation::getTicker);
+        buildLookupMap(mergedAllocations, ModelPortfolioAllocation::getTicker);
     Map<String, String> bbgByIsin =
-        buildLookupMap(allocations, ModelPortfolioAllocation::getBbgTicker);
+        buildLookupMap(mergedAllocations, ModelPortfolioAllocation::getBbgTicker);
 
     byte[] xlsxExport = exportService.generateOrdersExport(orders);
     byte[] sebFundXlsx = exportService.generateSebFundExport(orders, labelsByIsin);

--- a/src/test/groovy/ee/tuleva/onboarding/investment/check/limit/LimitCheckServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/check/limit/LimitCheckServiceTest.java
@@ -4,6 +4,7 @@ import static ee.tuleva.onboarding.fund.TulevaFund.TUK00;
 import static ee.tuleva.onboarding.fund.TulevaFund.TUK75;
 import static ee.tuleva.onboarding.investment.check.limit.BreachSeverity.OK;
 import static ee.tuleva.onboarding.investment.check.limit.CheckType.*;
+import static ee.tuleva.onboarding.investment.portfolio.Provider.INVESCO;
 import static ee.tuleva.onboarding.investment.portfolio.Provider.ISHARES;
 import static ee.tuleva.onboarding.investment.position.AccountType.*;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -626,6 +627,67 @@ class LimitCheckServiceTest {
 
     assertThatThrownBy(() -> service.runChecksAsOf(today))
         .isInstanceOf(LimitCheckPartialFailureException.class);
+  }
+
+  @Test
+  void includesInRunoffIsinsInProviderMap() {
+    service = createService();
+    var today = LocalDate.of(2026, 3, 4);
+    var fund = TUK75;
+
+    when(fundPositionRepository.findLatestNavDateByFundAndAsOfDate(fund, today))
+        .thenReturn(Optional.of(today));
+    when(fundPositionRepository.findByNavDateAndFundAndAccountType(today, fund, SECURITY))
+        .thenReturn(List.of());
+    when(fundPositionRepository.findByNavDateAndFundAndAccountType(today, fund, UNITS))
+        .thenReturn(List.of());
+    when(fundPositionRepository.sumMarketValueByFundAndAccountTypes(
+            fund, today, List.of(CASH, RECEIVABLES, LIABILITY)))
+        .thenReturn(BigDecimal.ZERO);
+    when(fundPositionRepository.sumMarketValueByFundAndAccountTypes(fund, today, List.of(SECURITY)))
+        .thenReturn(BigDecimal.ZERO);
+    when(fundPositionRepository.findByNavDateAndFundAndAccountType(today, fund, CASH))
+        .thenReturn(List.of());
+    when(fundPositionRepository.findByNavDateAndFundAndAccountType(today, fund, LIABILITY))
+        .thenReturn(List.of());
+    when(fundPositionRepository.findByNavDateAndFundAndAccountType(today, fund, FEE))
+        .thenReturn(List.of());
+
+    var currentAllocation =
+        ModelPortfolioAllocation.builder()
+            .isin("IE00NEW")
+            .fund(fund)
+            .provider(ISHARES)
+            .weight(BigDecimal.ONE)
+            .build();
+    when(modelPortfolioAllocationRepository.findLatestByFund(fund))
+        .thenReturn(List.of(currentAllocation));
+
+    var previousAllocation =
+        ModelPortfolioAllocation.builder()
+            .isin("IE00OLD")
+            .fund(fund)
+            .provider(INVESCO)
+            .weight(BigDecimal.ONE)
+            .build();
+    when(modelPortfolioAllocationRepository.findPreviousByFund(fund))
+        .thenReturn(List.of(previousAllocation));
+
+    when(positionLimitRepository.findLatestByFundAsOf(fund, today)).thenReturn(List.of());
+    when(providerLimitRepository.findLatestByFundAsOf(fund, today)).thenReturn(List.of());
+    when(fundLimitRepository.findLatestByFundAsOf(fund, today)).thenReturn(Optional.empty());
+    when(positionLimitChecker.check(any(), any(), any(), any())).thenReturn(List.of());
+    when(providerLimitChecker.check(any(), any(), any(), any(), any())).thenReturn(List.of());
+
+    service.runChecks();
+
+    verify(providerLimitChecker)
+        .check(
+            eq(fund),
+            anyList(),
+            any(),
+            eq(Map.of("IE00NEW", ISHARES, "IE00OLD", INVESCO)),
+            anyList());
   }
 
   private LimitCheckService createService() {

--- a/src/test/groovy/ee/tuleva/onboarding/investment/check/limit/LimitCheckServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/check/limit/LimitCheckServiceTest.java
@@ -639,19 +639,14 @@ class LimitCheckServiceTest {
         .thenReturn(Optional.of(today));
     when(fundPositionRepository.findByNavDateAndFundAndAccountType(today, fund, SECURITY))
         .thenReturn(List.of());
-    when(fundPositionRepository.findByNavDateAndFundAndAccountType(today, fund, UNITS))
-        .thenReturn(List.of());
-    when(fundPositionRepository.sumMarketValueByFundAndAccountTypes(
-            fund, today, List.of(CASH, RECEIVABLES, LIABILITY)))
-        .thenReturn(BigDecimal.ZERO);
-    when(fundPositionRepository.sumMarketValueByFundAndAccountTypes(fund, today, List.of(SECURITY)))
-        .thenReturn(BigDecimal.ZERO);
     when(fundPositionRepository.findByNavDateAndFundAndAccountType(today, fund, CASH))
         .thenReturn(List.of());
     when(fundPositionRepository.findByNavDateAndFundAndAccountType(today, fund, LIABILITY))
         .thenReturn(List.of());
     when(fundPositionRepository.findByNavDateAndFundAndAccountType(today, fund, FEE))
         .thenReturn(List.of());
+    when(navReportPositionProvider.getCalculatedAum(fund, today))
+        .thenReturn(Optional.of(new BigDecimal("1000000")));
 
     var currentAllocation =
         ModelPortfolioAllocation.builder()

--- a/src/test/groovy/ee/tuleva/onboarding/investment/check/tracking/TrackingDifferenceServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/check/tracking/TrackingDifferenceServiceTest.java
@@ -1069,10 +1069,10 @@ class TrackingDifferenceServiceTest {
   void includesInRunoffSecuritiesWithZeroModelWeight() {
     skipOtherFunds(TUK75);
 
-    given(fundValueProvider.getLatestValue(TUK75.getIsin(), CHECK_DATE))
-        .willReturn(Optional.of(fundValue("10.10", CHECK_DATE)));
-    given(fundValueProvider.getLatestValue(TUK75.getIsin(), CHECK_DATE.minusDays(1)))
-        .willReturn(Optional.of(fundValue("10.00", PREVIOUS_DATE)));
+    given(fundNavQueryService.findNavPerUnit(TUK75.getCode(), CHECK_DATE))
+        .willReturn(Optional.of(new BigDecimal("10.10")));
+    given(fundNavQueryService.findNavPerUnit(TUK75.getCode(), PREVIOUS_DATE))
+        .willReturn(Optional.of(new BigDecimal("10.00")));
 
     var currentAllocation =
         ModelPortfolioAllocation.builder()
@@ -1154,10 +1154,10 @@ class TrackingDifferenceServiceTest {
   void doesNotThrowForInRunoffSecuritiesWithMissingPrices() {
     skipOtherFunds(TUK75);
 
-    given(fundValueProvider.getLatestValue(TUK75.getIsin(), CHECK_DATE))
-        .willReturn(Optional.of(fundValue("10.10", CHECK_DATE)));
-    given(fundValueProvider.getLatestValue(TUK75.getIsin(), CHECK_DATE.minusDays(1)))
-        .willReturn(Optional.of(fundValue("10.00", PREVIOUS_DATE)));
+    given(fundNavQueryService.findNavPerUnit(TUK75.getCode(), CHECK_DATE))
+        .willReturn(Optional.of(new BigDecimal("10.10")));
+    given(fundNavQueryService.findNavPerUnit(TUK75.getCode(), PREVIOUS_DATE))
+        .willReturn(Optional.of(new BigDecimal("10.00")));
 
     var currentAllocation =
         ModelPortfolioAllocation.builder()

--- a/src/test/groovy/ee/tuleva/onboarding/investment/check/tracking/TrackingDifferenceServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/check/tracking/TrackingDifferenceServiceTest.java
@@ -1065,6 +1065,157 @@ class TrackingDifferenceServiceTest {
     return new FundValue("test", date, new BigDecimal(value), "TEST", Instant.now());
   }
 
+  @Test
+  void includesInRunoffSecuritiesWithZeroModelWeight() {
+    skipOtherFunds(TUK75);
+
+    given(fundValueProvider.getLatestValue(TUK75.getIsin(), CHECK_DATE))
+        .willReturn(Optional.of(fundValue("10.10", CHECK_DATE)));
+    given(fundValueProvider.getLatestValue(TUK75.getIsin(), CHECK_DATE.minusDays(1)))
+        .willReturn(Optional.of(fundValue("10.00", PREVIOUS_DATE)));
+
+    var currentAllocation =
+        ModelPortfolioAllocation.builder()
+            .fund(TUK75)
+            .isin("IE00NEW")
+            .weight(new BigDecimal("1.00"))
+            .effectiveDate(LocalDate.of(2026, 4, 1))
+            .build();
+    given(modelPortfolioAllocationRepository.findLatestByFund(TUK75))
+        .willReturn(List.of(currentAllocation));
+
+    var previousAllocation =
+        ModelPortfolioAllocation.builder()
+            .fund(TUK75)
+            .isin("IE00OLD")
+            .weight(new BigDecimal("1.00"))
+            .effectiveDate(LocalDate.of(2026, 1, 1))
+            .build();
+    given(modelPortfolioAllocationRepository.findPreviousByFund(TUK75))
+        .willReturn(List.of(previousAllocation));
+
+    var oldPosition =
+        FundPosition.builder()
+            .fund(TUK75)
+            .navDate(CHECK_DATE)
+            .accountType(SECURITY)
+            .accountId("IE00OLD")
+            .marketValue(new BigDecimal("500000"))
+            .build();
+    var newPosition =
+        FundPosition.builder()
+            .fund(TUK75)
+            .navDate(CHECK_DATE)
+            .accountType(SECURITY)
+            .accountId("IE00NEW")
+            .marketValue(new BigDecimal("500000"))
+            .build();
+    given(fundPositionRepository.findByNavDateAndFundAndAccountType(CHECK_DATE, TUK75, SECURITY))
+        .willReturn(List.of(oldPosition, newPosition));
+
+    given(
+            fundPositionRepository.sumMarketValueByFundAndAccountTypes(
+                TUK75, CHECK_DATE, List.of(SECURITY, CASH, RECEIVABLES, LIABILITY)))
+        .willReturn(new BigDecimal("1000000"));
+    given(
+            fundPositionRepository.sumMarketValueByFundAndAccountTypes(
+                TUK75, CHECK_DATE, List.of(CASH)))
+        .willReturn(ZERO);
+
+    given(positionPriceResolver.resolve(eq("IE00NEW"), eq(CHECK_DATE), any(Instant.class)))
+        .willReturn(Optional.of(resolvedPrice("102.00")));
+    given(positionPriceResolver.resolve(eq("IE00NEW"), eq(PREVIOUS_DATE), any(Instant.class)))
+        .willReturn(Optional.of(resolvedPrice("100.00")));
+    given(positionPriceResolver.resolve(eq("IE00OLD"), eq(CHECK_DATE), any(Instant.class)))
+        .willReturn(Optional.of(resolvedPrice("51.00")));
+    given(positionPriceResolver.resolve(eq("IE00OLD"), eq(PREVIOUS_DATE), any(Instant.class)))
+        .willReturn(Optional.of(resolvedPrice("50.00")));
+
+    given(feeRateRepository.findValidRate(TUK75, FeeType.MANAGEMENT, CHECK_DATE))
+        .willReturn(Optional.empty());
+    given(eventRepository.findMostRecentEvents(eq(TUK75), any(), eq(CHECK_DATE), eq(2)))
+        .willReturn(List.of());
+
+    var results = service.runChecksAsOf(CHECK_DATE);
+
+    var modelResult = results.stream().filter(r -> r.checkType() == MODEL_PORTFOLIO).findFirst();
+    assertThat(modelResult).isPresent();
+    assertThat(modelResult.get().securityAttributions()).hasSize(2);
+    var oldAttribution =
+        modelResult.get().securityAttributions().stream()
+            .filter(a -> a.isin().equals("IE00OLD"))
+            .findFirst();
+    assertThat(oldAttribution).isPresent();
+    assertThat(oldAttribution.get().modelWeight()).isEqualByComparingTo(ZERO);
+    assertThat(oldAttribution.get().actualWeight()).isEqualByComparingTo(new BigDecimal("0.5"));
+  }
+
+  @Test
+  void doesNotThrowForInRunoffSecuritiesWithMissingPrices() {
+    skipOtherFunds(TUK75);
+
+    given(fundValueProvider.getLatestValue(TUK75.getIsin(), CHECK_DATE))
+        .willReturn(Optional.of(fundValue("10.10", CHECK_DATE)));
+    given(fundValueProvider.getLatestValue(TUK75.getIsin(), CHECK_DATE.minusDays(1)))
+        .willReturn(Optional.of(fundValue("10.00", PREVIOUS_DATE)));
+
+    var currentAllocation =
+        ModelPortfolioAllocation.builder()
+            .fund(TUK75)
+            .isin("IE00NEW")
+            .weight(new BigDecimal("1.00"))
+            .effectiveDate(LocalDate.of(2026, 4, 1))
+            .build();
+    given(modelPortfolioAllocationRepository.findLatestByFund(TUK75))
+        .willReturn(List.of(currentAllocation));
+
+    var previousAllocation =
+        ModelPortfolioAllocation.builder()
+            .fund(TUK75)
+            .isin("IE00OLD")
+            .weight(new BigDecimal("1.00"))
+            .effectiveDate(LocalDate.of(2026, 1, 1))
+            .build();
+    given(modelPortfolioAllocationRepository.findPreviousByFund(TUK75))
+        .willReturn(List.of(previousAllocation));
+
+    var oldPosition =
+        FundPosition.builder()
+            .fund(TUK75)
+            .navDate(CHECK_DATE)
+            .accountType(SECURITY)
+            .accountId("IE00OLD")
+            .marketValue(new BigDecimal("100000"))
+            .build();
+    given(fundPositionRepository.findByNavDateAndFundAndAccountType(CHECK_DATE, TUK75, SECURITY))
+        .willReturn(List.of(oldPosition));
+
+    given(
+            fundPositionRepository.sumMarketValueByFundAndAccountTypes(
+                TUK75, CHECK_DATE, List.of(SECURITY, CASH, RECEIVABLES, LIABILITY)))
+        .willReturn(new BigDecimal("1000000"));
+    given(
+            fundPositionRepository.sumMarketValueByFundAndAccountTypes(
+                TUK75, CHECK_DATE, List.of(CASH)))
+        .willReturn(new BigDecimal("900000"));
+
+    given(positionPriceResolver.resolve(eq("IE00NEW"), eq(CHECK_DATE), any(Instant.class)))
+        .willReturn(Optional.of(resolvedPrice("102.00")));
+    given(positionPriceResolver.resolve(eq("IE00NEW"), eq(PREVIOUS_DATE), any(Instant.class)))
+        .willReturn(Optional.of(resolvedPrice("100.00")));
+    given(positionPriceResolver.resolve(eq("IE00OLD"), any(LocalDate.class), any()))
+        .willReturn(Optional.empty());
+
+    given(feeRateRepository.findValidRate(TUK75, FeeType.MANAGEMENT, CHECK_DATE))
+        .willReturn(Optional.empty());
+    given(eventRepository.findMostRecentEvents(eq(TUK75), any(), eq(CHECK_DATE), eq(2)))
+        .willReturn(List.of());
+
+    var results = service.runChecksAsOf(CHECK_DATE);
+
+    assertThat(results).isNotEmpty();
+  }
+
   private ResolvedPrice resolvedPrice(String value) {
     return ResolvedPrice.builder()
         .usedPrice(new BigDecimal(value))

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionInputServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionInputServiceTest.java
@@ -404,6 +404,100 @@ class TransactionInputServiceTest {
         .hasMessageContaining("field=minTransaction");
   }
 
+  @Test
+  void gatherInput_includesInRunoffInstrumentTypesAndOrderVenues() {
+    var positionDate = AS_OF_DATE;
+    when(fundPositionRepository.findLatestNavDateByFundAndAsOfDate(TUV100, AS_OF_DATE))
+        .thenReturn(Optional.of(positionDate));
+    when(fundPositionRepository.findByNavDateAndFundAndAccountType(positionDate, TUV100, SECURITY))
+        .thenReturn(List.of());
+    when(fundPositionRepository.findByNavDateAndFundAndAccountType(positionDate, TUV100, CASH))
+        .thenReturn(List.of());
+    when(feeAccrualRepository.getAccruedFeesForMonth(
+            eq(TUV100), any(), eq(List.of(FeeType.MANAGEMENT, FeeType.DEPOT)), any()))
+        .thenReturn(ZERO);
+
+    var currentAllocation =
+        ModelPortfolioAllocation.builder()
+            .fund(TUV100)
+            .isin("IE00NEW")
+            .weight(new BigDecimal("1.00"))
+            .instrumentType(InstrumentType.ETF)
+            .orderVenue(OrderVenue.SEB)
+            .build();
+    when(modelPortfolioAllocationRepository.findLatestByFund(TUV100))
+        .thenReturn(List.of(currentAllocation));
+
+    var previousAllocation =
+        ModelPortfolioAllocation.builder()
+            .fund(TUV100)
+            .isin("IE00OLD")
+            .weight(new BigDecimal("1.00"))
+            .instrumentType(InstrumentType.FUND)
+            .orderVenue(OrderVenue.FT)
+            .build();
+    when(modelPortfolioAllocationRepository.findPreviousByFund(TUV100))
+        .thenReturn(List.of(previousAllocation));
+
+    when(fundLimitRepository.findLatestByFund(TUV100))
+        .thenReturn(Optional.of(zeroFundLimit(TUV100)));
+    when(positionLimitRepository.findLatestByFund(TUV100)).thenReturn(List.of());
+
+    var result = service.gatherInput(TUV100, AS_OF_DATE, Map.of());
+
+    assertThat(result.instrumentTypes())
+        .containsEntry("IE00NEW", InstrumentType.ETF)
+        .containsEntry("IE00OLD", InstrumentType.FUND);
+    assertThat(result.orderVenues())
+        .containsEntry("IE00NEW", OrderVenue.SEB)
+        .containsEntry("IE00OLD", OrderVenue.FT);
+  }
+
+  @Test
+  void gatherInput_currentAllocationOverridesPreviousInstrumentTypeAndVenue() {
+    var positionDate = AS_OF_DATE;
+    when(fundPositionRepository.findLatestNavDateByFundAndAsOfDate(TUV100, AS_OF_DATE))
+        .thenReturn(Optional.of(positionDate));
+    when(fundPositionRepository.findByNavDateAndFundAndAccountType(positionDate, TUV100, SECURITY))
+        .thenReturn(List.of());
+    when(fundPositionRepository.findByNavDateAndFundAndAccountType(positionDate, TUV100, CASH))
+        .thenReturn(List.of());
+    when(feeAccrualRepository.getAccruedFeesForMonth(
+            eq(TUV100), any(), eq(List.of(FeeType.MANAGEMENT, FeeType.DEPOT)), any()))
+        .thenReturn(ZERO);
+
+    var currentAllocation =
+        ModelPortfolioAllocation.builder()
+            .fund(TUV100)
+            .isin("IE00SAME")
+            .weight(new BigDecimal("1.00"))
+            .instrumentType(InstrumentType.ETF)
+            .orderVenue(OrderVenue.SEB)
+            .build();
+    when(modelPortfolioAllocationRepository.findLatestByFund(TUV100))
+        .thenReturn(List.of(currentAllocation));
+
+    var previousAllocation =
+        ModelPortfolioAllocation.builder()
+            .fund(TUV100)
+            .isin("IE00SAME")
+            .weight(new BigDecimal("1.00"))
+            .instrumentType(InstrumentType.FUND)
+            .orderVenue(OrderVenue.FT)
+            .build();
+    when(modelPortfolioAllocationRepository.findPreviousByFund(TUV100))
+        .thenReturn(List.of(previousAllocation));
+
+    when(fundLimitRepository.findLatestByFund(TUV100))
+        .thenReturn(Optional.of(zeroFundLimit(TUV100)));
+    when(positionLimitRepository.findLatestByFund(TUV100)).thenReturn(List.of());
+
+    var result = service.gatherInput(TUV100, AS_OF_DATE, Map.of());
+
+    assertThat(result.instrumentTypes()).containsEntry("IE00SAME", InstrumentType.ETF);
+    assertThat(result.orderVenues()).containsEntry("IE00SAME", OrderVenue.SEB);
+  }
+
   private static FundLimit zeroFundLimit(TulevaFund fund) {
     return FundLimit.builder().fund(fund).reserveSoft(ZERO).minTransaction(ZERO).build();
   }


### PR DESCRIPTION
## Summary

Extends the in-runoff instrument handling from #1594 to four more components that use model portfolio allocations. During model portfolio transitions (1-7 days between model change and trade settlement), these components previously caused false alarms or silent gaps.

- **TrackingDifferenceService**: in-runoff securities now included with `modelWeight=0`, preventing false breach alerts and inflated residuals. Missing prices for in-runoff securities no longer throw `IncompletePriceDataException`.
- **LimitCheckService**: `buildIsinToProviderMap` merges previous + current allocations so in-runoff positions count toward provider concentration.
- **TransactionInputService**: `getInstrumentTypes` and `getOrderVenues` merge previous + current so sell orders for old instruments get correct type/venue instead of defaults.
- **TransactionPreparationService**: label/ticker/bbgTicker lookups merge previous + current so SEB Fund, SEB ETF, and FT ETF export files have complete data for in-runoff sell orders.

## Test plan

- [x] `TrackingDifferenceServiceTest` — in-runoff securities appear with zero model weight and correct actual weight
- [x] `TrackingDifferenceServiceTest` — missing prices for in-runoff securities don't throw
- [x] Existing tracking, limit, transaction, and health check tests pass
- [x] Full test suite green
- [ ] Deploy to staging, change model portfolio, verify no false tracking difference breaches

🤖 Generated with [Claude Code](https://claude.com/claude-code)