### PR TITLE
Alert if SEB positions report missing by 10:40 EET

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/investment/report/ReportImportAlertJob.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/report/ReportImportAlertJob.java
@@ -1,0 +1,57 @@
+package ee.tuleva.onboarding.investment.report;
+
+import static ee.tuleva.onboarding.investment.report.ReportProvider.SEB;
+import static ee.tuleva.onboarding.investment.report.ReportType.POSITIONS;
+import static ee.tuleva.onboarding.notification.OperationsNotificationService.Channel.INVESTMENT;
+
+import ee.tuleva.onboarding.deadline.PublicHolidays;
+import ee.tuleva.onboarding.notification.OperationsNotificationService;
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.springframework.context.annotation.Profile;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@Profile({"production", "staging"})
+public class ReportImportAlertJob {
+
+  private static final ZoneId TALLINN = ZoneId.of("Europe/Tallinn");
+
+  private final InvestmentReportRepository reportRepository;
+  private final OperationsNotificationService notificationService;
+  private final PublicHolidays publicHolidays;
+  private final Clock clock;
+
+  @Scheduled(cron = "0 40 10 * * MON-FRI", zone = "Europe/Tallinn")
+  @SchedulerLock(
+      name = "ReportImportAlert_sebPositions",
+      lockAtMostFor = "5m",
+      lockAtLeastFor = "1m")
+  public void alertIfSebPositionsMissing() {
+    LocalDate today = ZonedDateTime.now(clock).withZoneSameInstant(TALLINN).toLocalDate();
+    if (!publicHolidays.isWorkingDay(today)) {
+      return;
+    }
+    LocalDate expectedDate = publicHolidays.previousWorkingDay(today);
+    boolean exists =
+        reportRepository.existsByProviderAndReportTypeAndReportDate(SEB, POSITIONS, expectedDate);
+    if (exists) {
+      return;
+    }
+    String message =
+        "SEB positions report missing: expectedDate="
+            + expectedDate
+            + ", checkedAt=10:40 Tallinn."
+            + " NAV calculation at 11:00 will fail without it.";
+    log.warn("{}", message);
+    notificationService.sendMessage(message, INVESTMENT);
+  }
+}

--- a/src/test/groovy/ee/tuleva/onboarding/investment/report/ReportImportAlertJobScheduledTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/report/ReportImportAlertJobScheduledTest.java
@@ -1,0 +1,23 @@
+package ee.tuleva.onboarding.investment.report;
+
+import ee.tuleva.onboarding.config.ScheduledTest;
+import ee.tuleva.onboarding.deadline.PublicHolidays;
+import ee.tuleva.onboarding.notification.OperationsNotificationService;
+import java.time.Clock;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+@ScheduledTest(ReportImportAlertJob.class)
+@Import(PublicHolidays.class)
+@ActiveProfiles("production")
+class ReportImportAlertJobScheduledTest {
+
+  @MockitoBean InvestmentReportRepository reportRepository;
+  @MockitoBean OperationsNotificationService notificationService;
+  @MockitoBean Clock clock;
+
+  @Test
+  void cronExpressionsResolve() {}
+}

--- a/src/test/groovy/ee/tuleva/onboarding/investment/report/ReportImportAlertJobTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/report/ReportImportAlertJobTest.java
@@ -1,0 +1,89 @@
+package ee.tuleva.onboarding.investment.report;
+
+import static ee.tuleva.onboarding.investment.report.ReportProvider.SEB;
+import static ee.tuleva.onboarding.investment.report.ReportType.POSITIONS;
+import static ee.tuleva.onboarding.notification.OperationsNotificationService.Channel.INVESTMENT;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import ee.tuleva.onboarding.deadline.PublicHolidays;
+import ee.tuleva.onboarding.notification.OperationsNotificationService;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ReportImportAlertJobTest {
+
+  private static final ZoneId TALLINN = ZoneId.of("Europe/Tallinn");
+
+  // 2025-01-15 = Wednesday; 10:40 Tallinn = 08:40 UTC (winter EET = UTC+2)
+  private static final String WED_1040_UTC = "2025-01-15T08:40:00Z";
+  // Saturday
+  private static final String SAT_1040_UTC = "2025-01-18T08:40:00Z";
+  // 2026-02-24 = Tuesday Independence Day
+  private static final String INDEPENDENCE_DAY_1040_UTC = "2026-02-24T08:40:00Z";
+
+  @Mock private InvestmentReportRepository reportRepository;
+  @Mock private OperationsNotificationService notificationService;
+  private final PublicHolidays publicHolidays = new PublicHolidays();
+
+  @Test
+  void alertFires_whenSebPositionsReportMissing() {
+    var job = jobOn(WED_1040_UTC);
+    LocalDate expectedDate = LocalDate.of(2025, 1, 14); // previous working day (Tuesday)
+    given(reportRepository.existsByProviderAndReportTypeAndReportDate(SEB, POSITIONS, expectedDate))
+        .willReturn(false);
+
+    job.alertIfSebPositionsMissing();
+
+    verify(notificationService)
+        .sendMessage(contains("SEB positions report missing"), eq(INVESTMENT));
+    verify(notificationService).sendMessage(contains("2025-01-14"), eq(INVESTMENT));
+  }
+
+  @Test
+  void silent_whenSebPositionsReportExists() {
+    var job = jobOn(WED_1040_UTC);
+    LocalDate expectedDate = LocalDate.of(2025, 1, 14);
+    given(reportRepository.existsByProviderAndReportTypeAndReportDate(SEB, POSITIONS, expectedDate))
+        .willReturn(true);
+
+    job.alertIfSebPositionsMissing();
+
+    verifyNoInteractions(notificationService);
+  }
+
+  @Test
+  void silent_onNonWorkingDay() {
+    var job = jobOn(SAT_1040_UTC);
+
+    job.alertIfSebPositionsMissing();
+
+    verifyNoInteractions(notificationService);
+    verifyNoInteractions(reportRepository);
+  }
+
+  @Test
+  void silent_onWeekdayPublicHoliday() {
+    var job = jobOn(INDEPENDENCE_DAY_1040_UTC);
+
+    job.alertIfSebPositionsMissing();
+
+    verifyNoInteractions(notificationService);
+    verifyNoInteractions(reportRepository);
+  }
+
+  private ReportImportAlertJob jobOn(String instant) {
+    Clock clock = Clock.fixed(Instant.parse(instant), TALLINN);
+    return new ReportImportAlertJob(reportRepository, notificationService, publicHolidays, clock);
+  }
+}


### PR DESCRIPTION
## Summary
- `ReportImportAlertJob` runs at 10:40 EET Mon-Fri, checks if SEB positions report for previous working day exists in `investment_report` table
- If missing, sends Slack alert to INVESTMENT channel warning that the 11:00 NAV calculation will fail without position data
- Skips weekends and public holidays

## Test plan
- [x] `ReportImportAlertJobTest` — 4 unit tests (alert fires when missing, silent when exists, silent on weekend, silent on public holiday)
- [x] `ReportImportAlertJobScheduledTest` — cron expression validation
- [x] `./gradlew test` passes
- [ ] Post-deploy: verify alert fires correctly when SEB report is late

🤖 Generated with [Claude Code](https://claude.com/claude-code)