### PR TITLE
Fix portfolio reconciliation date, suppress weekend alerts, add TUK00 bond ETF price infrastructure

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/comparisons/fundvalue/retrieval/FundTicker.java
+++ b/src/main/java/ee/tuleva/onboarding/comparisons/fundvalue/retrieval/FundTicker.java
@@ -174,6 +174,30 @@ public enum FundTicker {
       "229055",
       "0P0000STQT",
       BenchmarkCategory.BOND_EURO),
+  VANGUARD_EUROZONE_GOV_BOND(
+      "VGEA.DE",
+      "VGEA.XETRA",
+      "IE00BH04GL39",
+      "Vanguard EUR Eurozone Government Bond UCITS ETF",
+      "VGEA",
+      null,
+      BenchmarkCategory.BOND_EURO),
+  XTRACKERS_EUR_CORPORATE_BOND(
+      "D5BG.DE",
+      "D5BG.XETRA",
+      "LU0478205379",
+      "Xtrackers II EUR Corporate Bond UCITS ETF",
+      "XBLC",
+      null,
+      BenchmarkCategory.BOND_EURO),
+  SPDR_GLOBAL_AGG_BOND_HEDGED(
+      "SPFF.DE",
+      "SPFF.XETRA",
+      "IE000AQ7A2X6",
+      "SPDR Bloomberg Global Aggregate Bond UCITS ETF EUR Hedged",
+      "SPFF",
+      null,
+      BenchmarkCategory.BOND_GLOBAL),
 
   // Benchmark proxy ETFs (not held in portfolios — used for BENCHMARK_MODEL comparison).
   // benchmarkCategory is intentionally null: these are the benchmarks themselves, not tracked
@@ -190,12 +214,22 @@ public enum FundTicker {
       "iShares Euro Aggregate Bond UCITS ETF",
       "EUN4",
       null),
+  // Step 1: EUNA stays as benchmark proxy (null category) until GAGH has price history.
+  // Step 2: After GAGH has 2+ days of prices, change EUNA to BOND_GLOBAL and switch
+  //         TrackingDifferenceService.benchmarkKey(BOND_GLOBAL) from EUNA to GAGH.
   ISHARES_GLOBAL_AGG_BOND_ETF(
       "EUNA.DE",
       "EUNA.XETRA",
       "IE00BDBRDM35",
-      "iShares Global Aggregate Bond UCITS ETF",
+      "iShares Core Global Aggregate Bond UCITS ETF EUR Hedged",
       "EUNA",
+      null),
+  AMUNDI_GLOBAL_AGG_BOND_HEDGED(
+      "GAGH.DE",
+      "GAGH.XETRA",
+      "LU1708330318",
+      "Amundi Index Bloomberg Global Aggregate Bond UCITS ETF EUR Hedged",
+      "GAGH",
       null);
 
   private final String yahooTicker;

--- a/src/main/java/ee/tuleva/onboarding/investment/event/NavEventListenerOrder.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/event/NavEventListenerOrder.java
@@ -6,4 +6,5 @@ public final class NavEventListenerOrder {
 
   public static final int TRACKING_DIFFERENCE = 100;
   public static final int LIMIT_CHECK = 200;
+  public static final int PORTFOLIO_RECONCILIATION = 300;
 }

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/PortfolioReconciliationJob.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/PortfolioReconciliationJob.java
@@ -1,19 +1,19 @@
 package ee.tuleva.onboarding.investment.transaction.ingest;
 
-import static ee.tuleva.onboarding.investment.JobRunSchedule.TIMEZONE;
-
+import ee.tuleva.onboarding.deadline.PublicHolidays;
 import ee.tuleva.onboarding.fund.TulevaFund;
+import ee.tuleva.onboarding.investment.event.NavEventListenerOrder;
 import ee.tuleva.onboarding.investment.event.RunPortfolioReconciliationRequested;
+import ee.tuleva.onboarding.savings.fund.nav.NavCalculationCompleted;
 import java.time.Clock;
 import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.context.annotation.Profile;
 import org.springframework.context.event.EventListener;
-import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
 @Slf4j
@@ -23,34 +23,32 @@ import org.springframework.stereotype.Component;
 public class PortfolioReconciliationJob {
 
   private final Clock clock;
+  private final PublicHolidays publicHolidays;
   private final PortfolioReconciliationService service;
 
-  @Scheduled(cron = "0 30 10 * * *", zone = TIMEZONE)
-  @SchedulerLock(
-      name = "portfolio-reconciliation-job",
-      lockAtMostFor = "10m",
-      lockAtLeastFor = "1m")
-  public void run() {
-    LocalDate today = LocalDate.now(clock);
-    runForDate(today);
+  @EventListener
+  @Order(NavEventListenerOrder.PORTFOLIO_RECONCILIATION)
+  void onNavCalculationCompleted(NavCalculationCompleted event) {
+    LocalDate navDate = publicHolidays.previousWorkingDay(LocalDate.now(clock));
+    reconcileFunds(event.funds(), navDate);
   }
 
   @EventListener
   void onPortfolioReconciliationRequested(RunPortfolioReconciliationRequested event) {
-    run();
+    LocalDate navDate = publicHolidays.previousWorkingDay(LocalDate.now(clock));
+    reconcileFunds(Arrays.asList(TulevaFund.values()), navDate);
   }
 
-  public void runForDate(LocalDate date) {
-    List<TulevaFund> funds = Arrays.asList(TulevaFund.values());
-    log.info("Running portfolio reconciliation job: date={}, fundCount={}", date, funds.size());
+  private void reconcileFunds(List<TulevaFund> funds, LocalDate navDate) {
+    log.info("Running portfolio reconciliation: navDate={}, fundCount={}", navDate, funds.size());
     for (TulevaFund fund : funds) {
       try {
-        service.reconcile(fund, date);
+        service.reconcile(fund, navDate);
       } catch (RuntimeException e) {
         log.error(
-            "Portfolio reconciliation failed: fundCode={}, date={}, error={}",
+            "Portfolio reconciliation failed: fundCode={}, navDate={}, error={}",
             fund.getCode(),
-            date,
+            navDate,
             e.getMessage(),
             e);
       }

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/SebPendingTransactionReconciliationJob.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/SebPendingTransactionReconciliationJob.java
@@ -4,6 +4,7 @@ import static ee.tuleva.onboarding.investment.JobRunSchedule.TIMEZONE;
 import static ee.tuleva.onboarding.investment.report.ReportProvider.SEB;
 import static ee.tuleva.onboarding.investment.report.ReportType.PENDING_TRANSACTIONS;
 
+import ee.tuleva.onboarding.deadline.PublicHolidays;
 import ee.tuleva.onboarding.investment.event.RunSebPendingTransactionReconciliationRequested;
 import ee.tuleva.onboarding.investment.report.InvestmentReport;
 import ee.tuleva.onboarding.investment.report.InvestmentReportService;
@@ -27,16 +28,22 @@ class SebPendingTransactionReconciliationJob {
   private static final int LOOKBACK_DAYS = 7;
 
   private final Clock clock;
+  private final PublicHolidays publicHolidays;
   private final InvestmentReportService reportService;
   private final SebPendingTransactionReconciliationService reconciliationService;
 
-  @Scheduled(cron = "0 0 9 * * *", zone = TIMEZONE)
+  @Scheduled(cron = "0 0 9 * * MON-FRI", zone = TIMEZONE)
   @SchedulerLock(
       name = "SebPendingTransactionReconciliationJob",
       lockAtMostFor = "30m",
       lockAtLeastFor = "1m")
   public void run() {
     LocalDate today = LocalDate.now(clock);
+    if (!publicHolidays.isWorkingDay(today)) {
+      log.info(
+          "Skipping SEB pending transaction reconciliation on non-working day: date={}", today);
+      return;
+    }
     log.info(
         "Running scheduled SEB pending transactions reconciliation: today={}, lookbackDays={}",
         today,

--- a/src/test/groovy/ee/tuleva/onboarding/comparisons/fundvalue/retrieval/FundTickerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/comparisons/fundvalue/retrieval/FundTickerTest.java
@@ -51,10 +51,14 @@ class FundTickerTest {
             "LU1291102447",
             "FR0013209921",
             "IE00BFNM3P36",
+            "IE00BH04GL39",
+            "LU0478205379",
+            "IE000AQ7A2X6",
             "IE00B4L5Y983",
             "IE00B4L5YC18",
             "IE00B3DKXQ41",
-            "IE00BDBRDM35");
+            "IE00BDBRDM35",
+            "LU1708330318");
   }
 
   @Test

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/PortfolioReconciliationJobTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/PortfolioReconciliationJobTest.java
@@ -4,14 +4,18 @@ import static ee.tuleva.onboarding.fund.TulevaFund.TKF100;
 import static ee.tuleva.onboarding.fund.TulevaFund.TUK00;
 import static ee.tuleva.onboarding.fund.TulevaFund.TUK75;
 import static ee.tuleva.onboarding.fund.TulevaFund.TUV100;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.verify;
 
+import ee.tuleva.onboarding.deadline.PublicHolidays;
 import ee.tuleva.onboarding.fund.TulevaFund;
 import ee.tuleva.onboarding.investment.event.RunPortfolioReconciliationRequested;
+import ee.tuleva.onboarding.savings.fund.nav.NavCalculationCompleted;
 import java.time.Clock;
 import java.time.LocalDate;
 import java.time.ZoneId;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -23,41 +27,45 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class PortfolioReconciliationJobTest {
 
   private static final ZoneId TALLINN = ZoneId.of("Europe/Tallinn");
-  private static final LocalDate TODAY = LocalDate.of(2026, 5, 18);
+  private static final LocalDate TODAY = LocalDate.of(2026, 5, 22);
+  private static final LocalDate NAV_DATE = LocalDate.of(2026, 5, 21);
 
   @Spy private Clock clock = Clock.fixed(TODAY.atStartOfDay(TALLINN).toInstant(), TALLINN);
 
+  @Mock private PublicHolidays publicHolidays;
   @Mock private PortfolioReconciliationService service;
 
   @InjectMocks private PortfolioReconciliationJob job;
 
   @Test
-  void run_invokesServiceForEachFundAtToday() {
-    job.run();
+  void onNavCalculationCompleted_reconcilesEventFundsForPreviousWorkingDay() {
+    given(publicHolidays.previousWorkingDay(TODAY)).willReturn(NAV_DATE);
 
-    for (TulevaFund fund : new TulevaFund[] {TUK75, TUK00, TUV100, TKF100}) {
-      verify(service).reconcile(fund, TODAY);
-    }
+    job.onNavCalculationCompleted(new NavCalculationCompleted(List.of(TUK75, TUK00)));
+
+    verify(service).reconcile(TUK75, NAV_DATE);
+    verify(service).reconcile(TUK00, NAV_DATE);
   }
 
   @Test
-  void run_continuesAfterServiceException() {
-    willThrow(new RuntimeException("boom")).given(service).reconcile(TUK75, TODAY);
+  void onNavCalculationCompleted_continuesAfterServiceException() {
+    given(publicHolidays.previousWorkingDay(TODAY)).willReturn(NAV_DATE);
+    willThrow(new RuntimeException("boom")).given(service).reconcile(TUK75, NAV_DATE);
 
-    job.run();
+    job.onNavCalculationCompleted(new NavCalculationCompleted(List.of(TUK75, TUK00)));
 
-    verify(service).reconcile(TUK75, TODAY);
-    verify(service).reconcile(TUK00, TODAY);
-    verify(service).reconcile(TUV100, TODAY);
-    verify(service).reconcile(TKF100, TODAY);
+    verify(service).reconcile(TUK75, NAV_DATE);
+    verify(service).reconcile(TUK00, NAV_DATE);
   }
 
   @Test
-  void onPortfolioReconciliationRequested_triggersRun() {
+  void onPortfolioReconciliationRequested_reconcilesAllFundsForPreviousWorkingDay() {
+    given(publicHolidays.previousWorkingDay(TODAY)).willReturn(NAV_DATE);
+
     job.onPortfolioReconciliationRequested(new RunPortfolioReconciliationRequested());
 
     for (TulevaFund fund : new TulevaFund[] {TUK75, TUK00, TUV100, TKF100}) {
-      verify(service).reconcile(fund, TODAY);
+      verify(service).reconcile(fund, NAV_DATE);
     }
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/SebPendingTransactionReconciliationJobScheduledTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/SebPendingTransactionReconciliationJobScheduledTest.java
@@ -1,0 +1,23 @@
+package ee.tuleva.onboarding.investment.transaction.ingest;
+
+import ee.tuleva.onboarding.config.ScheduledTest;
+import ee.tuleva.onboarding.deadline.PublicHolidays;
+import ee.tuleva.onboarding.investment.report.InvestmentReportService;
+import java.time.Clock;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+@ScheduledTest(SebPendingTransactionReconciliationJob.class)
+@Import(PublicHolidays.class)
+@ActiveProfiles("production")
+class SebPendingTransactionReconciliationJobScheduledTest {
+
+  @MockitoBean InvestmentReportService reportService;
+  @MockitoBean SebPendingTransactionReconciliationService reconciliationService;
+  @MockitoBean Clock clock;
+
+  @Test
+  void cronExpressionsResolve() {}
+}

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/SebPendingTransactionReconciliationJobTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/SebPendingTransactionReconciliationJobTest.java
@@ -5,7 +5,9 @@ import static ee.tuleva.onboarding.investment.report.ReportType.PENDING_TRANSACT
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 
+import ee.tuleva.onboarding.deadline.PublicHolidays;
 import ee.tuleva.onboarding.investment.event.RunSebPendingTransactionReconciliationRequested;
 import ee.tuleva.onboarding.investment.report.InvestmentReport;
 import ee.tuleva.onboarding.investment.report.InvestmentReportService;
@@ -25,16 +27,31 @@ class SebPendingTransactionReconciliationJobTest {
 
   private static final ZoneId TALLINN = ZoneId.of("Europe/Tallinn");
   private static final LocalDate TODAY = LocalDate.of(2026, 5, 18);
+  private static final LocalDate SATURDAY = LocalDate.of(2026, 5, 23);
 
   @Spy private Clock clock = Clock.fixed(TODAY.atStartOfDay(TALLINN).toInstant(), TALLINN);
 
+  @Mock private PublicHolidays publicHolidays;
   @Mock private InvestmentReportService reportService;
   @Mock private SebPendingTransactionReconciliationService reconciliationService;
 
   @InjectMocks private SebPendingTransactionReconciliationJob job;
 
   @Test
+  void run_skipsOnNonWorkingDay() {
+    Clock saturdayClock = Clock.fixed(SATURDAY.atStartOfDay(TALLINN).toInstant(), TALLINN);
+    given(clock.instant()).willReturn(saturdayClock.instant());
+    given(clock.getZone()).willReturn(saturdayClock.getZone());
+    given(publicHolidays.isWorkingDay(SATURDAY)).willReturn(false);
+
+    job.run();
+
+    verifyNoInteractions(reportService, reconciliationService);
+  }
+
+  @Test
   void run_iteratesTodayPlusLastSevenDaysAndReconcilesEachFoundReport() {
+    given(publicHolidays.isWorkingDay(TODAY)).willReturn(true);
     InvestmentReport day0 = report(TODAY);
     InvestmentReport day1 = report(TODAY.minusDays(1));
     InvestmentReport day3 = report(TODAY.minusDays(3));
@@ -60,6 +77,7 @@ class SebPendingTransactionReconciliationJobTest {
 
   @Test
   void run_includesTodayInFallbackScan() {
+    given(publicHolidays.isWorkingDay(TODAY)).willReturn(true);
     InvestmentReport today = report(TODAY);
     for (int i = 0; i <= 7; i++) {
       LocalDate date = TODAY.minusDays(i);
@@ -74,6 +92,7 @@ class SebPendingTransactionReconciliationJobTest {
 
   @Test
   void run_missingReportsAreSkipped() {
+    given(publicHolidays.isWorkingDay(TODAY)).willReturn(true);
     for (int i = 0; i <= 7; i++) {
       given(reportService.getReport(SEB, PENDING_TRANSACTIONS, TODAY.minusDays(i)))
           .willReturn(Optional.empty());
@@ -86,6 +105,7 @@ class SebPendingTransactionReconciliationJobTest {
 
   @Test
   void run_continuesAfterReconciliationException() {
+    given(publicHolidays.isWorkingDay(TODAY)).willReturn(true);
     InvestmentReport day1 = report(TODAY.minusDays(1));
     InvestmentReport day2 = report(TODAY.minusDays(2));
     given(reportService.getReport(SEB, PENDING_TRANSACTIONS, TODAY)).willReturn(Optional.empty());
@@ -109,6 +129,7 @@ class SebPendingTransactionReconciliationJobTest {
 
   @Test
   void onSebPendingTransactionReconciliationRequested_triggersRun() {
+    given(publicHolidays.isWorkingDay(TODAY)).willReturn(true);
     InvestmentReport today = report(TODAY);
     for (int i = 0; i <= 7; i++) {
       LocalDate date = TODAY.minusDays(i);


### PR DESCRIPTION
## Summary
- **Portfolio reconciliation date fix**: the job ran at 10:30 on a fixed cron and queried both `investment_portfolio_cost_basis` and `nav_report` for **today's date**. But `nav_report` stores data with **previousWorkingDay** as `nav_date` (T-1), so the query always returned empty — causing false "(puudub)" alerts for all ISINs. Replaced the cron with a `NavCalculationCompleted` event listener so reconciliation runs **after** NAV is published, using `previousWorkingDay(today)` to match the `nav_report` convention. Manual trigger via `RunPortfolioReconciliationRequested` / `JobTriggerPoller` still works.
- **SEB pending transaction reconciliation weekend fix**: the scheduled job ran every day including weekends (`0 0 9 * * *`), re-processing Friday's already-reconciled report and re-firing `[HOIATUS] Matchimata tehing` alerts as noise. Changed cron to `MON-FRI` and added `isWorkingDay` guard for public holidays.
- **TUK00 bond ETF price infrastructure**: Add `FundTicker` entries for 4 new instruments needed for the TUK00 ETF migration. Prices start flowing after deploy — no behavior change to existing funds.

### New FundTicker entries

| Enum | ISIN | Xetra | Bloomberg | Category | Purpose |
|------|------|-------|-----------|----------|---------|
| `VANGUARD_EUROZONE_GOV_BOND` | IE00BH04GL39 | VGEA | VGEA GY | BOND_EURO | TUK00 portfolio holding |
| `XTRACKERS_EUR_CORPORATE_BOND` | LU0478205379 | D5BG | XBLC GY | BOND_EURO | TUK00 portfolio holding |
| `SPDR_GLOBAL_AGG_BOND_HEDGED` | IE000AQ7A2X6 | SPFF | SPFF GY | BOND_GLOBAL | TUK00 portfolio holding |
| `AMUNDI_GLOBAL_AGG_BOND_HEDGED` | LU1708330318 | GAGH | GAGH GY | null | Future benchmark proxy (replaces EUNA after price history accumulates) |

**Follow-up (step 1a-2):** After GAGH has 2+ business days of price data, change EUNA from benchmark proxy to `BOND_GLOBAL` portfolio holding and switch `TrackingDifferenceService.benchmarkKey(BOND_GLOBAL)` from EUNA to GAGH.

## Test plan
- [x] `PortfolioReconciliationJobTest` — updated to verify event-driven trigger with correct date
- [x] `SebPendingTransactionReconciliationJobTest` — new `run_skipsOnNonWorkingDay` test + existing tests updated
- [x] `SebPendingTransactionReconciliationJobScheduledTest` — new cron expression smoke test
- [x] `FundTickerTest` — updated Xetra ISIN list with 4 new entries
- [x] Full test suite passes
- [x] Spotless check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)