### PR TITLE
Add NAV escalation alerts before EPIS deadlines

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/savings/fund/nav/NavAlertJob.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/nav/NavAlertJob.java
@@ -50,6 +50,43 @@ public class NavAlertJob {
     alertIfMissing(List.of(TKF100, TUV100), "15:20", "15:31", "17:45");
   }
 
+  @Scheduled(cron = "0 35 11 * * MON-FRI", zone = "Europe/Tallinn")
+  @SchedulerLock(name = "NavEscalation_pillar2", lockAtMostFor = "5m", lockAtLeastFor = "1m")
+  public void escalatePillar2IfStillMissing() {
+    escalateIfStillMissing(List.of(TUK75, TUK00), "11:30");
+  }
+
+  @Scheduled(cron = "0 35 15 * * MON-FRI", zone = "Europe/Tallinn")
+  @SchedulerLock(name = "NavEscalation_savingsPillar3", lockAtMostFor = "5m", lockAtLeastFor = "1m")
+  public void escalateSavingsPillar3IfStillMissing() {
+    escalateIfStillMissing(List.of(TKF100, TUV100), "15:30");
+  }
+
+  private void escalateIfStillMissing(List<TulevaFund> funds, String deadline) {
+    LocalDate today = ZonedDateTime.now(clock).withZoneSameInstant(TALLINN).toLocalDate();
+    if (!publicHolidays.isWorkingDay(today)) {
+      return;
+    }
+    List<TulevaFund> missing =
+        funds.stream()
+            .filter(TulevaFund::hasNavCalculation)
+            .filter(fund -> isNavMissingForToday(fund, today))
+            .toList();
+    if (missing.isEmpty()) {
+      return;
+    }
+    String missingCodes =
+        missing.stream().map(TulevaFund::getCode).collect(Collectors.joining(", ", "[", "]"));
+    String message =
+        "URGENT: NAV still missing, deadline was "
+            + deadline
+            + " Tallinn: funds="
+            + missingCodes
+            + ", autoRetriesContinueUntil=17:45 Tallinn";
+    log.error("{}", message);
+    notificationService.sendMessage(message, INVESTMENT);
+  }
+
   private void alertIfMissing(
       List<TulevaFund> funds,
       String cronFireTime,

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/nav/NavAlertJobTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/nav/NavAlertJobTest.java
@@ -31,11 +31,17 @@ class NavAlertJobTest {
   // 2025-01-15 = Wednesday; all times below are UTC+2 → EET (winter)
   private static final String WED_0906_UTC = "2025-01-15T09:06:00Z"; // 11:06 Tallinn
   private static final String WED_1331_UTC = "2025-01-15T13:31:00Z"; // 15:31 Tallinn
+  private static final String WED_0935_UTC = "2025-01-15T09:35:00Z"; // 11:35 Tallinn
+  private static final String WED_1335_UTC = "2025-01-15T13:35:00Z"; // 15:35 Tallinn
   private static final String SAT_1331_UTC = "2025-01-18T13:31:00Z"; // Saturday 15:31 Tallinn
   private static final String SAT_0906_UTC = "2025-01-18T09:06:00Z"; // Saturday 11:06 Tallinn
+  private static final String SAT_0935_UTC = "2025-01-18T09:35:00Z"; // Saturday 11:35 Tallinn
+  private static final String SAT_1335_UTC = "2025-01-18T13:35:00Z"; // Saturday 15:35 Tallinn
   // 2026-02-24 = Tuesday Independence Day (Estonian public holiday)
   private static final String INDEPENDENCE_DAY_0906_UTC = "2026-02-24T09:06:00Z";
   private static final String INDEPENDENCE_DAY_1331_UTC = "2026-02-24T13:31:00Z";
+  private static final String INDEPENDENCE_DAY_0935_UTC = "2026-02-24T09:35:00Z";
+  private static final String INDEPENDENCE_DAY_1335_UTC = "2026-02-24T13:35:00Z";
 
   @Mock private NavReportRepository navReportRepository;
   @Mock private OperationsNotificationService notificationService;
@@ -169,6 +175,104 @@ class NavAlertJobTest {
     var job = jobOn(INDEPENDENCE_DAY_1331_UTC);
 
     job.alertSavingsPillar3IfMissing();
+
+    verifyNoInteractions(notificationService);
+    verifyNoInteractions(navReportRepository);
+  }
+
+  @Test
+  void pillar2Escalation_fires_whenStillMissing() {
+    var job = jobOn(WED_0935_UTC);
+    LocalDate today = LocalDate.of(2025, 1, 15);
+    stubMissing(today, TUK75);
+    stubMissing(today, TUK00);
+
+    job.escalatePillar2IfStillMissing();
+
+    verify(notificationService)
+        .sendMessage(
+            org.mockito.ArgumentMatchers.argThat(
+                (String msg) ->
+                    msg.contains("URGENT") && msg.contains("TUK75") && msg.contains("TUK00")),
+            eq(INVESTMENT));
+  }
+
+  @Test
+  void pillar2Escalation_silent_whenPublished() {
+    var job = jobOn(WED_0935_UTC);
+    LocalDate today = LocalDate.of(2025, 1, 15);
+    stubPublished(today, TUK75);
+    stubPublished(today, TUK00);
+
+    job.escalatePillar2IfStillMissing();
+
+    verifyNoInteractions(notificationService);
+  }
+
+  @Test
+  void pillar2Escalation_silent_onNonWorkingDay() {
+    var job = jobOn(SAT_0935_UTC);
+
+    job.escalatePillar2IfStillMissing();
+
+    verifyNoInteractions(notificationService);
+    verifyNoInteractions(navReportRepository);
+  }
+
+  @Test
+  void pillar2Escalation_silent_onWeekdayPublicHoliday() {
+    var job = jobOn(INDEPENDENCE_DAY_0935_UTC);
+
+    job.escalatePillar2IfStillMissing();
+
+    verifyNoInteractions(notificationService);
+    verifyNoInteractions(navReportRepository);
+  }
+
+  @Test
+  void savingsPillar3Escalation_fires_whenStillMissing() {
+    var job = jobOn(WED_1335_UTC);
+    LocalDate today = LocalDate.of(2025, 1, 15);
+    stubMissing(today, TKF100);
+    stubMissing(today, TUV100);
+
+    job.escalateSavingsPillar3IfStillMissing();
+
+    verify(notificationService)
+        .sendMessage(
+            org.mockito.ArgumentMatchers.argThat(
+                (String msg) ->
+                    msg.contains("URGENT") && msg.contains("TKF100") && msg.contains("TUV100")),
+            eq(INVESTMENT));
+  }
+
+  @Test
+  void savingsPillar3Escalation_silent_whenPublished() {
+    var job = jobOn(WED_1335_UTC);
+    LocalDate today = LocalDate.of(2025, 1, 15);
+    stubPublished(today, TKF100);
+    stubPublished(today, TUV100);
+
+    job.escalateSavingsPillar3IfStillMissing();
+
+    verifyNoInteractions(notificationService);
+  }
+
+  @Test
+  void savingsPillar3Escalation_silent_onNonWorkingDay() {
+    var job = jobOn(SAT_1335_UTC);
+
+    job.escalateSavingsPillar3IfStillMissing();
+
+    verifyNoInteractions(notificationService);
+    verifyNoInteractions(navReportRepository);
+  }
+
+  @Test
+  void savingsPillar3Escalation_silent_onWeekdayPublicHoliday() {
+    var job = jobOn(INDEPENDENCE_DAY_1335_UTC);
+
+    job.escalateSavingsPillar3IfStillMissing();
 
     verifyNoInteractions(notificationService);
     verifyNoInteractions(navReportRepository);


### PR DESCRIPTION
## Summary
- Adds escalation alerts at **11:35** (pillar 2) and **15:35** (savings/pillar 3) that fire when NAV is still missing after EPIS contractual deadlines (11:30 / 15:30)
- Existing early-warning alerts (11:06 / 15:31) remain unchanged — these are a second tier with `URGENT` prefix and `log.error` severity
- Self-heal retries continue until 17:45 as before

## Test plan
- [x] Unit tests for both escalation methods: fires when missing, silent when published
- [x] Weekend and public holiday guard tests
- [x] Scheduled cron expression test (existing `NavAlertJobScheduledTest`)
- [x] All NAV tests green (`ee.tuleva.onboarding.savings.fund.nav.*`)
- [ ] Post-deploy: monitor Slack INVESTMENT channel on next NAV cycle — escalation should stay silent when NAV publishes on time

🤖 Generated with [Claude Code](https://claude.com/claude-code)