### PR TITLE
Migrate Coop Pank payment URLs to new platform

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/payment/CoopLanguage.java
+++ b/src/main/java/ee/tuleva/onboarding/payment/CoopLanguage.java
@@ -1,0 +1,15 @@
+package ee.tuleva.onboarding.payment;
+
+public final class CoopLanguage {
+
+  private CoopLanguage() {}
+
+  // Coop uses country code "ee" for Estonian, not ISO 639 "et".
+  public static String code(String currentLanguage) {
+    return switch (currentLanguage) {
+      case "en" -> "en";
+      case "ru" -> "ru";
+      default -> "ee";
+    };
+  }
+}

--- a/src/main/java/ee/tuleva/onboarding/payment/PaymentUrlEncoder.java
+++ b/src/main/java/ee/tuleva/onboarding/payment/PaymentUrlEncoder.java
@@ -1,0 +1,23 @@
+package ee.tuleva.onboarding.payment;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+public final class PaymentUrlEncoder {
+
+  private PaymentUrlEncoder() {}
+
+  public static String encode(Map<String, String> params) {
+    var sb = new StringBuilder();
+    for (var entry : params.entrySet()) {
+      if (!sb.isEmpty()) {
+        sb.append('&');
+      }
+      sb.append(URLEncoder.encode(entry.getKey(), StandardCharsets.UTF_8).replace("+", "%20"));
+      sb.append('=');
+      sb.append(URLEncoder.encode(entry.getValue(), StandardCharsets.UTF_8).replace("+", "%20"));
+    }
+    return sb.toString();
+  }
+}

--- a/src/main/java/ee/tuleva/onboarding/payment/recurring/CoopPankPaymentLinkGenerator.java
+++ b/src/main/java/ee/tuleva/onboarding/payment/recurring/CoopPankPaymentLinkGenerator.java
@@ -3,7 +3,6 @@ package ee.tuleva.onboarding.payment.recurring;
 import static ee.tuleva.onboarding.payment.PaymentData.PaymentType.SINGLE;
 import static ee.tuleva.onboarding.payment.PaymentDateProvider.format;
 import static ee.tuleva.onboarding.payment.recurring.RecurringPaymentRequest.PaymentInterval.MONTHLY;
-import static java.nio.charset.StandardCharsets.UTF_8;
 
 import ee.tuleva.onboarding.auth.principal.Person;
 import ee.tuleva.onboarding.epis.contact.ContactDetails;
@@ -15,9 +14,9 @@ import ee.tuleva.onboarding.payment.PaymentData;
 import ee.tuleva.onboarding.payment.PaymentDateProvider;
 import ee.tuleva.onboarding.payment.PaymentLink;
 import ee.tuleva.onboarding.payment.PaymentLinkGenerator;
+import ee.tuleva.onboarding.payment.PaymentUrlEncoder;
 import ee.tuleva.onboarding.payment.PrefilledLink;
-import java.net.URLEncoder;
-import java.util.Locale;
+import java.util.LinkedHashMap;
 import lombok.AllArgsConstructor;
 import lombok.SneakyThrows;
 import org.springframework.stereotype.Service;
@@ -26,6 +25,11 @@ import tools.jackson.databind.json.JsonMapper;
 @Service
 @AllArgsConstructor
 public class CoopPankPaymentLinkGenerator implements PaymentLinkGenerator {
+
+  private static final String HOST = "https://i.cooppank.ee/";
+  private static final String SINGLE_PATH = "i/payments/new";
+  private static final String STANDING_ORDER_PATH = "i/standing-orders/new";
+  private static final String MONTHLY_FREQ = "2";
 
   private final ContactDetailsService contactDetailsService;
   private final JsonMapper objectMapper;
@@ -39,7 +43,7 @@ public class CoopPankPaymentLinkGenerator implements PaymentLinkGenerator {
     ContactDetails contactDetails = contactDetailsService.getContactDetails(person);
     var url =
         switch (paymentData.getPaymentChannel()) {
-          case COOP -> "https://i.cooppank.ee/" + recurringPaymentPath(paymentData, contactDetails);
+          case COOP -> HOST + recurringPaymentPath(paymentData, contactDetails);
           case COOP_WEB ->
               SINGLE == paymentData.getType()
                   ? singlePaymentPath(paymentData, contactDetails)
@@ -71,52 +75,45 @@ public class CoopPankPaymentLinkGenerator implements PaymentLinkGenerator {
   }
 
   private String singlePaymentPath(PaymentData paymentData, ContactDetails contactDetails) {
-    return "newpmt"
-        + language()
-        + "?SaajaNimi="
-        + urlEncode(thirdPillarConfig.getRecipientName())
-        + "&SaajaKonto="
-        + thirdPillarConfig.getBankAccounts().get(paymentData.getPaymentChannel())
-        + (paymentData.getAmount() != null
-            ? "&MuutMakseSumma=" + paymentData.getAmount().toPlainString()
-            : "")
-        + "&MaksePohjus="
-        // Coop Pank's form only accepts lowercase %2c; URLEncoder emits %2C
-        + urlEncode(thirdPillarConfig.getDescription()).replace("%2C", "%2c")
-        + "&ViiteNumber="
-        + contactDetails.getPensionAccountNumber();
+    var params = new LinkedHashMap<String, String>();
+    params.put("bname", thirdPillarConfig.getRecipientName());
+    params.put("bacc", thirdPillarConfig.getBankAccounts().get(paymentData.getPaymentChannel()));
+    if (paymentData.getAmount() != null) {
+      params.put("amt", paymentData.getAmount().toPlainString());
+    }
+    params.put("cur", "EUR");
+    params.put("desc", thirdPillarConfig.getDescription());
+    params.put("ref", contactDetails.getPensionAccountNumber());
+    params.put("lang", lang());
+    return SINGLE_PATH + "?" + PaymentUrlEncoder.encode(params);
   }
 
   private String recurringPaymentPath(PaymentData paymentData, ContactDetails contactDetails) {
-    return "newpmt"
-        + language()
-        + "?whatform=PermPaymentNew"
-        + "&SaajaNimi="
-        + urlEncode(thirdPillarConfig.getRecipientName())
-        + "&SaajaKonto="
-        + thirdPillarConfig.getBankAccounts().get(paymentData.getPaymentChannel())
-        + (paymentData.getAmount() != null
-            ? "&MakseSumma=" + paymentData.getAmount().toPlainString()
-            : "")
-        + "&MaksePohjus="
-        // Coop Pank's form only accepts lowercase %2c; URLEncoder emits %2C
-        + urlEncode(thirdPillarConfig.getDescription()).replace("%2C", "%2c")
-        + "&ViiteNumber="
-        + contactDetails.getPensionAccountNumber()
-        + "&MakseSagedus=3" // Monthly
-        + "&MakseEsimene="
-        + format(paymentDateProvider.tenthDayOfMonth());
+    var params = new LinkedHashMap<String, String>();
+    params.put("bname", thirdPillarConfig.getRecipientName());
+    params.put("bacc", thirdPillarConfig.getBankAccounts().get(paymentData.getPaymentChannel()));
+    if (paymentData.getAmount() != null) {
+      params.put("amt", paymentData.getAmount().toPlainString());
+    }
+    params.put("cur", "EUR");
+    params.put("desc", thirdPillarConfig.getDescription());
+    params.put("ref", contactDetails.getPensionAccountNumber());
+    params.put("date", format(paymentDateProvider.tenthDayOfMonth()));
+    params.put("freq", MONTHLY_FREQ);
+    params.put("lang", lang());
+    return STANDING_ORDER_PATH + "?" + PaymentUrlEncoder.encode(params);
   }
 
   private static String formattedAmount(PaymentData paymentData) {
     return paymentData.getAmount() == null ? null : paymentData.getAmount().toPlainString();
   }
 
-  private String language() {
-    return Locale.ENGLISH.getLanguage().equals(localeService.getCurrentLanguage()) ? "-eng" : "";
-  }
-
-  private static String urlEncode(String value) {
-    return URLEncoder.encode(value, UTF_8).replace("+", "%20");
+  private String lang() {
+    // Coop uses country code "ee" for Estonian, not ISO 639 "et".
+    return switch (localeService.getCurrentLanguage()) {
+      case "en" -> "en";
+      case "ru" -> "ru";
+      default -> "ee";
+    };
   }
 }

--- a/src/main/java/ee/tuleva/onboarding/payment/recurring/CoopPankPaymentLinkGenerator.java
+++ b/src/main/java/ee/tuleva/onboarding/payment/recurring/CoopPankPaymentLinkGenerator.java
@@ -10,6 +10,7 @@ import ee.tuleva.onboarding.epis.contact.ContactDetailsService;
 import ee.tuleva.onboarding.error.exception.ErrorsResponseException;
 import ee.tuleva.onboarding.error.response.ErrorsResponse;
 import ee.tuleva.onboarding.locale.LocaleService;
+import ee.tuleva.onboarding.payment.CoopLanguage;
 import ee.tuleva.onboarding.payment.PaymentData;
 import ee.tuleva.onboarding.payment.PaymentDateProvider;
 import ee.tuleva.onboarding.payment.PaymentLink;
@@ -84,7 +85,7 @@ public class CoopPankPaymentLinkGenerator implements PaymentLinkGenerator {
     params.put("cur", "EUR");
     params.put("desc", thirdPillarConfig.getDescription());
     params.put("ref", contactDetails.getPensionAccountNumber());
-    params.put("lang", lang());
+    params.put("lang", CoopLanguage.code(localeService.getCurrentLanguage()));
     return SINGLE_PATH + "?" + PaymentUrlEncoder.encode(params);
   }
 
@@ -100,20 +101,11 @@ public class CoopPankPaymentLinkGenerator implements PaymentLinkGenerator {
     params.put("ref", contactDetails.getPensionAccountNumber());
     params.put("date", format(paymentDateProvider.tenthDayOfMonth()));
     params.put("freq", MONTHLY_FREQ);
-    params.put("lang", lang());
+    params.put("lang", CoopLanguage.code(localeService.getCurrentLanguage()));
     return STANDING_ORDER_PATH + "?" + PaymentUrlEncoder.encode(params);
   }
 
   private static String formattedAmount(PaymentData paymentData) {
     return paymentData.getAmount() == null ? null : paymentData.getAmount().toPlainString();
-  }
-
-  private String lang() {
-    // Coop uses country code "ee" for Estonian, not ISO 639 "et".
-    return switch (localeService.getCurrentLanguage()) {
-      case "en" -> "en";
-      case "ru" -> "ru";
-      default -> "ee";
-    };
   }
 }

--- a/src/main/java/ee/tuleva/onboarding/payment/savings/recurring/SavingsFundRecurringPaymentLinkGenerator.java
+++ b/src/main/java/ee/tuleva/onboarding/payment/savings/recurring/SavingsFundRecurringPaymentLinkGenerator.java
@@ -5,10 +5,12 @@ import static ee.tuleva.onboarding.payment.PaymentDateProvider.format;
 import ee.tuleva.onboarding.auth.principal.Person;
 import ee.tuleva.onboarding.error.exception.ErrorsResponseException;
 import ee.tuleva.onboarding.error.response.ErrorsResponse;
+import ee.tuleva.onboarding.locale.LocaleService;
 import ee.tuleva.onboarding.payment.PaymentData;
 import ee.tuleva.onboarding.payment.PaymentDateProvider;
 import ee.tuleva.onboarding.payment.PaymentLink;
 import ee.tuleva.onboarding.payment.PaymentLinkGenerator;
+import ee.tuleva.onboarding.payment.PaymentUrlEncoder;
 import ee.tuleva.onboarding.payment.PrefilledLink;
 import ee.tuleva.onboarding.payment.savings.SavingsFundRecipientConfiguration;
 import java.net.URLEncoder;
@@ -24,8 +26,13 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class SavingsFundRecurringPaymentLinkGenerator implements PaymentLinkGenerator {
 
+  private static final String COOP_STANDING_ORDER_URL =
+      "https://i.cooppank.ee/i/standing-orders/new";
+  private static final String COOP_MONTHLY_FREQ = "2";
+
   private final SavingsFundRecipientConfiguration recipientConfiguration;
   private final PaymentDateProvider paymentDateProvider;
+  private final LocaleService localeService;
 
   @Override
   public PaymentLink getPaymentLink(PaymentData paymentData, Person person) {
@@ -77,16 +84,17 @@ public class SavingsFundRecurringPaymentLinkGenerator implements PaymentLinkGene
   private String buildCoopUrl(
       String description, @Nullable String amount, LocalDate firstPaymentDate) {
     var params = new LinkedHashMap<String, String>();
-    params.put("whatform", "PermPaymentNew");
-    params.put("SaajaNimi", recipientConfiguration.getRecipientName());
-    params.put("SaajaKonto", recipientConfiguration.getRecipientIban());
+    params.put("bname", recipientConfiguration.getRecipientName());
+    params.put("bacc", recipientConfiguration.getRecipientIban());
     if (amount != null) {
-      params.put("MakseSumma", amount);
+      params.put("amt", amount);
     }
-    params.put("MaksePohjus", description);
-    params.put("MakseSagedus", "3");
-    params.put("MakseEsimene", format(firstPaymentDate));
-    return "https://i.cooppank.ee/newpmt?" + encode(params);
+    params.put("cur", "EUR");
+    params.put("desc", description);
+    params.put("date", format(firstPaymentDate));
+    params.put("freq", COOP_MONTHLY_FREQ);
+    params.put("lang", lang());
+    return COOP_STANDING_ORDER_URL + "?" + PaymentUrlEncoder.encode(params);
   }
 
   private String buildSwedbankUrl(
@@ -101,6 +109,15 @@ public class SavingsFundRecurringPaymentLinkGenerator implements PaymentLinkGene
     params.put("standingOrder.firstPaymentDate", format(firstPaymentDate));
     params.put("frequency", "K");
     return "https://www.swedbank.ee/private/d2d/payments2/standing_order/new?" + encode(params);
+  }
+
+  private String lang() {
+    // Coop uses country code "ee" for Estonian, not ISO 639 "et".
+    return switch (localeService.getCurrentLanguage()) {
+      case "en" -> "en";
+      case "ru" -> "ru";
+      default -> "ee";
+    };
   }
 
   private static String encode(Map<String, String> params) {

--- a/src/main/java/ee/tuleva/onboarding/payment/savings/recurring/SavingsFundRecurringPaymentLinkGenerator.java
+++ b/src/main/java/ee/tuleva/onboarding/payment/savings/recurring/SavingsFundRecurringPaymentLinkGenerator.java
@@ -6,6 +6,7 @@ import ee.tuleva.onboarding.auth.principal.Person;
 import ee.tuleva.onboarding.error.exception.ErrorsResponseException;
 import ee.tuleva.onboarding.error.response.ErrorsResponse;
 import ee.tuleva.onboarding.locale.LocaleService;
+import ee.tuleva.onboarding.payment.CoopLanguage;
 import ee.tuleva.onboarding.payment.PaymentData;
 import ee.tuleva.onboarding.payment.PaymentDateProvider;
 import ee.tuleva.onboarding.payment.PaymentLink;
@@ -13,11 +14,8 @@ import ee.tuleva.onboarding.payment.PaymentLinkGenerator;
 import ee.tuleva.onboarding.payment.PaymentUrlEncoder;
 import ee.tuleva.onboarding.payment.PrefilledLink;
 import ee.tuleva.onboarding.payment.savings.SavingsFundRecipientConfiguration;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.util.LinkedHashMap;
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.jspecify.annotations.Nullable;
 import org.springframework.stereotype.Service;
@@ -78,7 +76,8 @@ public class SavingsFundRecurringPaymentLinkGenerator implements PaymentLinkGene
     params.put("i_currency_id", "38");
     params.put("i_interval_type", "K");
     params.put("i_date_first_payment", format(firstPaymentDate));
-    return "https://www.lhv.ee/ibank/cf/portfolio/payment_standing_add?" + encode(params);
+    return "https://www.lhv.ee/ibank/cf/portfolio/payment_standing_add?"
+        + PaymentUrlEncoder.encode(params);
   }
 
   private String buildCoopUrl(
@@ -93,7 +92,7 @@ public class SavingsFundRecurringPaymentLinkGenerator implements PaymentLinkGene
     params.put("desc", description);
     params.put("date", format(firstPaymentDate));
     params.put("freq", COOP_MONTHLY_FREQ);
-    params.put("lang", lang());
+    params.put("lang", CoopLanguage.code(localeService.getCurrentLanguage()));
     return COOP_STANDING_ORDER_URL + "?" + PaymentUrlEncoder.encode(params);
   }
 
@@ -108,28 +107,7 @@ public class SavingsFundRecurringPaymentLinkGenerator implements PaymentLinkGene
     params.put("standingOrder.details", description);
     params.put("standingOrder.firstPaymentDate", format(firstPaymentDate));
     params.put("frequency", "K");
-    return "https://www.swedbank.ee/private/d2d/payments2/standing_order/new?" + encode(params);
-  }
-
-  private String lang() {
-    // Coop uses country code "ee" for Estonian, not ISO 639 "et".
-    return switch (localeService.getCurrentLanguage()) {
-      case "en" -> "en";
-      case "ru" -> "ru";
-      default -> "ee";
-    };
-  }
-
-  private static String encode(Map<String, String> params) {
-    var sb = new StringBuilder();
-    for (var entry : params.entrySet()) {
-      if (!sb.isEmpty()) {
-        sb.append('&');
-      }
-      sb.append(URLEncoder.encode(entry.getKey(), StandardCharsets.UTF_8).replace("+", "%20"));
-      sb.append('=');
-      sb.append(URLEncoder.encode(entry.getValue(), StandardCharsets.UTF_8).replace("+", "%20"));
-    }
-    return sb.toString();
+    return "https://www.swedbank.ee/private/d2d/payments2/standing_order/new?"
+        + PaymentUrlEncoder.encode(params);
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/payment/PaymentControllerSavingsRecurringTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/payment/PaymentControllerSavingsRecurringTest.java
@@ -18,6 +18,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import ee.tuleva.onboarding.auth.principal.AuthenticatedPerson;
 import ee.tuleva.onboarding.error.exception.ErrorsResponseException;
 import ee.tuleva.onboarding.error.response.ErrorsResponse;
+import ee.tuleva.onboarding.locale.LocaleService;
 import ee.tuleva.onboarding.payment.savings.SavingsFundRecipientConfiguration;
 import ee.tuleva.onboarding.payment.savings.recurring.SavingsFundRecurringPaymentLinkGenerator;
 import java.time.LocalDate;
@@ -48,8 +49,10 @@ class PaymentControllerSavingsRecurringTest {
   private final SavingsFundRecipientConfiguration recipientConfiguration =
       new SavingsFundRecipientConfiguration();
   private final PaymentDateProvider paymentDateProvider = mock(PaymentDateProvider.class);
+  private final LocaleService localeService = new LocaleService();
   private final SavingsFundRecurringPaymentLinkGenerator realSavingsRecurringGenerator =
-      new SavingsFundRecurringPaymentLinkGenerator(recipientConfiguration, paymentDateProvider);
+      new SavingsFundRecurringPaymentLinkGenerator(
+          recipientConfiguration, paymentDateProvider, localeService);
 
   @BeforeEach
   void delegateSavingsRecurringToRealGenerator() {

--- a/src/test/groovy/ee/tuleva/onboarding/payment/SinglePaymentLinkGeneratorSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/payment/SinglePaymentLinkGeneratorSpec.groovy
@@ -90,11 +90,7 @@ class SinglePaymentLinkGeneratorSpec extends Specification {
 
     then:
     returnedLink instanceof PrefilledLink
-    def url = returnedLink.url()
-    url == "i/payments/new?bname=AS%20Pensionikeskus&bacc=EE362200221067235244&cur=EUR&desc=30101119828%2C%20EE3600001707&ref=993432432&lang=en"
-    ["SaajaNimi", "SaajaKonto", "MaksePohjus", "ViiteNumber", "MakseSumma", "MuutMakseSumma", "whatform", "newpmt", "-eng"].each { legacy ->
-      assert !url.contains(legacy), "URL should not contain legacy key '${legacy}': ${url}"
-    }
+    returnedLink.url() == "i/payments/new?bname=AS%20Pensionikeskus&bacc=EE362200221067235244&cur=EUR&desc=30101119828%2C%20EE3600001707&ref=993432432&lang=en"
     (returnedLink as PrefilledLink).recipientName() == "AS Pensionikeskus"
     (returnedLink as PrefilledLink).recipientIban() == "EE362200221067235244"
     (returnedLink as PrefilledLink).description() == "30101119828, EE3600001707"

--- a/src/test/groovy/ee/tuleva/onboarding/payment/SinglePaymentLinkGeneratorSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/payment/SinglePaymentLinkGeneratorSpec.groovy
@@ -5,7 +5,10 @@ import ee.tuleva.onboarding.locale.LocaleService
 import ee.tuleva.onboarding.payment.provider.montonio.MontonioPaymentLinkGenerator
 import ee.tuleva.onboarding.payment.recurring.CoopPankPaymentLinkGenerator
 import ee.tuleva.onboarding.payment.PaymentDateProvider
+import org.springframework.context.i18n.LocaleContextHolder
 import spock.lang.Specification
+
+import java.util.Locale
 
 import static ee.tuleva.onboarding.auth.PersonFixture.samplePerson
 import static ee.tuleva.onboarding.config.JsonMapperFixture.jsonMapper
@@ -29,6 +32,14 @@ class SinglePaymentLinkGeneratorSpec extends Specification {
   MontonioPaymentLinkGenerator paymentProviderLinkGenerator = Mock()
   SinglePaymentLinkGenerator singlePaymentLinkGenerator =
       new SinglePaymentLinkGenerator(coopPankPaymentLinkGenerator, paymentProviderLinkGenerator)
+
+  def setup() {
+    LocaleContextHolder.setLocale(Locale.ENGLISH)
+  }
+
+  def cleanup() {
+    LocaleContextHolder.resetLocaleContext()
+  }
 
 
   def "can get a single payment link"() {
@@ -79,7 +90,11 @@ class SinglePaymentLinkGeneratorSpec extends Specification {
 
     then:
     returnedLink instanceof PrefilledLink
-    returnedLink.url() == "newpmt-eng?SaajaNimi=AS%20Pensionikeskus&SaajaKonto=EE362200221067235244&MaksePohjus=30101119828%2c%20EE3600001707&ViiteNumber=993432432"
+    def url = returnedLink.url()
+    url == "i/payments/new?bname=AS%20Pensionikeskus&bacc=EE362200221067235244&cur=EUR&desc=30101119828%2C%20EE3600001707&ref=993432432&lang=en"
+    ["SaajaNimi", "SaajaKonto", "MaksePohjus", "ViiteNumber", "MakseSumma", "MuutMakseSumma", "whatform", "newpmt", "-eng"].each { legacy ->
+      assert !url.contains(legacy), "URL should not contain legacy key '${legacy}': ${url}"
+    }
     (returnedLink as PrefilledLink).recipientName() == "AS Pensionikeskus"
     (returnedLink as PrefilledLink).recipientIban() == "EE362200221067235244"
     (returnedLink as PrefilledLink).description() == "30101119828, EE3600001707"

--- a/src/test/groovy/ee/tuleva/onboarding/payment/recurring/RecurringPaymentLinkGeneratorSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/payment/recurring/RecurringPaymentLinkGeneratorSpec.groovy
@@ -7,7 +7,10 @@ import ee.tuleva.onboarding.payment.PaymentData
 import ee.tuleva.onboarding.payment.PaymentDateProvider
 import ee.tuleva.onboarding.payment.PrefilledLink
 import ee.tuleva.onboarding.payment.RedirectLink
+import org.springframework.context.i18n.LocaleContextHolder
 import spock.lang.Specification
+
+import java.util.Locale
 
 import static ee.tuleva.onboarding.auth.PersonFixture.samplePerson
 import static ee.tuleva.onboarding.config.JsonMapperFixture.jsonMapper
@@ -27,6 +30,14 @@ class RecurringPaymentLinkGeneratorSpec extends Specification {
   def thirdPillarConfig = thirdPillarRecipientConfiguration()
   def coopPankPaymentLinkGenerator = new CoopPankPaymentLinkGenerator(contactDetailsService, objectMapper, localeService, paymentDateProvider, thirdPillarConfig)
   def recurringPaymentLinkGenerator = new RecurringPaymentLinkGenerator(contactDetailsService, paymentDateProvider, coopPankPaymentLinkGenerator, thirdPillarConfig)
+
+  def setup() {
+    LocaleContextHolder.setLocale(Locale.ENGLISH)
+  }
+
+  def cleanup() {
+    LocaleContextHolder.resetLocaleContext()
+  }
 
   def "can get a recurring payment link"() {
     given:
@@ -49,8 +60,8 @@ class RecurringPaymentLinkGeneratorSpec extends Specification {
     SEB            | RedirectLink  | "https://e.seb.ee/web/ipank?act=PENSION3_STPAYM&saajakonto=EE141010220263146225&saajanimi=" +
         "AS%20Pensionikeskus&selgitus=30101119828%2C%20EE3600001707&viitenr=993432432&summa=12.34&alguskuup=10.01.2020&sagedus=M"
     LUMINOR        | RedirectLink  | "https://luminor.ee/auth/#/web/view/autopilot/newpayment"
-    COOP           | PrefilledLink | "https://i.cooppank.ee/newpmt-eng?whatform=PermPaymentNew&SaajaNimi=AS%20Pensionikeskus&SaajaKonto=EE362200221067235244&MakseSumma=12.34&MaksePohjus=30101119828%2c%20EE3600001707&ViiteNumber=993432432&MakseSagedus=3&MakseEsimene=10.01.2020"
-    COOP_WEB       | PrefilledLink | "newpmt-eng?whatform=PermPaymentNew&SaajaNimi=AS%20Pensionikeskus&SaajaKonto=EE362200221067235244&MakseSumma=12.34&MaksePohjus=30101119828%2c%20EE3600001707&ViiteNumber=993432432&MakseSagedus=3&MakseEsimene=10.01.2020"
+    COOP           | PrefilledLink | "https://i.cooppank.ee/i/standing-orders/new?bname=AS%20Pensionikeskus&bacc=EE362200221067235244&amt=12.34&cur=EUR&desc=30101119828%2C%20EE3600001707&ref=993432432&date=10.01.2020&freq=2&lang=en"
+    COOP_WEB       | PrefilledLink | "i/standing-orders/new?bname=AS%20Pensionikeskus&bacc=EE362200221067235244&amt=12.34&cur=EUR&desc=30101119828%2C%20EE3600001707&ref=993432432&date=10.01.2020&freq=2&lang=en"
     PARTNER        | PrefilledLink | """{"accountNumber":"EE362200221067235244","recipientName":"AS Pensionikeskus","amount":12.34,"currency":"EUR","description":"30101119828, EE3600001707","reference":"993432432","interval":"MONTHLY","firstPaymentDate":"2020-01-10"}"""
   }
 
@@ -86,8 +97,26 @@ class RecurringPaymentLinkGeneratorSpec extends Specification {
     where:
     channel  | urlFragment
     LHV      | "&i_amount=100"
-    COOP     | "&MakseSumma=100"
-    COOP_WEB | "&MakseSumma=100"
+    COOP     | "&amt=100"
+    COOP_WEB | "&amt=100"
+  }
+
+  def "Coop recurring URL contains no legacy keys from the old platform"() {
+    given:
+    def person = samplePerson
+    def paymentData = new PaymentData(samplePerson.personalCode, 12.34, EUR, RECURRING, channel)
+
+    when:
+    def link = recurringPaymentLinkGenerator.getPaymentLink(paymentData, person) as PrefilledLink
+
+    then:
+    def url = link.url()
+    ["SaajaNimi", "SaajaKonto", "MaksePohjus", "ViiteNumber", "MakseSumma", "MuutMakseSumma", "MakseSagedus", "MakseEsimene", "whatform", "newpmt", "-eng"].each { legacy ->
+      assert !url.contains(legacy), "URL should not contain legacy key '${legacy}': ${url}"
+    }
+
+    where:
+    channel << [COOP, COOP_WEB]
   }
 
   def "renders SEB recurring amount as plain decimal even when BigDecimal would print scientific"() {

--- a/src/test/groovy/ee/tuleva/onboarding/payment/savings/recurring/SavingsFundRecurringPaymentLinkGeneratorTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/payment/savings/recurring/SavingsFundRecurringPaymentLinkGeneratorTest.java
@@ -104,7 +104,7 @@ class SavingsFundRecurringPaymentLinkGeneratorTest {
 
   @Test
   void buildsCoopUrlWithEstonianLocale() {
-    LocaleContextHolder.setLocale(new Locale("et"));
+    LocaleContextHolder.setLocale(Locale.of("et"));
 
     var link = prefilledLink(COOP);
 

--- a/src/test/groovy/ee/tuleva/onboarding/payment/savings/recurring/SavingsFundRecurringPaymentLinkGeneratorTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/payment/savings/recurring/SavingsFundRecurringPaymentLinkGeneratorTest.java
@@ -16,6 +16,7 @@ import static org.mockito.Mockito.mock;
 
 import ee.tuleva.onboarding.error.exception.ErrorsResponseException;
 import ee.tuleva.onboarding.error.response.ErrorResponse;
+import ee.tuleva.onboarding.locale.LocaleService;
 import ee.tuleva.onboarding.payment.PaymentData;
 import ee.tuleva.onboarding.payment.PaymentData.PaymentChannel;
 import ee.tuleva.onboarding.payment.PaymentDateProvider;
@@ -24,8 +25,11 @@ import ee.tuleva.onboarding.payment.PrefilledLink;
 import ee.tuleva.onboarding.payment.savings.SavingsFundRecipientConfiguration;
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.util.Locale;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.context.i18n.LocaleContextHolder;
 
 class SavingsFundRecurringPaymentLinkGeneratorTest {
 
@@ -37,15 +41,23 @@ class SavingsFundRecurringPaymentLinkGeneratorTest {
   private final SavingsFundRecipientConfiguration recipientConfiguration =
       new SavingsFundRecipientConfiguration();
   private final PaymentDateProvider paymentDateProvider = mock(PaymentDateProvider.class);
+  private final LocaleService localeService = new LocaleService();
 
   private final SavingsFundRecurringPaymentLinkGenerator generator =
-      new SavingsFundRecurringPaymentLinkGenerator(recipientConfiguration, paymentDateProvider);
+      new SavingsFundRecurringPaymentLinkGenerator(
+          recipientConfiguration, paymentDateProvider, localeService);
 
   @BeforeEach
   void setup() {
     recipientConfiguration.setRecipientName(RECIPIENT_NAME);
     recipientConfiguration.setRecipientIban(RECIPIENT_IBAN);
     given(paymentDateProvider.tenthDayOfMonth()).willReturn(FIRST_PAYMENT);
+    LocaleContextHolder.setLocale(Locale.ENGLISH);
+  }
+
+  @AfterEach
+  void cleanup() {
+    LocaleContextHolder.resetLocaleContext();
   }
 
   @Test
@@ -69,15 +81,34 @@ class SavingsFundRecurringPaymentLinkGeneratorTest {
     var link = prefilledLink(COOP);
 
     assertThat(link.url())
-        .startsWith("https://i.cooppank.ee/newpmt?")
-        .contains("whatform=PermPaymentNew")
-        .contains("SaajaNimi=Tuleva%20T%C3%A4iendav%20Kogumisfond")
-        .contains("SaajaKonto=EE711010220306707220")
-        .contains("MakseSumma=50")
-        .contains("MaksePohjus=38812121215")
-        .contains("MakseSagedus=3")
-        .contains("MakseEsimene=10.05.2026");
+        .startsWith("https://i.cooppank.ee/i/standing-orders/new?")
+        .contains("bname=Tuleva%20T%C3%A4iendav%20Kogumisfond")
+        .contains("bacc=EE711010220306707220")
+        .contains("amt=50")
+        .contains("cur=EUR")
+        .contains("desc=38812121215")
+        .contains("date=10.05.2026")
+        .contains("freq=2")
+        .contains("lang=en")
+        .doesNotContain(
+            "SaajaNimi",
+            "SaajaKonto",
+            "MaksePohjus",
+            "MakseSumma",
+            "MakseSagedus",
+            "MakseEsimene",
+            "whatform",
+            "newpmt");
     assertCommonRecipientFields(link);
+  }
+
+  @Test
+  void buildsCoopUrlWithEstonianLocale() {
+    LocaleContextHolder.setLocale(new Locale("et"));
+
+    var link = prefilledLink(COOP);
+
+    assertThat(link.url()).contains("lang=ee").doesNotContain("lang=et");
   }
 
   @Test


### PR DESCRIPTION
## Summary

- Coop Pank migrated their internet bank payments menu; the old `newpmt?SaajaNimi=…` URLs no longer pre-fill the form. Switch III sammas (single + recurring) and TKF (recurring) to the new `i/payments/new` / `i/standing-orders/new` paths with renamed params (`bname`, `bacc`, `amt`, `cur`, `desc`, `ref`, `date`, `freq`, `lang`).
- **Heads-up: the `freq` value for "monthly" changed.** Old platform: `MakseSagedus=3`. New platform: `freq=2`. Old `3` now means *quarterly* — anyone hardcoding the old value elsewhere should double-check.
- Coop's docs say uppercase `ET/RU/EN` for locale but only lowercase works in practice. Coop also uses country code `ee` for Estonian, not ISO 639 `et` — small Estonian-locale test added so this doesn't get "fixed" back later.

## Test plan

- [x] `./gradlew test` — full suite green locally and on CircleCI
- [x] Spotless clean
- [x] Live verification against Coop Pank: III single + recurring and TKF recurring all pre-fill (name, IBAN, amount, description, reference, first payment date, monthly frequency) in browser
- [x] Locale toggle confirmed: `lang=ee` → Estonian, `lang=en` → English
- [ ] Reviewer to confirm no other code path hardcoded the old `MakseSagedus=3`

## Out of scope

- "Seadista püsikas" first-screen button bug — likely an `onboarding-client` issue; separate ticket.
- Synthetic monitoring for third-party URL drift (future hardening).

🤖 Generated with [Claude Code](https://claude.com/claude-code)