### PR TITLE
Serve TKF onboarding document links from WordPress (GET /v1/savings/documents)

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/config/SecurityConfiguration.java
+++ b/src/main/java/ee/tuleva/onboarding/config/SecurityConfiguration.java
@@ -56,6 +56,8 @@ public class SecurityConfiguration {
                     .permitAll()
                     .requestMatchers(GET, "/v1/funds/*/nav")
                     .permitAll()
+                    .requestMatchers(GET, "/v1/savings/documents")
+                    .permitAll()
                     .requestMatchers(HEAD, "/v1/members")
                     .permitAll()
                     .requestMatchers(GET, "/v1/members/lookup")

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/documents/SavingsFundDocuments.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/documents/SavingsFundDocuments.java
@@ -1,0 +1,3 @@
+package ee.tuleva.onboarding.savings.fund.documents;
+
+public record SavingsFundDocuments(String terms, String prospectus, String keyInformation) {}

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/documents/SavingsFundDocumentsController.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/documents/SavingsFundDocumentsController.java
@@ -1,0 +1,21 @@
+package ee.tuleva.onboarding.savings.fund.documents;
+
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/v1/savings")
+@RequiredArgsConstructor
+public class SavingsFundDocumentsController {
+
+  private final SavingsFundDocumentsService savingsFundDocumentsService;
+
+  @Operation(summary = "Get savings fund (TKF) legal document URLs")
+  @GetMapping("/documents")
+  public SavingsFundDocuments getDocuments() {
+    return savingsFundDocumentsService.getDocuments();
+  }
+}

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/documents/SavingsFundDocumentsRefreshJob.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/documents/SavingsFundDocumentsRefreshJob.java
@@ -1,0 +1,24 @@
+package ee.tuleva.onboarding.savings.fund.documents;
+
+import lombok.RequiredArgsConstructor;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.springframework.context.annotation.Profile;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@Profile({"production", "staging"})
+@RequiredArgsConstructor
+class SavingsFundDocumentsRefreshJob {
+
+  private final SavingsFundDocumentsService savingsFundDocumentsService;
+
+  @Scheduled(cron = "0 0 * * * *", zone = "Europe/Tallinn")
+  @SchedulerLock(
+      name = "SavingsFundDocumentsRefreshJob_refresh",
+      lockAtMostFor = "55m",
+      lockAtLeastFor = "1m")
+  public void refresh() {
+    savingsFundDocumentsService.refresh();
+  }
+}

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/documents/SavingsFundDocumentsService.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/documents/SavingsFundDocumentsService.java
@@ -1,0 +1,85 @@
+package ee.tuleva.onboarding.savings.fund.documents;
+
+import static ee.tuleva.onboarding.notification.OperationsNotificationService.Channel.SAVINGS;
+
+import ee.tuleva.onboarding.notification.OperationsNotificationService;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.atomic.AtomicReference;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+public class SavingsFundDocumentsService {
+
+  static final SavingsFundDocuments FALLBACK =
+      new SavingsFundDocuments(
+          "https://tuleva.ee/wp-content/uploads/2026/02/Tuleva.eurofond.tingimused.02.02.2026.pdf",
+          "https://tuleva.ee/wp-content/uploads/2026/02/TKF100-Prospekt-kehtib-alates-27.02.2026.pdf",
+          "https://tuleva.ee/wp-content/uploads/2026/02/Pohiteave-TKF100-kehtib-alates-27.02.2026.pdf");
+
+  private static final Duration STALENESS_THRESHOLD = Duration.ofHours(48);
+
+  private final WordpressDocumentsClient client;
+  private final OperationsNotificationService notificationService;
+  private final Clock clock;
+
+  private final AtomicReference<SavingsFundDocuments> current = new AtomicReference<>(FALLBACK);
+  private final AtomicReference<Instant> lastSuccessfulRefreshAt;
+
+  public SavingsFundDocumentsService(
+      WordpressDocumentsClient client,
+      OperationsNotificationService notificationService,
+      Clock clock) {
+    this.client = client;
+    this.notificationService = notificationService;
+    this.clock = clock;
+    this.lastSuccessfulRefreshAt = new AtomicReference<>(clock.instant());
+  }
+
+  public SavingsFundDocuments getDocuments() {
+    return current.get();
+  }
+
+  public void refresh() {
+    try {
+      SavingsFundDocuments fetched = client.fetch();
+      current.set(fetched);
+      lastSuccessfulRefreshAt.set(clock.instant());
+      log.info("Refreshed savings fund documents from WordPress: documents={}", fetched);
+    } catch (Exception e) {
+      log.error(
+          "Failed to refresh savings fund documents from WordPress, serving last-known-good:"
+              + " error={}",
+          e.getMessage(),
+          e);
+      alert(
+          "Failed to refresh savings fund documents from WordPress, serving last-known-good:"
+              + " error="
+              + e.getMessage());
+      alertIfStale();
+    }
+  }
+
+  private void alertIfStale() {
+    Instant lastSuccess = lastSuccessfulRefreshAt.get();
+    Duration sinceSuccess = Duration.between(lastSuccess, clock.instant());
+    if (sinceSuccess.compareTo(STALENESS_THRESHOLD) > 0) {
+      alert(
+          "Savings fund documents have not refreshed from WordPress for "
+              + sinceSuccess.toHours()
+              + "h, still serving last-known-good: lastSuccessfulRefreshAt="
+              + lastSuccess);
+    }
+  }
+
+  private void alert(String message) {
+    try {
+      notificationService.sendMessage(message, SAVINGS);
+    } catch (Exception alertError) {
+      log.error("Failed to send savings fund documents alert", alertError);
+    }
+  }
+}

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/documents/WordpressDocumentsClient.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/documents/WordpressDocumentsClient.java
@@ -1,0 +1,90 @@
+package ee.tuleva.onboarding.savings.fund.documents;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.net.URI;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.retry.RetryTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+@Component
+@Slf4j
+class WordpressDocumentsClient {
+
+  private static final String EXPECTED_HOST = "tuleva.ee";
+  private static final String EXPECTED_PATH_PREFIX = "/wp-content/uploads/";
+
+  private final RestClient restClient;
+  private final WordpressDocumentsConfiguration configuration;
+  private final RetryTemplate retryTemplate;
+
+  WordpressDocumentsClient(
+      RestClient.Builder restClientBuilder,
+      WordpressDocumentsConfiguration configuration,
+      RetryTemplate wordpressDocumentsRetryTemplate) {
+    this.restClient = restClientBuilder.baseUrl(configuration.getUrl()).build();
+    this.configuration = configuration;
+    this.retryTemplate = wordpressDocumentsRetryTemplate;
+  }
+
+  SavingsFundDocuments fetch() {
+    return retryTemplate.invoke(() -> toDocuments(fetchPages()));
+  }
+
+  private WordpressPage[] fetchPages() {
+    log.info("Fetching savings fund documents from WordPress: slug={}", configuration.getSlug());
+    return restClient
+        .get()
+        .uri("/pages?slug={slug}", configuration.getSlug())
+        .accept(APPLICATION_JSON)
+        .retrieve()
+        .body(WordpressPage[].class);
+  }
+
+  private SavingsFundDocuments toDocuments(WordpressPage[] pages) {
+    if (pages == null || pages.length == 0 || pages[0].acf() == null) {
+      throw new WordpressDocumentsException(
+          "WordPress fund documents page returned no ACF data: slug=" + configuration.getSlug());
+    }
+    Acf acf = pages[0].acf();
+    return new SavingsFundDocuments(
+        validatedPdfUrl(acf.terms(), "terms_file"),
+        validatedPdfUrl(acf.prospectus(), "prospectus_file"),
+        validatedPdfUrl(acf.keyInformation(), "key_investor_info_file"));
+  }
+
+  private String validatedPdfUrl(String value, String field) {
+    if (value == null || value.isBlank()) {
+      throw new WordpressDocumentsException("Missing WordPress document field: field=" + field);
+    }
+    URI uri;
+    try {
+      uri = new URI(value);
+    } catch (Exception e) {
+      throw new WordpressDocumentsException(
+          "Invalid WordPress document URL: field=" + field + ", value=" + value);
+    }
+    boolean valid =
+        "https".equals(uri.getScheme())
+            && EXPECTED_HOST.equals(uri.getHost())
+            && uri.getRawPath() != null
+            && uri.getRawPath().startsWith(EXPECTED_PATH_PREFIX)
+            && uri.getRawPath().endsWith(".pdf")
+            && uri.getRawQuery() == null
+            && uri.getRawFragment() == null;
+    if (!valid) {
+      throw new WordpressDocumentsException(
+          "Invalid WordPress document URL: field=" + field + ", value=" + value);
+    }
+    return value;
+  }
+
+  record WordpressPage(Acf acf) {}
+
+  record Acf(
+      @JsonProperty("terms_file") String terms,
+      @JsonProperty("prospectus_file") String prospectus,
+      @JsonProperty("key_investor_info_file") String keyInformation) {}
+}

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/documents/WordpressDocumentsConfiguration.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/documents/WordpressDocumentsConfiguration.java
@@ -1,0 +1,36 @@
+package ee.tuleva.onboarding.savings.fund.documents;
+
+import java.time.Duration;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.retry.RetryPolicy;
+import org.springframework.core.retry.RetryTemplate;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.ResourceAccessException;
+
+@Configuration
+@ConfigurationProperties(prefix = "wordpress-documents")
+@Getter
+@Setter
+public class WordpressDocumentsConfiguration {
+
+  private String url = "https://tuleva.ee/wp-json/wp/v2";
+  private String slug = "tuleva-taiendav-kogumisfond-dokumendid";
+
+  @Bean
+  RetryTemplate wordpressDocumentsRetryTemplate() {
+    return new RetryTemplate(
+        RetryPolicy.builder()
+            .includes(HttpServerErrorException.class, ResourceAccessException.class)
+            .excludes(HttpClientErrorException.class)
+            .maxRetries(3)
+            .delay(Duration.ofSeconds(1))
+            .multiplier(2)
+            .maxDelay(Duration.ofSeconds(10))
+            .build());
+  }
+}

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/documents/WordpressDocumentsException.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/documents/WordpressDocumentsException.java
@@ -1,0 +1,8 @@
+package ee.tuleva.onboarding.savings.fund.documents;
+
+class WordpressDocumentsException extends RuntimeException {
+
+  WordpressDocumentsException(String message) {
+    super(message);
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -185,6 +185,10 @@ async:
 savings-fund:
   isin: EE0000003283
 
+wordpress-documents:
+  url: 'https://tuleva.ee/wp-json/wp/v2'
+  slug: 'tuleva-taiendav-kogumisfond-dokumendid'
+
 transaction-registry:
   alerts:
     to:

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/documents/SavingsFundDocumentsControllerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/documents/SavingsFundDocumentsControllerTest.java
@@ -1,0 +1,47 @@
+package ee.tuleva.onboarding.savings.fund.documents;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(SavingsFundDocumentsController.class)
+@AutoConfigureMockMvc
+@WithMockUser
+class SavingsFundDocumentsControllerTest {
+
+  @Autowired private MockMvc mvc;
+
+  @MockitoBean private SavingsFundDocumentsService savingsFundDocumentsService;
+
+  @Test
+  void getDocuments_returnsTheThreeDocumentUrls() throws Exception {
+    given(savingsFundDocumentsService.getDocuments())
+        .willReturn(
+            new SavingsFundDocuments(
+                "https://tuleva.ee/wp-content/uploads/2026/02/terms.pdf",
+                "https://tuleva.ee/wp-content/uploads/2026/02/prospectus.pdf",
+                "https://tuleva.ee/wp-content/uploads/2026/02/key-info.pdf"));
+
+    mvc.perform(get("/v1/savings/documents"))
+        .andExpect(status().isOk())
+        .andExpect(
+            content()
+                .json(
+                    """
+                    {
+                      "terms": "https://tuleva.ee/wp-content/uploads/2026/02/terms.pdf",
+                      "prospectus": "https://tuleva.ee/wp-content/uploads/2026/02/prospectus.pdf",
+                      "keyInformation": "https://tuleva.ee/wp-content/uploads/2026/02/key-info.pdf"
+                    }
+                    """));
+  }
+}

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/documents/SavingsFundDocumentsIntegrationTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/documents/SavingsFundDocumentsIntegrationTest.java
@@ -1,0 +1,44 @@
+package ee.tuleva.onboarding.savings.fund.documents;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class SavingsFundDocumentsIntegrationTest {
+
+  @Autowired private MockMvc mvc;
+
+  @MockitoBean private WordpressDocumentsClient wordpressDocumentsClient;
+
+  @Test
+  void servesBakedInFallbackToUnauthenticatedRequest_whenWordpressIsUnavailable() throws Exception {
+    given(wordpressDocumentsClient.fetch()).willThrow(new RuntimeException("WordPress is down"));
+
+    mvc.perform(get("/v1/savings/documents"))
+        .andExpect(status().isOk())
+        .andExpect(
+            content()
+                .json(
+                    """
+                    {
+                      "terms": "https://tuleva.ee/wp-content/uploads/2026/02/Tuleva.eurofond.tingimused.02.02.2026.pdf",
+                      "prospectus": "https://tuleva.ee/wp-content/uploads/2026/02/TKF100-Prospekt-kehtib-alates-27.02.2026.pdf",
+                      "keyInformation": "https://tuleva.ee/wp-content/uploads/2026/02/Pohiteave-TKF100-kehtib-alates-27.02.2026.pdf"
+                    }
+                    """));
+
+    verify(wordpressDocumentsClient, never()).fetch();
+  }
+}

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/documents/SavingsFundDocumentsRefreshJobTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/documents/SavingsFundDocumentsRefreshJobTest.java
@@ -1,0 +1,19 @@
+package ee.tuleva.onboarding.savings.fund.documents;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.Test;
+
+class SavingsFundDocumentsRefreshJobTest {
+
+  private final SavingsFundDocumentsService service = mock(SavingsFundDocumentsService.class);
+  private final SavingsFundDocumentsRefreshJob job = new SavingsFundDocumentsRefreshJob(service);
+
+  @Test
+  void refresh_delegatesToService() {
+    job.refresh();
+
+    verify(service).refresh();
+  }
+}

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/documents/SavingsFundDocumentsServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/documents/SavingsFundDocumentsServiceTest.java
@@ -1,0 +1,89 @@
+package ee.tuleva.onboarding.savings.fund.documents;
+
+import static ee.tuleva.onboarding.notification.OperationsNotificationService.Channel.SAVINGS;
+import static java.time.temporal.ChronoUnit.HOURS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import ee.tuleva.onboarding.notification.OperationsNotificationService;
+import ee.tuleva.onboarding.time.MutableClock;
+import org.junit.jupiter.api.Test;
+
+class SavingsFundDocumentsServiceTest {
+
+  private static final SavingsFundDocuments FETCHED =
+      new SavingsFundDocuments(
+          "https://tuleva.ee/wp-content/uploads/2026/06/terms.pdf",
+          "https://tuleva.ee/wp-content/uploads/2026/06/prospectus.pdf",
+          "https://tuleva.ee/wp-content/uploads/2026/06/key-info.pdf");
+
+  private final WordpressDocumentsClient client = mock(WordpressDocumentsClient.class);
+  private final OperationsNotificationService notificationService =
+      mock(OperationsNotificationService.class);
+  private final MutableClock clock = new MutableClock();
+
+  private final SavingsFundDocumentsService service =
+      new SavingsFundDocumentsService(client, notificationService, clock);
+
+  @Test
+  void getDocuments_returnsBakedInFallback_beforeAnyRefresh() {
+    assertThat(service.getDocuments()).isEqualTo(SavingsFundDocumentsService.FALLBACK);
+  }
+
+  @Test
+  void refresh_onSuccess_updatesServedDocuments() {
+    given(client.fetch()).willReturn(FETCHED);
+
+    service.refresh();
+
+    assertThat(service.getDocuments()).isEqualTo(FETCHED);
+  }
+
+  @Test
+  void refresh_onFailure_keepsLastKnownGood_andDoesNotThrow() {
+    given(client.fetch()).willReturn(FETCHED);
+    service.refresh();
+
+    given(client.fetch()).willThrow(new WordpressDocumentsException("WordPress down"));
+
+    assertThatCode(service::refresh).doesNotThrowAnyException();
+    assertThat(service.getDocuments()).isEqualTo(FETCHED);
+  }
+
+  @Test
+  void refresh_onFailure_alertsOperations() {
+    given(client.fetch()).willThrow(new WordpressDocumentsException("WordPress down"));
+
+    service.refresh();
+
+    verify(notificationService, times(1)).sendMessage(anyString(), eq(SAVINGS));
+  }
+
+  @Test
+  void refresh_onFailure_doesNotThrow_evenWhenAlertSendItselfThrows() {
+    given(client.fetch()).willThrow(new WordpressDocumentsException("WordPress down"));
+    willThrow(new RuntimeException("Slack down"))
+        .given(notificationService)
+        .sendMessage(anyString(), eq(SAVINGS));
+
+    assertThatCode(service::refresh).doesNotThrowAnyException();
+    assertThat(service.getDocuments()).isEqualTo(SavingsFundDocumentsService.FALLBACK);
+  }
+
+  @Test
+  void refresh_whenStuckOnFallbackBeyondThreshold_alsoSendsStalenessAlert() {
+    given(client.fetch()).willThrow(new WordpressDocumentsException("WordPress down"));
+
+    clock.tick(49, HOURS);
+    service.refresh();
+
+    verify(notificationService, times(2)).sendMessage(anyString(), eq(SAVINGS));
+  }
+}

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/documents/WordpressDocumentsClientTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/documents/WordpressDocumentsClientTest.java
@@ -1,0 +1,186 @@
+package ee.tuleva.onboarding.savings.fund.documents;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withBadRequest;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withServerError;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import java.time.Duration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.retry.RetryPolicy;
+import org.springframework.core.retry.RetryTemplate;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestClient;
+
+@SpringJUnitConfig(classes = WordpressDocumentsClientTest.TestConfig.class)
+class WordpressDocumentsClientTest {
+
+  private static final String URL =
+      "https://tuleva.ee/wp-json/wp/v2/pages?slug=tuleva-taiendav-kogumisfond-dokumendid";
+
+  @Autowired WordpressDocumentsClient client;
+  @Autowired MockRestServiceServer mockServer;
+
+  @BeforeEach
+  void resetMockServer() {
+    mockServer.reset();
+  }
+
+  @Test
+  void fetch_mapsAcfFieldsToDomainDocuments() {
+    mockServer
+        .expect(requestTo(URL))
+        .andRespond(withSuccess(validResponse(), MediaType.APPLICATION_JSON));
+
+    SavingsFundDocuments documents = client.fetch();
+
+    assertThat(documents)
+        .isEqualTo(
+            new SavingsFundDocuments(
+                "https://tuleva.ee/wp-content/uploads/2026/06/terms.pdf",
+                "https://tuleva.ee/wp-content/uploads/2026/06/prospectus.pdf",
+                "https://tuleva.ee/wp-content/uploads/2026/06/key-info.pdf"));
+    mockServer.verify();
+  }
+
+  @Test
+  void fetch_throwsWhenUrlHostIsNotTuleva() {
+    String body =
+        """
+        [{"acf": {
+          "terms_file": "https://evil.example.com/wp-content/uploads/2026/06/terms.pdf",
+          "prospectus_file": "https://tuleva.ee/wp-content/uploads/2026/06/prospectus.pdf",
+          "key_investor_info_file": "https://tuleva.ee/wp-content/uploads/2026/06/key-info.pdf"
+        }}]
+        """;
+    mockServer.expect(requestTo(URL)).andRespond(withSuccess(body, MediaType.APPLICATION_JSON));
+
+    assertThatThrownBy(() -> client.fetch()).isInstanceOf(WordpressDocumentsException.class);
+  }
+
+  @Test
+  void fetch_throwsWhenUrlIsNotPdf() {
+    String body =
+        """
+        [{"acf": {
+          "terms_file": "https://tuleva.ee/wp-content/uploads/2026/06/terms.docx",
+          "prospectus_file": "https://tuleva.ee/wp-content/uploads/2026/06/prospectus.pdf",
+          "key_investor_info_file": "https://tuleva.ee/wp-content/uploads/2026/06/key-info.pdf"
+        }}]
+        """;
+    mockServer.expect(requestTo(URL)).andRespond(withSuccess(body, MediaType.APPLICATION_JSON));
+
+    assertThatThrownBy(() -> client.fetch()).isInstanceOf(WordpressDocumentsException.class);
+  }
+
+  @Test
+  void fetch_throwsWhenFieldMissing() {
+    String body =
+        """
+        [{"acf": {
+          "prospectus_file": "https://tuleva.ee/wp-content/uploads/2026/06/prospectus.pdf",
+          "key_investor_info_file": "https://tuleva.ee/wp-content/uploads/2026/06/key-info.pdf"
+        }}]
+        """;
+    mockServer.expect(requestTo(URL)).andRespond(withSuccess(body, MediaType.APPLICATION_JSON));
+
+    assertThatThrownBy(() -> client.fetch()).isInstanceOf(WordpressDocumentsException.class);
+  }
+
+  @Test
+  void fetch_throwsWhenPageArrayEmpty() {
+    mockServer.expect(requestTo(URL)).andRespond(withSuccess("[]", MediaType.APPLICATION_JSON));
+
+    assertThatThrownBy(() -> client.fetch()).isInstanceOf(WordpressDocumentsException.class);
+  }
+
+  @Test
+  void fetch_retriesOnServerErrorThenSucceeds() {
+    mockServer.expect(requestTo(URL)).andRespond(withServerError());
+    mockServer.expect(requestTo(URL)).andRespond(withServerError());
+    mockServer
+        .expect(requestTo(URL))
+        .andRespond(withSuccess(validResponse(), MediaType.APPLICATION_JSON));
+
+    SavingsFundDocuments documents = client.fetch();
+
+    assertThat(documents.terms())
+        .isEqualTo("https://tuleva.ee/wp-content/uploads/2026/06/terms.pdf");
+    mockServer.verify();
+  }
+
+  @Test
+  void fetch_doesNotRetryOnClientError() {
+    mockServer
+        .expect(requestTo(URL))
+        .andExpect(method(HttpMethod.GET))
+        .andRespond(withBadRequest());
+
+    assertThatThrownBy(() -> client.fetch()).isInstanceOf(HttpClientErrorException.class);
+    mockServer.verify();
+  }
+
+  private static String validResponse() {
+    return """
+        [{"acf": {
+          "terms_file": "https://tuleva.ee/wp-content/uploads/2026/06/terms.pdf",
+          "prospectus_file": "https://tuleva.ee/wp-content/uploads/2026/06/prospectus.pdf",
+          "key_investor_info_file": "https://tuleva.ee/wp-content/uploads/2026/06/key-info.pdf"
+        }}]
+        """;
+  }
+
+  @Configuration
+  static class TestConfig {
+
+    @Bean
+    RestClient.Builder wordpressDocumentsRestClientBuilder() {
+      return RestClient.builder();
+    }
+
+    @Bean
+    MockRestServiceServer mockRestServiceServer(RestClient.Builder builder) {
+      return MockRestServiceServer.bindTo(builder).build();
+    }
+
+    @Bean
+    WordpressDocumentsConfiguration wordpressDocumentsConfiguration() {
+      return new WordpressDocumentsConfiguration();
+    }
+
+    @Bean
+    RetryTemplate wordpressDocumentsRetryTemplate() {
+      return new RetryTemplate(
+          RetryPolicy.builder()
+              .includes(HttpServerErrorException.class, ResourceAccessException.class)
+              .excludes(HttpClientErrorException.class)
+              .maxRetries(3)
+              .delay(Duration.ofMillis(1))
+              .multiplier(1)
+              .maxDelay(Duration.ofMillis(1))
+              .build());
+    }
+
+    @Bean
+    WordpressDocumentsClient wordpressDocumentsClient(
+        RestClient.Builder builder,
+        MockRestServiceServer mockServer,
+        WordpressDocumentsConfiguration configuration,
+        RetryTemplate wordpressDocumentsRetryTemplate) {
+      return new WordpressDocumentsClient(builder, configuration, wordpressDocumentsRetryTemplate);
+    }
+  }
+}


### PR DESCRIPTION
## What & why

The Täiendav Kogumisfond (TKF100) onboarding **signing step** links three legal documents — **terms (tingimused), prospectus (prospekt), key information (põhiteave)**. Those URLs were **hardcoded in the frontend** and silently went stale when the documents were re-issued.

This adds **`GET /v1/savings/documents`**, which mirrors the current URLs from the public fund-documents page's **WordPress ACF fields** and serves them to the frontend. WordPress stays the single editable source — the content team updates the documents in wp-admin, **no deploy anywhere**.

Issue: TulevaEE/TKF-VPII2026#63

## Hard requirement: a WordPress outage must never fail a deploy or break the signing page

Solved by a baked-in fallback + zero-network startup + graceful scheduled refresh:

- **In-memory `AtomicReference`** seeded with a **baked-in fallback** (today's effective URLs, verified 2026-05-26). Not `@Cacheable` — that would fetch on the request path on a miss.
- **Startup performs zero network I/O.** No bean-init/`ApplicationReadyEvent` fetch; config has safe defaults baked into the class. WordPress is contacted **only** by an hourly `@Scheduled` refresh (`production`/`staging`, `@SchedulerLock`).
- `refresh()` **never propagates**: on failure it keeps last-known-good, alerts operations (the alert send is itself guarded), and escalates a **staleness alert after 48h** on the fallback so a permanently-failing fetch can't sit silently.
- The endpoint is **`permitAll`** so an auth state can't blank the signing step.

### The key proof
`SavingsFundDocumentsIntegrationTest` is a context-level `@SpringBootTest` wired with a WordPress client that **always fails**, asserting the app **boots**, serves the **fallback** to an **unauthenticated** request, and **never calls WordPress** on the startup/request path.

## Design notes (house patterns)
- **Anti-corruption layer**: the WordPress JSON DTOs (`WordpressPage`/`Acf`) are **package-private**; validated and mapped to the public `SavingsFundDocuments` record at the boundary. URL validation rejects anything that isn't `https`, host `tuleva.ee`, path under `/wp-content/uploads/`, ending `.pdf`, no query/fragment. (`ModularityTest.verify()` is disabled, so visibility is enforced by hand.)
- **Native `RetryTemplate`** (Spring FW 7) retries 5xx / `ResourceAccessException`, not 4xx — mirrors `SebGatewayConfiguration`.
- **`Clock` injected**; `@ConfigurationProperties(prefix = "wordpress-documents")` with defaults baked into the class so missing config can't fail startup.
- **Alerting via `OperationsNotificationService` (SAVINGS channel)** rather than building a Mandrill message directly — that's the public ops-alert API and avoids reaching into another module's package-private `AlertMandrillMessageFactory`/`AlertProperties`. The "alert must not propagate" requirement is fully met (and the integration/unit tests prove `refresh()` never throws even when the alert send throws).

## Reviewer flags
- 👀 **Security**: please glance at the new `permitAll` for `GET /v1/savings/documents` — it exposes only URLs that are already public on the website.
- ⏳ **Live E2E waits on the WordPress prereq**: `show_in_rest` for the ACF group (TulevaEE/wordpress-theme#67) is likely **not deployed yet**, so live WordPress REST won't expose the fields. This PR is built and tested against the documented contract with mocked HTTP; the **baked-in fallback makes the app correct regardless**. Once #67 deploys, verify with:
  ```bash
  curl -s 'https://tuleva.ee/wp-json/wp/v2/pages?slug=tuleva-taiendav-kogumisfond-dokumendid' \
    | python3 -c 'import sys,json;a=json.load(sys.stdin)[0]["acf"];print(a["terms_file"],a["prospectus_file"],a["key_investor_info_file"],sep="\n")'
  ```

## Tests
Strict TDD. Controller (`@WebMvcTest`), anti-corruption mapping + retry (`MockRestServiceServer`), resilience + staleness (unit), and the context-level deploy-safety `@SpringBootTest`. `./gradlew spotlessApply` clean; **full `./gradlew test` suite green**.

## Frontend
Reads this endpoint: TulevaEE/onboarding-client#1557

🤖 Generated with [Claude Code](https://claude.com/claude-code)
