### PR TITLE
Fix BlackRock adjustment: round amounts, allow ops token for NAV calc

### DIFF
--- a/docs/br-adjustments.md
+++ b/docs/br-adjustments.md
@@ -19,6 +19,7 @@ given fund and date. The system computes the delta from whatever is currently in
 
 - Re-submitting the same value is safe (no duplicate entries)
 - Corrections work automatically (submit the corrected value, the system records the difference)
+- Amounts are rounded to 2 decimal places server-side (floating-point artifacts like `56980.95999999999` are handled automatically)
 
 ## Recording adjustments
 

--- a/src/main/java/ee/tuleva/onboarding/admin/AdminController.java
+++ b/src/main/java/ee/tuleva/onboarding/admin/AdminController.java
@@ -24,6 +24,7 @@ import ee.tuleva.onboarding.savings.fund.nav.NavPublisher;
 import ee.tuleva.onboarding.savings.fund.redemption.RedemptionBatchJob;
 import jakarta.transaction.Transactional;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.Clock;
 import java.time.LocalDate;
 import java.util.Arrays;
@@ -130,7 +131,7 @@ public class AdminController {
       @RequestParam(required = false) @DateTimeFormat(iso = DATE) LocalDate date,
       @RequestParam(defaultValue = "false") boolean publish) {
 
-    validateToken(token);
+    validateTokenWithOpsAccess(token);
 
     LocalDate calculationDate = date != null ? date : LocalDate.now(clock);
 
@@ -294,13 +295,14 @@ public class AdminController {
     validateTokenWithOpsAccess(token);
 
     TulevaFund fund = TulevaFund.fromCode(fundCode);
+    BigDecimal roundedAmount = amount.setScale(2, RoundingMode.HALF_UP);
     log.info(
         "Admin triggered BlackRock adjustment: fund={}, date={}, targetBalance={}",
         fund,
         date,
-        amount);
+        roundedAmount);
 
-    return navFeeAccrualLedger.recordBlackrockAdjustment(fund, date, amount);
+    return navFeeAccrualLedger.recordBlackrockAdjustment(fund, date, roundedAmount);
   }
 
   private void validateTokenWithOpsAccess(String token) {

--- a/src/test/groovy/ee/tuleva/onboarding/admin/AdminControllerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/admin/AdminControllerTest.java
@@ -465,6 +465,33 @@ class AdminControllerTest {
   }
 
   @Test
+  void recordBlackrockAdjustment_roundsAmountToTwoDecimalPlaces() throws Exception {
+    var result =
+        new BlackrockAdjustmentResult(
+            TulevaFund.TUK75,
+            LocalDate.of(2026, 4, 2),
+            BigDecimal.ZERO,
+            new BigDecimal("56980.96"),
+            new BigDecimal("56980.96"),
+            true);
+    given(
+            navFeeAccrualLedger.recordBlackrockAdjustment(
+                TulevaFund.TUK75, LocalDate.of(2026, 4, 2), new BigDecimal("56980.96")))
+        .willReturn(result);
+
+    mockMvc
+        .perform(
+            post("/admin/blackrock-adjustment")
+                .with(csrf())
+                .header("X-Admin-Token", "ops-token")
+                .param("fundCode", "TUK75")
+                .param("amount", "56980.95999999999")
+                .param("date", "2026-04-02"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.targetBalance").value(56980.96));
+  }
+
+  @Test
   void recordBlackrockAdjustment_withInvalidToken_returnsUnauthorized() throws Exception {
     mockMvc
         .perform(
@@ -478,14 +505,18 @@ class AdminControllerTest {
   }
 
   @Test
-  void calculateNav_withOpsToken_returnsUnauthorized() throws Exception {
+  void calculateNav_withOpsToken_returnsOk() throws Exception {
+    var result = sampleNavResult(LocalDate.of(2026, 2, 17));
+    when(navCalculationService.calculate("TKF100", LocalDate.of(2026, 2, 17))).thenReturn(result);
+
     mockMvc
         .perform(
             post("/admin/calculate-nav")
                 .with(csrf())
                 .header("X-Admin-Token", "ops-token")
                 .param("date", "2026-02-17"))
-        .andExpect(status().isUnauthorized());
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.navPerUnit").value(1.0));
   }
 
   @Test


### PR DESCRIPTION
## Summary
- Round `blackrock-adjustment` amount to 2 decimal places server-side, preventing validation errors from floating-point artifacts (e.g. `56980.95999999999`)
- Allow ops token to access `calculate-nav` endpoint so adjustments can be verified with the same token used for recording

## Test plan
- [x] New test: submitting amount with excess decimals rounds to 2 places and succeeds
- [x] Updated test: ops token accepted by `calculate-nav` (was previously asserting 401)
- [x] Full test suite passes with no regressions

Closes #1627

🤖 Generated with [Claude Code](https://claude.com/claude-code)