### PR TITLE
Show full price precision in NAV position reports

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/savings/fund/nav/NavReportMapper.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/nav/NavReportMapper.java
@@ -113,7 +113,7 @@ class NavReportMapper {
         .accountName(displayName)
         .accountId(detail.isin())
         .quantity(detail.units().setScale(3, HALF_UP))
-        .marketPrice(detail.price().setScale(4, HALF_UP))
+        .marketPrice(detail.price())
         .marketValue(detail.marketValue().setScale(2, HALF_UP))
         .build();
   }

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/nav/NavReportMapperTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/nav/NavReportMapperTest.java
@@ -2,8 +2,10 @@ package ee.tuleva.onboarding.savings.fund.nav;
 
 import static ee.tuleva.onboarding.currency.Currency.EUR;
 import static ee.tuleva.onboarding.fund.TulevaFund.TKF100;
+import static ee.tuleva.onboarding.fund.TulevaFund.TUK00;
 import static ee.tuleva.onboarding.fund.TulevaFund.TUK75;
 import static java.math.BigDecimal.ZERO;
+import static java.math.RoundingMode.HALF_UP;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import ee.tuleva.onboarding.deadline.PublicHolidays;
@@ -129,6 +131,46 @@ class NavReportMapperTest {
           assertThat(row.getFundCode()).isEqualTo("TKF100");
           assertThat(row.getCurrency()).isEqualTo(EUR);
         });
+  }
+
+  @Test
+  void securityPriceRetainsFullPrecisionSoMarketValueIsVerifiable() {
+    var navDate = LocalDate.of(2026, 5, 7);
+    var price = new BigDecimal("22.70196");
+    var units = new BigDecimal("125765.36");
+    var marketValue = units.multiply(price).setScale(2, HALF_UP);
+
+    var result =
+        NavCalculationResult.builder()
+            .fund(TUK00)
+            .calculationDate(LocalDate.of(2026, 5, 8))
+            .positionReportDate(navDate)
+            .priceDate(navDate)
+            .calculatedAt(Instant.parse("2026-05-08T09:00:00Z"))
+            .securitiesDetail(
+                List.of(
+                    new SecurityDetail("IE0031080751", "EGBI", units, price, marketValue, navDate)))
+            .cashPosition(new BigDecimal("1000.00"))
+            .receivables(ZERO)
+            .payables(ZERO)
+            .pendingSubscriptions(ZERO)
+            .pendingRedemptions(ZERO)
+            .managementFeeAccrual(ZERO)
+            .depotFeeAccrual(ZERO)
+            .blackrockAdjustment(ZERO)
+            .unitsOutstanding(new BigDecimal("100000.000"))
+            .navPerUnit(new BigDecimal("28.56"))
+            .aum(marketValue)
+            .build();
+
+    var rows = navReportMapper.map(result);
+
+    var securityRow = rows.get(0);
+    assertThat(securityRow.getMarketPrice()).isEqualTo(price);
+    assertThat(securityRow.getMarketPrice().scale()).isGreaterThan(4);
+    assertThat(
+            securityRow.getQuantity().multiply(securityRow.getMarketPrice()).setScale(2, HALF_UP))
+        .isEqualTo(securityRow.getMarketValue());
   }
 
   @Test


### PR DESCRIPTION
## Summary
- Remove 4-decimal truncation on security market prices in position reports
- Custodian flagged that `quantity × reported_price ≠ reported_market_value` (e.g. IE0031080751: 125,765.36 × 22.7020 = 2,855,125.20 vs actual 2,855,120.17)
- Now the full source price precision passes through, so market values are verifiable from the report

## Test plan
- [x] `NavReportMapperTest` passes — test data already uses natural precision
- [x] DB column `market_price numeric(20,8)` supports up to 8 decimals
- [x] CSV generator uses `toPlainString()`, no format assumption
- [x] NAV per unit (UNITS/NAV rows) unaffected — still uses fund-specific `navScale`

🤖 Generated with [Claude Code](https://claude.com/claude-code)