### PR TITLE
Add daily NAV reconciliation for all funds

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/savings/fund/nav/NavReconciliationJob.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/nav/NavReconciliationJob.java
@@ -1,0 +1,38 @@
+package ee.tuleva.onboarding.savings.fund.nav;
+
+import ee.tuleva.onboarding.deadline.PublicHolidays;
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.springframework.context.annotation.Profile;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@Profile({"production", "staging"})
+class NavReconciliationJob {
+
+  private static final ZoneId TALLINN = ZoneId.of("Europe/Tallinn");
+
+  private final NavReconciliationService reconciliationService;
+  private final PublicHolidays publicHolidays;
+  private final Clock clock;
+
+  @Scheduled(cron = "0 10 16 * * MON-FRI", zone = "Europe/Tallinn")
+  @SchedulerLock(name = "NavReconciliationJob", lockAtMostFor = "5m", lockAtLeastFor = "1m")
+  public void reconcileDaily() {
+    LocalDate today = ZonedDateTime.now(clock).withZoneSameInstant(TALLINN).toLocalDate();
+    if (!publicHolidays.isWorkingDay(today)) {
+      return;
+    }
+    LocalDate navDate = publicHolidays.previousWorkingDay(today);
+    log.info("Running CSV-to-API reconciliation: navDate={}", navDate);
+    reconciliationService.reconcile(navDate);
+  }
+}

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/nav/NavReconciliationService.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/nav/NavReconciliationService.java
@@ -1,0 +1,96 @@
+package ee.tuleva.onboarding.savings.fund.nav;
+
+import static ee.tuleva.onboarding.notification.OperationsNotificationService.Channel.INVESTMENT;
+
+import ee.tuleva.onboarding.comparisons.fundvalue.FundValue;
+import ee.tuleva.onboarding.comparisons.fundvalue.FundValueProvider;
+import ee.tuleva.onboarding.fund.TulevaFund;
+import ee.tuleva.onboarding.notification.OperationsNotificationService;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+class NavReconciliationService {
+
+  private final NavReportRepository navReportRepository;
+  private final FundValueProvider fundValueProvider;
+  private final OperationsNotificationService notificationService;
+
+  void reconcile(LocalDate navDate) {
+    for (TulevaFund fund : TulevaFund.values()) {
+      if (fund.hasNavCalculation()) {
+        reconcileFund(fund, navDate);
+      }
+    }
+  }
+
+  private void reconcileFund(TulevaFund fund, LocalDate navDate) {
+    List<NavReportRow> rows =
+        navReportRepository.findLatestByNavDateAndFundCode(navDate, fund.getCode());
+    if (rows.isEmpty()) {
+      log.info("No nav_report rows for reconciliation: fund={}, date={}", fund.getCode(), navDate);
+      return;
+    }
+
+    Optional<NavReportRow> navRow =
+        rows.stream().filter(r -> "NAV".equals(r.getAccountType())).findFirst();
+    Optional<NavReportRow> unitsRow =
+        rows.stream().filter(r -> "UNITS".equals(r.getAccountType())).findFirst();
+
+    List<String> mismatches = new ArrayList<>();
+
+    navRow.ifPresent(
+        row -> {
+          BigDecimal reportNav = row.getMarketPrice();
+          Optional<FundValue> fundValue =
+              fundValueProvider.getValueForDate(fund.getIsin(), navDate);
+          if (fundValue.isEmpty()) {
+            mismatches.add("NAV fund_value missing (nav_report has " + reportNav + ")");
+          } else if (reportNav.compareTo(fundValue.get().value()) != 0) {
+            mismatches.add(
+                "NAV mismatch: nav_report="
+                    + reportNav
+                    + ", fund_value="
+                    + fundValue.get().value());
+          }
+        });
+
+    unitsRow.ifPresent(
+        row -> {
+          BigDecimal reportAum = row.getMarketValue();
+          Optional<FundValue> fundValue =
+              fundValueProvider.getValueForDate(fund.getAumKey(), navDate);
+          if (fundValue.isEmpty()) {
+            mismatches.add("AUM fund_value missing (nav_report has " + reportAum + ")");
+          } else if (reportAum.compareTo(fundValue.get().value()) != 0) {
+            mismatches.add(
+                "AUM mismatch: nav_report="
+                    + reportAum
+                    + ", fund_value="
+                    + fundValue.get().value());
+          }
+        });
+
+    if (!mismatches.isEmpty()) {
+      String message =
+          "CSV-to-API reconciliation failed: fund="
+              + fund.getCode()
+              + ", date="
+              + navDate
+              + "\n"
+              + String.join("\n", mismatches);
+      log.warn("{}", message);
+      notificationService.sendMessage(message, INVESTMENT);
+    } else {
+      log.info("CSV-to-API reconciliation passed: fund={}, date={}", fund.getCode(), navDate);
+    }
+  }
+}

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/nav/NavReconciliationJobScheduledTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/nav/NavReconciliationJobScheduledTest.java
@@ -1,0 +1,21 @@
+package ee.tuleva.onboarding.savings.fund.nav;
+
+import ee.tuleva.onboarding.config.ScheduledTest;
+import ee.tuleva.onboarding.deadline.PublicHolidays;
+import java.time.Clock;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+@ScheduledTest(NavReconciliationJob.class)
+@Import(PublicHolidays.class)
+@ActiveProfiles("production")
+class NavReconciliationJobScheduledTest {
+
+  @MockitoBean NavReconciliationService reconciliationService;
+  @MockitoBean Clock clock;
+
+  @Test
+  void cronExpressionsResolve() {}
+}

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/nav/NavReconciliationJobTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/nav/NavReconciliationJobTest.java
@@ -1,0 +1,64 @@
+package ee.tuleva.onboarding.savings.fund.nav;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import ee.tuleva.onboarding.deadline.PublicHolidays;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class NavReconciliationJobTest {
+
+  private static final ZoneId TALLINN = ZoneId.of("Europe/Tallinn");
+
+  @Mock private NavReconciliationService reconciliationService;
+  private final PublicHolidays publicHolidays = new PublicHolidays();
+
+  @Test
+  void reconcileDaily_reconcilesPreviousWorkingDay() {
+    var job = jobOn("2026-05-07T14:00:00Z"); // Wednesday 16:00 Tallinn
+
+    job.reconcileDaily();
+
+    verify(reconciliationService).reconcile(LocalDate.of(2026, 5, 6));
+  }
+
+  @Test
+  void reconcileDaily_skipsNonWorkingDay() {
+    var job = jobOn("2026-05-09T14:00:00Z"); // Saturday
+
+    job.reconcileDaily();
+
+    verifyNoInteractions(reconciliationService);
+  }
+
+  @Test
+  void reconcileDaily_skipsPublicHoliday() {
+    var job = jobOn("2026-02-24T14:00:00Z"); // Estonian Independence Day (Tuesday)
+
+    job.reconcileDaily();
+
+    verifyNoInteractions(reconciliationService);
+  }
+
+  @Test
+  void reconcileDaily_afterWeekend_reconcilesFriday() {
+    var job = jobOn("2026-05-11T14:00:00Z"); // Monday 16:00 Tallinn
+
+    job.reconcileDaily();
+
+    verify(reconciliationService).reconcile(LocalDate.of(2026, 5, 8)); // Friday
+  }
+
+  private NavReconciliationJob jobOn(String instant) {
+    Clock clock = Clock.fixed(Instant.parse(instant), TALLINN);
+    return new NavReconciliationJob(reconciliationService, publicHolidays, clock);
+  }
+}

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/nav/NavReconciliationServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/nav/NavReconciliationServiceTest.java
@@ -1,0 +1,165 @@
+package ee.tuleva.onboarding.savings.fund.nav;
+
+import static ee.tuleva.onboarding.fund.TulevaFund.TKF100;
+import static ee.tuleva.onboarding.fund.TulevaFund.TUK75;
+import static ee.tuleva.onboarding.notification.OperationsNotificationService.Channel.INVESTMENT;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import ee.tuleva.onboarding.comparisons.fundvalue.FundValue;
+import ee.tuleva.onboarding.comparisons.fundvalue.FundValueProvider;
+import ee.tuleva.onboarding.fund.TulevaFund;
+import ee.tuleva.onboarding.notification.OperationsNotificationService;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class NavReconciliationServiceTest {
+
+  @Mock private NavReportRepository navReportRepository;
+  @Mock private FundValueProvider fundValueProvider;
+  @Mock private OperationsNotificationService notificationService;
+
+  @InjectMocks private NavReconciliationService reconciliationService;
+
+  private static final LocalDate NAV_DATE = LocalDate.of(2026, 5, 6);
+  private static final Instant CALC_TIME = Instant.parse("2026-05-07T12:00:00Z");
+
+  @BeforeEach
+  void setUp() {
+    for (TulevaFund fund : TulevaFund.values()) {
+      if (fund.hasNavCalculation()) {
+        lenient()
+            .when(navReportRepository.findLatestByNavDateAndFundCode(NAV_DATE, fund.getCode()))
+            .thenReturn(List.of());
+      }
+    }
+  }
+
+  @Test
+  void reconcile_silent_whenNavAndAumMatch() {
+    stubNavReport(TKF100, NAV_DATE, "9.6994", "969941.07");
+    stubFundValue(TKF100.getIsin(), NAV_DATE, "9.6994");
+    stubFundValue(TKF100.getAumKey(), NAV_DATE, "969941.07");
+
+    reconciliationService.reconcile(NAV_DATE);
+
+    verifyNoInteractions(notificationService);
+  }
+
+  @Test
+  void reconcile_alerts_whenNavMismatch() {
+    stubNavReport(TKF100, NAV_DATE, "9.6994", "969941.07");
+    stubFundValue(TKF100.getIsin(), NAV_DATE, "9.7000");
+    stubFundValue(TKF100.getAumKey(), NAV_DATE, "969941.07");
+
+    reconciliationService.reconcile(NAV_DATE);
+
+    verify(notificationService).sendMessage(contains("TKF100"), eq(INVESTMENT));
+    verify(notificationService).sendMessage(contains("NAV mismatch"), eq(INVESTMENT));
+  }
+
+  @Test
+  void reconcile_alerts_whenAumMismatch() {
+    stubNavReport(TKF100, NAV_DATE, "9.6994", "969941.07");
+    stubFundValue(TKF100.getIsin(), NAV_DATE, "9.6994");
+    stubFundValue(TKF100.getAumKey(), NAV_DATE, "970000.00");
+
+    reconciliationService.reconcile(NAV_DATE);
+
+    verify(notificationService).sendMessage(contains("TKF100"), eq(INVESTMENT));
+    verify(notificationService).sendMessage(contains("AUM mismatch"), eq(INVESTMENT));
+  }
+
+  @Test
+  void reconcile_alerts_whenFundValueMissing() {
+    stubNavReport(TKF100, NAV_DATE, "9.6994", "969941.07");
+    when(fundValueProvider.getValueForDate(TKF100.getIsin(), NAV_DATE))
+        .thenReturn(Optional.empty());
+    stubFundValue(TKF100.getAumKey(), NAV_DATE, "969941.07");
+
+    reconciliationService.reconcile(NAV_DATE);
+
+    verify(notificationService).sendMessage(contains("TKF100"), eq(INVESTMENT));
+    verify(notificationService).sendMessage(contains("missing"), eq(INVESTMENT));
+  }
+
+  @Test
+  void reconcile_alerts_whenAumFundValueMissing() {
+    stubNavReport(TKF100, NAV_DATE, "9.6994", "969941.07");
+    stubFundValue(TKF100.getIsin(), NAV_DATE, "9.6994");
+    when(fundValueProvider.getValueForDate(TKF100.getAumKey(), NAV_DATE))
+        .thenReturn(Optional.empty());
+
+    reconciliationService.reconcile(NAV_DATE);
+
+    verify(notificationService).sendMessage(contains("TKF100"), eq(INVESTMENT));
+    verify(notificationService).sendMessage(contains("AUM fund_value missing"), eq(INVESTMENT));
+  }
+
+  @Test
+  void reconcile_silent_whenNoNavReportRows() {
+    reconciliationService.reconcile(NAV_DATE);
+
+    verify(notificationService, never()).sendMessage(contains("TKF100"), eq(INVESTMENT));
+  }
+
+  @Test
+  void reconcile_checksPillar2Funds() {
+    stubNavReport(TUK75, NAV_DATE, "1.50000", "15000000.00");
+    stubFundValue(TUK75.getIsin(), NAV_DATE, "1.49999");
+    stubFundValue(TUK75.getAumKey(), NAV_DATE, "15000000.00");
+
+    reconciliationService.reconcile(NAV_DATE);
+
+    verify(notificationService).sendMessage(contains("TUK75"), eq(INVESTMENT));
+    verify(notificationService).sendMessage(contains("NAV mismatch"), eq(INVESTMENT));
+  }
+
+  private void stubNavReport(TulevaFund fund, LocalDate navDate, String navPerUnit, String aum) {
+    var navRow =
+        NavReportRow.builder()
+            .navDate(navDate)
+            .fundCode(fund.getCode())
+            .accountType("NAV")
+            .accountName("Net Asset Value")
+            .quantity(new BigDecimal("1.00"))
+            .marketPrice(new BigDecimal(navPerUnit))
+            .marketValue(new BigDecimal(navPerUnit))
+            .build();
+
+    var unitsRow =
+        NavReportRow.builder()
+            .navDate(navDate)
+            .fundCode(fund.getCode())
+            .accountType("UNITS")
+            .accountName("Total outstanding units:")
+            .quantity(new BigDecimal("100000.000"))
+            .marketPrice(new BigDecimal(navPerUnit))
+            .marketValue(new BigDecimal(aum))
+            .build();
+
+    when(navReportRepository.findLatestByNavDateAndFundCode(navDate, fund.getCode()))
+        .thenReturn(List.of(navRow, unitsRow));
+  }
+
+  private void stubFundValue(String key, LocalDate date, String value) {
+    when(fundValueProvider.getValueForDate(key, date))
+        .thenReturn(
+            Optional.of(new FundValue(key, date, new BigDecimal(value), "TULEVA", CALC_TIME)));
+  }
+}


### PR DESCRIPTION
## Summary
- `NavReconciliationJob` runs at 16:10 EET Mon-Fri
- For each fund with NAV calculation (TUK75, TUK00, TUV100, TKF100), compares published `nav_report` rows against `index_values` entries
- **TKF100**: same-source check (NavPublisher writes both)
- **TUK75, TUK00, TUV100**: cross-source check — catches discrepancies in the round-trip (Tuleva CSV → SEB → EPIS → PENSIONIKESKUS → index_values)
- Checks both NAV per unit and AUM values
- Alerts go to INVESTMENT Slack channel on mismatch or missing values
- Runs at 16:10 to ensure pillar 3 PENSIONIKESKUS values (published ~16:01) have landed

## Test plan
- [x] `NavReconciliationServiceTest` — 7 tests (match, NAV mismatch, AUM mismatch, NAV missing, AUM missing, no rows, pillar 2 fund)
- [x] `NavReconciliationJobTest` — 4 tests (working day, weekend, holiday, after-weekend Friday check)
- [x] `NavReconciliationJobScheduledTest` — cron expression validation
- [x] `./gradlew test` passes
- [ ] Post-deploy: monitor first few days for false positives from PENSIONIKESKUS precision differences

🤖 Generated with [Claude Code](https://claude.com/claude-code)