### PR TITLE
Only MODEL_PORTFOLIO TD checks block NAV publishing

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/investment/check/tracking/NavTrackingDifferenceGate.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/check/tracking/NavTrackingDifferenceGate.java
@@ -1,5 +1,6 @@
 package ee.tuleva.onboarding.investment.check.tracking;
 
+import static ee.tuleva.onboarding.investment.check.tracking.TrackingCheckType.MODEL_PORTFOLIO;
 import static ee.tuleva.onboarding.investment.event.PipelineStep.TRACKING_DIFFERENCE;
 import static java.util.stream.Collectors.joining;
 
@@ -27,7 +28,11 @@ public class NavTrackingDifferenceGate {
       trackingDifferenceNotifier.notify(results);
       pipelineTracker.stepCompleted(TRACKING_DIFFERENCE);
 
-      var breaches = results.stream().filter(TrackingDifferenceResult::breach).toList();
+      var breaches =
+          results.stream()
+              .filter(r -> r.checkType() == MODEL_PORTFOLIO)
+              .filter(TrackingDifferenceResult::breach)
+              .toList();
       if (!breaches.isEmpty()) {
         var details =
             breaches.stream()

--- a/src/test/groovy/ee/tuleva/onboarding/investment/check/tracking/NavTrackingDifferenceGateTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/check/tracking/NavTrackingDifferenceGateTest.java
@@ -82,6 +82,46 @@ class NavTrackingDifferenceGateTest {
   }
 
   @Test
+  void passes_whenOnlyBenchmarkBreach() {
+    var result = breachResult(TrackingCheckType.BENCHMARK);
+
+    given(trackingDifferenceService.checkFund(TUK75, NAV_DATE)).willReturn(List.of(result));
+
+    assertThat(gate.check(TUK75, NAV_DATE)).isEmpty();
+
+    then(trackingDifferenceNotifier).should().notify(List.of(result));
+  }
+
+  @Test
+  void passes_whenOnlyBenchmarkModelBreach() {
+    var result = breachResult(TrackingCheckType.BENCHMARK_MODEL);
+
+    given(trackingDifferenceService.checkFund(TUK75, NAV_DATE)).willReturn(List.of(result));
+
+    assertThat(gate.check(TUK75, NAV_DATE)).isEmpty();
+
+    then(trackingDifferenceNotifier).should().notify(List.of(result));
+  }
+
+  private static TrackingDifferenceResult breachResult(TrackingCheckType checkType) {
+    return TrackingDifferenceResult.builder()
+        .fund(TUK75)
+        .checkDate(NAV_DATE)
+        .checkType(checkType)
+        .trackingDifference(new BigDecimal("0.015"))
+        .fundReturn(new BigDecimal("0.02"))
+        .benchmarkReturn(new BigDecimal("0.005"))
+        .breach(true)
+        .consecutiveBreachDays(1)
+        .consecutiveNetTd(new BigDecimal("0.015"))
+        .securityAttributions(List.of())
+        .cashDrag(ZERO)
+        .feeDrag(ZERO)
+        .residual(ZERO)
+        .build();
+  }
+
+  @Test
   void passes_whenNoResults() {
     given(trackingDifferenceService.checkFund(TUK75, NAV_DATE)).willReturn(List.of());
 


### PR DESCRIPTION
## Summary
- BENCHMARK and BENCHMARK_MODEL TD checks no longer block NAV report publishing — only MODEL_PORTFOLIO does
- BENCHMARK is inherently noisy (fund vs ACWI pricing window mismatch), was already filtered from Slack alerts but still blocked the gate
- BENCHMARK_MODEL is new and unproven — keep as warning-only until we have confidence in it
- Both check types are still calculated, saved to DB, and included in Slack notifications

## Context
TUK00 NAV report was blocked on 2026-05-07 by a BENCHMARK TD breach. This is a false positive — TUK00 holds BlackRock fund-of-funds, not the index directly, so TD vs ACWI is expected.

## Test plan
- [x] New test: `passes_whenOnlyBenchmarkBreach` — BENCHMARK breach does not block
- [x] New test: `passes_whenOnlyBenchmarkModelBreach` — BENCHMARK_MODEL breach does not block
- [x] Existing test: `fails_whenBreachDetected` — MODEL_PORTFOLIO breach still blocks
- [x] All existing gate tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)