### PR TITLE
TKF #67: lock KYC short-survey → identical onboarding outcome (regression test)

### DIFF
--- a/src/test/groovy/ee/tuleva/onboarding/kyc/survey/KycShortSurveyRegressionTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyc/survey/KycShortSurveyRegressionTest.java
@@ -1,0 +1,157 @@
+package ee.tuleva.onboarding.kyc.survey;
+
+import static ee.tuleva.onboarding.auth.AuthenticatedPersonFixture.authenticatedPersonFromUser;
+import static ee.tuleva.onboarding.auth.UserFixture.sampleUserNonMember;
+import static ee.tuleva.onboarding.auth.authority.Authority.USER;
+import static ee.tuleva.onboarding.party.PartyId.Type.PERSON;
+import static ee.tuleva.onboarding.savings.fund.SavingsFundOnboardingStatus.COMPLETED;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import ee.tuleva.onboarding.kyc.KycCheckPerformedEvent;
+import ee.tuleva.onboarding.kyc.TestKycCheckerConfiguration;
+import ee.tuleva.onboarding.savings.fund.SavingsFundOnboardingRepository;
+import ee.tuleva.onboarding.user.User;
+import ee.tuleva.onboarding.user.UserRepository;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.event.ApplicationEvents;
+import org.springframework.test.context.event.RecordApplicationEvents;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Locks the assumption the TKF company-onboarding (#67) frontend-only approach depends on: a KYC
+ * survey that omits the profile items (INVESTMENT_GOALS, INVESTABLE_ASSETS, SOURCE_OF_INCOME) and
+ * the personal TERMS item is accepted and drives PERSON onboarding to the same COMPLETED outcome as
+ * the full survey.
+ *
+ * <p>Note: the risk level itself is produced by the external SQL function {@code
+ * kyc_ob_assess_user_risk} (deployed from the database-administration repo, not present in this
+ * service's schema), so it is stubbed by {@link TestKycCheckerConfiguration} here. The profile
+ * fields' irrelevance to the risk score is a property of that external function and is out of scope
+ * for this service test. What this test guarantees is the service-side contract: no validation
+ * requires the profile items, and the downstream onboarding-completion path is agnostic to them.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@RecordApplicationEvents
+@Import(TestKycCheckerConfiguration.class)
+class KycShortSurveyRegressionTest {
+
+  @Autowired private MockMvc mockMvc;
+  @Autowired private KycSurveyRepository kycSurveyRepository;
+  @Autowired private SavingsFundOnboardingRepository savingsFundOnboardingRepository;
+  @Autowired private UserRepository userRepository;
+  @Autowired private ApplicationEvents applicationEvents;
+
+  private User user;
+  private Authentication authentication;
+
+  private static final String SHORT_SURVEY =
+      """
+      {
+        "answers": [
+          { "type": "CITIZENSHIP", "value": { "type": "COUNTRIES", "value": ["EE"] } },
+          {
+            "type": "ADDRESS",
+            "value": {
+              "type": "ADDRESS",
+              "value": {
+                "street": "123 Main St",
+                "city": "Tallinn",
+                "postalCode": "10115",
+                "countryCode": "EE"
+              }
+            }
+          },
+          { "type": "EMAIL", "value": { "type": "TEXT", "value": "test@example.com" } },
+          { "type": "PHONE_NUMBER", "value": { "type": "TEXT", "value": "+37255555555" } },
+          { "type": "PEP_SELF_DECLARATION", "value": { "type": "OPTION", "value": "IS_NOT_PEP" } }
+        ]
+      }
+      """;
+
+  private static final String FULL_SURVEY =
+      """
+      {
+        "answers": [
+          { "type": "CITIZENSHIP", "value": { "type": "COUNTRIES", "value": ["EE"] } },
+          {
+            "type": "ADDRESS",
+            "value": {
+              "type": "ADDRESS",
+              "value": {
+                "street": "123 Main St",
+                "city": "Tallinn",
+                "postalCode": "10115",
+                "countryCode": "EE"
+              }
+            }
+          },
+          { "type": "EMAIL", "value": { "type": "TEXT", "value": "test@example.com" } },
+          { "type": "PHONE_NUMBER", "value": { "type": "TEXT", "value": "+37255555555" } },
+          { "type": "PEP_SELF_DECLARATION", "value": { "type": "OPTION", "value": "IS_NOT_PEP" } },
+          { "type": "INVESTMENT_GOALS", "value": { "type": "OPTION", "value": "LONG_TERM" } },
+          { "type": "INVESTABLE_ASSETS", "value": { "type": "OPTION", "value": "LESS_THAN_20K" } },
+          { "type": "SOURCE_OF_INCOME", "value": [ { "type": "OPTION", "value": "SALARY" } ] },
+          { "type": "TERMS", "value": { "type": "OPTION", "value": "ACCEPTED" } }
+        ]
+      }
+      """;
+
+  @BeforeEach
+  void setUp() {
+    user = userRepository.save(sampleUserNonMember().id(null).personalCode("48805051231").build());
+    var authPerson = authenticatedPersonFromUser(user).build();
+    authentication =
+        new UsernamePasswordAuthenticationToken(
+            authPerson, null, List.of(new SimpleGrantedAuthority(USER)));
+  }
+
+  @Test
+  void shortSurvey_omittingProfileItems_isAcceptedAndCompletesPersonOnboarding() throws Exception {
+    submitSurvey(SHORT_SURVEY);
+
+    var surveys = kycSurveyRepository.findAll();
+    assertThat(surveys).hasSize(1);
+    assertThat(surveys.getFirst().getSurvey().answers()).hasSize(5);
+
+    assertThat(applicationEvents.stream(KycCheckPerformedEvent.class).toList()).hasSize(1);
+    assertThat(savingsFundOnboardingRepository.findStatus(user.getPersonalCode(), PERSON))
+        .contains(COMPLETED);
+  }
+
+  @Test
+  void fullSurvey_completesPersonOnboarding_identicallyToShortSurvey() throws Exception {
+    submitSurvey(FULL_SURVEY);
+
+    assertThat(applicationEvents.stream(KycCheckPerformedEvent.class).toList()).hasSize(1);
+    assertThat(savingsFundOnboardingRepository.findStatus(user.getPersonalCode(), PERSON))
+        .contains(COMPLETED);
+  }
+
+  private void submitSurvey(String body) throws Exception {
+    mockMvc
+        .perform(
+            post("/v1/kyc/surveys")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body)
+                .with(csrf())
+                .with(authentication(authentication)))
+        .andExpect(status().isOk());
+  }
+}


### PR DESCRIPTION
## What

Adds `KycShortSurveyRegressionTest` — a `@SpringBootTest` integration test that locks the assumption the [TKF company-onboarding (#67)](https://github.com/TulevaEE/TKF-VPII2026/issues/67) **frontend-only** approach depends on:

> A KYC survey that omits the profile items (`INVESTMENT_GOALS`, `INVESTABLE_ASSETS`, `SOURCE_OF_INCOME`) **and** the personal `TERMS` item is accepted and drives PERSON onboarding to the **same `COMPLETED` outcome** as the full survey.

This is the "company-only person = no profile" invariant Codex flagged: it must be test-locked, not optional. The whole frontend-only plan rests on the backend not requiring profile answers.

## Why

The frontend will let a "only via company" user skip the profile + personal-terms steps and submit a shorter `POST /v1/kyc/surveys` payload. This test proves the backend already accepts that and completes PERSON onboarding exactly as today — so no backend change is needed, and the contract can't silently regress.

## How

- Posts a **short** survey (citizenship, address, email, phone, PEP — no profile, no terms) → asserts `200`, survey persisted (5 answers), `KycCheckPerformedEvent` fired, PERSON status `COMPLETED`.
- Posts a **full** survey → asserts the identical `COMPLETED` outcome.

**No production code change.** Confirmed green locally without touching prod code, which is the expected result (the assumption holds).

## Honest caveat (in the test's Javadoc)

The risk level itself is produced by the external `kyc_ob_assess_user_risk` SQL function (deployed from `database-administration`, not in this service's schema), so it's stubbed by `TestKycChecker`. The profile fields' irrelevance to the *risk score* is a property of that external function and out of scope here. What this test guarantees is the **service-side contract**: no validation requires the profile items and the onboarding-completion path is agnostic to them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)