### PR TITLE
Add MANUAL_EVENT AmlCheckType for specialist-logged off-system AML events

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/aml/AmlCheckType.java
+++ b/src/main/java/ee/tuleva/onboarding/aml/AmlCheckType.java
@@ -22,6 +22,10 @@ public enum AmlCheckType {
   TKF_RISK_LEVEL,
   TKF_RISK_LEVEL_OVERRIDE,
   INTERNAL_ESCALATION,
+  // Specialist-logged off-system AML event (manual EDD / phone call / external document check),
+  // created via the Metabase dashboard action "Lisa käsitsi AML-sündmus". No automated producer;
+  // rows carry metadata.source = "manual". Not consumed by risk views or the mandate gate.
+  MANUAL_EVENT,
   KYC_CHECK,
   KYB_COMPANY_STRUCTURE,
   KYB_SOLE_MEMBER_OWNERSHIP,

--- a/src/main/java/ee/tuleva/onboarding/aml/health/ScheduledAmlHealthCheckJob.java
+++ b/src/main/java/ee/tuleva/onboarding/aml/health/ScheduledAmlHealthCheckJob.java
@@ -26,6 +26,7 @@ public class ScheduledAmlHealthCheckJob {
           AmlCheckType.RISK_LEVEL_OVERRIDE_CONFIRMATION,
           AmlCheckType.SANCTION_OVERRIDE,
           AmlCheckType.INTERNAL_ESCALATION,
+          AmlCheckType.MANUAL_EVENT,
           AmlCheckType.KYB_COMPANY_STRUCTURE,
           AmlCheckType.KYB_SOLE_MEMBER_OWNERSHIP,
           AmlCheckType.KYB_DUAL_MEMBER_OWNERSHIP,

--- a/src/test/groovy/ee/tuleva/onboarding/aml/AmlCheckTypeTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/aml/AmlCheckTypeTest.java
@@ -15,6 +15,17 @@ class AmlCheckTypeTest {
   }
 
   @Test
+  void hasManualEventType() {
+    assertThat(AmlCheckType.valueOf("MANUAL_EVENT")).isNotNull();
+  }
+
+  @Test
+  void manualEventIsNotClientManual() {
+    // MANUAL_EVENT is specialist-created (Metabase action), not a client-self-addable check
+    assertThat(AmlCheckType.MANUAL_EVENT.isManual()).isFalse();
+  }
+
+  @Test
   void kybCheckTypesAreNotManual() {
     assertThat(AmlCheckType.KYB_SOLE_MEMBER_OWNERSHIP.isManual()).isFalse();
     assertThat(AmlCheckType.KYB_DUAL_MEMBER_OWNERSHIP.isManual()).isFalse();

--- a/src/test/groovy/ee/tuleva/onboarding/aml/health/ScheduledAmlHealthCheckJobTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/aml/health/ScheduledAmlHealthCheckJobTest.java
@@ -25,6 +25,7 @@ class ScheduledAmlHealthCheckJobTest {
           AmlCheckType.RISK_LEVEL_OVERRIDE_CONFIRMATION,
           AmlCheckType.SANCTION_OVERRIDE,
           AmlCheckType.INTERNAL_ESCALATION,
+          AmlCheckType.MANUAL_EVENT,
           AmlCheckType.KYB_COMPANY_STRUCTURE,
           AmlCheckType.KYB_SOLE_MEMBER_OWNERSHIP,
           AmlCheckType.KYB_DUAL_MEMBER_OWNERSHIP,


### PR DESCRIPTION
## What
Adds `MANUAL_EVENT` to `AmlCheckType` so the AML specialist's **"Lisa käsitsi AML-sündmus"** Metabase dashboard action can store off-system AML events (manual EDD, phone call, external document check) with an honest type instead of reusing `INTERNAL_ESCALATION`.

## Why
`aml_check.type` is read by Java as an enum (`@Enumerated`), so the Metabase action can only write a value that already exists in `AmlCheckType` — otherwise the app throws when loading that person's checks. Reusing `INTERNAL_ESCALATION` made the audit trail literally read "escalation" for what are manual notes. This adds the correct type.

## Changes
- **`AmlCheckType`**: add `MANUAL_EVENT` (`manual=false` → not client-self-addable via `POST /v1/amlchecks`). `aml_check.type` is `TEXT` (no CHECK / no PG enum) → **no DB migration needed**.
- **`ScheduledAmlHealthCheckJob`**: add to `SKIPPED_CHECK_TYPES` — there is no automated producer, so it must not raise a "delayed check" health alert. Matching test update.
- **`AmlCheckTypeTest`**: new type exists + is not client-manual.
- Not referenced by risk views (V13/V17 in database-administration) or the mandate gate (`allChecksPassed`), so it stays inert in scoring. Rows carry `metadata.source="manual"`.

## Follow-up (after this deploys — not in this PR)
- Switch the Metabase action to write `MANUAL_EVENT` (today it writes `INTERNAL_ESCALATION`, kept valid until deploy).
- Backfill the handful of `INTERNAL_ESCALATION` + `metadata.source='manual'` rows created during testing → `MANUAL_EVENT`.
- Dashboard card relabels live in `TulevaEE/tuleva` `work/sten/aml` (rev 7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)