### PR TITLE
Improve TD Slack notifications with full attribution

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/investment/check/tracking/SecurityAttribution.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/check/tracking/SecurityAttribution.java
@@ -8,4 +8,5 @@ record SecurityAttribution(
     BigDecimal actualWeight,
     BigDecimal weightDifference,
     BigDecimal securityReturn,
+    BigDecimal benchmarkReturn,
     BigDecimal contribution) {}

--- a/src/main/java/ee/tuleva/onboarding/investment/check/tracking/SecurityAttribution.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/check/tracking/SecurityAttribution.java
@@ -1,12 +1,13 @@
 package ee.tuleva.onboarding.investment.check.tracking;
 
 import java.math.BigDecimal;
+import org.jspecify.annotations.Nullable;
 
 record SecurityAttribution(
     String isin,
-    BigDecimal modelWeight,
-    BigDecimal actualWeight,
-    BigDecimal weightDifference,
+    @Nullable BigDecimal modelWeight,
+    @Nullable BigDecimal actualWeight,
+    @Nullable BigDecimal weightDifference,
     BigDecimal securityReturn,
-    BigDecimal benchmarkReturn,
+    @Nullable BigDecimal benchmarkReturn,
     BigDecimal contribution) {}

--- a/src/main/java/ee/tuleva/onboarding/investment/check/tracking/TrackingDifferenceCalculator.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/check/tracking/TrackingDifferenceCalculator.java
@@ -79,6 +79,7 @@ class TrackingDifferenceCalculator {
                       s.actualWeight(),
                       weightDiff,
                       secReturn,
+                      null,
                       contribution);
                 })
             .toList();

--- a/src/main/java/ee/tuleva/onboarding/investment/check/tracking/TrackingDifferenceNotifier.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/check/tracking/TrackingDifferenceNotifier.java
@@ -1,5 +1,8 @@
 package ee.tuleva.onboarding.investment.check.tracking;
 
+import static ee.tuleva.onboarding.investment.check.tracking.TrackingCheckType.BENCHMARK;
+import static ee.tuleva.onboarding.investment.check.tracking.TrackingCheckType.BENCHMARK_MODEL;
+import static ee.tuleva.onboarding.investment.check.tracking.TrackingCheckType.MODEL_PORTFOLIO;
 import static ee.tuleva.onboarding.notification.OperationsNotificationService.Channel.INVESTMENT;
 
 import ee.tuleva.onboarding.notification.OperationsNotificationService;
@@ -24,7 +27,8 @@ class TrackingDifferenceNotifier {
 
   void notify(List<TrackingDifferenceResult> results) {
     try {
-      var hasAnyBreaches = results.stream().anyMatch(TrackingDifferenceResult::breach);
+      var alertableResults = results.stream().filter(r -> r.checkType() != BENCHMARK).toList();
+      var hasAnyBreaches = alertableResults.stream().anyMatch(TrackingDifferenceResult::breach);
 
       if (!hasAnyBreaches) {
         notificationService.sendMessage(
@@ -35,7 +39,7 @@ class TrackingDifferenceNotifier {
       var message = new StringBuilder("TD BREACH DETECTED\n");
       var hasEscalation = false;
 
-      for (var result : results) {
+      for (var result : alertableResults) {
         if (!result.breach()) {
           continue;
         }
@@ -70,24 +74,50 @@ class TrackingDifferenceNotifier {
                 formatPercent(result.fundReturn()),
                 formatPercent(result.benchmarkReturn())));
 
+    if (result.checkType() == MODEL_PORTFOLIO) {
+      sb.append("\n  Action: check NAV calculation — weights, prices, cash, fees");
+    } else if (result.checkType() == BENCHMARK_MODEL) {
+      sb.append("\n  Action: review instrument prices and benchmark data for pricing errors");
+    }
+
     if (!result.securityAttributions().isEmpty()) {
-      var topContributors =
+      var sorted =
           result.securityAttributions().stream()
               .sorted(
                   Comparator.comparing(
                       (SecurityAttribution a) -> a.contribution().abs(), Comparator.reverseOrder()))
-              .limit(3)
               .toList();
 
-      sb.append("\n  Top: ");
-      for (int i = 0; i < topContributors.size(); i++) {
-        var attr = topContributors.get(i);
-        if (i > 0) sb.append(", ");
-        sb.append("%s (%s%%)".formatted(attr.isin(), formatPercent(attr.contribution())));
-      }
+      if (result.checkType() == BENCHMARK_MODEL) {
+        for (var attr : sorted) {
+          sb.append(
+              "\n  %s: instrument %s%%, benchmark %s%%, diff %s%%"
+                  .formatted(
+                      attr.isin(),
+                      formatPercent(attr.securityReturn()),
+                      formatPercent(attr.benchmarkReturn()),
+                      formatPercent(attr.contribution())));
+        }
+      } else {
+        for (var attr : sorted) {
+          sb.append(
+              "\n  %s: weight %s%%, return %s%%, impact %s%%"
+                  .formatted(
+                      attr.isin(),
+                      formatPercent(attr.weightDifference()),
+                      formatPercent(attr.securityReturn()),
+                      formatPercent(attr.contribution())));
+        }
 
-      if (result.cashDrag().signum() != 0) {
-        sb.append(", cash drag (%s%%)".formatted(formatPercent(result.cashDrag())));
+        if (result.cashDrag().signum() != 0) {
+          sb.append("\n  Cash drag: %s%%".formatted(formatPercent(result.cashDrag())));
+        }
+        if (result.feeDrag().signum() != 0) {
+          sb.append("\n  Fee drag: %s%%".formatted(formatPercent(result.feeDrag())));
+        }
+        if (result.residual().signum() != 0) {
+          sb.append("\n  Residual: %s%%".formatted(formatPercent(result.residual())));
+        }
       }
     }
 

--- a/src/main/java/ee/tuleva/onboarding/investment/check/tracking/TrackingDifferenceService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/check/tracking/TrackingDifferenceService.java
@@ -537,9 +537,7 @@ class TrackingDifferenceService {
                   map.put(
                       "weightDifference", Objects.requireNonNullElse(a.weightDifference(), ZERO));
                   map.put("securityReturn", a.securityReturn());
-                  if (a.benchmarkReturn() != null) {
-                    map.put("benchmarkReturn", a.benchmarkReturn());
-                  }
+                  map.put("benchmarkReturn", Objects.requireNonNullElse(a.benchmarkReturn(), ZERO));
                   map.put("contribution", a.contribution());
                   return map;
                 })

--- a/src/main/java/ee/tuleva/onboarding/investment/check/tracking/TrackingDifferenceService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/check/tracking/TrackingDifferenceService.java
@@ -325,15 +325,16 @@ class TrackingDifferenceService {
     var totalWeightedReturn = ZERO;
     var totalWeightedBenchmarkReturn = ZERO;
     var totalWeight = ZERO;
+    var attributions = new ArrayList<SecurityAttribution>();
 
     for (var s : validSecurities) {
       var benchmarkKey = resolveBenchmarkKey(s.isin());
       if (benchmarkKey == null) {
         continue;
       }
-      var benchmarkReturn =
+      var bmReturn =
           lookupReturn(benchmarkKey, s.today().date(), s.previous().date(), maxDailyReturn);
-      if (benchmarkReturn.isEmpty()) {
+      if (bmReturn.isEmpty()) {
         log.warn(
             "Missing benchmark model data: fund={}, isin={}, benchmarkKey={}",
             fund,
@@ -344,10 +345,15 @@ class TrackingDifferenceService {
       var secReturn =
           calculator.safeDailyReturn(s.today().price(), s.previous().price(), maxDailyReturn);
       var weight = s.actualWeight();
+      var returnDiff = secReturn.subtract(bmReturn.get()).setScale(SCALE, RoundingMode.HALF_UP);
+      var contribution = weight.multiply(returnDiff).setScale(SCALE, RoundingMode.HALF_UP);
       totalWeightedReturn = totalWeightedReturn.add(weight.multiply(secReturn));
       totalWeightedBenchmarkReturn =
-          totalWeightedBenchmarkReturn.add(weight.multiply(benchmarkReturn.get()));
+          totalWeightedBenchmarkReturn.add(weight.multiply(bmReturn.get()));
       totalWeight = totalWeight.add(weight);
+      attributions.add(
+          new SecurityAttribution(
+              s.isin(), null, weight, null, secReturn, bmReturn.get(), contribution));
     }
 
     if (totalWeight.signum() == 0) {
@@ -375,7 +381,7 @@ class TrackingDifferenceService {
             .breach(breach)
             .consecutiveBreachDays(days)
             .consecutiveNetTd(netTd)
-            .securityAttributions(List.of())
+            .securityAttributions(List.copyOf(attributions))
             .cashDrag(ZERO)
             .feeDrag(ZERO)
             .residual(ZERO)
@@ -523,14 +529,20 @@ class TrackingDifferenceService {
     var attributions =
         result.securityAttributions().stream()
             .map(
-                a ->
-                    Map.<String, Object>of(
-                        "isin", a.isin(),
-                        "modelWeight", a.modelWeight(),
-                        "actualWeight", a.actualWeight(),
-                        "weightDifference", a.weightDifference(),
-                        "securityReturn", a.securityReturn(),
-                        "contribution", a.contribution()))
+                a -> {
+                  var map = new java.util.LinkedHashMap<String, Object>();
+                  map.put("isin", a.isin());
+                  map.put("modelWeight", Objects.requireNonNullElse(a.modelWeight(), ZERO));
+                  map.put("actualWeight", Objects.requireNonNullElse(a.actualWeight(), ZERO));
+                  map.put(
+                      "weightDifference", Objects.requireNonNullElse(a.weightDifference(), ZERO));
+                  map.put("securityReturn", a.securityReturn());
+                  if (a.benchmarkReturn() != null) {
+                    map.put("benchmarkReturn", a.benchmarkReturn());
+                  }
+                  map.put("contribution", a.contribution());
+                  return map;
+                })
             .toList();
 
     return Map.of(

--- a/src/test/groovy/ee/tuleva/onboarding/investment/check/tracking/TrackingDifferenceNotifierTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/check/tracking/TrackingDifferenceNotifierTest.java
@@ -1,8 +1,11 @@
 package ee.tuleva.onboarding.investment.check.tracking;
 
 import static ee.tuleva.onboarding.fund.TulevaFund.TUK75;
+import static ee.tuleva.onboarding.investment.check.tracking.TrackingCheckType.BENCHMARK;
+import static ee.tuleva.onboarding.investment.check.tracking.TrackingCheckType.BENCHMARK_MODEL;
 import static ee.tuleva.onboarding.investment.check.tracking.TrackingCheckType.MODEL_PORTFOLIO;
 import static ee.tuleva.onboarding.notification.OperationsNotificationService.Channel.INVESTMENT;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.ArgumentMatchers.eq;
@@ -57,7 +60,7 @@ class TrackingDifferenceNotifierTest {
   }
 
   @Test
-  void includesTopContributors() {
+  void includesFullAttributionDetail() {
     var attributions =
         List.of(
             new SecurityAttribution(
@@ -66,14 +69,32 @@ class TrackingDifferenceNotifierTest {
                 new BigDecimal("0.55"),
                 new BigDecimal("-0.05"),
                 new BigDecimal("0.02"),
+                null,
                 new BigDecimal("-0.001")),
             new SecurityAttribution(
                 "IE00B",
-                new BigDecimal("0.40"),
-                new BigDecimal("0.45"),
+                new BigDecimal("0.20"),
+                new BigDecimal("0.25"),
                 new BigDecimal("0.05"),
                 new BigDecimal("-0.01"),
-                new BigDecimal("-0.0005")));
+                null,
+                new BigDecimal("-0.0005")),
+            new SecurityAttribution(
+                "IE00C",
+                new BigDecimal("0.10"),
+                new BigDecimal("0.10"),
+                new BigDecimal("0.00"),
+                new BigDecimal("0.005"),
+                null,
+                new BigDecimal("0.0000")),
+            new SecurityAttribution(
+                "IE00D",
+                new BigDecimal("0.10"),
+                new BigDecimal("0.10"),
+                new BigDecimal("0.00"),
+                new BigDecimal("-0.003"),
+                null,
+                new BigDecimal("0.0000")));
 
     var result =
         TrackingDifferenceResult.builder()
@@ -94,7 +115,14 @@ class TrackingDifferenceNotifierTest {
 
     notifier.notify(List.of(result));
 
-    then(notificationService).should().sendMessage(contains("IE00A"), eq(INVESTMENT));
+    var captor = org.mockito.ArgumentCaptor.forClass(String.class);
+    then(notificationService).should().sendMessage(captor.capture(), eq(INVESTMENT));
+    var message = captor.getValue();
+
+    assertThat(message).contains("IE00A").contains("IE00B").contains("IE00C").contains("IE00D");
+    assertThat(message).contains("weight");
+    assertThat(message).contains("Fee drag");
+    assertThat(message).contains("Residual");
   }
 
   @Test
@@ -104,6 +132,91 @@ class TrackingDifferenceNotifierTest {
     notifier.notify(List.of(result));
 
     then(notificationService).should().sendMessage(contains("TD ESCALATION"), eq(INVESTMENT));
+  }
+
+  @Test
+  void includesActionHintForModelPortfolio() {
+    var result = result(true, 1, new BigDecimal("0.0015"));
+
+    notifier.notify(List.of(result));
+
+    var captor = org.mockito.ArgumentCaptor.forClass(String.class);
+    then(notificationService).should().sendMessage(captor.capture(), eq(INVESTMENT));
+    assertThat(captor.getValue()).contains("check NAV calculation");
+  }
+
+  @Test
+  void includesActionHintAndAttributionForBenchmarkModel() {
+    var attributions =
+        List.of(
+            new SecurityAttribution(
+                "IE00BFG1TM61",
+                null,
+                new BigDecimal("0.40"),
+                null,
+                new BigDecimal("0.015"),
+                new BigDecimal("0.010"),
+                new BigDecimal("0.002")),
+            new SecurityAttribution(
+                "IE00BKPTWY98",
+                null,
+                new BigDecimal("0.20"),
+                null,
+                new BigDecimal("0.008"),
+                new BigDecimal("0.012"),
+                new BigDecimal("-0.0008")));
+
+    var result =
+        TrackingDifferenceResult.builder()
+            .fund(TUK75)
+            .checkDate(LocalDate.of(2026, 4, 3))
+            .checkType(BENCHMARK_MODEL)
+            .trackingDifference(new BigDecimal("0.005"))
+            .fundReturn(new BigDecimal("0.0100"))
+            .benchmarkReturn(new BigDecimal("0.0050"))
+            .breach(true)
+            .consecutiveBreachDays(1)
+            .consecutiveNetTd(new BigDecimal("0.005"))
+            .securityAttributions(attributions)
+            .cashDrag(BigDecimal.ZERO)
+            .feeDrag(BigDecimal.ZERO)
+            .residual(BigDecimal.ZERO)
+            .build();
+
+    notifier.notify(List.of(result));
+
+    var captor = org.mockito.ArgumentCaptor.forClass(String.class);
+    then(notificationService).should().sendMessage(captor.capture(), eq(INVESTMENT));
+    var message = captor.getValue();
+    assertThat(message).contains("review instrument prices and benchmark data");
+    assertThat(message).contains("IE00BFG1TM61").contains("IE00BKPTWY98");
+    assertThat(message).contains("instrument").contains("benchmark").contains("diff");
+  }
+
+  @Test
+  void filtersBenchmarkAcwiFromSlackAlerts() {
+    var benchmarkResult =
+        TrackingDifferenceResult.builder()
+            .fund(TUK75)
+            .checkDate(LocalDate.of(2026, 4, 3))
+            .checkType(BENCHMARK)
+            .trackingDifference(new BigDecimal("0.005"))
+            .fundReturn(new BigDecimal("0.0100"))
+            .benchmarkReturn(new BigDecimal("0.0050"))
+            .breach(true)
+            .consecutiveBreachDays(1)
+            .consecutiveNetTd(new BigDecimal("0.005"))
+            .securityAttributions(List.of())
+            .cashDrag(BigDecimal.ZERO)
+            .feeDrag(BigDecimal.ZERO)
+            .residual(BigDecimal.ZERO)
+            .build();
+
+    notifier.notify(List.of(benchmarkResult));
+
+    then(notificationService)
+        .should()
+        .sendMessage(contains("all funds within limits"), eq(INVESTMENT));
   }
 
   @Test

--- a/src/test/groovy/ee/tuleva/onboarding/investment/check/tracking/TrackingDifferenceServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/check/tracking/TrackingDifferenceServiceTest.java
@@ -200,6 +200,16 @@ class TrackingDifferenceServiceTest {
     assertThat(bmModel.get().fund()).isEqualTo(TUK75);
     // ETF return = 51/50 - 1 = 0.02, IWDA return = 81.6/80 - 1 = 0.02, TD ≈ 0
     assertThat(bmModel.get().trackingDifference().abs()).isLessThan(new BigDecimal("0.001"));
+
+    var attributions = bmModel.get().securityAttributions();
+    assertThat(attributions).hasSize(1);
+    var attr = attributions.getFirst();
+    assertThat(attr.isin()).isEqualTo(etfIsin);
+    assertThat(attr.modelWeight()).isNull();
+    assertThat(attr.actualWeight()).isEqualByComparingTo(new BigDecimal("0.95"));
+    assertThat(attr.securityReturn()).isEqualByComparingTo(new BigDecimal("0.02"));
+    assertThat(attr.benchmarkReturn()).isEqualByComparingTo(new BigDecimal("0.02"));
+    assertThat(attr.contribution().abs()).isLessThan(new BigDecimal("0.001"));
   }
 
   @Test


### PR DESCRIPTION
## Summary
- Filter BENCHMARK (ACWI) check from Slack alerts — produces timing noise from mismatched pricing windows (ETFs at European close vs end-of-day ACWI). Results still saved to DB for long-horizon Metabase analysis.
- Expand MODEL_PORTFOLIO attribution from top-3 summary to full per-instrument detail: weight diff, return, impact, cash drag, fee drag, residual.
- Add per-instrument attribution to BENCHMARK_MODEL: shows each instrument's return vs its benchmark return and weighted diff — makes it clear which instrument price to investigate.
- Add actionable hints per check type so next steps are obvious from the Slack message.

## Slack message examples

**MODEL_PORTFOLIO** (calculation issues):
```
[TUK75] MODEL_PORTFOLIO 2026-04-03: TD=+0.15% (fund=+1.00%, benchmark=+0.85%)
  Action: check NAV calculation — weights, prices, cash, fees
  IE00BFG1TM61: weight +2.00%, return +1.50%, impact +0.03%
  IE0009FT4LX4: weight -1.50%, return +1.20%, impact -0.02%
  Cash drag: -0.05%
  Residual: +0.01%
```

**BENCHMARK_MODEL** (pricing issues):
```
[TUK75] BENCHMARK_MODEL 2026-04-03: TD=+0.20% (fund=+1.10%, benchmark=+0.90%)
  Action: review instrument prices and benchmark data for pricing errors
  IE00BFG1TM61: instrument +1.50%, benchmark +1.00%, diff +0.20%
  IE00BKPTWY98: instrument +0.80%, benchmark +1.20%, diff -0.08%
```

## Test plan
- [x] New tests for BENCHMARK filtering, full attribution, action hints, BENCHMARK_MODEL attribution
- [x] Existing tests updated and passing
- [x] Full test suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)