### PR TITLE
Name the related persons with incomplete KYC in KYB validation error

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/kyb/RelatedPersonsKycMetadata.java
+++ b/src/main/java/ee/tuleva/onboarding/kyb/RelatedPersonsKycMetadata.java
@@ -1,0 +1,40 @@
+package ee.tuleva.onboarding.kyb;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+public final class RelatedPersonsKycMetadata {
+
+  private static final String INCOMPLETE_PERSONS = "incompletePersons";
+  private static final String PERSONAL_CODE = "personalCode";
+  private static final String KYC_STATUS = "kycStatus";
+
+  private RelatedPersonsKycMetadata() {}
+
+  public static Map<String, Object> forIncompletePersons(List<KybRelatedPerson> incomplete) {
+    if (incomplete.isEmpty()) {
+      return Map.of();
+    }
+    var persons =
+        incomplete.stream()
+            .map(
+                person ->
+                    Map.of(
+                        PERSONAL_CODE, person.personalCode().toString(),
+                        KYC_STATUS, person.kycStatus().name()))
+            .toList();
+    return Map.of(INCOMPLETE_PERSONS, persons);
+  }
+
+  @SuppressWarnings("unchecked")
+  public static List<String> incompletePersonalCodes(KybCheck check) {
+    var persons =
+        (List<Map<String, Object>>) check.metadata().getOrDefault(INCOMPLETE_PERSONS, List.of());
+    return persons.stream()
+        .map(person -> person.get(PERSONAL_CODE))
+        .filter(Objects::nonNull)
+        .map(String::valueOf)
+        .toList();
+  }
+}

--- a/src/main/java/ee/tuleva/onboarding/kyb/screener/RelatedPersonsKycScreener.java
+++ b/src/main/java/ee/tuleva/onboarding/kyb/screener/RelatedPersonsKycScreener.java
@@ -5,9 +5,8 @@ import static ee.tuleva.onboarding.kyb.KybKycStatus.COMPLETED;
 
 import ee.tuleva.onboarding.kyb.KybCheck;
 import ee.tuleva.onboarding.kyb.KybCompanyData;
-import ee.tuleva.onboarding.kyb.KybRelatedPerson;
+import ee.tuleva.onboarding.kyb.RelatedPersonsKycMetadata;
 import java.util.List;
-import java.util.Map;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -19,21 +18,9 @@ public class RelatedPersonsKycScreener implements KybScreener {
         companyData.relatedPersons().stream().filter(p -> p.kycStatus() != COMPLETED).toList();
 
     return List.of(
-        new KybCheck(RELATED_PERSONS_KYC, incomplete.isEmpty(), buildMetadata(incomplete)));
-  }
-
-  private Map<String, Object> buildMetadata(List<KybRelatedPerson> incomplete) {
-    if (incomplete.isEmpty()) {
-      return Map.of();
-    }
-    var incompletePersons =
-        incomplete.stream()
-            .map(
-                p ->
-                    Map.of(
-                        "personalCode", p.personalCode().toString(),
-                        "kycStatus", p.kycStatus().name()))
-            .toList();
-    return Map.of("incompletePersons", incompletePersons);
+        new KybCheck(
+            RELATED_PERSONS_KYC,
+            incomplete.isEmpty(),
+            RelatedPersonsKycMetadata.forIncompletePersons(incomplete)));
   }
 }

--- a/src/main/java/ee/tuleva/onboarding/kyb/survey/KybSurveyService.java
+++ b/src/main/java/ee/tuleva/onboarding/kyb/survey/KybSurveyService.java
@@ -12,6 +12,7 @@ import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.mapping;
 import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toMap;
 
 import ee.tuleva.onboarding.ariregister.CompanyDetail;
 import ee.tuleva.onboarding.ariregister.CompanyRelationship;
@@ -47,15 +48,14 @@ class KybSurveyService {
 
   private record FieldError(String field, String message) {}
 
-  private static FieldError fieldErrorFor(KybCheckType type) {
-    return switch (type) {
+  private static FieldError fieldErrorFor(KybCheck check, Map<String, String> namesByPersonalCode) {
+    return switch (check.type()) {
       case COMPANY_ACTIVE -> new FieldError("status", "Ettevõte ei ole aktiivne");
       case HIGH_RISK_NACE -> new FieldError("naceCode", "See tegevusala ei ole toetatud");
       case COMPANY_SANCTION -> new FieldError("name", "Ettevõtet ei ole võimalik teenindada");
       case COMPANY_PEP -> new FieldError("name", "Ettevõtet ei ole võimalik teenindada");
       case RELATED_PERSONS_KYC ->
-          new FieldError(
-              "relatedPersons", "Seotud isikute isikusamasuse tuvastamine on lõpetamata");
+          new FieldError("relatedPersons", relatedPersonsKycMessage(check, namesByPersonalCode));
       case COMPANY_LEGAL_FORM -> new FieldError("legalForm", "Ainult OÜ on toetatud");
       case COMPANY_REGISTERED_IN_ESTONIA ->
           new FieldError("address", "Ettevõte ei ole registreeritud Eestis");
@@ -66,6 +66,22 @@ class KybSurveyService {
           new FieldError("relatedPersons", "Ettevõtte omandistruktuur ei ole toetatud");
       case DATA_CHANGED, SELF_CERTIFICATION -> null;
     };
+  }
+
+  @SuppressWarnings("unchecked")
+  private static String relatedPersonsKycMessage(
+      KybCheck check, Map<String, String> namesByPersonalCode) {
+    var baseMessage = "Isikusamasuse tuvastamine on lõpetamata";
+    var incompletePersons =
+        (List<Map<String, String>>) check.metadata().getOrDefault("incompletePersons", List.of());
+    var names =
+        incompletePersons.stream()
+            .map(person -> person.get("personalCode"))
+            .filter(Objects::nonNull)
+            .map(personalCode -> namesByPersonalCode.getOrDefault(personalCode, personalCode))
+            .distinct()
+            .collect(joining(", "));
+    return names.isBlank() ? baseMessage : baseMessage + ": " + names;
   }
 
   private static String blockedReasonMessage(BlockedReason reason) {
@@ -234,7 +250,21 @@ class KybSurveyService {
       List<KybCheck> checks,
       Optional<String> onboardingError) {
 
-    var errorsByField = collectErrorsByField(checks);
+    var relatedPersons =
+        relationships.stream()
+            .map(r -> new RelatedPersonData(r.personalCode(), formatName(r)))
+            .collect(groupingBy(RelatedPersonData::personalCode))
+            .values()
+            .stream()
+            .map(List::getFirst)
+            .toList();
+
+    var namesByPersonalCode =
+        relatedPersons.stream()
+            .filter(person -> person.personalCode() != null && person.name() != null)
+            .collect(toMap(RelatedPersonData::personalCode, RelatedPersonData::name, (a, b) -> a));
+
+    var errorsByField = collectErrorsByField(checks, namesByPersonalCode);
 
     var nameErrors = new ArrayList<>(errorsByField.getOrDefault("name", List.of()));
     onboardingError.ifPresent(nameErrors::add);
@@ -245,15 +275,6 @@ class KybSurveyService {
             .map(CompanyStatus::valueOf)
             .map(LegalEntityStatus::fromCompanyStatus)
             .orElse(null);
-
-    var relatedPersons =
-        relationships.stream()
-            .map(r -> new RelatedPersonData(r.personalCode(), formatName(r)))
-            .collect(groupingBy(RelatedPersonData::personalCode))
-            .values()
-            .stream()
-            .map(List::getFirst)
-            .toList();
 
     return new LegalEntityData(
         validatedField(detail.getName(), nameErrors),
@@ -271,10 +292,11 @@ class KybSurveyService {
         validatedField(relatedPersons, errorsByField.getOrDefault("relatedPersons", List.of())));
   }
 
-  private static Map<String, List<String>> collectErrorsByField(List<KybCheck> checks) {
+  private static Map<String, List<String>> collectErrorsByField(
+      List<KybCheck> checks, Map<String, String> namesByPersonalCode) {
     return checks.stream()
         .filter(check -> !check.success())
-        .map(check -> fieldErrorFor(check.type()))
+        .map(check -> fieldErrorFor(check, namesByPersonalCode))
         .filter(Objects::nonNull)
         .collect(groupingBy(FieldError::field, mapping(FieldError::message, toList())));
   }

--- a/src/main/java/ee/tuleva/onboarding/kyb/survey/KybSurveyService.java
+++ b/src/main/java/ee/tuleva/onboarding/kyb/survey/KybSurveyService.java
@@ -8,6 +8,7 @@ import static ee.tuleva.onboarding.kyb.survey.BlockedReason.NO_WHITELIST_AFTER_C
 import static ee.tuleva.onboarding.party.PartyId.Type.LEGAL_ENTITY;
 import static ee.tuleva.onboarding.savings.fund.SavingsFundOnboardingStatus.REJECTED;
 import static ee.tuleva.onboarding.savings.fund.SavingsFundOnboardingStatus.WHITELISTED;
+import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.mapping;
@@ -48,14 +49,14 @@ class KybSurveyService {
 
   private record FieldError(String field, String message) {}
 
-  private static FieldError fieldErrorFor(KybCheck check, Map<String, String> namesByPersonalCode) {
+  private static FieldError fieldErrorFor(KybCheck check, List<RelatedPersonData> relatedPersons) {
     return switch (check.type()) {
       case COMPANY_ACTIVE -> new FieldError("status", "Ettevõte ei ole aktiivne");
       case HIGH_RISK_NACE -> new FieldError("naceCode", "See tegevusala ei ole toetatud");
       case COMPANY_SANCTION -> new FieldError("name", "Ettevõtet ei ole võimalik teenindada");
       case COMPANY_PEP -> new FieldError("name", "Ettevõtet ei ole võimalik teenindada");
       case RELATED_PERSONS_KYC ->
-          new FieldError("relatedPersons", relatedPersonsKycMessage(check, namesByPersonalCode));
+          new FieldError("relatedPersons", relatedPersonsKycMessage(check, relatedPersons));
       case COMPANY_LEGAL_FORM -> new FieldError("legalForm", "Ainult OÜ on toetatud");
       case COMPANY_REGISTERED_IN_ESTONIA ->
           new FieldError("address", "Ettevõte ei ole registreeritud Eestis");
@@ -68,16 +69,15 @@ class KybSurveyService {
     };
   }
 
-  @SuppressWarnings("unchecked")
   private static String relatedPersonsKycMessage(
-      KybCheck check, Map<String, String> namesByPersonalCode) {
+      KybCheck check, List<RelatedPersonData> relatedPersons) {
     var baseMessage = "Isikusamasuse tuvastamine on lõpetamata";
-    var incompletePersons =
-        (List<Map<String, String>>) check.metadata().getOrDefault("incompletePersons", List.of());
+    var namesByPersonalCode =
+        relatedPersons.stream()
+            .filter(person -> person.personalCode() != null && person.name() != null)
+            .collect(toMap(RelatedPersonData::personalCode, RelatedPersonData::name, (a, b) -> a));
     var names =
-        incompletePersons.stream()
-            .map(person -> person.get("personalCode"))
-            .filter(Objects::nonNull)
+        RelatedPersonsKycMetadata.incompletePersonalCodes(check).stream()
             .map(personalCode -> namesByPersonalCode.getOrDefault(personalCode, personalCode))
             .distinct()
             .collect(joining(", "));
@@ -250,21 +250,9 @@ class KybSurveyService {
       List<KybCheck> checks,
       Optional<String> onboardingError) {
 
-    var relatedPersons =
-        relationships.stream()
-            .map(r -> new RelatedPersonData(r.personalCode(), formatName(r)))
-            .collect(groupingBy(RelatedPersonData::personalCode))
-            .values()
-            .stream()
-            .map(List::getFirst)
-            .toList();
+    var relatedPersons = dedupedByPersonalCode(relationships);
 
-    var namesByPersonalCode =
-        relatedPersons.stream()
-            .filter(person -> person.personalCode() != null && person.name() != null)
-            .collect(toMap(RelatedPersonData::personalCode, RelatedPersonData::name, (a, b) -> a));
-
-    var errorsByField = collectErrorsByField(checks, namesByPersonalCode);
+    var errorsByField = collectErrorsByField(checks, relatedPersons);
 
     var nameErrors = new ArrayList<>(errorsByField.getOrDefault("name", List.of()));
     onboardingError.ifPresent(nameErrors::add);
@@ -292,11 +280,22 @@ class KybSurveyService {
         validatedField(relatedPersons, errorsByField.getOrDefault("relatedPersons", List.of())));
   }
 
+  private static List<RelatedPersonData> dedupedByPersonalCode(
+      List<CompanyRelationship> relationships) {
+    return relationships.stream()
+        .map(r -> new RelatedPersonData(r.personalCode(), formatName(r)))
+        .collect(
+            toMap(RelatedPersonData::personalCode, identity(), (a, b) -> a, LinkedHashMap::new))
+        .values()
+        .stream()
+        .toList();
+  }
+
   private static Map<String, List<String>> collectErrorsByField(
-      List<KybCheck> checks, Map<String, String> namesByPersonalCode) {
+      List<KybCheck> checks, List<RelatedPersonData> relatedPersons) {
     return checks.stream()
         .filter(check -> !check.success())
-        .map(check -> fieldErrorFor(check, namesByPersonalCode))
+        .map(check -> fieldErrorFor(check, relatedPersons))
         .filter(Objects::nonNull)
         .collect(groupingBy(FieldError::field, mapping(FieldError::message, toList())));
   }

--- a/src/test/groovy/ee/tuleva/onboarding/kyb/survey/KybSurveyServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyb/survey/KybSurveyServiceTest.java
@@ -132,6 +132,69 @@ class KybSurveyServiceTest {
   }
 
   @Test
+  void initialValidation_namesRelatedPersonsWithIncompleteKyc() {
+    var relationships =
+        List.of(
+            new CompanyRelationship(
+                "F",
+                "JUHL",
+                "Juhatuse liige",
+                "Jaan",
+                "Tamm",
+                PERSONAL_CODE,
+                null,
+                null,
+                null,
+                new BigDecimal("34.00"),
+                null,
+                "EST"),
+            new CompanyRelationship(
+                "F",
+                "OSANIK",
+                "Osanik",
+                "Mari",
+                "Maasikas",
+                "38501010003",
+                null,
+                null,
+                null,
+                new BigDecimal("33.00"),
+                null,
+                "EST"),
+            new CompanyRelationship(
+                "F",
+                "OSANIK",
+                "Osanik",
+                "Peeter",
+                "Kask",
+                "38501010004",
+                null,
+                null,
+                null,
+                new BigDecimal("33.00"),
+                null,
+                "EST"));
+    stubInitialValidation(
+        relationships,
+        sampleDetail(),
+        List.of(
+            new KybCheck(COMPANY_ACTIVE, true, Map.of()),
+            new KybCheck(
+                RELATED_PERSONS_KYC,
+                false,
+                Map.of(
+                    "incompletePersons",
+                    List.of(
+                        Map.of("personalCode", "38501010003", "kycStatus", "PENDING"),
+                        Map.of("personalCode", "38501010004", "kycStatus", "UNKNOWN"))))));
+
+    var result = service.initialValidation(REGISTRY_CODE, PERSONAL_CODE);
+
+    assertThat(result.relatedPersons().errors())
+        .containsExactly("Isikusamasuse tuvastamine on lõpetamata: Mari Maasikas, Peeter Kask");
+  }
+
+  @Test
   void initialValidation_returnsAddressErrorWhenNotRegisteredInEstonia() {
     stubInitialValidation(
         sampleRelationships(),


### PR DESCRIPTION
## What & why

Fixes the copy of the KYB validation error shown when a legal entity's related persons (shareholders / beneficial owners) haven't finished KYC — `TulevaEE/TKF-VPII2026#60`.

Today the `relatedPersons` field error (returned by `GET /v1/kyb/surveys/initial-validation`, rendered as a bullet in the frontend `RequirementsCheckStep`) is a single generic line:

> Seotud isikute isikusamasuse tuvastamine on lõpetamata

It doesn't say **who** still needs to verify their identity — confusing especially when more than one person is incomplete (the issue's "kaks osanikku" case).

## Change

The data to name them already exists: `RelatedPersonsKycScreener` records each incomplete person's personal code in the check metadata (`incompletePersons`), and the names come from the business-registry relationships. This PR joins them by personal code:

**Before**
> Seotud isikute isikusamasuse tuvastamine on lõpetamata

**After** (e.g. two incomplete)
> Isikusamasuse tuvastamine on lõpetamata: Mari Maasikas, Peeter Kask

Falls back to the generic line (no names) if none resolve. Per request, the word **"osanikud"** is intentionally avoided (related persons can also be beneficial owners, not only shareholders).

## Wording — please confirm @karoliina-tuleva

I implemented option **A**; happy to switch:

- **A (this PR):** `Isikusamasuse tuvastamine on lõpetamata: Mari Maasikas, Peeter Kask`
- **B:** `Isikusamasus on tuvastamata: Mari Maasikas, Peeter Kask`
- **C:** `Need isikud ei ole veel isikusamasust tuvastanud: Mari Maasikas, Peeter Kask`

The colon-list form is grammar-safe for 1 or N people (no singular/plural agreement issues).

## Out of scope (flagging for a follow-up)

The frontend lists this message under the header **"Sinu osaühing ei vasta hetkel meie reeglitele"** ("your company doesn't meet our rules"). Incomplete KYC is temporary/fixable, not a disqualification, so the header reads too harsh — worth splitting in a separate frontend ticket. This PR only changes the message text.

## Testing

- Added `KybSurveyServiceTest.initialValidation_namesRelatedPersonsWithIncompleteKyc`.
- `./gradlew test --tests "*KybSurveyServiceTest"` → green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
