### PR TITLE
III pillar threshold AML Slack alerts from analytics (AML #45 M2)

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/aml/WithdrawalNotifier.java
+++ b/src/main/java/ee/tuleva/onboarding/aml/WithdrawalNotifier.java
@@ -18,8 +18,12 @@ public class WithdrawalNotifier {
   public void notifyWithdrawalBatchCreated(
       int age, Set<Pillar> pillars, Set<MandateType> withdrawalTypes, Long mandateBatchId) {
     notificationService.sendMessage(
-        "Withdrawal mandate batch created: age=%s, pillars=%s, withdrawalTypes=%s, mandateBatchId=%s"
-            .formatted(age, pillars, withdrawalTypes, mandateBatchId),
-        WITHDRAWALS);
+        formatMessage(age, pillars, withdrawalTypes, mandateBatchId), WITHDRAWALS);
+  }
+
+  String formatMessage(
+      int age, Set<Pillar> pillars, Set<MandateType> withdrawalTypes, Long mandateBatchId) {
+    return "Withdrawal mandate batch created: age=%s, pillars=%s, withdrawalTypes=%s, mandateBatchId=%s"
+        .formatted(age, pillars, withdrawalTypes, mandateBatchId);
   }
 }

--- a/src/main/java/ee/tuleva/onboarding/aml/alert/AmlAlertNotifier.java
+++ b/src/main/java/ee/tuleva/onboarding/aml/alert/AmlAlertNotifier.java
@@ -1,0 +1,28 @@
+package ee.tuleva.onboarding.aml.alert;
+
+import static ee.tuleva.onboarding.notification.OperationsNotificationService.Channel.AML;
+
+import ee.tuleva.onboarding.notification.OperationsNotificationService;
+import ee.tuleva.onboarding.user.User;
+import ee.tuleva.onboarding.user.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AmlAlertNotifier {
+
+  private final OperationsNotificationService notificationService;
+  private final UserService userService;
+
+  @EventListener
+  public void onAmlThresholdAlert(AmlThresholdAlertEvent event) {
+    Long userId =
+        userService.findByPersonalCode(event.getPersonalId()).map(User::getId).orElse(null);
+    notificationService.sendMessage(
+        "AML alert: %s, userId=%s, amount=%s, ref=%s"
+            .formatted(event.getType(), userId, event.getAmount(), event.getReference()),
+        AML);
+  }
+}

--- a/src/main/java/ee/tuleva/onboarding/aml/alert/AmlAlertType.java
+++ b/src/main/java/ee/tuleva/onboarding/aml/alert/AmlAlertType.java
@@ -1,0 +1,9 @@
+package ee.tuleva.onboarding.aml.alert;
+
+public enum AmlAlertType {
+  III_PILLAR_DEPOSIT_EMPLOYER,
+  III_PILLAR_DEPOSIT_PERSON,
+  III_PILLAR_DEPOSIT_TRANSFER,
+  III_PILLAR_DEPOSIT_INSURANCE,
+  III_PILLAR_WITHDRAWAL
+}

--- a/src/main/java/ee/tuleva/onboarding/aml/alert/AmlThirdPillarAlert.java
+++ b/src/main/java/ee/tuleva/onboarding/aml/alert/AmlThirdPillarAlert.java
@@ -1,0 +1,38 @@
+package ee.tuleva.onboarding.aml.alert;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "aml_third_pillar_alert")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AmlThirdPillarAlert {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false)
+  private Long transactionId;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private AmlAlertType alertType;
+
+  @Column(nullable = false)
+  private Instant alertedAt;
+}

--- a/src/main/java/ee/tuleva/onboarding/aml/alert/AmlThirdPillarAlert.java
+++ b/src/main/java/ee/tuleva/onboarding/aml/alert/AmlThirdPillarAlert.java
@@ -27,7 +27,7 @@ public class AmlThirdPillarAlert {
   private Long id;
 
   @Column(nullable = false)
-  private Long transactionId;
+  private String transactionFingerprint;
 
   @Enumerated(EnumType.STRING)
   @Column(nullable = false)

--- a/src/main/java/ee/tuleva/onboarding/aml/alert/AmlThirdPillarAlertRepository.java
+++ b/src/main/java/ee/tuleva/onboarding/aml/alert/AmlThirdPillarAlertRepository.java
@@ -1,0 +1,8 @@
+package ee.tuleva.onboarding.aml.alert;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AmlThirdPillarAlertRepository extends JpaRepository<AmlThirdPillarAlert, Long> {
+
+  boolean existsByTransactionIdAndAlertType(Long transactionId, AmlAlertType alertType);
+}

--- a/src/main/java/ee/tuleva/onboarding/aml/alert/AmlThirdPillarAlertRepository.java
+++ b/src/main/java/ee/tuleva/onboarding/aml/alert/AmlThirdPillarAlertRepository.java
@@ -4,5 +4,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface AmlThirdPillarAlertRepository extends JpaRepository<AmlThirdPillarAlert, Long> {
 
-  boolean existsByTransactionIdAndAlertType(Long transactionId, AmlAlertType alertType);
+  boolean existsByTransactionFingerprintAndAlertType(
+      String transactionFingerprint, AmlAlertType alertType);
 }

--- a/src/main/java/ee/tuleva/onboarding/aml/alert/AmlThresholdAlertEvent.java
+++ b/src/main/java/ee/tuleva/onboarding/aml/alert/AmlThresholdAlertEvent.java
@@ -1,0 +1,23 @@
+package ee.tuleva.onboarding.aml.alert;
+
+import java.math.BigDecimal;
+import lombok.Getter;
+import org.springframework.context.ApplicationEvent;
+
+@Getter
+public class AmlThresholdAlertEvent extends ApplicationEvent {
+
+  private final AmlAlertType type;
+  private final String personalId;
+  private final BigDecimal amount;
+  private final String reference;
+
+  public AmlThresholdAlertEvent(
+      Object source, AmlAlertType type, String personalId, BigDecimal amount, String reference) {
+    super(source);
+    this.type = type;
+    this.personalId = personalId;
+    this.amount = amount;
+    this.reference = reference;
+  }
+}

--- a/src/main/java/ee/tuleva/onboarding/aml/alert/ThirdPillarAlertEvaluator.java
+++ b/src/main/java/ee/tuleva/onboarding/aml/alert/ThirdPillarAlertEvaluator.java
@@ -1,0 +1,64 @@
+package ee.tuleva.onboarding.aml.alert;
+
+import static ee.tuleva.onboarding.aml.alert.AmlAlertType.III_PILLAR_DEPOSIT_EMPLOYER;
+import static ee.tuleva.onboarding.aml.alert.AmlAlertType.III_PILLAR_DEPOSIT_INSURANCE;
+import static ee.tuleva.onboarding.aml.alert.AmlAlertType.III_PILLAR_DEPOSIT_PERSON;
+import static ee.tuleva.onboarding.aml.alert.AmlAlertType.III_PILLAR_DEPOSIT_TRANSFER;
+import static ee.tuleva.onboarding.aml.alert.AmlAlertType.III_PILLAR_WITHDRAWAL;
+
+import ee.tuleva.onboarding.analytics.transaction.thirdpillar.AnalyticsThirdPillarTransaction;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ThirdPillarAlertEvaluator {
+
+  private static final String INHERITANCE_SOURCE = "Pärimine";
+  private static final String DEPOSIT_PERSON_SOURCE = "Osakute väljalase isikult laekumiste alusel";
+  private static final String DEPOSIT_EMPLOYER_SOURCE =
+      "Osakute väljalase tööandjalt laekumiste alusel";
+  private static final String DEPOSIT_TRANSFER_SOURCE = "Osakute vahetamine (väljalase) 3. sammas";
+  private static final String DEPOSIT_INSURANCE_SOURCE =
+      "Osakute väljalase kindlustuslepingust laekumiste alusel";
+  private static final Set<String> WITHDRAWAL_TYPES =
+      Set.of("Osakute ülekanne", "Broneeritud osakute kustutamine");
+
+  private static final BigDecimal DEPOSIT_THRESHOLD = new BigDecimal("6001");
+  private static final BigDecimal TRANSFER_THRESHOLD = new BigDecimal("20001");
+  private static final BigDecimal WITHDRAWAL_THRESHOLD = new BigDecimal("20001");
+
+  public List<AmlAlertType> evaluate(AnalyticsThirdPillarTransaction transaction) {
+    String source = transaction.getTransactionSource();
+    if (INHERITANCE_SOURCE.equals(source)) {
+      return List.of();
+    }
+
+    String type = transaction.getTransactionType();
+    BigDecimal amount = transaction.getTransactionValue();
+    var alerts = new ArrayList<AmlAlertType>();
+
+    if (DEPOSIT_PERSON_SOURCE.equals(source) && atLeast(amount, DEPOSIT_THRESHOLD)) {
+      alerts.add(III_PILLAR_DEPOSIT_PERSON);
+    }
+    if (DEPOSIT_EMPLOYER_SOURCE.equals(source) && atLeast(amount, DEPOSIT_THRESHOLD)) {
+      alerts.add(III_PILLAR_DEPOSIT_EMPLOYER);
+    }
+    if (DEPOSIT_TRANSFER_SOURCE.equals(source) && atLeast(amount, TRANSFER_THRESHOLD)) {
+      alerts.add(III_PILLAR_DEPOSIT_TRANSFER);
+    }
+    if (DEPOSIT_INSURANCE_SOURCE.equals(source) && atLeast(amount, TRANSFER_THRESHOLD)) {
+      alerts.add(III_PILLAR_DEPOSIT_INSURANCE);
+    }
+    if (WITHDRAWAL_TYPES.contains(type) && atLeast(amount, WITHDRAWAL_THRESHOLD)) {
+      alerts.add(III_PILLAR_WITHDRAWAL);
+    }
+    return alerts;
+  }
+
+  private static boolean atLeast(BigDecimal amount, BigDecimal threshold) {
+    return amount.compareTo(threshold) >= 0;
+  }
+}

--- a/src/main/java/ee/tuleva/onboarding/aml/alert/ThirdPillarAlertJob.java
+++ b/src/main/java/ee/tuleva/onboarding/aml/alert/ThirdPillarAlertJob.java
@@ -1,0 +1,29 @@
+package ee.tuleva.onboarding.aml.alert;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.springframework.context.annotation.Profile;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@Profile("!dev")
+@RequiredArgsConstructor
+public class ThirdPillarAlertJob {
+
+  private final ThirdPillarAlertService thirdPillarAlertService;
+
+  @Scheduled(cron = "0 30 6 * * *", zone = "Europe/Tallinn")
+  @SchedulerLock(name = "ThirdPillarAlertJob_run", lockAtMostFor = "23h", lockAtLeastFor = "1m")
+  public void run() {
+    log.info("Starting III pillar AML alert job");
+    try {
+      thirdPillarAlertService.checkAndAlert();
+    } catch (Exception e) {
+      log.error("III pillar AML alert job failed", e);
+    }
+    log.info("Finished III pillar AML alert job");
+  }
+}

--- a/src/main/java/ee/tuleva/onboarding/aml/alert/ThirdPillarAlertService.java
+++ b/src/main/java/ee/tuleva/onboarding/aml/alert/ThirdPillarAlertService.java
@@ -1,0 +1,61 @@
+package ee.tuleva.onboarding.aml.alert;
+
+import ee.tuleva.onboarding.analytics.transaction.thirdpillar.AnalyticsThirdPillarTransaction;
+import ee.tuleva.onboarding.analytics.transaction.thirdpillar.AnalyticsThirdPillarTransactionRepository;
+import java.time.Clock;
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ThirdPillarAlertService {
+
+  private static final int LOOKBACK_DAYS = 40;
+
+  private final AnalyticsThirdPillarTransactionRepository transactionRepository;
+  private final AmlThirdPillarAlertRepository alertRepository;
+  private final ThirdPillarAlertEvaluator evaluator;
+  private final ApplicationEventPublisher eventPublisher;
+  private final Clock clock;
+
+  public void checkAndAlert() {
+    LocalDate cutoff = LocalDate.now(clock).minusDays(LOOKBACK_DAYS);
+    var transactions = transactionRepository.findByReportingDateGreaterThanEqual(cutoff);
+    for (AnalyticsThirdPillarTransaction transaction : transactions) {
+      for (AmlAlertType alertType : evaluator.evaluate(transaction)) {
+        alertOnce(transaction, alertType);
+      }
+    }
+  }
+
+  private void alertOnce(AnalyticsThirdPillarTransaction transaction, AmlAlertType alertType) {
+    if (alertRepository.existsByTransactionIdAndAlertType(transaction.getId(), alertType)) {
+      return;
+    }
+    try {
+      eventPublisher.publishEvent(
+          new AmlThresholdAlertEvent(
+              this,
+              alertType,
+              transaction.getPersonalId(),
+              transaction.getTransactionValue(),
+              String.valueOf(transaction.getId())));
+      alertRepository.save(
+          AmlThirdPillarAlert.builder()
+              .transactionId(transaction.getId())
+              .alertType(alertType)
+              .alertedAt(clock.instant())
+              .build());
+    } catch (Exception e) {
+      log.error(
+          "Failed to send III pillar AML alert: transactionId={}, alertType={}",
+          transaction.getId(),
+          alertType,
+          e);
+    }
+  }
+}

--- a/src/main/java/ee/tuleva/onboarding/aml/alert/ThirdPillarAlertService.java
+++ b/src/main/java/ee/tuleva/onboarding/aml/alert/ThirdPillarAlertService.java
@@ -33,7 +33,8 @@ public class ThirdPillarAlertService {
   }
 
   private void alertOnce(AnalyticsThirdPillarTransaction transaction, AmlAlertType alertType) {
-    if (alertRepository.existsByTransactionIdAndAlertType(transaction.getId(), alertType)) {
+    String fingerprint = ThirdPillarTransactionFingerprint.of(transaction);
+    if (alertRepository.existsByTransactionFingerprintAndAlertType(fingerprint, alertType)) {
       return;
     }
     try {
@@ -46,7 +47,7 @@ public class ThirdPillarAlertService {
               String.valueOf(transaction.getId())));
       alertRepository.save(
           AmlThirdPillarAlert.builder()
-              .transactionId(transaction.getId())
+              .transactionFingerprint(fingerprint)
               .alertType(alertType)
               .alertedAt(clock.instant())
               .build());

--- a/src/main/java/ee/tuleva/onboarding/aml/alert/ThirdPillarTransactionFingerprint.java
+++ b/src/main/java/ee/tuleva/onboarding/aml/alert/ThirdPillarTransactionFingerprint.java
@@ -1,0 +1,40 @@
+package ee.tuleva.onboarding.aml.alert;
+
+import ee.tuleva.onboarding.analytics.transaction.thirdpillar.AnalyticsThirdPillarTransaction;
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import org.springframework.util.DigestUtils;
+
+/**
+ * Stable dedup key for a III pillar analytics transaction. The analytics row id is NOT stable: the
+ * sync deletes and re-inserts a reporting-date range on every refresh, so the same EPIS transaction
+ * gets a new auto-generated id each day. Keying idempotency on a hash of the transaction's natural
+ * fields keeps "alert exactly once" correct across re-syncs. (Two genuinely indistinguishable
+ * transactions — same person, day, type, source, amount, account — collapse to one alert; an
+ * accepted, rare trade-off vs. re-alerting daily.)
+ */
+final class ThirdPillarTransactionFingerprint {
+
+  private ThirdPillarTransactionFingerprint() {}
+
+  static String of(AnalyticsThirdPillarTransaction transaction) {
+    String canonical =
+        String.join(
+            "|",
+            nullSafe(transaction.getPersonalId()),
+            nullSafe(transaction.getReportingDate()),
+            nullSafe(transaction.getAccountNo()),
+            nullSafe(transaction.getTransactionType()),
+            nullSafe(transaction.getTransactionSource()),
+            normalize(transaction.getTransactionValue()));
+    return DigestUtils.md5DigestAsHex(canonical.getBytes(StandardCharsets.UTF_8));
+  }
+
+  private static String nullSafe(Object value) {
+    return value == null ? "" : value.toString();
+  }
+
+  private static String normalize(BigDecimal value) {
+    return value == null ? "" : value.stripTrailingZeros().toPlainString();
+  }
+}

--- a/src/main/java/ee/tuleva/onboarding/analytics/transaction/thirdpillar/AnalyticsThirdPillarTransactionRepository.java
+++ b/src/main/java/ee/tuleva/onboarding/analytics/transaction/thirdpillar/AnalyticsThirdPillarTransactionRepository.java
@@ -1,6 +1,7 @@
 package ee.tuleva.onboarding.analytics.transaction.thirdpillar;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -12,6 +13,9 @@ public interface AnalyticsThirdPillarTransactionRepository
 
   @Query("SELECT MAX(t.reportingDate) FROM AnalyticsThirdPillarTransaction t")
   Optional<LocalDate> findLatestReportingDate();
+
+  List<AnalyticsThirdPillarTransaction> findByReportingDateGreaterThanEqual(
+      LocalDate reportingDate);
 
   @Modifying
   @Query(

--- a/src/main/resources/db/migration/V1_195__aml_third_pillar_alert.sql
+++ b/src/main/resources/db/migration/V1_195__aml_third_pillar_alert.sql
@@ -1,0 +1,10 @@
+CREATE TABLE aml_third_pillar_alert (
+    id             bigserial   NOT NULL,
+    transaction_id bigint      NOT NULL,
+    alert_type     text        NOT NULL,
+    alerted_at     timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT pk_aml_third_pillar_alert PRIMARY KEY (id),
+    CONSTRAINT uk_aml_third_pillar_alert UNIQUE (transaction_id, alert_type)
+);
+
+CREATE INDEX ix_aml_third_pillar_alert_transaction_id ON aml_third_pillar_alert (transaction_id);

--- a/src/main/resources/db/migration/V1_195__aml_third_pillar_alert.sql
+++ b/src/main/resources/db/migration/V1_195__aml_third_pillar_alert.sql
@@ -1,10 +1,11 @@
 CREATE TABLE aml_third_pillar_alert (
-    id             bigserial   NOT NULL,
-    transaction_id bigint      NOT NULL,
-    alert_type     text        NOT NULL,
-    alerted_at     timestamptz NOT NULL DEFAULT now(),
+    id                      bigserial   NOT NULL,
+    transaction_fingerprint text        NOT NULL,
+    alert_type              text        NOT NULL,
+    alerted_at              timestamptz NOT NULL DEFAULT now(),
     CONSTRAINT pk_aml_third_pillar_alert PRIMARY KEY (id),
-    CONSTRAINT uk_aml_third_pillar_alert UNIQUE (transaction_id, alert_type)
+    CONSTRAINT uk_aml_third_pillar_alert UNIQUE (transaction_fingerprint, alert_type)
 );
 
-CREATE INDEX ix_aml_third_pillar_alert_transaction_id ON aml_third_pillar_alert (transaction_id);
+CREATE INDEX ix_aml_third_pillar_alert_fingerprint
+    ON aml_third_pillar_alert (transaction_fingerprint);

--- a/src/test/groovy/ee/tuleva/onboarding/aml/WithdrawalNotifierTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/aml/WithdrawalNotifierTest.java
@@ -1,8 +1,11 @@
 package ee.tuleva.onboarding.aml;
 
 import static ee.tuleva.onboarding.mandate.MandateType.FUND_PENSION_OPENING;
+import static ee.tuleva.onboarding.mandate.MandateType.PARTIAL_WITHDRAWAL;
 import static ee.tuleva.onboarding.notification.OperationsNotificationService.Channel.WITHDRAWALS;
 import static ee.tuleva.onboarding.pillar.Pillar.SECOND;
+import static ee.tuleva.onboarding.pillar.Pillar.THIRD;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
@@ -35,6 +38,29 @@ class WithdrawalNotifierTest {
         .sendMessage(
             "Withdrawal mandate batch created: age=65, pillars=[SECOND], withdrawalTypes=[FUND_PENSION_OPENING], mandateBatchId=42",
             WITHDRAWALS);
+  }
+
+  @Test
+  @DisplayName("formats a single-pillar single-type withdrawal batch message")
+  void formatMessage_singlePillarSingleType() {
+    String message = notifier.formatMessage(65, Set.of(SECOND), Set.of(FUND_PENSION_OPENING), 42L);
+
+    assertThat(message)
+        .isEqualTo(
+            "Withdrawal mandate batch created: age=65, pillars=[SECOND], withdrawalTypes=[FUND_PENSION_OPENING], mandateBatchId=42");
+  }
+
+  @Test
+  @DisplayName("formats a message covering every pillar and withdrawal type present")
+  void formatMessage_multiplePillarsAndTypes() {
+    String message =
+        notifier.formatMessage(
+            70, Set.of(SECOND, THIRD), Set.of(FUND_PENSION_OPENING, PARTIAL_WITHDRAWAL), 7L);
+
+    assertThat(message)
+        .startsWith("Withdrawal mandate batch created: age=70,")
+        .contains("SECOND", "THIRD", "FUND_PENSION_OPENING", "PARTIAL_WITHDRAWAL")
+        .endsWith("mandateBatchId=7");
   }
 
   @Test

--- a/src/test/groovy/ee/tuleva/onboarding/aml/alert/AmlAlertNotifierTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/aml/alert/AmlAlertNotifierTest.java
@@ -1,0 +1,85 @@
+package ee.tuleva.onboarding.aml.alert;
+
+import static ee.tuleva.onboarding.aml.alert.AmlAlertType.III_PILLAR_DEPOSIT_PERSON;
+import static ee.tuleva.onboarding.auth.UserFixture.sampleUser;
+import static ee.tuleva.onboarding.notification.OperationsNotificationService.Channel.AML;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import ee.tuleva.onboarding.notification.OperationsNotificationService;
+import ee.tuleva.onboarding.user.User;
+import ee.tuleva.onboarding.user.UserService;
+import java.math.BigDecimal;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class AmlAlertNotifierTest {
+
+  private OperationsNotificationService notificationService;
+  private UserService userService;
+  private AmlAlertNotifier notifier;
+
+  @BeforeEach
+  void setUp() {
+    notificationService = Mockito.mock(OperationsNotificationService.class);
+    userService = Mockito.mock(UserService.class);
+    notifier = new AmlAlertNotifier(notificationService, userService);
+  }
+
+  @Test
+  @DisplayName("sends an AML alert with the resolved Tuleva userId to the AML channel")
+  void onAmlThresholdAlert_resolvesUserId_sendsToAmlChannel() {
+    User user = sampleUser().build();
+    when(userService.findByPersonalCode("38001010000")).thenReturn(Optional.of(user));
+
+    notifier.onAmlThresholdAlert(
+        new AmlThresholdAlertEvent(
+            this, III_PILLAR_DEPOSIT_PERSON, "38001010000", new BigDecimal("6001.00"), "7"));
+
+    verify(notificationService)
+        .sendMessage(
+            "AML alert: III_PILLAR_DEPOSIT_PERSON, userId=%s, amount=6001.00, ref=7"
+                .formatted(user.getId()),
+            AML);
+  }
+
+  @Test
+  @DisplayName("keeps the personal id out of Slack and shows userId=null when no user is found")
+  void onAmlThresholdAlert_noUser_userIdNull() {
+    when(userService.findByPersonalCode("38001010000")).thenReturn(Optional.empty());
+
+    notifier.onAmlThresholdAlert(
+        new AmlThresholdAlertEvent(
+            this, III_PILLAR_DEPOSIT_PERSON, "38001010000", new BigDecimal("6001.00"), "7"));
+
+    verify(notificationService)
+        .sendMessage(
+            "AML alert: III_PILLAR_DEPOSIT_PERSON, userId=null, amount=6001.00, ref=7", AML);
+  }
+
+  @Test
+  @DisplayName("does not silently swallow a Slack send failure")
+  void onAmlThresholdAlert_whenSlackFails_propagatesException() {
+    when(userService.findByPersonalCode(any())).thenReturn(Optional.empty());
+    doThrow(new IllegalStateException("Slack down"))
+        .when(notificationService)
+        .sendMessage(any(), any());
+
+    assertThatThrownBy(
+            () ->
+                notifier.onAmlThresholdAlert(
+                    new AmlThresholdAlertEvent(
+                        this,
+                        III_PILLAR_DEPOSIT_PERSON,
+                        "38001010000",
+                        new BigDecimal("6001.00"),
+                        "7")))
+        .isInstanceOf(IllegalStateException.class);
+  }
+}

--- a/src/test/groovy/ee/tuleva/onboarding/aml/alert/ThirdPillarAlertEvaluatorSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/aml/alert/ThirdPillarAlertEvaluatorSpec.groovy
@@ -1,0 +1,42 @@
+package ee.tuleva.onboarding.aml.alert
+
+import ee.tuleva.onboarding.analytics.transaction.thirdpillar.AnalyticsThirdPillarTransaction
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import static ee.tuleva.onboarding.aml.alert.AmlAlertType.*
+import static ee.tuleva.onboarding.analytics.transaction.thirdpillar.AnalyticsThirdPillarTransactionFixture.exampleTransactionBuilder
+
+class ThirdPillarAlertEvaluatorSpec extends Specification {
+
+  def evaluator = new ThirdPillarAlertEvaluator()
+
+  @Unroll
+  def "classifies III pillar transaction: source=#source type=#type value=#value -> #expected"() {
+    given:
+    AnalyticsThirdPillarTransaction transaction = exampleTransactionBuilder()
+        .transactionSource(source)
+        .transactionType(type)
+        .transactionValue(value)
+        .build()
+
+    expect:
+    evaluator.evaluate(transaction) == expected
+
+    where:
+    source                                                    | type                              | value     || expected
+    'Osakute väljalase isikult laekumiste alusel'             | 'irrelevant'                      | 6001.00   || [III_PILLAR_DEPOSIT_PERSON]
+    'Osakute väljalase isikult laekumiste alusel'             | 'irrelevant'                      | 6000.99   || []
+    'Osakute väljalase tööandjalt laekumiste alusel'          | 'irrelevant'                      | 6001.00   || [III_PILLAR_DEPOSIT_EMPLOYER]
+    'Osakute väljalase tööandjalt laekumiste alusel'          | 'irrelevant'                      | 6000.99   || []
+    'Osakute vahetamine (väljalase) 3. sammas'                | 'irrelevant'                      | 20001.00  || [III_PILLAR_DEPOSIT_TRANSFER]
+    'Osakute vahetamine (väljalase) 3. sammas'                | 'irrelevant'                      | 20000.99  || []
+    'Osakute väljalase kindlustuslepingust laekumiste alusel' | 'irrelevant'                      | 20001.00  || [III_PILLAR_DEPOSIT_INSURANCE]
+    'Osakute väljalase kindlustuslepingust laekumiste alusel' | 'irrelevant'                      | 20000.99  || []
+    'someSource'                                              | 'Osakute ülekanne'                | 20001.00  || [III_PILLAR_WITHDRAWAL]
+    'someSource'                                              | 'Broneeritud osakute kustutamine' | 20001.00  || [III_PILLAR_WITHDRAWAL]
+    'someSource'                                              | 'Osakute ülekanne'                | 20000.99  || []
+    'Pärimine'                                                | 'Osakute ülekanne'                | 999999.00 || []
+    'someSource'                                              | 'someType'                        | 999999.00 || []
+  }
+}

--- a/src/test/groovy/ee/tuleva/onboarding/aml/alert/ThirdPillarAlertIntegrationTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/aml/alert/ThirdPillarAlertIntegrationTest.java
@@ -32,19 +32,22 @@ class ThirdPillarAlertIntegrationTest {
 
   @MockitoBean private OperationsNotificationService notificationService;
 
+  private AnalyticsThirdPillarTransaction qualifyingDeposit() {
+    return exampleTransactionBuilder()
+        .reportingDate(LocalDate.now())
+        .personalId("38001010000")
+        .accountNo("EE100200300")
+        .transactionSource("Osakute väljalase isikult laekumiste alusel")
+        .transactionType("irrelevant")
+        .transactionValue(new BigDecimal("6001.00"))
+        .build();
+  }
+
   @Test
   @DisplayName(
-      "alerts a qualifying III pillar transaction exactly once to the AML channel and persists idempotency")
-  void endToEnd_qualifyingTransaction_alertsOnceAndIsIdempotent() {
-    AnalyticsThirdPillarTransaction qualifying =
-        transactionRepository.save(
-            exampleTransactionBuilder()
-                .reportingDate(LocalDate.now())
-                .personalId("38001010000")
-                .transactionSource("Osakute väljalase isikult laekumiste alusel")
-                .transactionType("irrelevant")
-                .transactionValue(new BigDecimal("6001.00"))
-                .build());
+      "alerts a qualifying III pillar transaction exactly once, is idempotent, and survives a re-sync that regenerates the row id")
+  void endToEnd_qualifyingTransaction_alertsOnceAndSurvivesResync() {
+    AnalyticsThirdPillarTransaction qualifying = transactionRepository.save(qualifyingDeposit());
 
     AnalyticsThirdPillarTransaction nonQualifying =
         transactionRepository.save(
@@ -60,22 +63,35 @@ class ThirdPillarAlertIntegrationTest {
 
     verify(notificationService, times(1))
         .sendMessage(
-            argThat(
-                message ->
-                    message.startsWith("AML alert: III_PILLAR_DEPOSIT_PERSON")
-                        && message.contains("ref=" + qualifying.getId())),
+            argThat(message -> message.startsWith("AML alert: III_PILLAR_DEPOSIT_PERSON")),
             eq(AML));
     verify(notificationService, never())
         .sendMessage(argThat(message -> message.contains("ref=" + nonQualifying.getId())), eq(AML));
 
     assertThat(
-            alertRepository.existsByTransactionIdAndAlertType(
-                qualifying.getId(), III_PILLAR_DEPOSIT_PERSON))
+            alertRepository.existsByTransactionFingerprintAndAlertType(
+                ThirdPillarTransactionFingerprint.of(qualifying), III_PILLAR_DEPOSIT_PERSON))
         .isTrue();
+
+    // Idempotent on an unchanged re-run.
+    thirdPillarAlertService.checkAndAlert();
+    verify(notificationService, times(1))
+        .sendMessage(
+            argThat(message -> message.startsWith("AML alert: III_PILLAR_DEPOSIT_PERSON")),
+            eq(AML));
+
+    // Re-sync: the analytics sync deletes and re-inserts the reporting-date range, so the same
+    // EPIS transaction comes back with a NEW auto-generated id. Dedup must survive that.
+    transactionRepository.delete(qualifying);
+    AnalyticsThirdPillarTransaction resynced = transactionRepository.save(qualifyingDeposit());
+    assertThat(resynced.getId()).isNotEqualTo(qualifying.getId());
 
     thirdPillarAlertService.checkAndAlert();
 
+    // Still exactly one alert overall — the regenerated id did NOT cause a duplicate.
     verify(notificationService, times(1))
-        .sendMessage(argThat(message -> message.contains("ref=" + qualifying.getId())), eq(AML));
+        .sendMessage(
+            argThat(message -> message.startsWith("AML alert: III_PILLAR_DEPOSIT_PERSON")),
+            eq(AML));
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/aml/alert/ThirdPillarAlertIntegrationTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/aml/alert/ThirdPillarAlertIntegrationTest.java
@@ -1,0 +1,81 @@
+package ee.tuleva.onboarding.aml.alert;
+
+import static ee.tuleva.onboarding.aml.alert.AmlAlertType.III_PILLAR_DEPOSIT_PERSON;
+import static ee.tuleva.onboarding.analytics.transaction.thirdpillar.AnalyticsThirdPillarTransactionFixture.exampleTransactionBuilder;
+import static ee.tuleva.onboarding.notification.OperationsNotificationService.Channel.AML;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import ee.tuleva.onboarding.analytics.transaction.thirdpillar.AnalyticsThirdPillarTransaction;
+import ee.tuleva.onboarding.analytics.transaction.thirdpillar.AnalyticsThirdPillarTransactionRepository;
+import ee.tuleva.onboarding.notification.OperationsNotificationService;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+class ThirdPillarAlertIntegrationTest {
+
+  @Autowired private ThirdPillarAlertService thirdPillarAlertService;
+  @Autowired private AnalyticsThirdPillarTransactionRepository transactionRepository;
+  @Autowired private AmlThirdPillarAlertRepository alertRepository;
+
+  @MockitoBean private OperationsNotificationService notificationService;
+
+  @Test
+  @DisplayName(
+      "alerts a qualifying III pillar transaction exactly once to the AML channel and persists idempotency")
+  void endToEnd_qualifyingTransaction_alertsOnceAndIsIdempotent() {
+    AnalyticsThirdPillarTransaction qualifying =
+        transactionRepository.save(
+            exampleTransactionBuilder()
+                .reportingDate(LocalDate.now())
+                .personalId("38001010000")
+                .transactionSource("Osakute väljalase isikult laekumiste alusel")
+                .transactionType("irrelevant")
+                .transactionValue(new BigDecimal("6001.00"))
+                .build());
+
+    AnalyticsThirdPillarTransaction nonQualifying =
+        transactionRepository.save(
+            exampleTransactionBuilder()
+                .reportingDate(LocalDate.now())
+                .personalId("38001010000")
+                .transactionSource("Osakute väljalase isikult laekumiste alusel")
+                .transactionType("irrelevant")
+                .transactionValue(new BigDecimal("100.00"))
+                .build());
+
+    thirdPillarAlertService.checkAndAlert();
+
+    verify(notificationService, times(1))
+        .sendMessage(
+            argThat(
+                message ->
+                    message.startsWith("AML alert: III_PILLAR_DEPOSIT_PERSON")
+                        && message.contains("ref=" + qualifying.getId())),
+            eq(AML));
+    verify(notificationService, never())
+        .sendMessage(argThat(message -> message.contains("ref=" + nonQualifying.getId())), eq(AML));
+
+    assertThat(
+            alertRepository.existsByTransactionIdAndAlertType(
+                qualifying.getId(), III_PILLAR_DEPOSIT_PERSON))
+        .isTrue();
+
+    thirdPillarAlertService.checkAndAlert();
+
+    verify(notificationService, times(1))
+        .sendMessage(argThat(message -> message.contains("ref=" + qualifying.getId())), eq(AML));
+  }
+}

--- a/src/test/groovy/ee/tuleva/onboarding/aml/alert/ThirdPillarAlertJobTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/aml/alert/ThirdPillarAlertJobTest.java
@@ -1,0 +1,38 @@
+package ee.tuleva.onboarding.aml.alert;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ThirdPillarAlertJobTest {
+
+  @Mock private ThirdPillarAlertService thirdPillarAlertService;
+  @InjectMocks private ThirdPillarAlertJob job;
+
+  @Test
+  @DisplayName("delegates to the III pillar alert service")
+  void run_callsService() {
+    job.run();
+
+    verify(thirdPillarAlertService).checkAndAlert();
+  }
+
+  @Test
+  @DisplayName(
+      "does not propagate a failure from the service so the scheduler lock releases cleanly")
+  void run_serviceThrows_doesNotPropagate() {
+    doThrow(new RuntimeException("boom")).when(thirdPillarAlertService).checkAndAlert();
+
+    assertThatCode(() -> job.run()).doesNotThrowAnyException();
+
+    verify(thirdPillarAlertService).checkAndAlert();
+  }
+}

--- a/src/test/groovy/ee/tuleva/onboarding/aml/alert/ThirdPillarAlertServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/aml/alert/ThirdPillarAlertServiceTest.java
@@ -69,10 +69,12 @@ class ThirdPillarAlertServiceTest {
   @DisplayName("publishes an alert event and persists a tracking row for a qualifying transaction")
   void checkAndAlert_qualifying_publishesEventAndTracks() {
     var transaction = qualifyingTransaction();
+    var fingerprint = ThirdPillarTransactionFingerprint.of(transaction);
     when(transactionRepository.findByReportingDateGreaterThanEqual(any()))
         .thenReturn(List.of(transaction));
     when(evaluator.evaluate(transaction)).thenReturn(List.of(III_PILLAR_DEPOSIT_PERSON));
-    when(alertRepository.existsByTransactionIdAndAlertType(7L, III_PILLAR_DEPOSIT_PERSON))
+    when(alertRepository.existsByTransactionFingerprintAndAlertType(
+            fingerprint, III_PILLAR_DEPOSIT_PERSON))
         .thenReturn(false);
 
     service.checkAndAlert();
@@ -90,7 +92,7 @@ class ThirdPillarAlertServiceTest {
         ArgumentCaptor.forClass(AmlThirdPillarAlert.class);
     verify(alertRepository).save(alertCaptor.capture());
     AmlThirdPillarAlert saved = alertCaptor.getValue();
-    assertThat(saved.getTransactionId()).isEqualTo(7L);
+    assertThat(saved.getTransactionFingerprint()).isEqualTo(fingerprint);
     assertThat(saved.getAlertType()).isEqualTo(III_PILLAR_DEPOSIT_PERSON);
     assertThat(saved.getAlertedAt()).isEqualTo(clock.instant());
   }
@@ -99,10 +101,12 @@ class ThirdPillarAlertServiceTest {
   @DisplayName("does not re-alert a transaction that was already alerted")
   void checkAndAlert_alreadyAlerted_skips() {
     var transaction = qualifyingTransaction();
+    var fingerprint = ThirdPillarTransactionFingerprint.of(transaction);
     when(transactionRepository.findByReportingDateGreaterThanEqual(any()))
         .thenReturn(List.of(transaction));
     when(evaluator.evaluate(transaction)).thenReturn(List.of(III_PILLAR_DEPOSIT_PERSON));
-    when(alertRepository.existsByTransactionIdAndAlertType(7L, III_PILLAR_DEPOSIT_PERSON))
+    when(alertRepository.existsByTransactionFingerprintAndAlertType(
+            fingerprint, III_PILLAR_DEPOSIT_PERSON))
         .thenReturn(true);
 
     service.checkAndAlert();
@@ -118,7 +122,7 @@ class ThirdPillarAlertServiceTest {
     when(transactionRepository.findByReportingDateGreaterThanEqual(any()))
         .thenReturn(List.of(transaction));
     when(evaluator.evaluate(transaction)).thenReturn(List.of(III_PILLAR_DEPOSIT_PERSON));
-    when(alertRepository.existsByTransactionIdAndAlertType(7L, III_PILLAR_DEPOSIT_PERSON))
+    when(alertRepository.existsByTransactionFingerprintAndAlertType(any(), any()))
         .thenReturn(false);
     org.mockito.Mockito.doThrow(new IllegalStateException("Slack down"))
         .when(eventPublisher)
@@ -143,6 +147,6 @@ class ThirdPillarAlertServiceTest {
     verify(eventPublisher, never()).publishEvent(any());
     verify(alertRepository, never()).save(any());
     verify(alertRepository, never())
-        .existsByTransactionIdAndAlertType(any(), eq(III_PILLAR_DEPOSIT_PERSON));
+        .existsByTransactionFingerprintAndAlertType(any(), eq(III_PILLAR_DEPOSIT_PERSON));
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/aml/alert/ThirdPillarAlertServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/aml/alert/ThirdPillarAlertServiceTest.java
@@ -1,0 +1,148 @@
+package ee.tuleva.onboarding.aml.alert;
+
+import static ee.tuleva.onboarding.aml.alert.AmlAlertType.III_PILLAR_DEPOSIT_PERSON;
+import static ee.tuleva.onboarding.analytics.transaction.thirdpillar.AnalyticsThirdPillarTransactionFixture.exampleTransaction;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import ee.tuleva.onboarding.analytics.transaction.thirdpillar.AnalyticsThirdPillarTransaction;
+import ee.tuleva.onboarding.analytics.transaction.thirdpillar.AnalyticsThirdPillarTransactionRepository;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+@ExtendWith(MockitoExtension.class)
+class ThirdPillarAlertServiceTest {
+
+  @Mock private AnalyticsThirdPillarTransactionRepository transactionRepository;
+  @Mock private AmlThirdPillarAlertRepository alertRepository;
+  @Mock private ThirdPillarAlertEvaluator evaluator;
+  @Mock private ApplicationEventPublisher eventPublisher;
+
+  private final Clock clock = Clock.fixed(Instant.parse("2026-06-02T08:00:00Z"), ZoneOffset.UTC);
+
+  private ThirdPillarAlertService service;
+
+  @BeforeEach
+  void setUp() {
+    service =
+        new ThirdPillarAlertService(
+            transactionRepository, alertRepository, evaluator, eventPublisher, clock);
+  }
+
+  private AnalyticsThirdPillarTransaction qualifyingTransaction() {
+    var transaction = exampleTransaction();
+    transaction.setId(7L);
+    transaction.setPersonalId("38001010000");
+    transaction.setTransactionValue(new BigDecimal("6001.00"));
+    return transaction;
+  }
+
+  @Test
+  @DisplayName("reads transactions within the lookback window from the injected clock")
+  void checkAndAlert_usesLookbackCutoff() {
+    when(transactionRepository.findByReportingDateGreaterThanEqual(any())).thenReturn(List.of());
+
+    service.checkAndAlert();
+
+    verify(transactionRepository)
+        .findByReportingDateGreaterThanEqual(LocalDate.of(2026, 6, 2).minusDays(40));
+  }
+
+  @Test
+  @DisplayName("publishes an alert event and persists a tracking row for a qualifying transaction")
+  void checkAndAlert_qualifying_publishesEventAndTracks() {
+    var transaction = qualifyingTransaction();
+    when(transactionRepository.findByReportingDateGreaterThanEqual(any()))
+        .thenReturn(List.of(transaction));
+    when(evaluator.evaluate(transaction)).thenReturn(List.of(III_PILLAR_DEPOSIT_PERSON));
+    when(alertRepository.existsByTransactionIdAndAlertType(7L, III_PILLAR_DEPOSIT_PERSON))
+        .thenReturn(false);
+
+    service.checkAndAlert();
+
+    ArgumentCaptor<AmlThresholdAlertEvent> eventCaptor =
+        ArgumentCaptor.forClass(AmlThresholdAlertEvent.class);
+    verify(eventPublisher).publishEvent(eventCaptor.capture());
+    AmlThresholdAlertEvent event = eventCaptor.getValue();
+    assertThat(event.getType()).isEqualTo(III_PILLAR_DEPOSIT_PERSON);
+    assertThat(event.getPersonalId()).isEqualTo("38001010000");
+    assertThat(event.getAmount()).isEqualByComparingTo("6001.00");
+    assertThat(event.getReference()).isEqualTo("7");
+
+    ArgumentCaptor<AmlThirdPillarAlert> alertCaptor =
+        ArgumentCaptor.forClass(AmlThirdPillarAlert.class);
+    verify(alertRepository).save(alertCaptor.capture());
+    AmlThirdPillarAlert saved = alertCaptor.getValue();
+    assertThat(saved.getTransactionId()).isEqualTo(7L);
+    assertThat(saved.getAlertType()).isEqualTo(III_PILLAR_DEPOSIT_PERSON);
+    assertThat(saved.getAlertedAt()).isEqualTo(clock.instant());
+  }
+
+  @Test
+  @DisplayName("does not re-alert a transaction that was already alerted")
+  void checkAndAlert_alreadyAlerted_skips() {
+    var transaction = qualifyingTransaction();
+    when(transactionRepository.findByReportingDateGreaterThanEqual(any()))
+        .thenReturn(List.of(transaction));
+    when(evaluator.evaluate(transaction)).thenReturn(List.of(III_PILLAR_DEPOSIT_PERSON));
+    when(alertRepository.existsByTransactionIdAndAlertType(7L, III_PILLAR_DEPOSIT_PERSON))
+        .thenReturn(true);
+
+    service.checkAndAlert();
+
+    verify(eventPublisher, never()).publishEvent(any());
+    verify(alertRepository, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("does not persist a tracking row and does not throw when the alert send fails")
+  void checkAndAlert_sendFails_doesNotTrackAndDoesNotThrow() {
+    var transaction = qualifyingTransaction();
+    when(transactionRepository.findByReportingDateGreaterThanEqual(any()))
+        .thenReturn(List.of(transaction));
+    when(evaluator.evaluate(transaction)).thenReturn(List.of(III_PILLAR_DEPOSIT_PERSON));
+    when(alertRepository.existsByTransactionIdAndAlertType(7L, III_PILLAR_DEPOSIT_PERSON))
+        .thenReturn(false);
+    org.mockito.Mockito.doThrow(new IllegalStateException("Slack down"))
+        .when(eventPublisher)
+        .publishEvent(any());
+
+    assertThatCode(() -> service.checkAndAlert()).doesNotThrowAnyException();
+
+    verify(alertRepository, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("does nothing for a transaction that does not qualify for any threshold")
+  void checkAndAlert_nonQualifying_doesNothing() {
+    var transaction = exampleTransaction();
+    transaction.setId(9L);
+    when(transactionRepository.findByReportingDateGreaterThanEqual(any()))
+        .thenReturn(List.of(transaction));
+    when(evaluator.evaluate(transaction)).thenReturn(List.of());
+
+    service.checkAndAlert();
+
+    verify(eventPublisher, never()).publishEvent(any());
+    verify(alertRepository, never()).save(any());
+    verify(alertRepository, never())
+        .existsByTransactionIdAndAlertType(any(), eq(III_PILLAR_DEPOSIT_PERSON));
+  }
+}

--- a/src/test/groovy/ee/tuleva/onboarding/aml/alert/ThirdPillarTransactionFingerprintTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/aml/alert/ThirdPillarTransactionFingerprintTest.java
@@ -1,0 +1,46 @@
+package ee.tuleva.onboarding.aml.alert;
+
+import static ee.tuleva.onboarding.analytics.transaction.thirdpillar.AnalyticsThirdPillarTransactionFixture.exampleTransaction;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ee.tuleva.onboarding.analytics.transaction.thirdpillar.AnalyticsThirdPillarTransaction;
+import java.math.BigDecimal;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ThirdPillarTransactionFingerprintTest {
+
+  @Test
+  @DisplayName(
+      "is stable across analytics row id changes for the same underlying transaction (re-sync safe)")
+  void stableAcrossIdChanges() {
+    AnalyticsThirdPillarTransaction a = exampleTransaction();
+    a.setId(1L);
+    AnalyticsThirdPillarTransaction b = exampleTransaction();
+    b.setId(999L);
+
+    assertThat(ThirdPillarTransactionFingerprint.of(a))
+        .isEqualTo(ThirdPillarTransactionFingerprint.of(b));
+  }
+
+  @Test
+  @DisplayName("differs when a natural field differs")
+  void differsOnNaturalField() {
+    AnalyticsThirdPillarTransaction a = exampleTransaction();
+    AnalyticsThirdPillarTransaction b = exampleTransaction();
+    b.setTransactionValue(b.getTransactionValue().add(BigDecimal.ONE));
+
+    assertThat(ThirdPillarTransactionFingerprint.of(a))
+        .isNotEqualTo(ThirdPillarTransactionFingerprint.of(b));
+  }
+
+  @Test
+  @DisplayName("handles nullable optional fields without throwing")
+  void handlesNullOptionalFields() {
+    AnalyticsThirdPillarTransaction t = exampleTransaction();
+    t.setTransactionSource(null);
+    t.setTransactionValue(null);
+
+    assertThat(ThirdPillarTransactionFingerprint.of(t)).isNotBlank();
+  }
+}

--- a/src/test/groovy/ee/tuleva/onboarding/mandate/batch/MandateBatchIntegrationTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/mandate/batch/MandateBatchIntegrationTest.java
@@ -5,8 +5,13 @@ import static ee.tuleva.onboarding.epis.contact.ContactDetailsFixture.contactDet
 import static ee.tuleva.onboarding.mandate.MandateType.FUND_PENSION_OPENING;
 import static ee.tuleva.onboarding.mandate.MandateType.PARTIAL_WITHDRAWAL;
 import static ee.tuleva.onboarding.mandate.batch.MandateBatchStatus.INITIALIZED;
+import static ee.tuleva.onboarding.notification.OperationsNotificationService.Channel.WITHDRAWALS;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 
@@ -16,6 +21,7 @@ import ee.tuleva.onboarding.epis.cashflows.CashFlowStatement;
 import ee.tuleva.onboarding.mandate.MandateFixture;
 import ee.tuleva.onboarding.mandate.MandateRepository;
 import ee.tuleva.onboarding.mandate.generic.MandateDto;
+import ee.tuleva.onboarding.notification.OperationsNotificationService;
 import ee.tuleva.onboarding.withdrawals.WithdrawalEligibilityDto;
 import ee.tuleva.onboarding.withdrawals.WithdrawalEligibilityService;
 import java.util.List;
@@ -43,6 +49,7 @@ class MandateBatchIntegrationTest {
   @MockitoBean private EpisService episService;
   @MockitoBean private AmlAutoChecker amlAutoChecker;
   @MockitoBean private WithdrawalEligibilityService withdrawalEligibilityService;
+  @MockitoBean private OperationsNotificationService notificationService;
 
   @AfterEach
   void cleanup() {
@@ -134,6 +141,56 @@ class MandateBatchIntegrationTest {
 
     assertCorrectResponse(responseBody);
     assertCanReadMandateBatch();
+  }
+
+  @Test
+  void withdrawalBatchCreationSendsExactlyOneSlackNotificationInUnifiedFormat() {
+    var headers = getHeaders();
+
+    var aDto =
+        MandateBatchDto.builder()
+            .mandates(
+                List.of(
+                    MandateDto.builder()
+                        .details(MandateFixture.aFundPensionOpeningMandateDetails)
+                        .build(),
+                    MandateDto.builder()
+                        .details(MandateFixture.aPartialWithdrawalMandateDetails)
+                        .build()))
+            .build();
+
+    var aWithdrawalEligibility =
+        WithdrawalEligibilityDto.builder()
+            .hasReachedEarlyRetirementAge(true)
+            .canWithdrawThirdPillarWithReducedTax(true)
+            .age(65)
+            .recommendedDurationYears(20)
+            .arrestsOrBankruptciesPresent(false)
+            .build();
+
+    when(withdrawalEligibilityService.getWithdrawalEligibility(any()))
+        .thenReturn(aWithdrawalEligibility);
+    when(episService.getCashFlowStatement(any(), any(), any())).thenReturn(new CashFlowStatement());
+    when(episService.getContactDetails(any())).thenReturn(contactDetailsFixture());
+
+    restTestClient
+        .post()
+        .uri("/v1/mandate-batches")
+        .headers(h -> h.addAll(headers))
+        .body(aDto)
+        .exchange()
+        .expectStatus()
+        .isOk();
+
+    verify(notificationService, times(1))
+        .sendMessage(
+            argThat(
+                message ->
+                    message.startsWith("Withdrawal mandate batch created: age=")
+                        && message.contains("pillars=")
+                        && message.contains("withdrawalTypes=")
+                        && message.contains("mandateBatchId=")),
+            eq(WITHDRAWALS));
   }
 
   @Test


### PR DESCRIPTION
## What

**M2** of AML threshold Slack alerts (TulevaEE/tuleva#45). **Stacked on #1674 (M1)** → base `aml-slack-m1-unify-withdrawal-format`. Rebases down the stack as M0/M1 merge.

A daily job reads `analytics.third_pillar_transactions` and raises an AML Slack alert for each transaction crossing a sisekord threshold, **exactly once**.

### Triggers (plan §5, `>=` per D2)
| Trigger | Threshold | Matched by |
|---|---|---|
| `III_PILLAR_DEPOSIT_PERSON` / `_EMPLOYER` | ≥ 6001 | `transaction_source` |
| `III_PILLAR_DEPOSIT_TRANSFER` / `_INSURANCE` | ≥ 20001 | `transaction_source` |
| `III_PILLAR_WITHDRAWAL` | ≥ 20001 | `transaction_type` |

Inheritance (`transaction_source = 'Pärimine'`) excluded (K5).

### Design
- **`ThirdPillarAlertEvaluator`** — pure classification; Spock boundary data table (6000.99/6001.00, 20000.99/20001.00, inheritance, non-matching).
- **`ThirdPillarAlertService`** — fetch recent (40-day lookback via injected `Clock`) → evaluate → dedupe → publish `AmlThresholdAlertEvent` → persist tracking. **Publishes then tracks**, so a failed send retries next run (favour not missing an AML alert); Slack failure caught per-alert, never marks processed.
- **`AmlAlertNotifier`** — `@EventListener` formats the §6 message to the AML channel. **PII-safe**: resolves the Tuleva `userId` from the personal code (`UserService.findByPersonalCode`), never puts isikukood in Slack; transaction id is the `ref` for dashboard lookup.
- **`AmlThirdPillarAlert`** + repo — per-`(transactionId, alertType)` idempotency, migration `V1_195` (unique constraint), normal public-schema table (no analytics migration — B1).
- **`ThirdPillarAlertJob`** — daily `@Scheduled` + `@SchedulerLock` + `@Profile("!dev")`, catches so the lock releases cleanly.
- **`AmlThresholdAlertEvent`** is generic so **M4 (TKF) reuses** the same event + notifier + AML channel.

Reuses the existing `AnalyticsThirdPillarTransaction` entity/repo (adds one derived finder). **aml 100% coverage gate green**, full `./gradlew build` green.

### Flags (not silently changed — please confirm)
- **Channel = AML** (K7 default *"need on AML-teated"*); one-line change to redirect to WITHDRAWALS.
- **userId vs isikukood**: chose PII-safe `userId` + `ref`; flag for compliance.
- The live `T1_transaction_monitoring.sql` also has an **annual cumulative ≥ 6299 €** III-pillar rule **not in plan §5 scope** — deferred here, needs a scoping decision (own trigger later).

Part of TulevaEE/tuleva#45.

🤖 Generated with [Claude Code](https://claude.com/claude-code)