### PR TITLE
chore: gitignore /tmp/ and remove dead implementation-plan.md reference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .gradle
 /build/
 /temp/
+/tmp/
 !gradle/wrapper/gradle-wrapper.jar
 
 ### STS ###

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,8 +73,6 @@ Scheduled jobs: `SebPendingTransactionReconciliationJob` (daily 09:00 EET, 7-day
 
 NAV cross-check: SEB execution `unit_price` vs `nav_report.market_price` for same ISIN+date, ETF-only, T+0, `1.0%` tolerance. Alerts (unmatched rows, price mismatches, overdue settlements) go through `EmailService.sendSystemEmail` (Mandrill).
 
-See `tmp/transaction-registry/implementation-plan.md` for the full milestone-by-milestone history.
-
 ## Database
 
 ### Migrations


### PR DESCRIPTION
## Summary

- Add `/tmp/` to `.gitignore` (next to the existing `/temp/`) so local scratch files can never be accidentally staged. The four tracked `tmp/investment_*.sql` files remain tracked.
- Remove the `AGENTS.md`/`CLAUDE.md` reference to `tmp/transaction-registry/implementation-plan.md` — a local-only scratch doc that no longer exists (was never committed).

No code or behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)