### PR TITLE
Unify withdrawal batch message via formatMessage (AML #45 M1)

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/aml/WithdrawalNotifier.java
+++ b/src/main/java/ee/tuleva/onboarding/aml/WithdrawalNotifier.java
@@ -18,8 +18,12 @@ public class WithdrawalNotifier {
   public void notifyWithdrawalBatchCreated(
       int age, Set<Pillar> pillars, Set<MandateType> withdrawalTypes, Long mandateBatchId) {
     notificationService.sendMessage(
-        "Withdrawal mandate batch created: age=%s, pillars=%s, withdrawalTypes=%s, mandateBatchId=%s"
-            .formatted(age, pillars, withdrawalTypes, mandateBatchId),
-        WITHDRAWALS);
+        formatMessage(age, pillars, withdrawalTypes, mandateBatchId), WITHDRAWALS);
+  }
+
+  String formatMessage(
+      int age, Set<Pillar> pillars, Set<MandateType> withdrawalTypes, Long mandateBatchId) {
+    return "Withdrawal mandate batch created: age=%s, pillars=%s, withdrawalTypes=%s, mandateBatchId=%s"
+        .formatted(age, pillars, withdrawalTypes, mandateBatchId);
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/aml/WithdrawalNotifierTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/aml/WithdrawalNotifierTest.java
@@ -1,8 +1,11 @@
 package ee.tuleva.onboarding.aml;
 
 import static ee.tuleva.onboarding.mandate.MandateType.FUND_PENSION_OPENING;
+import static ee.tuleva.onboarding.mandate.MandateType.PARTIAL_WITHDRAWAL;
 import static ee.tuleva.onboarding.notification.OperationsNotificationService.Channel.WITHDRAWALS;
 import static ee.tuleva.onboarding.pillar.Pillar.SECOND;
+import static ee.tuleva.onboarding.pillar.Pillar.THIRD;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
@@ -35,6 +38,29 @@ class WithdrawalNotifierTest {
         .sendMessage(
             "Withdrawal mandate batch created: age=65, pillars=[SECOND], withdrawalTypes=[FUND_PENSION_OPENING], mandateBatchId=42",
             WITHDRAWALS);
+  }
+
+  @Test
+  @DisplayName("formats a single-pillar single-type withdrawal batch message")
+  void formatMessage_singlePillarSingleType() {
+    String message = notifier.formatMessage(65, Set.of(SECOND), Set.of(FUND_PENSION_OPENING), 42L);
+
+    assertThat(message)
+        .isEqualTo(
+            "Withdrawal mandate batch created: age=65, pillars=[SECOND], withdrawalTypes=[FUND_PENSION_OPENING], mandateBatchId=42");
+  }
+
+  @Test
+  @DisplayName("formats a message covering every pillar and withdrawal type present")
+  void formatMessage_multiplePillarsAndTypes() {
+    String message =
+        notifier.formatMessage(
+            70, Set.of(SECOND, THIRD), Set.of(FUND_PENSION_OPENING, PARTIAL_WITHDRAWAL), 7L);
+
+    assertThat(message)
+        .startsWith("Withdrawal mandate batch created: age=70,")
+        .contains("SECOND", "THIRD", "FUND_PENSION_OPENING", "PARTIAL_WITHDRAWAL")
+        .endsWith("mandateBatchId=7");
   }
 
   @Test

--- a/src/test/groovy/ee/tuleva/onboarding/mandate/batch/MandateBatchIntegrationTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/mandate/batch/MandateBatchIntegrationTest.java
@@ -5,8 +5,13 @@ import static ee.tuleva.onboarding.epis.contact.ContactDetailsFixture.contactDet
 import static ee.tuleva.onboarding.mandate.MandateType.FUND_PENSION_OPENING;
 import static ee.tuleva.onboarding.mandate.MandateType.PARTIAL_WITHDRAWAL;
 import static ee.tuleva.onboarding.mandate.batch.MandateBatchStatus.INITIALIZED;
+import static ee.tuleva.onboarding.notification.OperationsNotificationService.Channel.WITHDRAWALS;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 
@@ -16,6 +21,7 @@ import ee.tuleva.onboarding.epis.cashflows.CashFlowStatement;
 import ee.tuleva.onboarding.mandate.MandateFixture;
 import ee.tuleva.onboarding.mandate.MandateRepository;
 import ee.tuleva.onboarding.mandate.generic.MandateDto;
+import ee.tuleva.onboarding.notification.OperationsNotificationService;
 import ee.tuleva.onboarding.withdrawals.WithdrawalEligibilityDto;
 import ee.tuleva.onboarding.withdrawals.WithdrawalEligibilityService;
 import java.util.List;
@@ -43,6 +49,7 @@ class MandateBatchIntegrationTest {
   @MockitoBean private EpisService episService;
   @MockitoBean private AmlAutoChecker amlAutoChecker;
   @MockitoBean private WithdrawalEligibilityService withdrawalEligibilityService;
+  @MockitoBean private OperationsNotificationService notificationService;
 
   @AfterEach
   void cleanup() {
@@ -134,6 +141,56 @@ class MandateBatchIntegrationTest {
 
     assertCorrectResponse(responseBody);
     assertCanReadMandateBatch();
+  }
+
+  @Test
+  void withdrawalBatchCreationSendsExactlyOneSlackNotificationInUnifiedFormat() {
+    var headers = getHeaders();
+
+    var aDto =
+        MandateBatchDto.builder()
+            .mandates(
+                List.of(
+                    MandateDto.builder()
+                        .details(MandateFixture.aFundPensionOpeningMandateDetails)
+                        .build(),
+                    MandateDto.builder()
+                        .details(MandateFixture.aPartialWithdrawalMandateDetails)
+                        .build()))
+            .build();
+
+    var aWithdrawalEligibility =
+        WithdrawalEligibilityDto.builder()
+            .hasReachedEarlyRetirementAge(true)
+            .canWithdrawThirdPillarWithReducedTax(true)
+            .age(65)
+            .recommendedDurationYears(20)
+            .arrestsOrBankruptciesPresent(false)
+            .build();
+
+    when(withdrawalEligibilityService.getWithdrawalEligibility(any()))
+        .thenReturn(aWithdrawalEligibility);
+    when(episService.getCashFlowStatement(any(), any(), any())).thenReturn(new CashFlowStatement());
+    when(episService.getContactDetails(any())).thenReturn(contactDetailsFixture());
+
+    restTestClient
+        .post()
+        .uri("/v1/mandate-batches")
+        .headers(h -> h.addAll(headers))
+        .body(aDto)
+        .exchange()
+        .expectStatus()
+        .isOk();
+
+    verify(notificationService, times(1))
+        .sendMessage(
+            argThat(
+                message ->
+                    message.startsWith("Withdrawal mandate batch created: age=")
+                        && message.contains("pillars=")
+                        && message.contains("withdrawalTypes=")
+                        && message.contains("mandateBatchId=")),
+            eq(WITHDRAWALS));
   }
 
   @Test


### PR DESCRIPTION
## What

**M1** of the AML threshold-based Slack notifications plan (TulevaEE/tuleva#45). **Stacked on #1673 (M0)** — base branch is `aml-slack-m0-withdrawal-notifier`, so this diff shows only the M1 change. Rebases onto master once M0 merges.

- Extracts a unit-tested `formatMessage(...)` seam in `WithdrawalNotifier` (plan §8 M1: *"Unit-TDD: formatMessage(...)"*); `notifyWithdrawalBatchCreated` delegates to it.
- Adds a full-stack `@SpringBootTest` (`MandateBatchIntegrationTest`) asserting that creating a withdrawal mandate batch emits **exactly one** Slack message in the unified format to `WITHDRAWALS`.

## Honest scope note

The message **content is unchanged**. No amount is available at batch-creation time (`PartialWithdrawalMandateDetails` carries units/%, not money — confirmed by the plan's adversarial review), so M1 is a **structural + coverage** step, not a message-content change. The real III-pillar threshold withdrawal alert (≥ 20 001 €, amount known) lands in **M2** from `analytics.third_pillar_transactions`.

## TDD

1. RED — `formatMessage` unit tests (incl. multi-pillar/multi-type) fail to compile.
2. GREEN — extract `formatMessage`.
3. Integration test characterises the batch-creation → one-Slack-message path.
4. `spotlessApply` + full `./gradlew build` green.

Part of TulevaEE/tuleva#45.

🤖 Generated with [Claude Code](https://claude.com/claude-code)