### PR TITLE
Use calculation date in NAV CSV filename

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/savings/fund/nav/NavReportEmailSender.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/nav/NavReportEmailSender.java
@@ -33,6 +33,7 @@ class NavReportEmailSender {
 
     var fundCode = result.fund().getCode();
     var navDate = result.positionReportDate();
+    var calculationDate = result.calculationDate();
 
     var message = new MandrillMessage();
     message.setFromEmail("funds@tuleva.ee");
@@ -71,7 +72,7 @@ class NavReportEmailSender {
 
     var attachment = new MessageContent();
     attachment.setName(
-        fundCode + " NAV arvutamine " + navDate.format(FILENAME_DATE_FORMAT) + ".csv");
+        fundCode + " NAV arvutamine " + calculationDate.format(FILENAME_DATE_FORMAT) + ".csv");
     attachment.setType("text/csv");
     attachment.setContent(Base64.getEncoder().encodeToString(csvBytes));
     message.setAttachments(List.of(attachment));

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/nav/NavReportEmailSenderTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/nav/NavReportEmailSenderTest.java
@@ -67,7 +67,7 @@ class NavReportEmailSenderTest {
     assertThat(message.getTo().get(4).getType()).isEqualTo(BCC);
 
     var attachment = message.getAttachments().getFirst();
-    assertThat(attachment.getName()).isEqualTo("TKF100 NAV arvutamine 13032026.csv");
+    assertThat(attachment.getName()).isEqualTo("TKF100 NAV arvutamine 16032026.csv");
     assertThat(attachment.getType()).isEqualTo("text/csv");
     assertThat(Base64.getDecoder().decode(attachment.getContent())).isEqualTo(csvBytes);
   }


### PR DESCRIPTION
## Summary
- NAV CSV attachment filename now uses `calculationDate` (when NAV was calculated) instead of `positionReportDate` (the NAV date)
- Email subject still uses the NAV date, which is correct
- Example: for May 7 NAV calculated on May 8, subject = "TKF100 NAV arvutamine 07.05.2026", filename = "TKF100 NAV arvutamine 08052026.csv"

## Why
Consumer scripts (limit_check, tracking_difference, etc.) identify CSV files by the filename date, which historically matched the calculation date. The onboarding-service was using the position report date, causing filename mismatches.

## Test plan
- [x] `NavReportEmailSenderTest` updated and passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)