### PR TITLE
Route company recurring payments to Swedbank business standing order

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/payment/savings/recurring/SavingsFundRecurringPaymentLinkGenerator.java
+++ b/src/main/java/ee/tuleva/onboarding/payment/savings/recurring/SavingsFundRecurringPaymentLinkGenerator.java
@@ -14,6 +14,7 @@ import ee.tuleva.onboarding.payment.PaymentLinkGenerator;
 import ee.tuleva.onboarding.payment.PaymentUrlEncoder;
 import ee.tuleva.onboarding.payment.PrefilledLink;
 import ee.tuleva.onboarding.payment.savings.SavingsFundRecipientConfiguration;
+import ee.tuleva.onboarding.user.personalcode.PersonalCodeValidator;
 import java.time.LocalDate;
 import java.util.LinkedHashMap;
 import lombok.RequiredArgsConstructor;
@@ -27,6 +28,12 @@ public class SavingsFundRecurringPaymentLinkGenerator implements PaymentLinkGene
   private static final String COOP_STANDING_ORDER_URL =
       "https://i.cooppank.ee/i/standing-orders/new";
   private static final String COOP_MONTHLY_FREQ = "2";
+  private static final String SWEDBANK_PRIVATE_STANDING_ORDER_URL =
+      "https://www.swedbank.ee/private/d2d/payments2/standing_order/new_foreign?";
+  private static final String SWEDBANK_BUSINESS_STANDING_ORDER_URL =
+      "https://www.swedbank.ee/business/d2d/payments/standing_order?language=EST";
+
+  private static final PersonalCodeValidator personalCodeValidator = new PersonalCodeValidator();
 
   private final SavingsFundRecipientConfiguration recipientConfiguration;
   private final PaymentDateProvider paymentDateProvider;
@@ -98,6 +105,9 @@ public class SavingsFundRecurringPaymentLinkGenerator implements PaymentLinkGene
 
   private String buildSwedbankUrl(
       String description, @Nullable String amount, LocalDate firstPaymentDate) {
+    if (isLegalEntity(description)) {
+      return SWEDBANK_BUSINESS_STANDING_ORDER_URL;
+    }
     var params = new LinkedHashMap<String, String>();
     params.put("standingOrder.beneficiaryAccountNumber", recipientConfiguration.getRecipientIban());
     params.put("standingOrder.beneficiaryName", recipientConfiguration.getRecipientName());
@@ -107,7 +117,10 @@ public class SavingsFundRecurringPaymentLinkGenerator implements PaymentLinkGene
     params.put("standingOrder.details", description);
     params.put("standingOrder.firstPaymentDate", format(firstPaymentDate));
     params.put("frequency", "K");
-    return "https://www.swedbank.ee/private/d2d/payments2/standing_order/new?"
-        + PaymentUrlEncoder.encode(params);
+    return SWEDBANK_PRIVATE_STANDING_ORDER_URL + PaymentUrlEncoder.encode(params);
+  }
+
+  private static boolean isLegalEntity(String recipientCode) {
+    return !personalCodeValidator.isValid(recipientCode);
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/payment/savings/recurring/SavingsFundRecurringPaymentLinkGeneratorTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/payment/savings/recurring/SavingsFundRecurringPaymentLinkGeneratorTest.java
@@ -34,6 +34,7 @@ import org.springframework.context.i18n.LocaleContextHolder;
 class SavingsFundRecurringPaymentLinkGeneratorTest {
 
   private static final String PERSONAL_CODE = "38812121215";
+  private static final String REGISTRY_CODE = "12345678";
   private static final String RECIPIENT_NAME = "Tuleva Täiendav Kogumisfond";
   private static final String RECIPIENT_IBAN = "EE711010220306707220";
   private static final LocalDate FIRST_PAYMENT = LocalDate.of(2026, 5, 10);
@@ -112,11 +113,11 @@ class SavingsFundRecurringPaymentLinkGeneratorTest {
   }
 
   @Test
-  void buildsSwedbankUrl() {
+  void buildsSwedbankPrivateUrlForPerson() {
     var link = prefilledLink(SWEDBANK);
 
     assertThat(link.url())
-        .startsWith("https://www.swedbank.ee/private/d2d/payments2/standing_order/new?")
+        .startsWith("https://www.swedbank.ee/private/d2d/payments2/standing_order/new_foreign?")
         .contains("standingOrder.beneficiaryAccountNumber=EE711010220306707220")
         .contains("standingOrder.beneficiaryName=Tuleva%20T%C3%A4iendav%20Kogumisfond")
         .contains("standingOrder.amount=50")
@@ -124,6 +125,27 @@ class SavingsFundRecurringPaymentLinkGeneratorTest {
         .contains("standingOrder.firstPaymentDate=10.05.2026")
         .contains("frequency=K");
     assertCommonRecipientFields(link);
+  }
+
+  @Test
+  void buildsSwedbankBusinessLandingUrlForLegalEntity() {
+    var paymentData =
+        PaymentData.builder()
+            .amount(new BigDecimal("50"))
+            .currency(EUR)
+            .type(SAVINGS_RECURRING)
+            .paymentChannel(SWEDBANK)
+            .recipientPersonalCode(REGISTRY_CODE)
+            .build();
+
+    var link = (PrefilledLink) generator.getPaymentLink(paymentData, person());
+
+    assertThat(link.url())
+        .isEqualTo("https://www.swedbank.ee/business/d2d/payments/standing_order?language=EST");
+    assertThat(link.recipientName()).isEqualTo(RECIPIENT_NAME);
+    assertThat(link.recipientIban()).isEqualTo(RECIPIENT_IBAN);
+    assertThat(link.description()).isEqualTo(REGISTRY_CODE);
+    assertThat(link.amount()).isEqualTo("50");
   }
 
   @Test


### PR DESCRIPTION
## Problem

[TKF-VPII2026#75](https://github.com/TulevaEE/TKF-VPII2026/issues/75): the savings-fund **recurring (püsimakse)** Swedbank link sent *everyone* to the **private-person** standing-order page. Companies paying from an OÜ landed on the generic private Swedbank page (and the intuitive "Sisene" logs into a *personal* account) instead of a usable standing-order form.

## Fix

`SavingsFundRecurringPaymentLinkGenerator` now picks the Swedbank URL based on the payer (legal entity detected via `PersonalCodeValidator`, the same approach as `PaymentInternalReferenceService`):

| Payer | URL |
|---|---|
| Legal entity | `…/business/d2d/payments/standing_order?language=EST` (business page, no pre-fill) |
| Private person | `…/private/d2d/payments2/standing_order/new_foreign?…` (was `/new`) |

The private path moves to `new_foreign` per Swedbank — the recipient IBAN (`EE71`**`1010`**`…`) is an LHV account, so it's a cross-bank standing order, which `/new` doesn't pre-fill.

The companion frontend change (legal-entity Swedbank → copy-fields LANDING UI, since the business page can't pre-fill) is in onboarding-client `swedbank-business-recurring-landing`.

## Tests

`SavingsFundRecurringPaymentLinkGeneratorTest` — renamed the person case and added `buildsSwedbankBusinessLandingUrlForLegalEntity`. Green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
