### PR TITLE
Accept free-text "Muu" investment goal on company (KYB) onboarding

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/kyb/survey/KybSurveyController.java
+++ b/src/main/java/ee/tuleva/onboarding/kyb/survey/KybSurveyController.java
@@ -1,5 +1,6 @@
 package ee.tuleva.onboarding.kyb.survey;
 
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.FORBIDDEN;
 import static org.springframework.http.HttpStatus.NOT_IMPLEMENTED;
 
@@ -11,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.*;
 
 @Slf4j
@@ -52,6 +54,15 @@ class KybSurveyController {
     return new ResponseEntity<>(
         Map.of("error", "ONBOARDING_NOT_ALLOWED", "error_description", exception.getMessage()),
         FORBIDDEN);
+  }
+
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  ResponseEntity<Map<String, String>> handleValidationError(
+      MethodArgumentNotValidException exception) {
+    log.info("Invalid KYB survey submission: message={}", exception.getMessage());
+    return new ResponseEntity<>(
+        Map.of("error", "VALIDATION_FAILED", "error_description", exception.getMessage()),
+        BAD_REQUEST);
   }
 
   @ExceptionHandler(Exception.class)

--- a/src/main/java/ee/tuleva/onboarding/kyb/survey/KybSurveyResponseItem.java
+++ b/src/main/java/ee/tuleva/onboarding/kyb/survey/KybSurveyResponseItem.java
@@ -30,7 +30,7 @@ sealed interface KybSurveyResponseItem extends Serializable {
 
   record CompanyAddress(@Valid AddressValue value) implements KybSurveyResponseItem {}
 
-  record InvestmentGoals(OptionValue<InvestmentGoal> value) implements KybSurveyResponseItem {}
+  record InvestmentGoals(@Valid InvestmentGoalsValue value) implements KybSurveyResponseItem {}
 
   record InvestableAssets(OptionValue<AssetRange> value) implements KybSurveyResponseItem {}
 
@@ -52,6 +52,18 @@ sealed interface KybSurveyResponseItem extends Serializable {
       @NotBlank String postalCode)
       implements Serializable {}
 
+  // Union type for the investment goal: predefined option or free text ("Muu"). Mirrors KYC.
+  @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+  @JsonSubTypes({
+    @JsonSubTypes.Type(value = InvestmentGoalsValue.Option.class, name = "OPTION"),
+    @JsonSubTypes.Type(value = InvestmentGoalsValue.Text.class, name = "TEXT"),
+  })
+  sealed interface InvestmentGoalsValue extends Serializable {
+    record Option(InvestmentGoal value) implements InvestmentGoalsValue {}
+
+    record Text(@NotBlank String value) implements InvestmentGoalsValue {}
+  }
+
   @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
   @JsonSubTypes({
     @JsonSubTypes.Type(value = CompanyIncomeSourceItem.Option.class, name = "OPTION"),
@@ -63,6 +75,7 @@ sealed interface KybSurveyResponseItem extends Serializable {
   // Enums
   enum InvestmentGoal {
     LONG_TERM,
+    ASSET_MANAGEMENT,
     SPECIFIC_GOAL,
     CHILD,
     TRADING

--- a/src/test/groovy/ee/tuleva/onboarding/kyb/survey/KybSurveyControllerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyb/survey/KybSurveyControllerTest.java
@@ -99,6 +99,49 @@ class KybSurveyControllerTest {
   }
 
   @Test
+  void submit_acceptsOptionInvestmentGoal_returns200() throws Exception {
+    submitSurveyWithGoal("{ \"type\": \"OPTION\", \"value\": \"LONG_TERM\" }")
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  void submit_acceptsAssetManagementInvestmentGoal_returns200() throws Exception {
+    submitSurveyWithGoal("{ \"type\": \"OPTION\", \"value\": \"ASSET_MANAGEMENT\" }")
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  void submit_acceptsFreeTextInvestmentGoal_returns200() throws Exception {
+    submitSurveyWithGoal("{ \"type\": \"TEXT\", \"value\": \"Soovin investeerida kinnisvarasse\" }")
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  void submit_rejectsBlankFreeTextInvestmentGoal() throws Exception {
+    submitSurveyWithGoal("{ \"type\": \"TEXT\", \"value\": \"\" }")
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void submit_rejectsWhitespaceFreeTextInvestmentGoal() throws Exception {
+    submitSurveyWithGoal("{ \"type\": \"TEXT\", \"value\": \"   \" }")
+        .andExpect(status().isBadRequest());
+  }
+
+  private org.springframework.test.web.servlet.ResultActions submitSurveyWithGoal(
+      String goalValueJson) throws Exception {
+    var body =
+        "{ \"answers\": [ { \"type\": \"INVESTMENT_GOALS\", \"value\": " + goalValueJson + " } ] }";
+    return mvc.perform(
+        post("/v1/kyb/surveys")
+            .param("registry-code", REGISTRY_CODE)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(body)
+            .with(csrf())
+            .with(authentication(personAuth())));
+  }
+
+  @Test
   void initialValidation_returns501OnUnexpectedError() throws Exception {
     when(kybSurveyService.initialValidation(REGISTRY_CODE, PERSONAL_CODE))
         .thenThrow(new RuntimeException("Ariregister timeout"));

--- a/src/test/groovy/ee/tuleva/onboarding/kyb/survey/KybSurveyRepositoryTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyb/survey/KybSurveyRepositoryTest.java
@@ -1,0 +1,56 @@
+package ee.tuleva.onboarding.kyb.survey;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ee.tuleva.onboarding.kyb.survey.KybSurveyResponseItem.InvestmentGoal;
+import ee.tuleva.onboarding.kyb.survey.KybSurveyResponseItem.InvestmentGoals;
+import ee.tuleva.onboarding.kyb.survey.KybSurveyResponseItem.InvestmentGoalsValue;
+import ee.tuleva.onboarding.user.User;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jpa.test.autoconfigure.TestEntityManager;
+
+@DataJpaTest
+class KybSurveyRepositoryTest {
+
+  @Autowired private TestEntityManager entityManager;
+
+  @Autowired private KybSurveyRepository repository;
+
+  @Test
+  void roundTripsLegacyOptionAndNewTextInvestmentGoalsWithoutMigration() {
+    var user = createUser("37605030299");
+
+    var survey =
+        new KybSurveyResponse(
+            List.of(
+                new InvestmentGoals(new InvestmentGoalsValue.Option(InvestmentGoal.LONG_TERM)),
+                new InvestmentGoals(
+                    new InvestmentGoalsValue.Text("Soovin investeerida kinnisvarasse"))));
+
+    var saved =
+        repository.save(
+            KybSurvey.builder()
+                .userId(user.getId())
+                .registryCode("12345678")
+                .survey(survey)
+                .build());
+    entityManager.flush();
+    entityManager.clear();
+
+    var reloaded = repository.findById(saved.getId()).orElseThrow();
+
+    assertThat(reloaded.getSurvey()).isEqualTo(survey);
+  }
+
+  private User createUser(String personalCode) {
+    var user = new User();
+    user.setPersonalCode(personalCode);
+    user.setFirstName("Jaan");
+    user.setLastName("Tamm");
+    user.setEmail("jaan.tamm@example.com");
+    return entityManager.persist(user);
+  }
+}

--- a/src/test/groovy/ee/tuleva/onboarding/kyb/survey/KybSurveyResponseItemTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyb/survey/KybSurveyResponseItemTest.java
@@ -4,6 +4,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import ee.tuleva.onboarding.kyb.survey.KybSurveyResponseItem.AddressDetails;
+import ee.tuleva.onboarding.kyb.survey.KybSurveyResponseItem.InvestmentGoal;
+import ee.tuleva.onboarding.kyb.survey.KybSurveyResponseItem.InvestmentGoals;
+import ee.tuleva.onboarding.kyb.survey.KybSurveyResponseItem.InvestmentGoalsValue;
 import jakarta.validation.Validation;
 import jakarta.validation.Validator;
 import org.junit.jupiter.api.Test;
@@ -52,13 +55,38 @@ class KybSurveyResponseItemTest {
     assertThat(address.value().value().postalCode()).isEqualTo("50104");
 
     var goals = (KybSurveyResponseItem.InvestmentGoals) response.answers().get(2);
-    assertThat(goals.value().value()).isEqualTo(KybSurveyResponseItem.InvestmentGoal.LONG_TERM);
+    assertThat(goals.value()).isEqualTo(new InvestmentGoalsValue.Option(InvestmentGoal.LONG_TERM));
 
     var assets = (KybSurveyResponseItem.InvestableAssets) response.answers().get(3);
     assertThat(assets.value().value()).isEqualTo(KybSurveyResponseItem.AssetRange.MORE_THAN_80K);
 
     var sourceOfIncome = (KybSurveyResponseItem.CompanySourceOfIncome) response.answers().get(4);
     assertThat(sourceOfIncome.value()).hasSize(2);
+  }
+
+  @Test
+  void deserializesAssetManagementInvestmentGoalAsOption() throws Exception {
+    var json =
+        "{ \"type\": \"INVESTMENT_GOALS\", \"value\": { \"type\": \"OPTION\", \"value\": \"ASSET_MANAGEMENT\" } }";
+
+    var item = objectMapper.readValue(json, KybSurveyResponseItem.class);
+
+    assertThat(item)
+        .isEqualTo(
+            new InvestmentGoals(new InvestmentGoalsValue.Option(InvestmentGoal.ASSET_MANAGEMENT)));
+  }
+
+  @Test
+  void deserializesFreeTextInvestmentGoalAsText() throws Exception {
+    var json =
+        "{ \"type\": \"INVESTMENT_GOALS\", \"value\": { \"type\": \"TEXT\", \"value\": \"Soovin investeerida kinnisvarasse\" } }";
+
+    var item = objectMapper.readValue(json, KybSurveyResponseItem.class);
+
+    assertThat(item)
+        .isEqualTo(
+            new InvestmentGoals(
+                new InvestmentGoalsValue.Text("Soovin investeerida kinnisvarasse")));
   }
 
   @Test


### PR DESCRIPTION
## What

Fixes the company (OÜ / KYB) onboarding bug where choosing investment goal **„Muu"** made the final submit step fail with no useful error. Backend half of TulevaEE/TKF-VPII2026#78.

## Root cause

Company onboarding modelled the investment goal as `InvestmentGoals(OptionValue<InvestmentGoal>)` — **no TEXT variant**. The shared frontend sends `{type:'TEXT', value:'<free text>'}` for „Muu", which can't deserialize into the enum. The personal (KYC) flow already models the same item as a sealed `Option | Text` and works.

> ⚠️ **The reported "HTTP 400" was actually a 501.** The controller's catch-all `@ExceptionHandler(Exception.class)` swallows deserialization/validation failures into `501 NOT_IMPLEMENTED` (confirmed by `@WebMvcTest`). Behaviour matched the report (submit silently fails); the status was mislabelled.

## Changes

- **`KybSurveyResponseItem`**: replace `InvestmentGoals(OptionValue<InvestmentGoal>)` with `InvestmentGoals(@Valid InvestmentGoalsValue)` — a sealed `Option | Text` with `@JsonTypeInfo`/`@JsonSubTypes` `OPTION`/`TEXT`, copied from the KYC pattern. `Text.value` is `@NotBlank` so the server (not just the FE) rejects empty/whitespace free text. *(KYC's `Text` lacks `@NotBlank` — noted as a separate latent gap in the plan.)*
- **`InvestmentGoal` enum**: add `ASSET_MANAGEMENT` (a structured OPTION, not free text) for the upcoming "Vaba raha paigutamine (varahaldus)" choice in the FE PR.
- **`KybSurveyController`**: add a local `@ExceptionHandler(MethodArgumentNotValidException)` → **400**, so request-validation errors surface as 400 instead of being swallowed into 501 by the catch-all. This is a small deviation from the plan (which assumed 400 was already the behaviour) and makes KYB symmetric with KYC, where validation errors are 400.

## Backward compatibility

The wire format for `OPTION` values is unchanged (`{type:'OPTION', value:'LONG_TERM'}`), so existing stored surveys read back **with no migration**. No backend consumer reads the company `InvestmentGoals` value as `OptionValue` (verified). Proven by a `@DataJpaTest` round-trip of a survey containing both a legacy `OPTION/LONG_TERM` goal and a new `TEXT` goal.

## Tests (TDD)

- `KybSurveyControllerTest` (`@WebMvcTest`): free-text TEXT → 200, `ASSET_MANAGEMENT` OPTION → 200, OPTION/LONG_TERM backward-compat → 200, blank/whitespace TEXT → **400**.
- `KybSurveyResponseItemTest`: `ASSET_MANAGEMENT` deserializes to `Option`, free text to `Text`, existing full-survey deserialization still passes.
- `KybSurveyRepositoryTest` (`@DataJpaTest`): JSON column round-trip of legacy OPTION + new TEXT, no migration.

## Out of scope

- AML risk-flag on free-text „Muu" → **#87**.
- FE „Varahaldus" option + copy → follow-up PR (after this merges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)