### PR TITLE
Extract withdrawal Slack notification into WithdrawalNotifier (AML #45 M0)

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/aml/WithdrawalNotifier.java
+++ b/src/main/java/ee/tuleva/onboarding/aml/WithdrawalNotifier.java
@@ -1,0 +1,25 @@
+package ee.tuleva.onboarding.aml;
+
+import static ee.tuleva.onboarding.notification.OperationsNotificationService.Channel.WITHDRAWALS;
+
+import ee.tuleva.onboarding.mandate.MandateType;
+import ee.tuleva.onboarding.notification.OperationsNotificationService;
+import ee.tuleva.onboarding.pillar.Pillar;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class WithdrawalNotifier {
+
+  private final OperationsNotificationService notificationService;
+
+  public void notifyWithdrawalBatchCreated(
+      int age, Set<Pillar> pillars, Set<MandateType> withdrawalTypes, Long mandateBatchId) {
+    notificationService.sendMessage(
+        "Withdrawal mandate batch created: age=%s, pillars=%s, withdrawalTypes=%s, mandateBatchId=%s"
+            .formatted(age, pillars, withdrawalTypes, mandateBatchId),
+        WITHDRAWALS);
+  }
+}

--- a/src/main/java/ee/tuleva/onboarding/mandate/batch/MandateBatchService.java
+++ b/src/main/java/ee/tuleva/onboarding/mandate/batch/MandateBatchService.java
@@ -1,11 +1,11 @@
 package ee.tuleva.onboarding.mandate.batch;
 
-import static ee.tuleva.onboarding.notification.OperationsNotificationService.Channel.WITHDRAWALS;
 import static ee.tuleva.onboarding.pillar.Pillar.SECOND;
 import static ee.tuleva.onboarding.signature.response.SignatureStatus.OUTSTANDING_TRANSACTION;
 import static ee.tuleva.onboarding.signature.response.SignatureStatus.SIGNATURE;
 import static java.util.stream.Collectors.toList;
 
+import ee.tuleva.onboarding.aml.WithdrawalNotifier;
 import ee.tuleva.onboarding.auth.principal.AuthenticatedPerson;
 import ee.tuleva.onboarding.epis.EpisService;
 import ee.tuleva.onboarding.error.response.ErrorResponse;
@@ -18,7 +18,6 @@ import ee.tuleva.onboarding.mandate.exception.MandateProcessingException;
 import ee.tuleva.onboarding.mandate.generic.GenericMandateService;
 import ee.tuleva.onboarding.mandate.generic.MandateDto;
 import ee.tuleva.onboarding.mandate.processor.MandateProcessorService;
-import ee.tuleva.onboarding.notification.OperationsNotificationService;
 import ee.tuleva.onboarding.signature.SignatureFile;
 import ee.tuleva.onboarding.signature.SignatureService;
 import ee.tuleva.onboarding.signature.idcard.IdCardSignatureSession;
@@ -51,7 +50,7 @@ public class MandateBatchService {
   private final MandateProcessorService mandateProcessor;
   private final EpisService episService;
   private final MandateBatchProcessingPoller mandateBatchProcessingPoller;
-  private final OperationsNotificationService notificationService;
+  private final WithdrawalNotifier withdrawalNotifier;
 
   public Optional<MandateBatch> getByIdAndUser(Long id, User user) {
     var batch =
@@ -114,10 +113,8 @@ public class MandateBatchService {
               .map(MandateDto::getMandateType)
               .collect(Collectors.toSet());
 
-      notificationService.sendMessage(
-          "Withdrawal mandate batch created: age=%s, pillars=%s, withdrawalTypes=%s, mandateBatchId=%s"
-              .formatted(age, pillars, withdrawalTypes, mandateBatch.getId()),
-          WITHDRAWALS);
+      withdrawalNotifier.notifyWithdrawalBatchCreated(
+          age, pillars, withdrawalTypes, mandateBatch.getId());
     } catch (Exception e) {
       log.error("Failed to send mandate batch slack message with exception", e);
     }

--- a/src/test/groovy/ee/tuleva/onboarding/aml/WithdrawalNotifierTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/aml/WithdrawalNotifierTest.java
@@ -1,0 +1,53 @@
+package ee.tuleva.onboarding.aml;
+
+import static ee.tuleva.onboarding.mandate.MandateType.FUND_PENSION_OPENING;
+import static ee.tuleva.onboarding.notification.OperationsNotificationService.Channel.WITHDRAWALS;
+import static ee.tuleva.onboarding.pillar.Pillar.SECOND;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+
+import ee.tuleva.onboarding.notification.OperationsNotificationService;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class WithdrawalNotifierTest {
+
+  private OperationsNotificationService notificationService;
+  private WithdrawalNotifier notifier;
+
+  @BeforeEach
+  void setUp() {
+    notificationService = Mockito.mock(OperationsNotificationService.class);
+    notifier = new WithdrawalNotifier(notificationService);
+  }
+
+  @Test
+  @DisplayName("sends a withdrawal batch created Slack message to the withdrawals channel")
+  void notifyWithdrawalBatchCreated_sendsSlackMessage() {
+    notifier.notifyWithdrawalBatchCreated(65, Set.of(SECOND), Set.of(FUND_PENSION_OPENING), 42L);
+
+    verify(notificationService)
+        .sendMessage(
+            "Withdrawal mandate batch created: age=65, pillars=[SECOND], withdrawalTypes=[FUND_PENSION_OPENING], mandateBatchId=42",
+            WITHDRAWALS);
+  }
+
+  @Test
+  @DisplayName("does not silently swallow a Slack send failure")
+  void notifyWithdrawalBatchCreated_whenSlackFails_propagatesException() {
+    doThrow(new IllegalStateException("Slack down"))
+        .when(notificationService)
+        .sendMessage(any(), any());
+
+    assertThatThrownBy(
+            () ->
+                notifier.notifyWithdrawalBatchCreated(
+                    65, Set.of(SECOND), Set.of(FUND_PENSION_OPENING), 42L))
+        .isInstanceOf(IllegalStateException.class);
+  }
+}

--- a/src/test/groovy/ee/tuleva/onboarding/mandate/batch/MandateBatchServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/mandate/batch/MandateBatchServiceTest.java
@@ -2,9 +2,10 @@ package ee.tuleva.onboarding.mandate.batch;
 
 import static ee.tuleva.onboarding.auth.UserFixture.sampleUser;
 import static ee.tuleva.onboarding.mandate.MandateFixture.*;
+import static ee.tuleva.onboarding.mandate.MandateType.FUND_PENSION_OPENING;
+import static ee.tuleva.onboarding.mandate.MandateType.PARTIAL_WITHDRAWAL;
 import static ee.tuleva.onboarding.mandate.batch.MandateBatchStatus.INITIALIZED;
 import static ee.tuleva.onboarding.mandate.batch.MandateBatchStatus.SIGNED;
-import static ee.tuleva.onboarding.notification.OperationsNotificationService.Channel.WITHDRAWALS;
 import static ee.tuleva.onboarding.signature.response.SignatureStatus.OUTSTANDING_TRANSACTION;
 import static ee.tuleva.onboarding.signature.response.SignatureStatus.SIGNATURE;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
@@ -12,6 +13,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
+import ee.tuleva.onboarding.aml.WithdrawalNotifier;
 import ee.tuleva.onboarding.auth.AuthenticatedPersonFixture;
 import ee.tuleva.onboarding.epis.EpisService;
 import ee.tuleva.onboarding.error.response.ErrorResponse;
@@ -24,7 +26,6 @@ import ee.tuleva.onboarding.mandate.event.AfterMandateSignedEvent;
 import ee.tuleva.onboarding.mandate.exception.MandateProcessingException;
 import ee.tuleva.onboarding.mandate.generic.GenericMandateService;
 import ee.tuleva.onboarding.mandate.processor.MandateProcessorService;
-import ee.tuleva.onboarding.notification.OperationsNotificationService;
 import ee.tuleva.onboarding.signature.SignatureFile;
 import ee.tuleva.onboarding.signature.SignatureService;
 import ee.tuleva.onboarding.signature.idcard.IdCardSignatureSession;
@@ -40,6 +41,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.NoSuchElementException;
 import java.util.Optional;
+import java.util.Set;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -63,7 +65,7 @@ public class MandateBatchServiceTest {
   @Mock private MandateBatchProcessingPoller mandateBatchProcessingPoller;
   @Mock private EpisService episService;
   @Mock private ApplicationEventPublisher applicationEventPublisher;
-  @Mock private OperationsNotificationService notificationService;
+  @Mock private WithdrawalNotifier withdrawalNotifier;
 
   @Mock private SignatureService signService;
 
@@ -192,16 +194,12 @@ public class MandateBatchServiceTest {
     assertThat(result.getMandates().size()).isEqualTo(2);
     assertThat(result.getStatus()).isEqualTo(INITIALIZED);
 
-    verify(notificationService, times(1))
-        .sendMessage(
-            argThat(
-                message -> {
-                  var age = PersonalCode.getAge(authenticatedPerson.getPersonalCode());
-                  return message.contains("age=" + age)
-                      && message.contains("SECOND")
-                      && message.contains("FUND_PENSION_OPENING");
-                }),
-            eq(WITHDRAWALS));
+    verify(withdrawalNotifier, times(1))
+        .notifyWithdrawalBatchCreated(
+            eq(PersonalCode.getAge(authenticatedPerson.getPersonalCode())),
+            eq(aMandateBatchDto.getWithdrawalBatchPillars()),
+            eq(Set.of(FUND_PENSION_OPENING)),
+            any());
   }
 
   @Test
@@ -242,16 +240,12 @@ public class MandateBatchServiceTest {
     assertThat(result.getMandates().size()).isEqualTo(2);
     assertThat(result.getStatus()).isEqualTo(INITIALIZED);
 
-    verify(notificationService, times(1))
-        .sendMessage(
-            argThat(
-                message -> {
-                  var age = PersonalCode.getAge(authenticatedPerson.getPersonalCode());
-                  return message.contains("age=" + age)
-                      && message.contains("THIRD")
-                      && message.contains("FUND_PENSION_OPENING");
-                }),
-            eq(WITHDRAWALS));
+    verify(withdrawalNotifier, times(1))
+        .notifyWithdrawalBatchCreated(
+            eq(PersonalCode.getAge(authenticatedPerson.getPersonalCode())),
+            eq(aMandateBatchDto.getWithdrawalBatchPillars()),
+            eq(Set.of(FUND_PENSION_OPENING)),
+            any());
   }
 
   @Test
@@ -389,16 +383,12 @@ public class MandateBatchServiceTest {
 
     assertThat(result.getMandates().size()).isEqualTo(1);
     assertThat(result.getStatus()).isEqualTo(INITIALIZED);
-    verify(notificationService, times(1))
-        .sendMessage(
-            argThat(
-                message -> {
-                  var age = PersonalCode.getAge(authenticatedPerson.getPersonalCode());
-                  return message.contains("age=" + age)
-                      && message.contains("THIRD")
-                      && message.contains("PARTIAL_WITHDRAWAL");
-                }),
-            eq(WITHDRAWALS));
+    verify(withdrawalNotifier, times(1))
+        .notifyWithdrawalBatchCreated(
+            eq(PersonalCode.getAge(authenticatedPerson.getPersonalCode())),
+            eq(aMandateBatchDto.getWithdrawalBatchPillars()),
+            eq(Set.of(PARTIAL_WITHDRAWAL)),
+            any());
   }
 
   @Test
@@ -431,7 +421,9 @@ public class MandateBatchServiceTest {
     when(mandateBatchRepository.save(
             argThat(mandateBatch -> mandateBatch.getStatus().equals(INITIALIZED))))
         .thenReturn(aMandateBatch);
-    doThrow(new IllegalStateException()).when(notificationService).sendMessage(any(), any());
+    doThrow(new IllegalStateException())
+        .when(withdrawalNotifier)
+        .notifyWithdrawalBatchCreated(anyInt(), any(), any(), any());
 
     MandateBatch result =
         mandateBatchService.createMandateBatch(authenticatedPerson, aMandateBatchDto);


### PR DESCRIPTION
## What

**M0** of the AML threshold-based Slack notifications plan (TulevaEE/tuleva#45). A **pure refactor — no behavior change.**

Extracts the existing *"Withdrawal mandate batch created"* Slack notification out of `MandateBatchService.createMandateBatch` into a new `ee.tuleva.onboarding.aml.WithdrawalNotifier`.

## Why

- This is the seam the rest of #45 builds on (M1 reshapes this notification; M2/M4 add the III-pillar and TKF threshold alerts).
- The notifier lives in the **`aml` package** so the 100% AML coverage gate applies to it (plan §9 B4).

## Notes

- The `try/catch` in `createMandateBatch` is **kept**, so a Slack failure is still swallowed + logged and batch creation is unaffected — behavior is identical.
- The extracted `WithdrawalNotifier` itself **propagates** exceptions; a new test asserts it does **not** silently swallow a Slack send failure (per the adversarial review note in the plan).
- The Slack message string is moved verbatim (`age=…, pillars=…, withdrawalTypes=…, mandateBatchId=…`).

## TDD

1. RED — `WithdrawalNotifierTest` (send + propagation) fails to compile (no class).
2. GREEN — add `WithdrawalNotifier`.
3. REFACTOR — `MandateBatchService` delegates to it; `MandateBatchServiceTest` updated to mock the notifier.
4. `./gradlew spotlessApply` + full `./gradlew build` green.

Part of TulevaEE/tuleva#45.

🤖 Generated with [Claude Code](https://claude.com/claude-code)