### PR TITLE
Add NAV transaction impact alert for high-volume days

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/investment/config/InvestmentParameter.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/config/InvestmentParameter.java
@@ -2,5 +2,6 @@ package ee.tuleva.onboarding.investment.config;
 
 public enum InvestmentParameter {
   TRACKING_BREACH_THRESHOLD,
-  TRACKING_MAX_DAILY_RETURN
+  TRACKING_MAX_DAILY_RETURN,
+  NAV_IMPACT_VOLUME_THRESHOLD
 }

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/nav/NavTransactionImpactAlertJob.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/nav/NavTransactionImpactAlertJob.java
@@ -53,8 +53,8 @@ public class NavTransactionImpactAlertJob {
   private volatile LocalDate lastAlertDate;
   private final Set<String> sentAlerts = ConcurrentHashMap.newKeySet();
 
-  @EventListener
-  void onFundPositionsImported(FundPositionsImported event) {
+  @EventListener(classes = FundPositionsImported.class)
+  void onFundPositionsImported() {
     try {
       checkAll();
     } catch (Exception e) {

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/nav/NavTransactionImpactAlertJob.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/nav/NavTransactionImpactAlertJob.java
@@ -1,0 +1,220 @@
+package ee.tuleva.onboarding.savings.fund.nav;
+
+import static ee.tuleva.onboarding.fund.TulevaFund.TKF100;
+import static ee.tuleva.onboarding.investment.config.InvestmentParameter.NAV_IMPACT_VOLUME_THRESHOLD;
+import static ee.tuleva.onboarding.notification.OperationsNotificationService.Channel.SAVINGS;
+import static ee.tuleva.onboarding.savings.fund.SavingFundPayment.Status.RESERVED;
+import static ee.tuleva.onboarding.savings.fund.redemption.RedemptionRequest.Status.VERIFIED;
+import static java.math.BigDecimal.ZERO;
+import static java.math.RoundingMode.HALF_UP;
+
+import ee.tuleva.onboarding.deadline.PublicHolidays;
+import ee.tuleva.onboarding.investment.config.InvestmentParameterRepository;
+import ee.tuleva.onboarding.investment.event.FundPositionsImported;
+import ee.tuleva.onboarding.notification.OperationsNotificationService;
+import ee.tuleva.onboarding.savings.fund.SavingFundPayment;
+import ee.tuleva.onboarding.savings.fund.SavingFundPaymentRepository;
+import ee.tuleva.onboarding.savings.fund.redemption.RedemptionRequest;
+import ee.tuleva.onboarding.savings.fund.redemption.RedemptionRequestRepository;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@Profile({"production", "staging"})
+public class NavTransactionImpactAlertJob {
+
+  private static final ZoneId TALLINN = ZoneId.of("Europe/Tallinn");
+  private static final LocalTime CUTOFF_TIME = LocalTime.of(16, 0);
+
+  private final SavingFundPaymentRepository savingFundPaymentRepository;
+  private final RedemptionRequestRepository redemptionRequestRepository;
+  private final FundNavProvider fundNavProvider;
+  private final InvestmentParameterRepository investmentParameterRepository;
+  private final OperationsNotificationService notificationService;
+  private final PublicHolidays publicHolidays;
+  private final Clock clock;
+
+  private volatile LocalDate lastAlertDate;
+  private final Set<String> sentAlerts = ConcurrentHashMap.newKeySet();
+
+  @EventListener
+  void onFundPositionsImported(FundPositionsImported event) {
+    try {
+      checkAll();
+    } catch (Exception e) {
+      log.error("NAV transaction impact alert failed", e);
+    }
+  }
+
+  private void checkAll() {
+    LocalDate today = clock.instant().atZone(TALLINN).toLocalDate();
+    if (!publicHolidays.isWorkingDay(today)) {
+      return;
+    }
+
+    resetIdempotencyGuardIfNewDay(today);
+
+    LocalDate navDate = publicHolidays.previousWorkingDay(today);
+
+    checkTkf100Volume(today, navDate);
+    checkPevaRava(today, navDate);
+    checkR16BookingDay(today, navDate);
+  }
+
+  private void resetIdempotencyGuardIfNewDay(LocalDate today) {
+    if (!today.equals(lastAlertDate)) {
+      sentAlerts.clear();
+      lastAlertDate = today;
+    }
+  }
+
+  private void sendOnce(String alertKey, String message) {
+    if (sentAlerts.add(alertKey)) {
+      log.info("{}", message);
+      notificationService.sendMessage(message, SAVINGS);
+    }
+  }
+
+  private void checkTkf100Volume(LocalDate today, LocalDate navDate) {
+    try {
+      BigDecimal threshold =
+          investmentParameterRepository.findLatestValue(NAV_IMPACT_VOLUME_THRESHOLD, today);
+
+      Instant cutoff = ZonedDateTime.of(navDate, CUTOFF_TIME, TALLINN).toInstant();
+
+      List<SavingFundPayment> reservedPayments =
+          savingFundPaymentRepository.findPaymentsWithStatus(RESERVED).stream()
+              .filter(p -> p.getReceivedBefore() != null && p.getReceivedBefore().isBefore(cutoff))
+              .toList();
+      BigDecimal subscriptionEur =
+          reservedPayments.stream().map(SavingFundPayment::getAmount).reduce(ZERO, BigDecimal::add);
+
+      List<RedemptionRequest> redemptions =
+          redemptionRequestRepository.findByStatusAndRequestedAtBefore(VERIFIED, cutoff);
+      BigDecimal redemptionEur = estimateRedemptionEur(redemptions);
+
+      BigDecimal totalVolume = subscriptionEur.add(redemptionEur);
+
+      if (totalVolume.compareTo(threshold) >= 0) {
+        sendOnce(
+            "TKF100",
+            formatTkf100Alert(
+                navDate,
+                subscriptionEur,
+                redemptionEur,
+                totalVolume,
+                redemptions.size(),
+                reservedPayments.size()));
+      }
+    } catch (Exception e) {
+      log.error("TKF100 volume check failed, continuing with pension fund checks", e);
+    }
+  }
+
+  private BigDecimal estimateRedemptionEur(List<RedemptionRequest> redemptions) {
+    if (redemptions.isEmpty()) {
+      return ZERO;
+    }
+    try {
+      BigDecimal nav = fundNavProvider.getDisplayNav(TKF100);
+      return redemptions.stream()
+          .map(r -> r.getFundUnits().multiply(nav))
+          .reduce(ZERO, BigDecimal::add);
+    } catch (Exception e) {
+      log.warn("NAV lookup failed, estimating redemptions from requestedAmount", e);
+      return redemptions.stream()
+          .map(RedemptionRequest::getRequestedAmount)
+          .reduce(ZERO, BigDecimal::add);
+    }
+  }
+
+  private void checkPevaRava(LocalDate today, LocalDate navDate) {
+    if (isPevaRavaExecutionDate(today)) {
+      sendOnce(
+          "PEVA_RAVA",
+          "NAV IMPACT ALERT — PEVA/RAVA execution date (navDate=%s)\n".formatted(navDate)
+              + "  All Pillar 2 fund switches and exits will use today's NAV.\n"
+              + "  Funds affected: TUK75, TUK00\n"
+              + "  Manual NAV verification strongly recommended.");
+    }
+  }
+
+  private void checkR16BookingDay(LocalDate today, LocalDate navDate) {
+    if (isR16BookingDay(today)) {
+      sendOnce(
+          "R16",
+          "NAV IMPACT ALERT — R16 booking day (navDate=%s)\n".formatted(navDate)
+              + "  Fondimaksed + ühekordsed väljamaksed: Pensionikeskus will book unit redemptions\n"
+              + "  using today's NAV (12:00-16:00).\n"
+              + "  Funds affected: TUK75, TUK00, TUV100\n"
+              + "  Manual NAV verification recommended.");
+    }
+  }
+
+  boolean isPevaRavaExecutionDate(LocalDate today) {
+    int year = today.getYear();
+    return today.equals(publicHolidays.nextWorkingDay(LocalDate.of(year, 1, 1)))
+        || today.equals(publicHolidays.nextWorkingDay(LocalDate.of(year, 5, 1)))
+        || today.equals(adjustedSep1(year));
+  }
+
+  private LocalDate adjustedSep1(int year) {
+    LocalDate sep1 = LocalDate.of(year, 9, 1);
+    return publicHolidays.isWorkingDay(sep1) ? sep1 : publicHolidays.nextWorkingDay(sep1);
+  }
+
+  boolean isR16BookingDay(LocalDate today) {
+    LocalDate the15th = today.withDayOfMonth(Math.min(15, today.lengthOfMonth()));
+    LocalDate adjusted =
+        publicHolidays.isWorkingDay(the15th) ? the15th : publicHolidays.nextWorkingDay(the15th);
+    return today.equals(adjusted);
+  }
+
+  private String formatTkf100Alert(
+      LocalDate navDate,
+      BigDecimal subscriptionEur,
+      BigDecimal redemptionEur,
+      BigDecimal totalVolume,
+      int redemptionCount,
+      int subscriptionCount) {
+    BigDecimal impactAt1bp = totalVolume.multiply(new BigDecimal("0.0001")).setScale(2, HALF_UP);
+    BigDecimal impactAt10bp = totalVolume.multiply(new BigDecimal("0.001")).setScale(2, HALF_UP);
+    BigDecimal impactAt100bp = totalVolume.multiply(new BigDecimal("0.01")).setScale(2, HALF_UP);
+
+    return "NAV IMPACT ALERT — TKF100 (navDate=%s)\n".formatted(navDate)
+        + String.format(
+            Locale.US,
+            "  Pending Subscriptions: %,.2f EUR (%d payments)\n",
+            subscriptionEur,
+            subscriptionCount)
+        + String.format(
+            Locale.US,
+            "  Pending Redemptions: %,.2f EUR (%d requests)\n",
+            redemptionEur,
+            redemptionCount)
+        + String.format(Locale.US, "  Total Volume: %,.2f EUR\n", totalVolume)
+        + String.format(
+            Locale.US,
+            "  Impact: 1bp = %,.2f EUR, 10bp = %,.2f EUR, 100bp = %,.2f EUR\n",
+            impactAt1bp,
+            impactAt10bp,
+            impactAt100bp)
+        + "  Manual NAV verification recommended.";
+  }
+}

--- a/src/main/resources/db/migration/V1_192__nav_impact_volume_threshold.sql
+++ b/src/main/resources/db/migration/V1_192__nav_impact_volume_threshold.sql
@@ -1,0 +1,2 @@
+INSERT INTO investment_parameter (effective_date, parameter_name, fund_code, numeric_value)
+VALUES ('2026-01-01', 'NAV_IMPACT_VOLUME_THRESHOLD', NULL, 1000000);

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/nav/NavTransactionImpactAlertJobTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/nav/NavTransactionImpactAlertJobTest.java
@@ -17,7 +17,6 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import ee.tuleva.onboarding.deadline.PublicHolidays;
 import ee.tuleva.onboarding.fund.TulevaFund;
 import ee.tuleva.onboarding.investment.config.InvestmentParameterRepository;
-import ee.tuleva.onboarding.investment.event.FundPositionsImported;
 import ee.tuleva.onboarding.notification.OperationsNotificationService;
 import ee.tuleva.onboarding.party.PartyId;
 import ee.tuleva.onboarding.savings.fund.SavingFundPayment;
@@ -56,7 +55,7 @@ class NavTransactionImpactAlertJobTest {
     // 2026-01-17 = Saturday
     var job = jobOn("2026-01-17T08:00:00Z");
 
-    job.onFundPositionsImported(new FundPositionsImported());
+    job.onFundPositionsImported();
 
     verifyNoInteractions(notificationService);
     verifyNoInteractions(savingFundPaymentRepository);
@@ -72,7 +71,7 @@ class NavTransactionImpactAlertJobTest {
     stubTkf100Subscriptions(new BigDecimal("50000"));
     stubTkf100Redemptions(List.of());
 
-    job.onFundPositionsImported(new FundPositionsImported());
+    job.onFundPositionsImported();
 
     verify(notificationService, never()).sendMessage(contains("TKF100"), eq(SAVINGS));
   }
@@ -86,7 +85,7 @@ class NavTransactionImpactAlertJobTest {
     stubTkf100Redemptions(List.of(redemption(new BigDecimal("200000"))));
     stubNav(NAV);
 
-    job.onFundPositionsImported(new FundPositionsImported());
+    job.onFundPositionsImported();
 
     verify(notificationService).sendMessage(contains("TKF100"), eq(SAVINGS));
   }
@@ -102,7 +101,7 @@ class NavTransactionImpactAlertJobTest {
     // 400 units × 1.50 = 600 EUR → above 500 threshold
     stubTkf100Redemptions(List.of(redemption(new BigDecimal("400"))));
 
-    job.onFundPositionsImported(new FundPositionsImported());
+    job.onFundPositionsImported();
 
     verify(notificationService).sendMessage(contains("TKF100"), eq(SAVINGS));
   }
@@ -118,7 +117,7 @@ class NavTransactionImpactAlertJobTest {
     stubTkf100RedemptionsLenient(List.of());
     stubNavLenient(NAV);
 
-    job.onFundPositionsImported(new FundPositionsImported());
+    job.onFundPositionsImported();
 
     verify(notificationService).sendMessage(contains("PEVA/RAVA"), eq(SAVINGS));
   }
@@ -132,7 +131,7 @@ class NavTransactionImpactAlertJobTest {
     stubTkf100RedemptionsLenient(List.of());
     stubNavLenient(NAV);
 
-    job.onFundPositionsImported(new FundPositionsImported());
+    job.onFundPositionsImported();
 
     verify(notificationService).sendMessage(contains("PEVA/RAVA"), eq(SAVINGS));
   }
@@ -146,7 +145,7 @@ class NavTransactionImpactAlertJobTest {
     stubTkf100RedemptionsLenient(List.of());
     stubNavLenient(NAV);
 
-    job.onFundPositionsImported(new FundPositionsImported());
+    job.onFundPositionsImported();
 
     verify(notificationService).sendMessage(contains("PEVA/RAVA"), eq(SAVINGS));
   }
@@ -159,7 +158,7 @@ class NavTransactionImpactAlertJobTest {
     stubTkf100Subscriptions(ZERO);
     stubTkf100Redemptions(List.of());
 
-    job.onFundPositionsImported(new FundPositionsImported());
+    job.onFundPositionsImported();
 
     verify(notificationService, never()).sendMessage(contains("PEVA/RAVA"), eq(SAVINGS));
   }
@@ -175,7 +174,7 @@ class NavTransactionImpactAlertJobTest {
     stubTkf100RedemptionsLenient(List.of());
     stubNavLenient(NAV);
 
-    job.onFundPositionsImported(new FundPositionsImported());
+    job.onFundPositionsImported();
 
     verify(notificationService).sendMessage(contains("R16"), eq(SAVINGS));
   }
@@ -189,7 +188,7 @@ class NavTransactionImpactAlertJobTest {
     stubTkf100RedemptionsLenient(List.of());
     stubNavLenient(NAV);
 
-    job.onFundPositionsImported(new FundPositionsImported());
+    job.onFundPositionsImported();
 
     verify(notificationService).sendMessage(contains("R16"), eq(SAVINGS));
   }
@@ -202,7 +201,7 @@ class NavTransactionImpactAlertJobTest {
     stubTkf100Subscriptions(ZERO);
     stubTkf100Redemptions(List.of());
 
-    job.onFundPositionsImported(new FundPositionsImported());
+    job.onFundPositionsImported();
 
     verify(notificationService, never()).sendMessage(contains("R16"), eq(SAVINGS));
   }
@@ -215,7 +214,7 @@ class NavTransactionImpactAlertJobTest {
     stubTkf100Subscriptions(ZERO);
     stubTkf100Redemptions(List.of());
 
-    job.onFundPositionsImported(new FundPositionsImported());
+    job.onFundPositionsImported();
 
     verify(notificationService, never()).sendMessage(contains("R16"), eq(SAVINGS));
   }
@@ -229,7 +228,7 @@ class NavTransactionImpactAlertJobTest {
     given(investmentParameterRepository.findLatestValue(any(), any(LocalDate.class)))
         .willThrow(new RuntimeException("DB down"));
 
-    job.onFundPositionsImported(new FundPositionsImported());
+    job.onFundPositionsImported();
 
     verify(notificationService).sendMessage(contains("PEVA/RAVA"), eq(SAVINGS));
   }
@@ -245,8 +244,8 @@ class NavTransactionImpactAlertJobTest {
     stubTkf100RedemptionsLenient(List.of());
     stubNavLenient(NAV);
 
-    job.onFundPositionsImported(new FundPositionsImported());
-    job.onFundPositionsImported(new FundPositionsImported());
+    job.onFundPositionsImported();
+    job.onFundPositionsImported();
 
     verify(notificationService).sendMessage(contains("PEVA/RAVA"), eq(SAVINGS));
   }
@@ -264,7 +263,7 @@ class NavTransactionImpactAlertJobTest {
     // requestedAmount = 400 * 1.1234 = 449.36 (from redemption helper) → below 500
     stubTkf100Redemptions(List.of(redemption(new BigDecimal("400"))));
 
-    job.onFundPositionsImported(new FundPositionsImported());
+    job.onFundPositionsImported();
 
     verify(notificationService, never()).sendMessage(contains("TKF100"), eq(SAVINGS));
   }
@@ -280,7 +279,7 @@ class NavTransactionImpactAlertJobTest {
     // requestedAmount = 100000 * 1.1234 = 112340 (fallback), total > 1M
     stubTkf100Redemptions(List.of(redemption(new BigDecimal("100000"))));
 
-    job.onFundPositionsImported(new FundPositionsImported());
+    job.onFundPositionsImported();
 
     verify(notificationService).sendMessage(contains("TKF100"), eq(SAVINGS));
   }
@@ -309,7 +308,7 @@ class NavTransactionImpactAlertJobTest {
     given(savingFundPaymentRepository.findPaymentsWithStatus(RESERVED))
         .willReturn(List.of(beforeCutoff, afterCutoff));
 
-    job.onFundPositionsImported(new FundPositionsImported());
+    job.onFundPositionsImported();
 
     verify(notificationService).sendMessage(contains("200.00"), eq(SAVINGS));
   }

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/nav/NavTransactionImpactAlertJobTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/nav/NavTransactionImpactAlertJobTest.java
@@ -1,0 +1,402 @@
+package ee.tuleva.onboarding.savings.fund.nav;
+
+import static ee.tuleva.onboarding.investment.config.InvestmentParameter.NAV_IMPACT_VOLUME_THRESHOLD;
+import static ee.tuleva.onboarding.notification.OperationsNotificationService.Channel.SAVINGS;
+import static ee.tuleva.onboarding.savings.fund.SavingFundPayment.Status.RESERVED;
+import static ee.tuleva.onboarding.savings.fund.redemption.RedemptionRequest.Status.VERIFIED;
+import static java.math.BigDecimal.ZERO;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import ee.tuleva.onboarding.deadline.PublicHolidays;
+import ee.tuleva.onboarding.fund.TulevaFund;
+import ee.tuleva.onboarding.investment.config.InvestmentParameterRepository;
+import ee.tuleva.onboarding.investment.event.FundPositionsImported;
+import ee.tuleva.onboarding.notification.OperationsNotificationService;
+import ee.tuleva.onboarding.party.PartyId;
+import ee.tuleva.onboarding.savings.fund.SavingFundPayment;
+import ee.tuleva.onboarding.savings.fund.SavingFundPaymentRepository;
+import ee.tuleva.onboarding.savings.fund.redemption.RedemptionRequest;
+import ee.tuleva.onboarding.savings.fund.redemption.RedemptionRequestRepository;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class NavTransactionImpactAlertJobTest {
+
+  private static final ZoneId TALLINN = ZoneId.of("Europe/Tallinn");
+  private static final BigDecimal ONE_MILLION = new BigDecimal("1000000");
+  private static final BigDecimal NAV = new BigDecimal("1.1234");
+
+  @Mock private SavingFundPaymentRepository savingFundPaymentRepository;
+  @Mock private RedemptionRequestRepository redemptionRequestRepository;
+  @Mock private FundNavProvider fundNavProvider;
+  @Mock private InvestmentParameterRepository investmentParameterRepository;
+  @Mock private OperationsNotificationService notificationService;
+  private final PublicHolidays publicHolidays = new PublicHolidays();
+
+  // --- Non-working day ---
+
+  @Test
+  void silent_onNonWorkingDay() {
+    // 2026-01-17 = Saturday
+    var job = jobOn("2026-01-17T08:00:00Z");
+
+    job.onFundPositionsImported(new FundPositionsImported());
+
+    verifyNoInteractions(notificationService);
+    verifyNoInteractions(savingFundPaymentRepository);
+  }
+
+  // --- TKF100 volume-based ---
+
+  @Test
+  void tkf100_noAlert_whenBelowThreshold() {
+    // 2026-03-10 = Tuesday, regular day
+    var job = jobOn("2026-03-10T08:00:00Z");
+    stubThreshold(ONE_MILLION);
+    stubTkf100Subscriptions(new BigDecimal("50000"));
+    stubTkf100Redemptions(List.of());
+
+    job.onFundPositionsImported(new FundPositionsImported());
+
+    verify(notificationService, never()).sendMessage(contains("TKF100"), eq(SAVINGS));
+  }
+
+  @Test
+  void tkf100_alert_whenAboveThreshold() {
+    // 2026-03-10 = Tuesday, regular day
+    var job = jobOn("2026-03-10T08:00:00Z");
+    stubThreshold(ONE_MILLION);
+    stubTkf100Subscriptions(new BigDecimal("800000"));
+    stubTkf100Redemptions(List.of(redemption(new BigDecimal("200000"))));
+    stubNav(NAV);
+
+    job.onFundPositionsImported(new FundPositionsImported());
+
+    verify(notificationService).sendMessage(contains("TKF100"), eq(SAVINGS));
+  }
+
+  @Test
+  void tkf100_redemptionEur_estimatedFromUnitsTimesNav() {
+    // 2026-03-10 = Tuesday
+    var job = jobOn("2026-03-10T08:00:00Z");
+    stubThreshold(new BigDecimal("500"));
+    var nav = new BigDecimal("1.50000");
+    stubNav(nav);
+    stubTkf100Subscriptions(ZERO);
+    // 400 units × 1.50 = 600 EUR → above 500 threshold
+    stubTkf100Redemptions(List.of(redemption(new BigDecimal("400"))));
+
+    job.onFundPositionsImported(new FundPositionsImported());
+
+    verify(notificationService).sendMessage(contains("TKF100"), eq(SAVINGS));
+  }
+
+  // --- PEVA/RAVA execution dates ---
+
+  @Test
+  void pevaRava_alert_onJan2_firstBizDayAfterJan1() {
+    // 2026-01-02 = Friday (Jan 1 is holiday, Jan 2 is 1st biz day after)
+    var job = jobOn("2026-01-02T08:00:00Z");
+    stubThresholdLenient(ONE_MILLION);
+    stubTkf100SubscriptionsLenient(ZERO);
+    stubTkf100RedemptionsLenient(List.of());
+    stubNavLenient(NAV);
+
+    job.onFundPositionsImported(new FundPositionsImported());
+
+    verify(notificationService).sendMessage(contains("PEVA/RAVA"), eq(SAVINGS));
+  }
+
+  @Test
+  void pevaRava_alert_onMay4_firstBizDayAfterMay1() {
+    // 2026-05-01 = Friday (holiday), May 2 = Sat, May 3 = Sun → May 4 = Monday
+    var job = jobOn("2026-05-04T08:00:00Z");
+    stubThresholdLenient(ONE_MILLION);
+    stubTkf100SubscriptionsLenient(ZERO);
+    stubTkf100RedemptionsLenient(List.of());
+    stubNavLenient(NAV);
+
+    job.onFundPositionsImported(new FundPositionsImported());
+
+    verify(notificationService).sendMessage(contains("PEVA/RAVA"), eq(SAVINGS));
+  }
+
+  @Test
+  void pevaRava_alert_onSep1_whenBusinessDay() {
+    // 2026-09-01 = Tuesday (business day)
+    var job = jobOn("2026-09-01T08:00:00Z");
+    stubThresholdLenient(ONE_MILLION);
+    stubTkf100SubscriptionsLenient(ZERO);
+    stubTkf100RedemptionsLenient(List.of());
+    stubNavLenient(NAV);
+
+    job.onFundPositionsImported(new FundPositionsImported());
+
+    verify(notificationService).sendMessage(contains("PEVA/RAVA"), eq(SAVINGS));
+  }
+
+  @Test
+  void pevaRava_noAlert_onRegularDay() {
+    // 2026-03-10 = Tuesday, no PEVA/RAVA
+    var job = jobOn("2026-03-10T08:00:00Z");
+    stubThreshold(ONE_MILLION);
+    stubTkf100Subscriptions(ZERO);
+    stubTkf100Redemptions(List.of());
+
+    job.onFundPositionsImported(new FundPositionsImported());
+
+    verify(notificationService, never()).sendMessage(contains("PEVA/RAVA"), eq(SAVINGS));
+  }
+
+  // --- R16 booking day (15th of month) ---
+
+  @Test
+  void r16_alert_on15thOfMonth() {
+    // 2026-03-16 = Monday (March 15 is Sunday → adjusted to Monday 16th)
+    var job = jobOn("2026-03-16T08:00:00Z");
+    stubThresholdLenient(ONE_MILLION);
+    stubTkf100SubscriptionsLenient(ZERO);
+    stubTkf100RedemptionsLenient(List.of());
+    stubNavLenient(NAV);
+
+    job.onFundPositionsImported(new FundPositionsImported());
+
+    verify(notificationService).sendMessage(contains("R16"), eq(SAVINGS));
+  }
+
+  @Test
+  void r16_alert_on15thWhenBusinessDay() {
+    // 2026-04-15 = Wednesday (business day, 15th is directly the booking day)
+    var job = jobOn("2026-04-15T08:00:00Z");
+    stubThresholdLenient(ONE_MILLION);
+    stubTkf100SubscriptionsLenient(ZERO);
+    stubTkf100RedemptionsLenient(List.of());
+    stubNavLenient(NAV);
+
+    job.onFundPositionsImported(new FundPositionsImported());
+
+    verify(notificationService).sendMessage(contains("R16"), eq(SAVINGS));
+  }
+
+  @Test
+  void r16_noAlert_on16thWhen15thIsBusinessDay() {
+    // 2026-04-16 = Thursday (15th was Wednesday = biz day, so 16th is NOT booking day)
+    var job = jobOn("2026-04-16T08:00:00Z");
+    stubThreshold(ONE_MILLION);
+    stubTkf100Subscriptions(ZERO);
+    stubTkf100Redemptions(List.of());
+
+    job.onFundPositionsImported(new FundPositionsImported());
+
+    verify(notificationService, never()).sendMessage(contains("R16"), eq(SAVINGS));
+  }
+
+  @Test
+  void r16_noAlert_onRegularDay() {
+    // 2026-03-10 = Tuesday, not near 15th
+    var job = jobOn("2026-03-10T08:00:00Z");
+    stubThreshold(ONE_MILLION);
+    stubTkf100Subscriptions(ZERO);
+    stubTkf100Redemptions(List.of());
+
+    job.onFundPositionsImported(new FundPositionsImported());
+
+    verify(notificationService, never()).sendMessage(contains("R16"), eq(SAVINGS));
+  }
+
+  // --- Exception isolation ---
+
+  @Test
+  void exceptionInTkf100_doesNotBlockPensionFundAlerts() {
+    // 2026-01-02 = PEVA/RAVA execution date
+    var job = jobOn("2026-01-02T08:00:00Z");
+    given(investmentParameterRepository.findLatestValue(any(), any(LocalDate.class)))
+        .willThrow(new RuntimeException("DB down"));
+
+    job.onFundPositionsImported(new FundPositionsImported());
+
+    verify(notificationService).sendMessage(contains("PEVA/RAVA"), eq(SAVINGS));
+  }
+
+  // --- Idempotency ---
+
+  @Test
+  void duplicateEvent_sameDay_doesNotSendAlertTwice() {
+    // 2026-01-02 = PEVA/RAVA execution date
+    var job = jobOn("2026-01-02T08:00:00Z");
+    stubThresholdLenient(ONE_MILLION);
+    stubTkf100SubscriptionsLenient(ZERO);
+    stubTkf100RedemptionsLenient(List.of());
+    stubNavLenient(NAV);
+
+    job.onFundPositionsImported(new FundPositionsImported());
+    job.onFundPositionsImported(new FundPositionsImported());
+
+    verify(notificationService).sendMessage(contains("PEVA/RAVA"), eq(SAVINGS));
+  }
+
+  // --- NAV failure fallback ---
+
+  @Test
+  void tkf100_fallsBackToRequestedAmount_whenNavLookupFails() {
+    // 2026-03-10 = Tuesday
+    var job = jobOn("2026-03-10T08:00:00Z");
+    stubThreshold(new BigDecimal("500"));
+    stubTkf100Subscriptions(ZERO);
+    given(fundNavProvider.getDisplayNav(TulevaFund.TKF100))
+        .willThrow(new IllegalStateException("Stale NAV"));
+    // requestedAmount = 400 * 1.1234 = 449.36 (from redemption helper) → below 500
+    stubTkf100Redemptions(List.of(redemption(new BigDecimal("400"))));
+
+    job.onFundPositionsImported(new FundPositionsImported());
+
+    verify(notificationService, never()).sendMessage(contains("TKF100"), eq(SAVINGS));
+  }
+
+  @Test
+  void tkf100_alertsWithFallbackRedemptionEstimate_whenNavLookupFails() {
+    // 2026-03-10 = Tuesday
+    var job = jobOn("2026-03-10T08:00:00Z");
+    stubThreshold(ONE_MILLION);
+    given(fundNavProvider.getDisplayNav(TulevaFund.TKF100))
+        .willThrow(new IllegalStateException("Stale NAV"));
+    stubTkf100Subscriptions(new BigDecimal("900000"));
+    // requestedAmount = 100000 * 1.1234 = 112340 (fallback), total > 1M
+    stubTkf100Redemptions(List.of(redemption(new BigDecimal("100000"))));
+
+    job.onFundPositionsImported(new FundPositionsImported());
+
+    verify(notificationService).sendMessage(contains("TKF100"), eq(SAVINGS));
+  }
+
+  // --- Cutoff boundary ---
+
+  @Test
+  void tkf100_excludesPaymentsAfterCutoff() {
+    // 2026-03-10 = Tuesday, navDate = 2026-03-09, cutoff = 2026-03-09 16:00 Tallinn = 14:00 UTC
+    var job = jobOn("2026-03-10T08:00:00Z");
+    stubThreshold(new BigDecimal("100"));
+    stubTkf100Redemptions(List.of());
+
+    var beforeCutoff =
+        SavingFundPayment.builder()
+            .amount(new BigDecimal("200"))
+            .receivedBefore(Instant.parse("2026-03-09T12:00:00Z"))
+            .status(RESERVED)
+            .build();
+    var afterCutoff =
+        SavingFundPayment.builder()
+            .amount(new BigDecimal("900000"))
+            .receivedBefore(Instant.parse("2026-03-09T14:00:00Z"))
+            .status(RESERVED)
+            .build();
+    given(savingFundPaymentRepository.findPaymentsWithStatus(RESERVED))
+        .willReturn(List.of(beforeCutoff, afterCutoff));
+
+    job.onFundPositionsImported(new FundPositionsImported());
+
+    verify(notificationService).sendMessage(contains("200.00"), eq(SAVINGS));
+  }
+
+  // --- Helpers ---
+
+  private NavTransactionImpactAlertJob jobOn(String instant) {
+    Clock clock = Clock.fixed(Instant.parse(instant), TALLINN);
+    return new NavTransactionImpactAlertJob(
+        savingFundPaymentRepository,
+        redemptionRequestRepository,
+        fundNavProvider,
+        investmentParameterRepository,
+        notificationService,
+        publicHolidays,
+        clock);
+  }
+
+  private void stubThreshold(BigDecimal value) {
+    given(
+            investmentParameterRepository.findLatestValue(
+                eq(NAV_IMPACT_VOLUME_THRESHOLD), any(LocalDate.class)))
+        .willReturn(value);
+  }
+
+  private void stubThresholdLenient(BigDecimal value) {
+    lenient()
+        .when(
+            investmentParameterRepository.findLatestValue(
+                eq(NAV_IMPACT_VOLUME_THRESHOLD), any(LocalDate.class)))
+        .thenReturn(value);
+  }
+
+  private void stubTkf100Subscriptions(BigDecimal totalAmount) {
+    var payment =
+        SavingFundPayment.builder()
+            .amount(totalAmount)
+            .receivedBefore(Instant.parse("2026-01-01T10:00:00Z"))
+            .status(RESERVED)
+            .build();
+    given(savingFundPaymentRepository.findPaymentsWithStatus(RESERVED))
+        .willReturn(totalAmount.signum() > 0 ? List.of(payment) : List.of());
+  }
+
+  private void stubTkf100SubscriptionsLenient(BigDecimal totalAmount) {
+    var payment =
+        SavingFundPayment.builder()
+            .amount(totalAmount)
+            .receivedBefore(Instant.parse("2026-01-01T10:00:00Z"))
+            .status(RESERVED)
+            .build();
+    lenient()
+        .when(savingFundPaymentRepository.findPaymentsWithStatus(RESERVED))
+        .thenReturn(totalAmount.signum() > 0 ? List.of(payment) : List.of());
+  }
+
+  private void stubTkf100Redemptions(List<RedemptionRequest> redemptions) {
+    given(
+            redemptionRequestRepository.findByStatusAndRequestedAtBefore(
+                eq(VERIFIED), any(Instant.class)))
+        .willReturn(redemptions);
+  }
+
+  private void stubTkf100RedemptionsLenient(List<RedemptionRequest> redemptions) {
+    lenient()
+        .when(
+            redemptionRequestRepository.findByStatusAndRequestedAtBefore(
+                eq(VERIFIED), any(Instant.class)))
+        .thenReturn(redemptions);
+  }
+
+  private void stubNav(BigDecimal nav) {
+    given(fundNavProvider.getDisplayNav(TulevaFund.TKF100)).willReturn(nav);
+  }
+
+  private void stubNavLenient(BigDecimal nav) {
+    lenient().when(fundNavProvider.getDisplayNav(TulevaFund.TKF100)).thenReturn(nav);
+  }
+
+  private RedemptionRequest redemption(BigDecimal fundUnits) {
+    return RedemptionRequest.builder()
+        .userId(1L)
+        .partyId(new PartyId(PartyId.Type.PERSON, "38001010000"))
+        .fundUnits(fundUnits)
+        .requestedAmount(fundUnits.multiply(NAV))
+        .customerIban("EE123456789012345678")
+        .status(VERIFIED)
+        .build();
+  }
+}


### PR DESCRIPTION
## Summary

- Sends morning Slack alerts (SAVINGS channel) when today's NAV calculation has significant financial impact
- **TKF100**: volume-based alert when pending subscriptions + redemptions exceed configurable threshold (default 1M EUR, stored in `investment_parameter` table)
- **Pillar 2 (TUK75/TUK00)**: calendar-based alert on PEVA/RAVA execution dates (Jan 1, May 1, Sep 1 adjusted to business day) — all fund switches and exits settle at this NAV
- **All pension funds**: calendar-based alert on R16 booking day (15th of month adjusted) — fondimaksed + ühekordsed redemptions booked by Pensionikeskus using this NAV
- Triggered by `FundPositionsImported` event (~08:00 when SEB position data arrives), giving 3+ hours before NAV calculation
- Idempotent per day — duplicate events don't re-send alerts
- NAV lookup failure fallback: estimates redemption EUR from `requestedAmount` when `getDisplayNav()` is unavailable
- Date logic based on Andmetöötlusreeglid Lisa 1 (sections 2.1, 2.4, 2.5)

## Test plan

- [x] 17 unit tests covering all scenarios (non-working day, threshold boundary, PEVA/RAVA dates with holiday adjustment, R16 15th with weekend adjustment, exception isolation, idempotency, NAV fallback, cutoff filtering)
- [x] Test coverage: 97.8% instructions, 92.9% branches, 100% methods
- [x] Full test suite passes
- [ ] Deploy to staging — verify alert fires on position import
- [ ] Verify PEVA/RAVA date detection for upcoming Jan 2027 cycle
- [ ] Verify threshold can be adjusted via Metabase (`investment_parameter` table)

🤖 Generated with [Claude Code](https://claude.com/claude-code)