### PR TITLE
Add price config for new ETFs

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/comparisons/fundvalue/retrieval/FundTicker.java
+++ b/src/main/java/ee/tuleva/onboarding/comparisons/fundvalue/retrieval/FundTicker.java
@@ -95,6 +95,22 @@ public enum FundTicker {
       "USAS",
       null,
       BenchmarkCategory.EQUITY_DM),
+  AMUNDI_WORLD_EX_USA_SCREENED(
+      "WLXU.DE",
+      "WLXU.XETRA",
+      "FR0013209921",
+      "Amundi MSCI World Ex USA Screened UCITS ETF",
+      "WLXU",
+      null,
+      BenchmarkCategory.EQUITY_DM),
+  ISHARES_EM_IMI_SCREENED(
+      "AYEM.DE",
+      "AYEM.XETRA",
+      "IE00BFNM3P36",
+      "iShares MSCI EM IMI Screened UCITS ETF",
+      "AYEM",
+      null,
+      BenchmarkCategory.EQUITY_EM),
   ISHARES_DEVELOPED_WORLD_ESG_SCREENED(
       "0P000152G5.F",
       "IE00BFG1TM61.EUFUND",

--- a/src/test/groovy/ee/tuleva/onboarding/comparisons/fundvalue/retrieval/FundTickerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/comparisons/fundvalue/retrieval/FundTickerTest.java
@@ -49,6 +49,8 @@ class FundTickerTest {
             "LU1291099718",
             "LU1291106356",
             "LU1291102447",
+            "FR0013209921",
+            "IE00BFNM3P36",
             "IE00B4L5Y983",
             "IE00B4L5YC18",
             "IE00B3DKXQ41",


### PR DESCRIPTION
## Summary
- Add `AMUNDI_WORLD_EX_USA_SCREENED` (FR0013209921, XETRA: WLXU, EQUITY_DM) and `ISHARES_EM_IMI_SCREENED` (IE00BFNM3P36, XETRA: AYEM, EQUITY_EM) to `FundTicker` enum
- Enables price retrieval for new instruments
- No existing behavior changes; prices will start flowing after deploy

## Test plan
- [x] `FundTickerTest` updated and passing (XETRA ISIN list, uniqueness checks)
- [x] Full test suite green — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)