### PR TITLE
TD: read fund's own NAV from nav_report instead of index_values

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/investment/check/tracking/TrackingDifferenceService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/check/tracking/TrackingDifferenceService.java
@@ -25,6 +25,7 @@ import ee.tuleva.onboarding.investment.portfolio.ModelPortfolioAllocation;
 import ee.tuleva.onboarding.investment.portfolio.ModelPortfolioAllocationRepository;
 import ee.tuleva.onboarding.investment.position.FundPosition;
 import ee.tuleva.onboarding.investment.position.FundPositionRepository;
+import ee.tuleva.onboarding.savings.fund.nav.FundNavQueryService;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.Clock;
@@ -66,6 +67,7 @@ class TrackingDifferenceService {
   private final Clock clock;
   private final FundPositionRepository fundPositionRepository;
   private final ModelPortfolioAllocationRepository modelPortfolioAllocationRepository;
+  // External feeds (benchmarks, ETF prices). Fund's own NAV no longer comes from here.
   private final FundValueProvider fundValueProvider;
   private final PriorityPriceProvider priorityPriceProvider;
   private final PositionPriceResolver positionPriceResolver;
@@ -73,6 +75,9 @@ class TrackingDifferenceService {
   private final FeeRateRepository feeRateRepository;
   private final TrackingDifferenceEventRepository eventRepository;
   private final TrackingDifferenceCalculator calculator;
+  // Tuleva-internal source of truth for fund's own NAV per unit, populated by every NAV
+  // calculation run (regardless of whether publishing succeeds).
+  private final FundNavQueryService fundNavQueryService;
 
   List<TrackingDifferenceResult> runChecks() {
     return runChecksAsOf(LocalDate.now(clock), List.of(TulevaFund.values()));
@@ -91,13 +96,13 @@ class TrackingDifferenceService {
     var incompleteChecks = new ArrayList<String>();
 
     for (var fund : funds) {
-      var latestNav = fundValueProvider.getLatestValue(fund.getIsin(), asOfDate);
-      if (latestNav.isEmpty()) {
+      var checkDate =
+          fundNavQueryService.findLatestNavDateOnOrBefore(fund.getCode(), asOfDate).orElse(null);
+      if (checkDate == null) {
         log.warn("No NAV data for fund: fund={}, asOfDate={}", fund, asOfDate);
         continue;
       }
 
-      var checkDate = latestNav.get().date();
       try {
         checkFund(fund, checkDate).forEach(results::add);
       } catch (IncompletePriceDataException e) {
@@ -129,20 +134,30 @@ class TrackingDifferenceService {
   List<TrackingDifferenceResult> checkFund(TulevaFund fund, LocalDate checkDate) {
     var results = new ArrayList<TrackingDifferenceResult>();
 
-    var todayNav = fundValueProvider.getLatestValue(fund.getIsin(), checkDate);
-    var yesterdayNav = fundValueProvider.getLatestValue(fund.getIsin(), checkDate.minusDays(1));
+    // Fund's own NAV comes from nav_report (Tuleva-internal). Today's row is persisted by
+    // NavPublisher BEFORE the gate runs, so it is always present when called from the gate.
+    // For yesterday we walk back to the previous working day rather than relying on the
+    // fundValueProvider's at-or-before fallback.
+    var previousDate = publicHolidays.previousWorkingDay(checkDate);
+    var todayValue = fundNavQueryService.findNavPerUnit(fund.getCode(), checkDate);
+    var yesterdayValue = fundNavQueryService.findNavPerUnit(fund.getCode(), previousDate);
 
-    if (todayNav.isEmpty() || yesterdayNav.isEmpty()) {
+    if (todayValue.isEmpty() || yesterdayValue.isEmpty()) {
       log.warn(
-          "Missing NAV data: fund={}, checkDate={}, todayNav={}, yesterdayNav={}",
+          "Missing NAV data: fund={}, checkDate={}, previousDate={}, todayNav={}, yesterdayNav={}",
           fund,
           checkDate,
-          todayNav.isPresent(),
-          yesterdayNav.isPresent());
+          previousDate,
+          todayValue.isPresent(),
+          yesterdayValue.isPresent());
       return results;
     }
 
-    var previousDate = yesterdayNav.get().date();
+    var todayNav =
+        new FundValue(fund.getIsin(), checkDate, todayValue.get(), "TULEVA", clock.instant());
+    var yesterdayNav =
+        new FundValue(
+            fund.getIsin(), previousDate, yesterdayValue.get(), "TULEVA", clock.instant());
 
     var allocations = modelPortfolioAllocationRepository.findLatestByFund(fund);
     if (allocations.isEmpty()) {
@@ -188,8 +203,8 @@ class TrackingDifferenceService {
             .fund(fund)
             .checkDate(checkDate)
             .checkType(MODEL_PORTFOLIO)
-            .todayNav(todayNav.get().value())
-            .yesterdayNav(yesterdayNav.get().value())
+            .todayNav(todayNav.value())
+            .yesterdayNav(yesterdayNav.value())
             .securities(securities)
             .cashWeight(cashWeight)
             .annualFeeRate(annualFeeRate)
@@ -205,7 +220,7 @@ class TrackingDifferenceService {
               results.add(withConsecutive);
             });
 
-    buildBenchmarkCheck(fund, checkDate, previousDate, todayNav.get(), yesterdayNav.get())
+    buildBenchmarkCheck(fund, checkDate, previousDate, todayNav, yesterdayNav)
         .ifPresent(
             result -> {
               saveEvent(result);

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/nav/FundNavQueryService.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/nav/FundNavQueryService.java
@@ -1,0 +1,31 @@
+package ee.tuleva.onboarding.savings.fund.nav;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+// Reads aggregated NAV values from nav_report. Tuleva-internal source of truth for fund-level
+// NAV per unit. Used by tracking-difference checks so they don't depend on index_values, which
+// is the channel for external feeds (PENSIONIKESKUS, MSCI, etc.) and lags by ~1 day for pillar 2.
+@Service
+@RequiredArgsConstructor
+public class FundNavQueryService {
+
+  // Matches NavReportMapper.navRow which writes account_type='NAV' on every published calculation.
+  private static final String NAV_ACCOUNT_TYPE = "NAV";
+
+  private final NavReportRepository navReportRepository;
+
+  public Optional<BigDecimal> findNavPerUnit(String fundCode, LocalDate navDate) {
+    return navReportRepository
+        .findFirstByFundCodeAndNavDateAndAccountType(fundCode, navDate, NAV_ACCOUNT_TYPE)
+        .map(NavReportRow::getMarketPrice);
+  }
+
+  public Optional<LocalDate> findLatestNavDateOnOrBefore(String fundCode, LocalDate asOfDate) {
+    return navReportRepository.findLatestNavDateByFundAndAccountTypeOnOrBefore(
+        fundCode, NAV_ACCOUNT_TYPE, asOfDate);
+  }
+}

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/nav/NavReportRepository.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/nav/NavReportRepository.java
@@ -2,6 +2,7 @@ package ee.tuleva.onboarding.savings.fund.nav;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -10,6 +11,23 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
 interface NavReportRepository extends JpaRepository<NavReportRow, Long> {
+
+  Optional<NavReportRow> findFirstByFundCodeAndNavDateAndAccountType(
+      String fundCode, LocalDate navDate, String accountType);
+
+  @Query(
+      value =
+          """
+          SELECT MAX(nav_date) FROM nav_report
+          WHERE fund_code = :fundCode
+            AND account_type = :accountType
+            AND nav_date <= :asOfDate
+          """,
+      nativeQuery = true)
+  Optional<LocalDate> findLatestNavDateByFundAndAccountTypeOnOrBefore(
+      @Param("fundCode") String fundCode,
+      @Param("accountType") String accountType,
+      @Param("asOfDate") LocalDate asOfDate);
 
   @Query(
       value =

--- a/src/test/groovy/ee/tuleva/onboarding/investment/check/tracking/TrackingDifferenceServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/check/tracking/TrackingDifferenceServiceTest.java
@@ -58,6 +58,7 @@ class TrackingDifferenceServiceTest {
   @Mock FeeRateRepository feeRateRepository;
   @Mock TrackingDifferenceEventRepository eventRepository;
   @Mock InvestmentParameterRepository parameterRepository;
+  @Mock ee.tuleva.onboarding.savings.fund.nav.FundNavQueryService fundNavQueryService;
 
   private TrackingDifferenceService service;
 
@@ -70,6 +71,12 @@ class TrackingDifferenceServiceTest {
   void setUp() {
     lenient()
         .when(fundValueProvider.getLatestValue(anyString(), any(LocalDate.class)))
+        .thenReturn(Optional.empty());
+    lenient()
+        .when(fundNavQueryService.findNavPerUnit(anyString(), any(LocalDate.class)))
+        .thenReturn(Optional.empty());
+    lenient()
+        .when(fundNavQueryService.findLatestNavDateOnOrBefore(anyString(), any(LocalDate.class)))
         .thenReturn(Optional.empty());
     lenient()
         .when(
@@ -92,7 +99,8 @@ class TrackingDifferenceServiceTest {
             publicHolidays,
             feeRateRepository,
             eventRepository,
-            new TrackingDifferenceCalculator(parameterRepository));
+            new TrackingDifferenceCalculator(parameterRepository),
+            fundNavQueryService);
   }
 
   @Test
@@ -126,10 +134,10 @@ class TrackingDifferenceServiceTest {
   void calculatesBenchmarkModelForEquityFund() {
     skipOtherFunds(TUK75);
 
-    given(fundValueProvider.getLatestValue(TUK75.getIsin(), CHECK_DATE))
-        .willReturn(Optional.of(fundValue("10.10", CHECK_DATE)));
-    given(fundValueProvider.getLatestValue(TUK75.getIsin(), CHECK_DATE.minusDays(1)))
-        .willReturn(Optional.of(fundValue("10.00", PREVIOUS_DATE)));
+    given(fundNavQueryService.findNavPerUnit(TUK75.getCode(), CHECK_DATE))
+        .willReturn(Optional.of(new BigDecimal("10.10")));
+    given(fundNavQueryService.findNavPerUnit(TUK75.getCode(), PREVIOUS_DATE))
+        .willReturn(Optional.of(new BigDecimal("10.00")));
 
     var etfIsin = "IE00BFNM3G45";
     var allocation =
@@ -216,10 +224,10 @@ class TrackingDifferenceServiceTest {
   void calculatesBenchmarkModelForBondFund() {
     skipOtherFunds(TUK00);
 
-    given(fundValueProvider.getLatestValue(TUK00.getIsin(), CHECK_DATE))
-        .willReturn(Optional.of(fundValue("10.10", CHECK_DATE)));
-    given(fundValueProvider.getLatestValue(TUK00.getIsin(), CHECK_DATE.minusDays(1)))
-        .willReturn(Optional.of(fundValue("10.00", PREVIOUS_DATE)));
+    given(fundNavQueryService.findNavPerUnit(TUK00.getCode(), CHECK_DATE))
+        .willReturn(Optional.of(new BigDecimal("10.10")));
+    given(fundNavQueryService.findNavPerUnit(TUK00.getCode(), PREVIOUS_DATE))
+        .willReturn(Optional.of(new BigDecimal("10.00")));
 
     var bondIsin = "LU0826455353";
     var allocation =
@@ -289,10 +297,10 @@ class TrackingDifferenceServiceTest {
   void calculatesBenchmarkModelForEmMutualFund() {
     skipOtherFunds(TUK75);
 
-    given(fundValueProvider.getLatestValue(TUK75.getIsin(), CHECK_DATE))
-        .willReturn(Optional.of(fundValue("10.10", CHECK_DATE)));
-    given(fundValueProvider.getLatestValue(TUK75.getIsin(), CHECK_DATE.minusDays(1)))
-        .willReturn(Optional.of(fundValue("10.00", PREVIOUS_DATE)));
+    given(fundNavQueryService.findNavPerUnit(TUK75.getCode(), CHECK_DATE))
+        .willReturn(Optional.of(new BigDecimal("10.10")));
+    given(fundNavQueryService.findNavPerUnit(TUK75.getCode(), PREVIOUS_DATE))
+        .willReturn(Optional.of(new BigDecimal("10.00")));
 
     // EM mutual fund ISIN → should resolve to MSCI_EM
     var emIsin = "IE00BKPTWY98";
@@ -363,10 +371,10 @@ class TrackingDifferenceServiceTest {
   void benchmarkModelSkipsWhenBenchmarkDataMissing() {
     skipOtherFunds(TUK75);
 
-    given(fundValueProvider.getLatestValue(TUK75.getIsin(), CHECK_DATE))
-        .willReturn(Optional.of(fundValue("10.10", CHECK_DATE)));
-    given(fundValueProvider.getLatestValue(TUK75.getIsin(), CHECK_DATE.minusDays(1)))
-        .willReturn(Optional.of(fundValue("10.00", PREVIOUS_DATE)));
+    given(fundNavQueryService.findNavPerUnit(TUK75.getCode(), CHECK_DATE))
+        .willReturn(Optional.of(new BigDecimal("10.10")));
+    given(fundNavQueryService.findNavPerUnit(TUK75.getCode(), PREVIOUS_DATE))
+        .willReturn(Optional.of(new BigDecimal("10.00")));
 
     var etfIsin = "IE00BFNM3G45";
     var allocation =
@@ -428,10 +436,12 @@ class TrackingDifferenceServiceTest {
 
   @Test
   void runChecksForFundsOnlyChecksSpecifiedFunds() {
-    given(fundValueProvider.getLatestValue(TUK75.getIsin(), CHECK_DATE))
-        .willReturn(Optional.of(fundValue("10.10", CHECK_DATE)));
-    given(fundValueProvider.getLatestValue(TUK75.getIsin(), CHECK_DATE.minusDays(1)))
-        .willReturn(Optional.of(fundValue("10.00", PREVIOUS_DATE)));
+    given(fundNavQueryService.findLatestNavDateOnOrBefore(TUK75.getCode(), CHECK_DATE))
+        .willReturn(Optional.of(CHECK_DATE));
+    given(fundNavQueryService.findNavPerUnit(TUK75.getCode(), CHECK_DATE))
+        .willReturn(Optional.of(new BigDecimal("10.10")));
+    given(fundNavQueryService.findNavPerUnit(TUK75.getCode(), PREVIOUS_DATE))
+        .willReturn(Optional.of(new BigDecimal("10.00")));
 
     setupFundDataForFund(TUK75);
 
@@ -444,10 +454,10 @@ class TrackingDifferenceServiceTest {
   void calculatesBenchmarkModelForEmEtf() {
     skipOtherFunds(TUK75);
 
-    given(fundValueProvider.getLatestValue(TUK75.getIsin(), CHECK_DATE))
-        .willReturn(Optional.of(fundValue("10.10", CHECK_DATE)));
-    given(fundValueProvider.getLatestValue(TUK75.getIsin(), CHECK_DATE.minusDays(1)))
-        .willReturn(Optional.of(fundValue("10.00", PREVIOUS_DATE)));
+    given(fundNavQueryService.findNavPerUnit(TUK75.getCode(), CHECK_DATE))
+        .willReturn(Optional.of(new BigDecimal("10.10")));
+    given(fundNavQueryService.findNavPerUnit(TUK75.getCode(), PREVIOUS_DATE))
+        .willReturn(Optional.of(new BigDecimal("10.00")));
 
     // EM ETF ISIN → should resolve to EUNM.DE (IE00B4L5YC18.XETR)
     var emEtfIsin = "IE00BMDBMY19";
@@ -517,10 +527,10 @@ class TrackingDifferenceServiceTest {
   void benchmarkModelSkipsUnknownIsinInEquityFund() {
     skipOtherFunds(TUK75);
 
-    given(fundValueProvider.getLatestValue(TUK75.getIsin(), CHECK_DATE))
-        .willReturn(Optional.of(fundValue("10.10", CHECK_DATE)));
-    given(fundValueProvider.getLatestValue(TUK75.getIsin(), CHECK_DATE.minusDays(1)))
-        .willReturn(Optional.of(fundValue("10.00", PREVIOUS_DATE)));
+    given(fundNavQueryService.findNavPerUnit(TUK75.getCode(), CHECK_DATE))
+        .willReturn(Optional.of(new BigDecimal("10.10")));
+    given(fundNavQueryService.findNavPerUnit(TUK75.getCode(), PREVIOUS_DATE))
+        .willReturn(Optional.of(new BigDecimal("10.00")));
 
     // Unknown ISIN not in FundTicker → resolveBenchmarkKey returns null → skipped
     var unknownIsin = "IE00UNKNOWN00";
@@ -585,10 +595,10 @@ class TrackingDifferenceServiceTest {
   void benchmarkModelSkipsUnknownBondIsin() {
     skipOtherFunds(TUK00);
 
-    given(fundValueProvider.getLatestValue(TUK00.getIsin(), CHECK_DATE))
-        .willReturn(Optional.of(fundValue("10.10", CHECK_DATE)));
-    given(fundValueProvider.getLatestValue(TUK00.getIsin(), CHECK_DATE.minusDays(1)))
-        .willReturn(Optional.of(fundValue("10.00", PREVIOUS_DATE)));
+    given(fundNavQueryService.findNavPerUnit(TUK00.getCode(), CHECK_DATE))
+        .willReturn(Optional.of(new BigDecimal("10.10")));
+    given(fundNavQueryService.findNavPerUnit(TUK00.getCode(), PREVIOUS_DATE))
+        .willReturn(Optional.of(new BigDecimal("10.00")));
 
     // Bond ISIN not in BOND_BENCHMARK_KEYS → skipped
     var unknownBondIsin = "LU0000000000";
@@ -669,11 +679,8 @@ class TrackingDifferenceServiceTest {
 
   @Test
   void skipsWhenNoNavData() {
-    for (var fund : TulevaFund.values()) {
-      given(fundValueProvider.getLatestValue(fund.getIsin(), CHECK_DATE))
-          .willReturn(Optional.empty());
-    }
-
+    // Lenient default already returns Optional.empty() for findLatestNavDateOnOrBefore,
+    // so every fund is skipped before findNavPerUnit is even called.
     var results = service.runChecksAsOf(CHECK_DATE);
 
     assertThat(results).isEmpty();
@@ -683,9 +690,9 @@ class TrackingDifferenceServiceTest {
   void skipsWhenNoPreviousNavDate() {
     skipOtherFunds(TUK75);
 
-    given(fundValueProvider.getLatestValue(TUK75.getIsin(), CHECK_DATE))
-        .willReturn(Optional.of(fundValue("10.10", CHECK_DATE)));
-    given(fundValueProvider.getLatestValue(TUK75.getIsin(), CHECK_DATE.minusDays(1)))
+    given(fundNavQueryService.findNavPerUnit(TUK75.getCode(), CHECK_DATE))
+        .willReturn(Optional.of(new BigDecimal("10.10")));
+    given(fundNavQueryService.findNavPerUnit(TUK75.getCode(), PREVIOUS_DATE))
         .willReturn(Optional.empty());
 
     var results = service.runChecksAsOf(CHECK_DATE);
@@ -747,10 +754,10 @@ class TrackingDifferenceServiceTest {
   void handlesZeroTotalNav() {
     skipOtherFunds(TUK75);
 
-    given(fundValueProvider.getLatestValue(TUK75.getIsin(), CHECK_DATE))
-        .willReturn(Optional.of(fundValue("10.10", CHECK_DATE)));
-    given(fundValueProvider.getLatestValue(TUK75.getIsin(), CHECK_DATE.minusDays(1)))
-        .willReturn(Optional.of(fundValue("10.00", PREVIOUS_DATE)));
+    given(fundNavQueryService.findNavPerUnit(TUK75.getCode(), CHECK_DATE))
+        .willReturn(Optional.of(new BigDecimal("10.10")));
+    given(fundNavQueryService.findNavPerUnit(TUK75.getCode(), PREVIOUS_DATE))
+        .willReturn(Optional.of(new BigDecimal("10.00")));
 
     var allocation =
         ModelPortfolioAllocation.builder()
@@ -804,10 +811,10 @@ class TrackingDifferenceServiceTest {
   void usesCutoffAdjustedPriceForSecurityReturn() {
     skipOtherFunds(TUK75);
 
-    given(fundValueProvider.getLatestValue(TUK75.getIsin(), CHECK_DATE))
-        .willReturn(Optional.of(fundValue("10.10", CHECK_DATE)));
-    given(fundValueProvider.getLatestValue(TUK75.getIsin(), CHECK_DATE.minusDays(1)))
-        .willReturn(Optional.of(fundValue("10.00", PREVIOUS_DATE)));
+    given(fundNavQueryService.findNavPerUnit(TUK75.getCode(), CHECK_DATE))
+        .willReturn(Optional.of(new BigDecimal("10.10")));
+    given(fundNavQueryService.findNavPerUnit(TUK75.getCode(), PREVIOUS_DATE))
+        .willReturn(Optional.of(new BigDecimal("10.00")));
 
     var allocation =
         ModelPortfolioAllocation.builder()
@@ -862,10 +869,10 @@ class TrackingDifferenceServiceTest {
   void throwsWhenSecurityPriceDataIncomplete() {
     skipOtherFunds(TUK75);
 
-    given(fundValueProvider.getLatestValue(TUK75.getIsin(), CHECK_DATE))
-        .willReturn(Optional.of(fundValue("10.10", CHECK_DATE)));
-    given(fundValueProvider.getLatestValue(TUK75.getIsin(), CHECK_DATE.minusDays(1)))
-        .willReturn(Optional.of(fundValue("10.00", PREVIOUS_DATE)));
+    given(fundNavQueryService.findNavPerUnit(TUK75.getCode(), CHECK_DATE))
+        .willReturn(Optional.of(new BigDecimal("10.10")));
+    given(fundNavQueryService.findNavPerUnit(TUK75.getCode(), PREVIOUS_DATE))
+        .willReturn(Optional.of(new BigDecimal("10.00")));
 
     var allocation1 =
         ModelPortfolioAllocation.builder()
@@ -913,10 +920,10 @@ class TrackingDifferenceServiceTest {
   private void setupFundData(TulevaFund fund) {
     skipOtherFunds(fund);
 
-    given(fundValueProvider.getLatestValue(fund.getIsin(), CHECK_DATE))
-        .willReturn(Optional.of(fundValue("10.10", CHECK_DATE)));
-    given(fundValueProvider.getLatestValue(fund.getIsin(), CHECK_DATE.minusDays(1)))
-        .willReturn(Optional.of(fundValue("10.00", PREVIOUS_DATE)));
+    given(fundNavQueryService.findNavPerUnit(fund.getCode(), CHECK_DATE))
+        .willReturn(Optional.of(new BigDecimal("10.10")));
+    given(fundNavQueryService.findNavPerUnit(fund.getCode(), PREVIOUS_DATE))
+        .willReturn(Optional.of(new BigDecimal("10.00")));
 
     var allocation =
         ModelPortfolioAllocation.builder()
@@ -1014,9 +1021,11 @@ class TrackingDifferenceServiceTest {
   }
 
   private void skipOtherFunds(TulevaFund fund) {
+    given(fundNavQueryService.findLatestNavDateOnOrBefore(fund.getCode(), CHECK_DATE))
+        .willReturn(Optional.of(CHECK_DATE));
     for (var f : TulevaFund.values()) {
       if (f != fund) {
-        given(fundValueProvider.getLatestValue(f.getIsin(), CHECK_DATE))
+        given(fundNavQueryService.findLatestNavDateOnOrBefore(f.getCode(), CHECK_DATE))
             .willReturn(Optional.empty());
       }
     }

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/nav/FundNavQueryServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/nav/FundNavQueryServiceTest.java
@@ -1,0 +1,61 @@
+package ee.tuleva.onboarding.savings.fund.nav;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class FundNavQueryServiceTest {
+
+  @Mock NavReportRepository navReportRepository;
+
+  @InjectMocks FundNavQueryService service;
+
+  private static final LocalDate NAV_DATE = LocalDate.of(2026, 5, 7);
+
+  @Test
+  void findNavPerUnit_returnsMarketPriceFromNavRow() {
+    var navRow =
+        NavReportRow.builder()
+            .fundCode("TUK00")
+            .navDate(NAV_DATE)
+            .accountType("NAV")
+            .accountName("Net Asset Value")
+            .marketPrice(new BigDecimal("0.60985"))
+            .build();
+    given(navReportRepository.findFirstByFundCodeAndNavDateAndAccountType("TUK00", NAV_DATE, "NAV"))
+        .willReturn(Optional.of(navRow));
+
+    var result = service.findNavPerUnit("TUK00", NAV_DATE);
+
+    assertThat(result).hasValue(new BigDecimal("0.60985"));
+  }
+
+  @Test
+  void findNavPerUnit_returnsEmptyWhenNoRow() {
+    given(navReportRepository.findFirstByFundCodeAndNavDateAndAccountType("TUK00", NAV_DATE, "NAV"))
+        .willReturn(Optional.empty());
+
+    assertThat(service.findNavPerUnit("TUK00", NAV_DATE)).isEmpty();
+  }
+
+  @Test
+  void findLatestNavDateOnOrBefore_delegatesToRepositoryWithNavAccountType() {
+    given(
+            navReportRepository.findLatestNavDateByFundAndAccountTypeOnOrBefore(
+                "TUK00", "NAV", NAV_DATE))
+        .willReturn(Optional.of(NAV_DATE.minusDays(1)));
+
+    var result = service.findLatestNavDateOnOrBefore("TUK00", NAV_DATE);
+
+    assertThat(result).hasValue(NAV_DATE.minusDays(1));
+  }
+}


### PR DESCRIPTION
## Why

The TD gate was reading \"today's NAV\" via `FundValueProvider.getLatestValue`, which queries `index_values`. For pillar 2 funds (TUK00, TUK75) the fresh NAV is never written to `index_values` and the official PENSIONIKESKUS value lands at D+1 ~09:50 — *after* the gate runs at D+1 ~08:20. Both today and yesterday lookups collapsed onto the same prior-day row, producing `fundReturn=0` and a false TD breach that blocked publishing (this morning's TUK00 alert was exactly this — `MODEL_PORTFOLIO TD=-0.003084 (fund=0.000000, benchmark=0.003084)`).

## What

The `nav_report` table already has an aggregated `NAV` row per (fund, date) — the `account_type='NAV'` row, with `nav_per_unit` in `market_price`. It's written by `NavReportMapper.navRow()` on every NAV calculation, *before* the gate runs, regardless of whether publishing succeeds. So TD can read its own inputs from there.

This is the right place architecturally too: `index_values` is for external feeds (PENSIONIKESKUS, MSCI, ETF prices). `nav_report` is Tuleva's own output. TD is checking the consistency of *our* calculation, so it should read *our* values.

- New: `FundNavQueryService` (public) wraps two new `NavReportRepository` lookups
- `TrackingDifferenceService.checkFund` reads today/yesterday via the new service and uses `publicHolidays.previousWorkingDay(checkDate)` explicitly instead of relying on the `getLatestValue` at-or-before fallback
- `runChecksAsOf` discovers the latest NAV date via the new service
- Benchmark and per-security price reads (`FundValueProvider`, `PriorityPriceProvider`, `PositionPriceResolver`) are unchanged — those are external by nature and continue to use `index_values`
- No schema changes, no migration, no backfill. Existing `nav_report` rows are sufficient.

## Test plan
- [x] `./gradlew test` — full suite passes
- [x] `FundNavQueryServiceTest` — new unit tests for the wrapper
- [x] `TrackingDifferenceServiceTest` — existing tests refactored to mock `FundNavQueryService` for fund's own NAV; `FundValueProvider` mocks remain only for benchmarks
- [ ] Verify on staging: TD gate runs against TUK00/TUK75 with fresh NAV from `nav_report` and produces a real `fundReturn` (not 0)

## Notes
This is the proper fix for the same bug class as the reverted commit `1faf441df`. That earlier attempt fixed today by passing `result.navPerUnit()` as an override and started writing pillar 2 NAVs to `index_values`. That muddled `index_values` (TULEVA-source row would have shadowed PENSIONIKESKUS arrivals via `INSERT WHERE NOT EXISTS`). This version leaves `index_values` alone entirely and uses the right data source instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)