### PR TITLE
Add AUM reconciliation tolerance and escalate NavUnitImpact to FAIL

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/investment/check/health/NavUnitImpactChecker.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/check/health/NavUnitImpactChecker.java
@@ -1,6 +1,6 @@
 package ee.tuleva.onboarding.investment.check.health;
 
-import static ee.tuleva.onboarding.investment.check.health.HealthCheckSeverity.WARNING;
+import static ee.tuleva.onboarding.investment.check.health.HealthCheckSeverity.FAIL;
 import static ee.tuleva.onboarding.investment.check.health.HealthCheckType.NAV_UNIT_IMPACT;
 import static java.math.RoundingMode.HALF_UP;
 
@@ -45,7 +45,7 @@ class NavUnitImpactChecker {
           new HealthCheckFinding(
               fund,
               NAV_UNIT_IMPACT,
-              WARNING,
+              FAIL,
               "NAV_SEB=%s vs NAV_EPIS=%s = %s%% NAV difference"
                   .formatted(
                       navWithReported.toPlainString(),

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/nav/NavReconciliationService.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/nav/NavReconciliationService.java
@@ -1,6 +1,7 @@
 package ee.tuleva.onboarding.savings.fund.nav;
 
 import static ee.tuleva.onboarding.notification.OperationsNotificationService.Channel.INVESTMENT;
+import static java.math.RoundingMode.HALF_UP;
 
 import ee.tuleva.onboarding.comparisons.fundvalue.FundValue;
 import ee.tuleva.onboarding.comparisons.fundvalue.FundValueProvider;
@@ -19,6 +20,11 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 class NavReconciliationService {
+
+  // Pensionikeskus computes AUM as registry_units × NAV_per_unit, which differs from
+  // Tuleva's bottom-up calculation (assets - liabilities) by the value of pending
+  // subscription/redemption units. Differences under 0.10% are expected.
+  static final BigDecimal AUM_TOLERANCE_PERCENT = new BigDecimal("0.10");
 
   private final NavReportRepository navReportRepository;
   private final FundValueProvider fundValueProvider;
@@ -70,7 +76,7 @@ class NavReconciliationService {
               fundValueProvider.getValueForDate(fund.getAumKey(), navDate);
           if (fundValue.isEmpty()) {
             mismatches.add("AUM fund_value missing (nav_report has " + reportAum + ")");
-          } else if (reportAum.compareTo(fundValue.get().value()) != 0) {
+          } else if (exceedsTolerance(reportAum, fundValue.get().value())) {
             mismatches.add(
                 "AUM mismatch: nav_report="
                     + reportAum
@@ -92,5 +98,18 @@ class NavReconciliationService {
     } else {
       log.info("CSV-to-API reconciliation passed: fund={}, date={}", fund.getCode(), navDate);
     }
+  }
+
+  private boolean exceedsTolerance(BigDecimal expected, BigDecimal actual) {
+    if (expected.signum() == 0) {
+      return actual.signum() != 0;
+    }
+    BigDecimal percentDiff =
+        expected
+            .subtract(actual)
+            .abs()
+            .multiply(new BigDecimal("100"))
+            .divide(expected.abs(), 6, HALF_UP);
+    return percentDiff.compareTo(AUM_TOLERANCE_PERCENT) > 0;
   }
 }

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/nav/NavReconciliationService.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/nav/NavReconciliationService.java
@@ -21,9 +21,6 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 class NavReconciliationService {
 
-  // Pensionikeskus computes AUM as registry_units × NAV_per_unit, which differs from
-  // Tuleva's bottom-up calculation (assets - liabilities) by the value of pending
-  // subscription/redemption units. Differences under 0.10% are expected.
   static final BigDecimal AUM_TOLERANCE_PERCENT = new BigDecimal("0.10");
 
   private final NavReportRepository navReportRepository;

--- a/src/test/groovy/ee/tuleva/onboarding/investment/check/health/NavUnitImpactCheckerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/check/health/NavUnitImpactCheckerTest.java
@@ -2,7 +2,7 @@ package ee.tuleva.onboarding.investment.check.health;
 
 import static ee.tuleva.onboarding.fund.TulevaFund.TKF100;
 import static ee.tuleva.onboarding.fund.TulevaFund.TUK75;
-import static ee.tuleva.onboarding.investment.check.health.HealthCheckSeverity.WARNING;
+import static ee.tuleva.onboarding.investment.check.health.HealthCheckSeverity.FAIL;
 import static ee.tuleva.onboarding.investment.check.health.HealthCheckType.NAV_UNIT_IMPACT;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -26,7 +26,7 @@ class NavUnitImpactCheckerTest {
   }
 
   @Test
-  void warningWhenUnitDifferenceAffectsNav() {
+  void failWhenUnitDifferenceAffectsNav() {
     // TKF100 navScale=4: 1000000/100000 = 10.0000, 1000000/100001 = 9.9999
     var findings =
         checker.check(
@@ -38,7 +38,7 @@ class NavUnitImpactCheckerTest {
             f -> {
               assertThat(f.fund()).isEqualTo(TKF100);
               assertThat(f.checkType()).isEqualTo(NAV_UNIT_IMPACT);
-              assertThat(f.severity()).isEqualTo(WARNING);
+              assertThat(f.severity()).isEqualTo(FAIL);
             });
   }
 

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/nav/NavReconciliationServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/nav/NavReconciliationServiceTest.java
@@ -74,8 +74,7 @@ class NavReconciliationServiceTest {
   }
 
   @Test
-  void reconcile_silent_whenAumWithinTolerance() {
-    // 0.0002% difference — typical Pensionikeskus vs Tuleva gap from pending subscriptions
+  void reconcile_silent_whenPensionikeskusAumDiffersFromTulevaByPendingSubscriptionUnits() {
     stubNavReport(TUK75, NAV_DATE, "1.53105", "1055262737.00");
     stubFundValue(TUK75.getIsin(), NAV_DATE, "1.53105");
     stubFundValue(TUK75.getAumKey(), NAV_DATE, "1055264997");
@@ -87,7 +86,6 @@ class NavReconciliationServiceTest {
 
   @Test
   void reconcile_alerts_whenAumExceedsTolerance() {
-    // >0.10% difference
     stubNavReport(TKF100, NAV_DATE, "9.6994", "969941.07");
     stubFundValue(TKF100.getIsin(), NAV_DATE, "9.6994");
     stubFundValue(TKF100.getAumKey(), NAV_DATE, "971000.00");

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/nav/NavReconciliationServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/nav/NavReconciliationServiceTest.java
@@ -74,10 +74,23 @@ class NavReconciliationServiceTest {
   }
 
   @Test
-  void reconcile_alerts_whenAumMismatch() {
+  void reconcile_silent_whenAumWithinTolerance() {
+    // 0.0002% difference — typical Pensionikeskus vs Tuleva gap from pending subscriptions
+    stubNavReport(TUK75, NAV_DATE, "1.53105", "1055262737.00");
+    stubFundValue(TUK75.getIsin(), NAV_DATE, "1.53105");
+    stubFundValue(TUK75.getAumKey(), NAV_DATE, "1055264997");
+
+    reconciliationService.reconcile(NAV_DATE);
+
+    verify(notificationService, never()).sendMessage(contains("TUK75"), eq(INVESTMENT));
+  }
+
+  @Test
+  void reconcile_alerts_whenAumExceedsTolerance() {
+    // >0.10% difference
     stubNavReport(TKF100, NAV_DATE, "9.6994", "969941.07");
     stubFundValue(TKF100.getIsin(), NAV_DATE, "9.6994");
-    stubFundValue(TKF100.getAumKey(), NAV_DATE, "970000.00");
+    stubFundValue(TKF100.getAumKey(), NAV_DATE, "971000.00");
 
     reconciliationService.reconcile(NAV_DATE);
 

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/nav/NavReconciliationServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/nav/NavReconciliationServiceTest.java
@@ -99,6 +99,17 @@ class NavReconciliationServiceTest {
   }
 
   @Test
+  void reconcile_alerts_whenAumIsZeroButFundValueIsNot() {
+    stubNavReport(TKF100, NAV_DATE, "9.6994", "0.00");
+    stubFundValue(TKF100.getIsin(), NAV_DATE, "9.6994");
+    stubFundValue(TKF100.getAumKey(), NAV_DATE, "100.00");
+
+    reconciliationService.reconcile(NAV_DATE);
+
+    verify(notificationService).sendMessage(contains("AUM mismatch"), eq(INVESTMENT));
+  }
+
+  @Test
   void reconcile_alerts_whenFundValueMissing() {
     stubNavReport(TKF100, NAV_DATE, "9.6994", "969941.07");
     when(fundValueProvider.getValueForDate(TKF100.getIsin(), NAV_DATE))


### PR DESCRIPTION
## Summary

- **NavReconciliationService**: AUM comparison uses 0.10% tolerance instead of exact match. Pensionikeskus computes AUM as `registry_units × NAV_per_unit`, which diverges from Tuleva's bottom-up calculation (`assets − liabilities`) by the value of pending subscription units still booked as receivables. Observed differences on 2026-05-14: TUK75 0.0002%, TUK00 0.0002%, TUV100 0.0012%.
- **NavUnitImpactChecker**: WARNING → FAIL. Blocks position import when SEB/EPIS unit count divergence affects published NAV price. No false positives observed during monitoring period since early May (6 days past the 2026-05-12 review date).

## Test plan

- [x] `NavReconciliationServiceTest` — within-tolerance AUM passes silently, over-tolerance alerts
- [x] `NavUnitImpactCheckerTest` — severity is FAIL, blocks via `HealthCheckResult.hasFails()`
- [x] Full test suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)