### PR TITLE
TKF fall back to remitter id code when description lacks code

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/savings/fund/PaymentVerificationService.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/PaymentVerificationService.java
@@ -68,16 +68,10 @@ public class PaymentVerificationService {
   public void process(SavingFundPayment payment) {
     log.info("Processing payment {}", payment.getId());
 
-    var partyIdFromDescription = extractPartyId(payment.getDescription());
-    var partyIdOpt = partyIdFromDescription.or(() -> parsePartyId(payment.getRemitterIdCode()));
+    var partyIdOpt = extractPartyId(payment);
     if (partyIdOpt.isEmpty()) {
-      identityCheckFailure(payment, "selgituses puudub isikukood/registrikood");
+      identityCheckFailure(payment, "makse ei sisalda tuvastatavat isikukoodi/registrikoodi");
       return;
-    }
-    if (partyIdFromDescription.isEmpty()) {
-      log.info(
-          "Payment {} has no code in description, falling back to remitter id code",
-          payment.getId());
     }
 
     PartyId partyId = partyIdOpt.get();
@@ -139,7 +133,17 @@ public class PaymentVerificationService {
     return payment.getReceivedBefore().atZone(ESTONIAN_ZONE).toLocalDate();
   }
 
-  Optional<PartyId> extractPartyId(String text) {
+  private Optional<PartyId> extractPartyId(SavingFundPayment payment) {
+    var partyIdFromDescription = extractPartyIdFromDescription(payment.getDescription());
+    if (partyIdFromDescription.isPresent()) {
+      return partyIdFromDescription;
+    }
+    log.info(
+        "Payment {} has no code in description, falling back to remitter id code", payment.getId());
+    return parsePartyId(payment.getRemitterIdCode());
+  }
+
+  Optional<PartyId> extractPartyIdFromDescription(String text) {
     return extractPersonalCode(text)
         .map(code -> new PartyId(PERSON, code))
         .or(() -> extractRegistryCode(text).map(code -> new PartyId(LEGAL_ENTITY, code)));

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/PaymentVerificationService.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/PaymentVerificationService.java
@@ -68,13 +68,19 @@ public class PaymentVerificationService {
   public void process(SavingFundPayment payment) {
     log.info("Processing payment {}", payment.getId());
 
-    var extractPartyId = extractPartyId(payment.getDescription());
-    if (extractPartyId.isEmpty()) {
+    var partyIdFromDescription = extractPartyId(payment.getDescription());
+    var partyIdOpt = partyIdFromDescription.or(() -> parsePartyId(payment.getRemitterIdCode()));
+    if (partyIdOpt.isEmpty()) {
       identityCheckFailure(payment, "selgituses puudub isikukood/registrikood");
       return;
     }
+    if (partyIdFromDescription.isEmpty()) {
+      log.info(
+          "Payment {} has no code in description, falling back to remitter id code",
+          payment.getId());
+    }
 
-    PartyId partyId = extractPartyId.get();
+    PartyId partyId = partyIdOpt.get();
     var messages = VerificationMessages.forType(partyId.type());
 
     var remitterPartyId = parsePartyId(payment.getRemitterIdCode());

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/PaymentVerificationServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/PaymentVerificationServiceTest.java
@@ -55,13 +55,15 @@ class PaymentVerificationServiceTest {
 
     verify(savingFundPaymentRepository).changeStatus(payment.getId(), TO_BE_RETURNED);
     verify(savingFundPaymentRepository)
-        .addReturnReason(payment.getId(), "selgituses puudub isikukood/registrikood");
+        .addReturnReason(payment.getId(), "makse ei sisalda tuvastatavat isikukoodi/registrikoodi");
     verify(savingsFundLedger)
         .recordUnattributedPayment(payment.getAmount(), payment.getId(), LocalDate.of(2025, 10, 1));
     verify(applicationEventPublisher)
         .publishEvent(
             new UnattributedPaymentEvent(
-                payment.getId(), payment.getAmount(), "selgituses puudub isikukood/registrikood"));
+                payment.getId(),
+                payment.getAmount(),
+                "makse ei sisalda tuvastatavat isikukoodi/registrikoodi"));
     verifyNoMoreInteractions(savingFundPaymentRepository);
   }
 
@@ -341,40 +343,45 @@ class PaymentVerificationServiceTest {
   }
 
   @Test
-  void extractPartyId() {
-    assertThat(service.extractPartyId(null)).isEmpty();
-    assertThat(service.extractPartyId("")).isEmpty();
-    assertThat(service.extractPartyId("abc")).isEmpty();
-    assertThat(service.extractPartyId("abc123")).isEmpty();
-    assertThat(service.extractPartyId("1234567890")).isEmpty();
-    assertThat(service.extractPartyId("12345678901")).isEmpty();
-    assertThat(service.extractPartyId("45009144745")).contains(new PartyId(PERSON, "45009144745"));
-    assertThat(service.extractPartyId("37508295796")).contains(new PartyId(PERSON, "37508295796"));
-    assertThat(service.extractPartyId("37508295795"))
+  void extractPartyIdFromDescription() {
+    assertThat(service.extractPartyIdFromDescription(null)).isEmpty();
+    assertThat(service.extractPartyIdFromDescription("")).isEmpty();
+    assertThat(service.extractPartyIdFromDescription("abc")).isEmpty();
+    assertThat(service.extractPartyIdFromDescription("abc123")).isEmpty();
+    assertThat(service.extractPartyIdFromDescription("1234567890")).isEmpty();
+    assertThat(service.extractPartyIdFromDescription("12345678901")).isEmpty();
+    assertThat(service.extractPartyIdFromDescription("45009144745"))
+        .contains(new PartyId(PERSON, "45009144745"));
+    assertThat(service.extractPartyIdFromDescription("37508295796"))
+        .contains(new PartyId(PERSON, "37508295796"));
+    assertThat(service.extractPartyIdFromDescription("37508295795"))
         .withFailMessage("invalid personal code not accepted")
         .isEmpty();
-    assertThat(service.extractPartyId("375082957961"))
+    assertThat(service.extractPartyIdFromDescription("375082957961"))
         .withFailMessage("additional digits not accepted")
         .isEmpty();
-    assertThat(service.extractPartyId("137508295796"))
+    assertThat(service.extractPartyIdFromDescription("137508295796"))
         .withFailMessage("additional digits not accepted")
         .isEmpty();
-    assertThat(service.extractPartyId("some prefix 37508295796"))
+    assertThat(service.extractPartyIdFromDescription("some prefix 37508295796"))
         .contains(new PartyId(PERSON, "37508295796"));
-    assertThat(service.extractPartyId("some prefix,37508295796,some suffix"))
+    assertThat(service.extractPartyIdFromDescription("some prefix,37508295796,some suffix"))
         .contains(new PartyId(PERSON, "37508295796"));
-    assertThat(service.extractPartyId("some prefix+37508295796/some suffix,45009144745"))
+    assertThat(
+            service.extractPartyIdFromDescription(
+                "some prefix+37508295796/some suffix,45009144745"))
         .contains(new PartyId(PERSON, "37508295796"));
-    assertThat(service.extractPartyId("12345678")).contains(new PartyId(LEGAL_ENTITY, "12345678"));
-    assertThat(service.extractPartyId("company 12345678"))
+    assertThat(service.extractPartyIdFromDescription("12345678"))
         .contains(new PartyId(LEGAL_ENTITY, "12345678"));
-    assertThat(service.extractPartyId("1234567"))
+    assertThat(service.extractPartyIdFromDescription("company 12345678"))
+        .contains(new PartyId(LEGAL_ENTITY, "12345678"));
+    assertThat(service.extractPartyIdFromDescription("1234567"))
         .withFailMessage("7 digits not a valid registry code")
         .isEmpty();
-    assertThat(service.extractPartyId("123456789"))
+    assertThat(service.extractPartyIdFromDescription("123456789"))
         .withFailMessage("9 digits not a valid registry code")
         .isEmpty();
-    assertThat(service.extractPartyId("P13694547 makse 37508295796"))
+    assertThat(service.extractPartyIdFromDescription("P13694547 makse 37508295796"))
         .withFailMessage(
             "11-digit personal code must take precedence over any 8-digit substring elsewhere")
         .contains(new PartyId(PERSON, "37508295796"));

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/PaymentVerificationServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/PaymentVerificationServiceTest.java
@@ -48,8 +48,8 @@ class PaymentVerificationServiceTest {
           partyResolver);
 
   @Test
-  void process_noCodeInDescription() {
-    var payment = createPayment("37508295796", "my money");
+  void process_returnsPaymentWhenNoCodeAnywhere() {
+    var payment = createPayment(null, "my money");
 
     service.process(payment);
 
@@ -62,6 +62,37 @@ class PaymentVerificationServiceTest {
         .publishEvent(
             new UnattributedPaymentEvent(
                 payment.getId(), payment.getAmount(), "selgituses puudub isikukood/registrikood"));
+    verifyNoMoreInteractions(savingFundPaymentRepository);
+  }
+
+  @Test
+  void process_success_fallsBackToRemitterIdCodeWhenDescriptionLacksCode() {
+    var payment = createPayment("37508295796", "my money");
+    var user =
+        User.builder()
+            .id(123L)
+            .personalCode("37508295796")
+            .firstName("PÄRT")
+            .lastName("ÕLEKÕRS")
+            .build();
+    when(userRepository.findByPersonalCode("37508295796")).thenReturn(Optional.of(user));
+    when(savingsFundOnboardingService.isOnboardingCompleted(any(PartyId.class))).thenReturn(true);
+
+    service.process(payment);
+
+    verify(userRepository).findByPersonalCode("37508295796");
+    verify(savingsFundOnboardingService).isOnboardingCompleted(new PartyId(PERSON, "37508295796"));
+    verify(savingsFundLedger)
+        .recordPaymentReceived(
+            new PartyId(PERSON, "37508295796"),
+            payment.getAmount(),
+            payment.getId(),
+            LocalDate.of(2025, 10, 1));
+    var inOrder = inOrder(savingFundPaymentRepository);
+    inOrder
+        .verify(savingFundPaymentRepository)
+        .attachParty(payment.getId(), new PartyId(PERSON, "37508295796"));
+    inOrder.verify(savingFundPaymentRepository).changeStatus(payment.getId(), VERIFIED);
     verifyNoMoreInteractions(savingFundPaymentRepository);
   }
 


### PR DESCRIPTION
## Summary

If a Täiendava Kogumisfondi payment arrives without a personal/registry code in the description but the bank statement carries a valid id in the remitter id field (`RltdPties/Dbtr/Id/PrvtId/Othr/Id` from camt.052/053), use that instead of returning the money.

The existing cross-check between description and remitter id still rejects mismatches (e.g. selgituses olev kood ≠ maksja isikukood), so this only changes behavior for the slice where the description gives us nothing but the bank already told us who the payer is. `parsePartyId` (strict, no substring extraction) is used for the remitter id field, matching how it's used elsewhere — so Wise customer ids like `P13694547` still don't match.

## Test plan

- [x] `process_success_fallsBackToRemitterIdCodeWhenDescriptionLacksCode` — new unit test for the fallback (description has no code, remitter id code matches an onboarded user → VERIFIED + recordPaymentReceived)
- [x] `process_returnsPaymentWhenNoCodeAnywhere` — renamed/repurposed from old `process_noCodeInDescription`; covers the genuine "no code anywhere" case (still TO_BE_RETURNED)
- [x] `process_personalCodeMismatch` — passes unchanged (cross-check intact)
- [x] All 21 `PaymentVerificationServiceTest` cases green
- [x] `savings.fund.*` + `banking.processor.*` suites green locally
- [x] CircleCI workflow green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)