### PR TITLE
TKF: pre-go-live payment guard for legal entities

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/savings/fund/PaymentVerificationService.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/PaymentVerificationService.java
@@ -30,6 +30,9 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 @RequiredArgsConstructor
 public class PaymentVerificationService {
+  // Pre-go-live: remove this constant and the LEGAL_ENTITY guard in process() at TKF go-live.
+  private static final String TULEVA_FONDID_AS_REGISTRY_CODE = "14118923";
+
   private static final PersonalCodeValidator personalCodeValidator = new PersonalCodeValidator();
   private static final RegistryCodeValidator registryCodeValidator = new RegistryCodeValidator();
   private static final ZoneId ESTONIAN_ZONE = ZoneId.of("Europe/Tallinn");
@@ -97,6 +100,11 @@ public class PaymentVerificationService {
 
     if (!savingsFundOnboardingService.isOnboardingCompleted(partyId)) {
       identityCheckFailure(payment, messages.notOnboarded());
+      return;
+    }
+
+    if (partyId.type() == LEGAL_ENTITY && !partyId.code().equals(TULEVA_FONDID_AS_REGISTRY_CODE)) {
+      identityCheckFailure(payment, "pre-go-live: only Tuleva Fondid AS can receive TKF payments");
       return;
     }
 

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/PaymentVerificationServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/PaymentVerificationServiceTest.java
@@ -418,27 +418,27 @@ class PaymentVerificationServiceTest {
 
   @Test
   void process_companyPayment_success() {
-    var payment = createPayment("12345678", "company 12345678");
-    var company = Company.builder().registryCode("12345678").name("Tuleva AS").build();
-    when(companyRepository.findByRegistryCode("12345678")).thenReturn(Optional.of(company));
-    when(savingsFundOnboardingService.isOnboardingCompleted(new PartyId(LEGAL_ENTITY, "12345678")))
+    var payment = createPayment("14118923", "company 14118923");
+    var company = Company.builder().registryCode("14118923").name("Tuleva AS").build();
+    when(companyRepository.findByRegistryCode("14118923")).thenReturn(Optional.of(company));
+    when(savingsFundOnboardingService.isOnboardingCompleted(new PartyId(LEGAL_ENTITY, "14118923")))
         .thenReturn(true);
 
     service.process(payment);
 
-    verify(companyRepository).findByRegistryCode("12345678");
+    verify(companyRepository).findByRegistryCode("14118923");
     verify(savingsFundOnboardingService)
-        .isOnboardingCompleted(new PartyId(LEGAL_ENTITY, "12345678"));
+        .isOnboardingCompleted(new PartyId(LEGAL_ENTITY, "14118923"));
     verify(savingsFundLedger)
         .recordPaymentReceived(
-            new PartyId(LEGAL_ENTITY, "12345678"),
+            new PartyId(LEGAL_ENTITY, "14118923"),
             payment.getAmount(),
             payment.getId(),
             LocalDate.of(2025, 10, 1));
     var inOrder = inOrder(savingFundPaymentRepository);
     inOrder
         .verify(savingFundPaymentRepository)
-        .attachParty(payment.getId(), new PartyId(LEGAL_ENTITY, "12345678"));
+        .attachParty(payment.getId(), new PartyId(LEGAL_ENTITY, "14118923"));
     inOrder.verify(savingFundPaymentRepository).changeStatus(payment.getId(), VERIFIED);
     verifyNoMoreInteractions(savingFundPaymentRepository);
   }
@@ -505,33 +505,54 @@ class PaymentVerificationServiceTest {
             .remitterName("Tuleva AS")
             .remitterIban("BE72967148007616")
             .remitterIdCode("P13694547")
-            .description("12345678")
+            .description("14118923")
             .receivedBefore(Instant.parse("2025-10-01T20:59:59.999999Z"))
             .build();
-    var company = Company.builder().registryCode("12345678").name("Tuleva AS").build();
-    when(companyRepository.findByRegistryCode("12345678")).thenReturn(Optional.of(company));
-    when(savingsFundOnboardingService.isOnboardingCompleted(new PartyId(LEGAL_ENTITY, "12345678")))
+    var company = Company.builder().registryCode("14118923").name("Tuleva AS").build();
+    when(companyRepository.findByRegistryCode("14118923")).thenReturn(Optional.of(company));
+    when(savingsFundOnboardingService.isOnboardingCompleted(new PartyId(LEGAL_ENTITY, "14118923")))
         .thenReturn(true);
 
     service.process(payment);
 
-    verify(companyRepository).findByRegistryCode("12345678");
+    verify(companyRepository).findByRegistryCode("14118923");
     verify(savingsFundOnboardingService)
-        .isOnboardingCompleted(new PartyId(LEGAL_ENTITY, "12345678"));
+        .isOnboardingCompleted(new PartyId(LEGAL_ENTITY, "14118923"));
     verify(savingsFundLedger)
         .recordPaymentReceived(
-            new PartyId(LEGAL_ENTITY, "12345678"),
+            new PartyId(LEGAL_ENTITY, "14118923"),
             payment.getAmount(),
             payment.getId(),
             LocalDate.of(2025, 10, 1));
     verify(savingFundPaymentRepository)
-        .attachParty(payment.getId(), new PartyId(LEGAL_ENTITY, "12345678"));
+        .attachParty(payment.getId(), new PartyId(LEGAL_ENTITY, "14118923"));
     verify(savingFundPaymentRepository).changeStatus(payment.getId(), VERIFIED);
     verifyNoMoreInteractions(savingFundPaymentRepository);
   }
 
   @Test
   void process_companyPayment_success_nameMismatchAllowed_whenRemitterIdCodeMatches() {
+    var payment = createPayment("14118923", "company 14118923");
+    var company = Company.builder().registryCode("14118923").name("Tuleva AS").build();
+    when(companyRepository.findByRegistryCode("14118923")).thenReturn(Optional.of(company));
+    when(savingsFundOnboardingService.isOnboardingCompleted(new PartyId(LEGAL_ENTITY, "14118923")))
+        .thenReturn(true);
+
+    service.process(payment);
+
+    verify(savingsFundLedger)
+        .recordPaymentReceived(
+            new PartyId(LEGAL_ENTITY, "14118923"),
+            payment.getAmount(),
+            payment.getId(),
+            LocalDate.of(2025, 10, 1));
+    verify(savingFundPaymentRepository)
+        .attachParty(payment.getId(), new PartyId(LEGAL_ENTITY, "14118923"));
+    verify(savingFundPaymentRepository).changeStatus(payment.getId(), VERIFIED);
+  }
+
+  @Test
+  void process_companyPayment_preGoLive_returnsPaymentForNonTulevaFondidLegalEntity() {
     var payment = createPayment("12345678", "company 12345678");
     var company = Company.builder().registryCode("12345678").name("Tuleva AS").build();
     when(companyRepository.findByRegistryCode("12345678")).thenReturn(Optional.of(company));
@@ -540,15 +561,74 @@ class PaymentVerificationServiceTest {
 
     service.process(payment);
 
+    verify(savingFundPaymentRepository).changeStatus(payment.getId(), TO_BE_RETURNED);
+    verify(savingFundPaymentRepository)
+        .addReturnReason(
+            payment.getId(), "pre-go-live: only Tuleva Fondid AS can receive TKF payments");
+    verify(savingsFundLedger)
+        .recordUnattributedPayment(payment.getAmount(), payment.getId(), LocalDate.of(2025, 10, 1));
+    verify(applicationEventPublisher)
+        .publishEvent(
+            new UnattributedPaymentEvent(
+                payment.getId(),
+                payment.getAmount(),
+                "pre-go-live: only Tuleva Fondid AS can receive TKF payments"));
+    verify(savingsFundLedger, never()).recordPaymentReceived(any(), any(), any(), any());
+    verify(savingFundPaymentRepository, never()).attachParty(any(), any());
+    verifyNoMoreInteractions(savingFundPaymentRepository);
+  }
+
+  @Test
+  void process_companyPayment_preGoLive_tulevaFondidAsPaymentGoesThrough() {
+    var payment = createPayment("14118923", "company 14118923");
+    var company = Company.builder().registryCode("14118923").name("PÄRT ÕLEKÕRS").build();
+    when(companyRepository.findByRegistryCode("14118923")).thenReturn(Optional.of(company));
+    when(savingsFundOnboardingService.isOnboardingCompleted(new PartyId(LEGAL_ENTITY, "14118923")))
+        .thenReturn(true);
+
+    service.process(payment);
+
     verify(savingsFundLedger)
         .recordPaymentReceived(
-            new PartyId(LEGAL_ENTITY, "12345678"),
+            new PartyId(LEGAL_ENTITY, "14118923"),
             payment.getAmount(),
             payment.getId(),
             LocalDate.of(2025, 10, 1));
-    verify(savingFundPaymentRepository)
-        .attachParty(payment.getId(), new PartyId(LEGAL_ENTITY, "12345678"));
-    verify(savingFundPaymentRepository).changeStatus(payment.getId(), VERIFIED);
+    var inOrder = inOrder(savingFundPaymentRepository);
+    inOrder
+        .verify(savingFundPaymentRepository)
+        .attachParty(payment.getId(), new PartyId(LEGAL_ENTITY, "14118923"));
+    inOrder.verify(savingFundPaymentRepository).changeStatus(payment.getId(), VERIFIED);
+    verifyNoMoreInteractions(savingFundPaymentRepository);
+  }
+
+  @Test
+  void process_personalPayment_preGoLive_personPaymentsUnaffected() {
+    var payment = createPayment("37508295796", "to user 37508295796");
+    var user =
+        User.builder()
+            .id(123L)
+            .personalCode("37508295796")
+            .firstName("PÄRT")
+            .lastName("ÕLEKÕRS")
+            .build();
+    when(userRepository.findByPersonalCode(any())).thenReturn(Optional.of(user));
+    when(savingsFundOnboardingService.isOnboardingCompleted(any(PartyId.class))).thenReturn(true);
+
+    service.process(payment);
+
+    verify(savingsFundLedger)
+        .recordPaymentReceived(
+            new PartyId(PERSON, "37508295796"),
+            payment.getAmount(),
+            payment.getId(),
+            LocalDate.of(2025, 10, 1));
+    var inOrder = inOrder(savingFundPaymentRepository);
+    inOrder
+        .verify(savingFundPaymentRepository)
+        .attachParty(payment.getId(), new PartyId(PERSON, "37508295796"));
+    inOrder.verify(savingFundPaymentRepository).changeStatus(payment.getId(), VERIFIED);
+    verifyNoMoreInteractions(savingFundPaymentRepository);
   }
 
   @Test


### PR DESCRIPTION
## Summary

Pre-go-live invariant for the TKF KYC pilot: **legal-entity SEPA payments to the TKF account are returned automatically with reason `"pre-go-live: only Tuleva Fondid AS can receive TKF payments"`, except when the registry code matches Tuleva Fondid AS (`14118923`)**. Person payments are unaffected.

The guard sits in `PaymentVerificationService.process()` after the existing onboarding check, so onboarded pilot companies still see the natural `"ettevõte ei ole täiendava kogumisfondiga liitunud"` message until they complete KYB. Returned payments flow through the existing `PaymentReturningJob` path; no ledger emissions (`recordPaymentReceived`) occur for blocked payments.

## Diff shape

- `PaymentVerificationService.java`: one constant + a 4-line `if`-block. **At TKF go-live, delete both.**
- `PaymentVerificationServiceTest.java`: three new pre-go-live tests + three existing legal-entity success tests retargeted to `14118923` (the Tuleva Fondid AS regcode, already used as a fixture in `SavingFundPaymentExtractorTest`).

No config-layer, no migration, no event-listener changes.

## Side effects

- `PaymentReturningJob` (runs every minute) issues the SEPA return ~1-2 min after the blocked payment arrives.
- `SavingsFundNotifier.onUnattributedPayment` emits a Slack `Savings fund unattributed payment: ... reason=pre-go-live: ...` line per blocked payment. Ops filters by the `pre-go-live:` prefix.
- `SavingsPaymentFailedEvent` (client-side email) is **not** emitted, since `payment.getPartyId()` is `null` at `identityCheckFailure` time.

## Refs

- TulevaEE/TKF-VPII2026#32
- TulevaEE/TKF-VPII2026#34

## Test plan

- [x] `PaymentVerificationServiceTest` — full class green (24 tests, 3 new)
- [x] `./gradlew test --tests "ee.tuleva.onboarding.savings.fund.*"` — all savings.fund tests green on H2
- [x] `./gradlew spotlessCheck` clean
- [ ] CI green on this PR
- [ ] Manual staging verification per plan §Verifikatsioon (whitelist a pilot OÜ, complete KYB, send €1, observe `Identity check failed for payment ...: pre-go-live: ...` in logs and SEPA return on bank statement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)