### PR TITLE
AML(#78) M3: flag companies that changed owner before onboarding (KYB_OWNER_CHANGED)

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/aml/AmlCheckType.java
+++ b/src/main/java/ee/tuleva/onboarding/aml/AmlCheckType.java
@@ -40,6 +40,7 @@ public enum AmlCheckType {
   KYB_COMPANY_LEGAL_FORM,
   KYB_COMPANY_REGISTERED_IN_ESTONIA,
   KYB_SELF_CERTIFICATION,
+  KYB_OWNER_CHANGED,
   KYB_DATA_CHANGED;
 
   @Getter final boolean manual;

--- a/src/main/java/ee/tuleva/onboarding/aml/AmlKybCheckEventListener.java
+++ b/src/main/java/ee/tuleva/onboarding/aml/AmlKybCheckEventListener.java
@@ -34,6 +34,7 @@ public class AmlKybCheckEventListener {
               KybCheckType.COMPANY_REGISTERED_IN_ESTONIA,
               AmlCheckType.KYB_COMPANY_REGISTERED_IN_ESTONIA),
           entry(KybCheckType.SELF_CERTIFICATION, AmlCheckType.KYB_SELF_CERTIFICATION),
+          entry(KybCheckType.OWNER_CHANGED, AmlCheckType.KYB_OWNER_CHANGED),
           entry(KybCheckType.DATA_CHANGED, AmlCheckType.KYB_DATA_CHANGED));
 
   private final AmlService amlService;

--- a/src/main/java/ee/tuleva/onboarding/kyb/KybCheckType.java
+++ b/src/main/java/ee/tuleva/onboarding/kyb/KybCheckType.java
@@ -14,6 +14,7 @@ public enum KybCheckType {
   COMPANY_LEGAL_FORM,
   COMPANY_REGISTERED_IN_ESTONIA,
   SELF_CERTIFICATION,
+  OWNER_CHANGED(false),
   DATA_CHANGED(false);
 
   private final boolean onboardingGate;

--- a/src/main/java/ee/tuleva/onboarding/kyb/KybCompanyData.java
+++ b/src/main/java/ee/tuleva/onboarding/kyb/KybCompanyData.java
@@ -12,4 +12,5 @@ public record KybCompanyData(
     SelfCertification selfCertification,
     @Nullable String countryCode,
     @Nullable String fullAddress,
-    @Nullable LocalDate foundingDate) {}
+    @Nullable LocalDate foundingDate,
+    boolean ownerChangedBeforeOnboarding) {}

--- a/src/main/java/ee/tuleva/onboarding/kyb/KybCompanyDataMapper.java
+++ b/src/main/java/ee/tuleva/onboarding/kyb/KybCompanyDataMapper.java
@@ -29,6 +29,15 @@ class KybCompanyDataMapper {
       PersonalCode personalCode,
       List<CompanyRelationship> relationships,
       SelfCertification selfCertification) {
+    return toKybCompanyData(detail, personalCode, relationships, selfCertification, false);
+  }
+
+  KybCompanyData toKybCompanyData(
+      CompanyDetail detail,
+      PersonalCode personalCode,
+      List<CompanyRelationship> relationships,
+      SelfCertification selfCertification,
+      boolean ownerChangedBeforeOnboarding) {
 
     var status = detail.getStatus().map(CompanyStatus::valueOf).orElse(null);
     var legalForm = detail.getLegalForm().map(LegalForm::fromString).orElse(null);
@@ -69,7 +78,8 @@ class KybCompanyDataMapper {
         selfCertification,
         countryCode,
         fullAddress,
-        foundingDate);
+        foundingDate,
+        ownerChangedBeforeOnboarding);
   }
 
   private KybRelatedPerson toRelatedPerson(PersonalCode code, List<CompanyRelationship> roles) {

--- a/src/main/java/ee/tuleva/onboarding/kyb/LegalEntityScreener.java
+++ b/src/main/java/ee/tuleva/onboarding/kyb/LegalEntityScreener.java
@@ -20,6 +20,7 @@ public class LegalEntityScreener {
   private final KybCompanyDataMapper kybCompanyDataMapper;
   private final KybScreeningService kybScreeningService;
   private final LatestKybSurveyInputs latestKybSurveyInputs;
+  private final OwnershipChangeDetector ownershipChangeDetector;
   private final Clock clock;
 
   public List<CompanyRelationship> fetchActiveRelationships(String registryCode) {
@@ -38,7 +39,11 @@ public class LegalEntityScreener {
     var detail = fetchCompanyDetail(registryCode);
     var data =
         kybCompanyDataMapper.toKybCompanyData(
-            detail, personalCode, relationships, selfCertification);
+            detail,
+            personalCode,
+            relationships,
+            selfCertification,
+            ownerChangedBeforeOnboarding(registryCode));
     return kybScreeningService.screen(data);
   }
 
@@ -57,8 +62,17 @@ public class LegalEntityScreener {
     var detail = fetchCompanyDetail(registryCode);
     var data =
         kybCompanyDataMapper.toKybCompanyData(
-            detail, personalCode, relationships, selfCertification);
+            detail,
+            personalCode,
+            relationships,
+            selfCertification,
+            ownerChangedBeforeOnboarding(registryCode));
     return new ValidationResult(detail, kybScreeningService.validate(data));
+  }
+
+  private boolean ownerChangedBeforeOnboarding(String registryCode) {
+    return ownershipChangeDetector.ownerChangedBeforeOnboarding(
+        ariregisterClient.getCompanyRelationships(registryCode));
   }
 
   public record ValidationResult(CompanyDetail detail, List<KybCheck> checks) {}

--- a/src/main/java/ee/tuleva/onboarding/kyb/OwnershipChangeDetector.java
+++ b/src/main/java/ee/tuleva/onboarding/kyb/OwnershipChangeDetector.java
@@ -1,0 +1,36 @@
+package ee.tuleva.onboarding.kyb;
+
+import static java.util.stream.Collectors.toSet;
+
+import ee.tuleva.onboarding.ariregister.CompanyRelationship;
+import java.util.List;
+import java.util.Set;
+import org.springframework.stereotype.Component;
+
+@Component
+public class OwnershipChangeDetector {
+
+  private static final String SHAREHOLDER_ROLE = "OSAN";
+
+  public boolean ownerChangedBeforeOnboarding(List<CompanyRelationship> relationshipHistory) {
+    Set<String> currentOwners =
+        relationshipHistory.stream()
+            .filter(this::isOwner)
+            .filter(this::isActive)
+            .map(CompanyRelationship::personalCode)
+            .collect(toSet());
+
+    return relationshipHistory.stream()
+        .filter(this::isOwner)
+        .map(CompanyRelationship::personalCode)
+        .anyMatch(code -> code != null && !currentOwners.contains(code));
+  }
+
+  private boolean isOwner(CompanyRelationship relationship) {
+    return SHAREHOLDER_ROLE.equals(relationship.roleCode()) || relationship.controlMethod() != null;
+  }
+
+  private boolean isActive(CompanyRelationship relationship) {
+    return relationship.endDate() == null;
+  }
+}

--- a/src/main/java/ee/tuleva/onboarding/kyb/screener/OwnerChangeScreener.java
+++ b/src/main/java/ee/tuleva/onboarding/kyb/screener/OwnerChangeScreener.java
@@ -1,0 +1,21 @@
+package ee.tuleva.onboarding.kyb.screener;
+
+import static ee.tuleva.onboarding.kyb.KybCheckType.OWNER_CHANGED;
+
+import ee.tuleva.onboarding.kyb.KybCheck;
+import ee.tuleva.onboarding.kyb.KybCompanyData;
+import java.util.List;
+import java.util.Map;
+import org.springframework.stereotype.Component;
+
+@Component
+public class OwnerChangeScreener implements KybScreener {
+
+  @Override
+  public List<KybCheck> screen(KybCompanyData companyData) {
+    var ownerChanged = companyData.ownerChangedBeforeOnboarding();
+    return List.of(
+        new KybCheck(
+            OWNER_CHANGED, !ownerChanged, Map.of("ownerChangedBeforeOnboarding", ownerChanged)));
+  }
+}

--- a/src/main/java/ee/tuleva/onboarding/kyb/survey/KybSurveyService.java
+++ b/src/main/java/ee/tuleva/onboarding/kyb/survey/KybSurveyService.java
@@ -84,7 +84,7 @@ class KybSurveyService {
                   "relatedPersons",
                   "COMPANY_STRUCTURE",
                   "Ettevõtte omandistruktuur ei ole toetatud"));
-      case DATA_CHANGED, SELF_CERTIFICATION, COMPANY_AGE -> Stream.of();
+      case DATA_CHANGED, SELF_CERTIFICATION, COMPANY_AGE, OWNER_CHANGED -> Stream.of();
     };
   }
 

--- a/src/test/groovy/ee/tuleva/onboarding/kyb/KybCheckTypeTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyb/KybCheckTypeTest.java
@@ -10,6 +10,7 @@ class KybCheckTypeTest {
   @Test
   void riskSignalChecksDoNotGateOnboarding() {
     assertThat(COMPANY_AGE.isOnboardingGate()).isFalse();
+    assertThat(OWNER_CHANGED.isOnboardingGate()).isFalse();
     assertThat(DATA_CHANGED.isOnboardingGate()).isFalse();
   }
 

--- a/src/test/groovy/ee/tuleva/onboarding/kyb/KybEndToEndTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyb/KybEndToEndTest.java
@@ -45,7 +45,7 @@ class KybEndToEndTest {
   void rule31_soleOwnerBoardMemberBeneficialOwner_allChecksPass() {
     var results = kybScreeningService.screen(rule31Pass());
 
-    assertThat(results).hasSize(11).allMatch(KybCheck::success);
+    assertThat(results).hasSize(12).allMatch(KybCheck::success);
     assertCheckPersisted(JAAN, KYB_SOLE_MEMBER_OWNERSHIP, true);
   }
 
@@ -203,7 +203,8 @@ class KybEndToEndTest {
             VALID_CERT,
             "EE",
             "Harju maakond, Tallinn, Pärnu mnt 1",
-            null);
+            null,
+            false);
 
     var results = kybScreeningService.screen(data);
 
@@ -350,6 +351,7 @@ class KybEndToEndTest {
             KYB_COMPANY_LEGAL_FORM,
             KYB_COMPANY_REGISTERED_IN_ESTONIA,
             KYB_SELF_CERTIFICATION,
+            KYB_OWNER_CHANGED,
             KYB_DATA_CHANGED);
     assertThat(amlChecks).allMatch(AmlCheck::isSuccess);
   }

--- a/src/test/groovy/ee/tuleva/onboarding/kyb/KybScreeningIntegrationTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyb/KybScreeningIntegrationTest.java
@@ -57,11 +57,12 @@ class KybScreeningIntegrationTest {
             new SelfCertification(true, true, true),
             "EE",
             "Harju maakond, Tallinn, Pärnu mnt 1",
-            null);
+            null,
+            false);
 
     var results = kybScreeningService.screen(data);
 
-    assertThat(results).hasSize(11).allMatch(KybCheck::success);
+    assertThat(results).hasSize(12).allMatch(KybCheck::success);
 
     var amlChecks =
         amlCheckRepository.findAllByPersonalCodeAndCreatedTimeAfter(
@@ -79,6 +80,7 @@ class KybScreeningIntegrationTest {
             KYB_COMPANY_LEGAL_FORM,
             KYB_COMPANY_REGISTERED_IN_ESTONIA,
             KYB_SELF_CERTIFICATION,
+            KYB_OWNER_CHANGED,
             KYB_DATA_CHANGED);
     assertThat(amlChecks).allMatch(AmlCheck::isSuccess);
   }
@@ -96,7 +98,8 @@ class KybScreeningIntegrationTest {
             new SelfCertification(true, true, true),
             "EE",
             "Harju maakond, Tallinn, Pärnu mnt 1",
-            null);
+            null,
+            false);
 
     var results = kybScreeningService.screen(data);
 
@@ -125,7 +128,8 @@ class KybScreeningIntegrationTest {
             new SelfCertification(true, true, true),
             "EE",
             "Harju maakond, Tallinn, Pärnu mnt 1",
-            null);
+            null,
+            false);
 
     kybScreeningService.screen(data);
 
@@ -138,7 +142,8 @@ class KybScreeningIntegrationTest {
             new SelfCertification(true, true, true),
             "EE",
             "Harju maakond, Tallinn, Pärnu mnt 1",
-            null);
+            null,
+            false);
 
     var secondResults = kybScreeningService.screen(changedData);
 
@@ -165,7 +170,8 @@ class KybScreeningIntegrationTest {
             new SelfCertification(true, true, true),
             "EE",
             "Harju maakond, Tallinn, Pärnu mnt 1",
-            null);
+            null,
+            false);
 
     var results = kybScreeningService.screen(data);
 
@@ -196,7 +202,8 @@ class KybScreeningIntegrationTest {
             new SelfCertification(true, true, true),
             "EE",
             "Harju maakond, Tallinn, Pärnu mnt 1",
-            LocalDate.now(clock).minusMonths(1));
+            LocalDate.now(clock).minusMonths(1),
+            false);
 
     kybScreeningService.screen(data);
 
@@ -206,5 +213,32 @@ class KybScreeningIntegrationTest {
     var ageCheck = amlChecks.stream().filter(c -> c.getType() == KYB_COMPANY_AGE).findFirst();
     assertThat(ageCheck).as("KYB_COMPANY_AGE AmlCheck should be persisted").isPresent();
     assertThat(ageCheck.get().isSuccess()).isFalse();
+  }
+
+  @Test
+  void companyThatChangedOwnerBeforeOnboardingCreatesFailingOwnerChangeCheck() {
+    var person =
+        new KybRelatedPerson(PERSONAL_CODE, true, true, true, BigDecimal.valueOf(100), COMPLETED);
+    var data =
+        new KybCompanyData(
+            new CompanyDto(new RegistryCode("12345678"), "Test OÜ", "62011", LegalForm.OÜ),
+            PERSONAL_CODE,
+            R,
+            List.of(person),
+            new SelfCertification(true, true, true),
+            "EE",
+            "Harju maakond, Tallinn, Pärnu mnt 1",
+            null,
+            true);
+
+    kybScreeningService.screen(data);
+
+    var amlChecks =
+        amlCheckRepository.findAllByPersonalCodeAndCreatedTimeAfter(
+            PERSONAL_CODE.value(), aYearAgo());
+    var ownerChangedCheck =
+        amlChecks.stream().filter(c -> c.getType() == KYB_OWNER_CHANGED).findFirst();
+    assertThat(ownerChangedCheck).as("KYB_OWNER_CHANGED AmlCheck should be persisted").isPresent();
+    assertThat(ownerChangedCheck.get().isSuccess()).isFalse();
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/kyb/KybScreeningServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyb/KybScreeningServiceTest.java
@@ -75,7 +75,8 @@ class KybScreeningServiceTest {
             new SelfCertification(true, true, true),
             "EE",
             "Harju maakond, Tallinn, Pärnu mnt 1",
-            null);
+            null,
+            false);
 
     var results = kybScreeningService.screen(data);
 
@@ -111,7 +112,8 @@ class KybScreeningServiceTest {
             new SelfCertification(true, true, true),
             "EE",
             "Harju maakond, Tallinn, Pärnu mnt 1",
-            null);
+            null,
+            false);
 
     var results = kybScreeningService.screen(data);
 
@@ -147,7 +149,8 @@ class KybScreeningServiceTest {
             new SelfCertification(true, true, true),
             "EE",
             "Harju maakond, Tallinn, Pärnu mnt 1",
-            null);
+            null,
+            false);
 
     var results = kybScreeningService.screen(data);
 
@@ -186,7 +189,8 @@ class KybScreeningServiceTest {
             new SelfCertification(true, true, true),
             "EE",
             "Harju maakond, Tallinn, Pärnu mnt 1",
-            null);
+            null,
+            false);
 
     var results = kybScreeningService.screen(data);
 
@@ -207,7 +211,8 @@ class KybScreeningServiceTest {
             new SelfCertification(true, true, true),
             "EE",
             "Harju maakond, Tallinn, Pärnu mnt 1",
-            null);
+            null,
+            false);
 
     var results = kybScreeningService.screen(data);
 
@@ -234,7 +239,8 @@ class KybScreeningServiceTest {
             new SelfCertification(true, true, true),
             "EE",
             "Harju maakond, Tallinn, Pärnu mnt 1",
-            null);
+            null,
+            false);
 
     var results = kybScreeningService.validate(data);
 

--- a/src/test/groovy/ee/tuleva/onboarding/kyb/KybTestFixtures.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyb/KybTestFixtures.java
@@ -108,7 +108,8 @@ public final class KybTestFixtures {
         selfCertification,
         "EE",
         "Harju maakond, Tallinn, Pärnu mnt 1",
-        null);
+        null,
+        false);
   }
 
   // =====================================================================

--- a/src/test/groovy/ee/tuleva/onboarding/kyb/LegalEntityScreenerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyb/LegalEntityScreenerTest.java
@@ -40,6 +40,7 @@ class LegalEntityScreenerTest {
           kybCompanyDataMapper,
           kybScreeningService,
           latestKybSurveyInputs,
+          new OwnershipChangeDetector(),
           FIXED_CLOCK);
 
   @Test
@@ -71,8 +72,11 @@ class LegalEntityScreenerTest {
             SELF_CERT,
             "EE",
             "Harju maakond, Tallinn, Pärnu mnt 1",
-            null);
-    given(kybCompanyDataMapper.toKybCompanyData(detail, PERSONAL_CODE, relationships, SELF_CERT))
+            null,
+            false);
+    given(
+            kybCompanyDataMapper.toKybCompanyData(
+                detail, PERSONAL_CODE, relationships, SELF_CERT, false))
         .willReturn(companyData);
     var checks = List.of(new KybCheck(KybCheckType.COMPANY_ACTIVE, true, Map.of()));
     given(kybScreeningService.screen(companyData)).willReturn(checks);
@@ -97,8 +101,9 @@ class LegalEntityScreenerTest {
             null,
             "EE",
             "Harju maakond, Tallinn, Pärnu mnt 1",
-            null);
-    given(kybCompanyDataMapper.toKybCompanyData(detail, PERSONAL_CODE, relationships, null))
+            null,
+            false);
+    given(kybCompanyDataMapper.toKybCompanyData(detail, PERSONAL_CODE, relationships, null, false))
         .willReturn(companyData);
     var checks = List.of(new KybCheck(KybCheckType.COMPANY_ACTIVE, true, Map.of()));
     given(kybScreeningService.validate(companyData)).willReturn(checks);
@@ -130,10 +135,11 @@ class LegalEntityScreenerTest {
             SELF_CERT,
             "EE",
             "Harju maakond, Tallinn, Pärnu mnt 1",
-            null);
+            null,
+            false);
     given(
             kybCompanyDataMapper.toKybCompanyData(
-                detail, PERSONAL_CODE, List.of(boardMember), SELF_CERT))
+                detail, PERSONAL_CODE, List.of(boardMember), SELF_CERT, false))
         .willReturn(companyData);
     var checks = List.of(new KybCheck(KybCheckType.COMPANY_ACTIVE, true, Map.of()));
     given(kybScreeningService.screen(companyData)).willReturn(checks);

--- a/src/test/groovy/ee/tuleva/onboarding/kyb/OwnershipChangeDetectorTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyb/OwnershipChangeDetectorTest.java
@@ -1,0 +1,104 @@
+package ee.tuleva.onboarding.kyb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ee.tuleva.onboarding.ariregister.CompanyRelationship;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class OwnershipChangeDetectorTest {
+
+  private final OwnershipChangeDetector detector = new OwnershipChangeDetector();
+
+  @Test
+  void detectsChangeWhenAFormerOwnerHasExited() {
+    var history =
+        List.of(
+            owner("38501010001", LocalDate.of(2010, 1, 1), LocalDate.of(2018, 1, 1)),
+            owner("49001010001", LocalDate.of(2018, 1, 1), null));
+
+    assertThat(detector.ownerChangedBeforeOnboarding(history)).isTrue();
+  }
+
+  @Test
+  void noChangeWhenTheSoleOwnerNeverLeft() {
+    var history = List.of(owner("38501010001", LocalDate.of(2010, 1, 1), null));
+
+    assertThat(detector.ownerChangedBeforeOnboarding(history)).isFalse();
+  }
+
+  @Test
+  void noChangeWhenAnOwnerRecordWasSplitButThePersonIsStillAnOwner() {
+    var history =
+        List.of(
+            owner("38501010001", LocalDate.of(2010, 1, 1), LocalDate.of(2015, 1, 1)),
+            owner("38501010001", LocalDate.of(2015, 1, 1), null));
+
+    assertThat(detector.ownerChangedBeforeOnboarding(history)).isFalse();
+  }
+
+  @Test
+  void detectsChangeWhenABeneficialOwnerHasExited() {
+    var history =
+        List.of(
+            beneficialOwner("38501010001", LocalDate.of(2010, 1, 1), LocalDate.of(2020, 1, 1)),
+            beneficialOwner("49001010001", LocalDate.of(2020, 1, 1), null));
+
+    assertThat(detector.ownerChangedBeforeOnboarding(history)).isTrue();
+  }
+
+  @Test
+  void noChangeWhenOnlyABoardMemberChanged() {
+    var history =
+        List.of(
+            boardMember("38501010001", LocalDate.of(2010, 1, 1), LocalDate.of(2019, 1, 1)),
+            boardMember("49001010001", LocalDate.of(2019, 1, 1), null),
+            owner("37801010009", LocalDate.of(2010, 1, 1), null));
+
+    assertThat(detector.ownerChangedBeforeOnboarding(history)).isFalse();
+  }
+
+  @Test
+  void noChangeForEmptyHistory() {
+    assertThat(detector.ownerChangedBeforeOnboarding(List.of())).isFalse();
+  }
+
+  private static CompanyRelationship owner(String personalCode, LocalDate start, LocalDate end) {
+    return relationship("OSAN", personalCode, start, end, new BigDecimal("100.00"), null);
+  }
+
+  private static CompanyRelationship beneficialOwner(
+      String personalCode, LocalDate start, LocalDate end) {
+    return relationship(
+        "OSAN", personalCode, start, end, new BigDecimal("100.00"), "Osaluse kaudu");
+  }
+
+  private static CompanyRelationship boardMember(
+      String personalCode, LocalDate start, LocalDate end) {
+    return relationship("JUHL", personalCode, start, end, null, null);
+  }
+
+  private static CompanyRelationship relationship(
+      String roleCode,
+      String personalCode,
+      LocalDate startDate,
+      LocalDate endDate,
+      BigDecimal ownershipPercent,
+      String controlMethod) {
+    return new CompanyRelationship(
+        "F",
+        roleCode,
+        roleCode,
+        "First",
+        "Last",
+        personalCode,
+        null,
+        startDate,
+        endDate,
+        ownershipPercent,
+        controlMethod,
+        "EST");
+  }
+}

--- a/src/test/groovy/ee/tuleva/onboarding/kyb/screener/CompanyActiveScreenerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyb/screener/CompanyActiveScreenerTest.java
@@ -46,6 +46,7 @@ class CompanyActiveScreenerTest {
         new SelfCertification(true, true, true),
         "EE",
         "Harju maakond, Tallinn, Pärnu mnt 1",
-        null);
+        null,
+        false);
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/kyb/screener/CompanyAgeScreenerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyb/screener/CompanyAgeScreenerTest.java
@@ -67,6 +67,7 @@ class CompanyAgeScreenerTest {
         new SelfCertification(true, true, true),
         "EE",
         "Harju maakond, Tallinn, Pärnu mnt 1",
-        foundingDate);
+        foundingDate,
+        false);
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/kyb/screener/CompanyLegalFormScreenerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyb/screener/CompanyLegalFormScreenerTest.java
@@ -58,6 +58,7 @@ class CompanyLegalFormScreenerTest {
         new SelfCertification(true, true, true),
         "EE",
         "Harju maakond, Tallinn, Pärnu mnt 1",
-        null);
+        null,
+        false);
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/kyb/screener/CompanyNaceScreenerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyb/screener/CompanyNaceScreenerTest.java
@@ -72,6 +72,7 @@ class CompanyNaceScreenerTest {
         new SelfCertification(true, true, true),
         "EE",
         "Harju maakond, Tallinn, Pärnu mnt 1",
-        null);
+        null,
+        false);
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/kyb/screener/CompanyRegisteredInEstoniaScreenerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyb/screener/CompanyRegisteredInEstoniaScreenerTest.java
@@ -76,6 +76,7 @@ class CompanyRegisteredInEstoniaScreenerTest {
         new SelfCertification(true, true, true),
         countryCode,
         fullAddress,
-        null);
+        null,
+        false);
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/kyb/screener/CompanySanctionScreenerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyb/screener/CompanySanctionScreenerTest.java
@@ -117,7 +117,8 @@ class CompanySanctionScreenerTest {
         new SelfCertification(true, true, true),
         "EE",
         "Harju maakond, Tallinn, Pärnu mnt 1",
-        null);
+        null,
+        false);
   }
 
   private MatchResponse emptyResponse() {

--- a/src/test/groovy/ee/tuleva/onboarding/kyb/screener/CompanyStructureScreenerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyb/screener/CompanyStructureScreenerTest.java
@@ -91,6 +91,7 @@ class CompanyStructureScreenerTest {
         new SelfCertification(true, true, true),
         "EE",
         "Harju maakond, Tallinn, Pärnu mnt 1",
-        null);
+        null,
+        false);
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/kyb/screener/DualMemberOwnershipScreenerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyb/screener/DualMemberOwnershipScreenerTest.java
@@ -37,7 +37,8 @@ class DualMemberOwnershipScreenerTest {
             new SelfCertification(true, true, true),
             "EE",
             "Harju maakond, Tallinn, Pärnu mnt 1",
-            null);
+            null,
+            false);
 
     var result = screener.screen(data);
 
@@ -63,7 +64,8 @@ class DualMemberOwnershipScreenerTest {
             new SelfCertification(true, true, true),
             "EE",
             "Harju maakond, Tallinn, Pärnu mnt 1",
-            null);
+            null,
+            false);
 
     var result = screener.screen(data);
 
@@ -89,7 +91,8 @@ class DualMemberOwnershipScreenerTest {
             new SelfCertification(true, true, true),
             "EE",
             "Harju maakond, Tallinn, Pärnu mnt 1",
-            null);
+            null,
+            false);
 
     var result = screener.screen(data);
 
@@ -115,7 +118,8 @@ class DualMemberOwnershipScreenerTest {
             new SelfCertification(true, true, true),
             "EE",
             "Harju maakond, Tallinn, Pärnu mnt 1",
-            null);
+            null,
+            false);
 
     var result = screener.screen(data);
 
@@ -136,7 +140,8 @@ class DualMemberOwnershipScreenerTest {
             new SelfCertification(true, true, true),
             "EE",
             "Harju maakond, Tallinn, Pärnu mnt 1",
-            null);
+            null,
+            false);
 
     var result = screener.screen(data);
 

--- a/src/test/groovy/ee/tuleva/onboarding/kyb/screener/OwnerChangeScreenerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyb/screener/OwnerChangeScreenerTest.java
@@ -1,0 +1,45 @@
+package ee.tuleva.onboarding.kyb.screener;
+
+import static ee.tuleva.onboarding.kyb.KybCheckType.OWNER_CHANGED;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ee.tuleva.onboarding.kyb.*;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class OwnerChangeScreenerTest {
+
+  private final OwnerChangeScreener screener = new OwnerChangeScreener();
+
+  @Test
+  void failsWhenOwnerChangedBeforeOnboarding() {
+    var result = screener.screen(company(true));
+
+    assertThat(result)
+        .containsExactly(
+            new KybCheck(OWNER_CHANGED, false, Map.of("ownerChangedBeforeOnboarding", true)));
+  }
+
+  @Test
+  void passesWhenOwnerNeverChanged() {
+    var result = screener.screen(company(false));
+
+    assertThat(result)
+        .containsExactly(
+            new KybCheck(OWNER_CHANGED, true, Map.of("ownerChangedBeforeOnboarding", false)));
+  }
+
+  private static KybCompanyData company(boolean ownerChangedBeforeOnboarding) {
+    return new KybCompanyData(
+        new CompanyDto(new RegistryCode("12345678"), "Test OÜ", "62011", LegalForm.OÜ),
+        new PersonalCode("38501010001"),
+        CompanyStatus.R,
+        List.of(),
+        new SelfCertification(true, true, true),
+        "EE",
+        "Harju maakond, Tallinn, Pärnu mnt 1",
+        null,
+        ownerChangedBeforeOnboarding);
+  }
+}

--- a/src/test/groovy/ee/tuleva/onboarding/kyb/screener/RelatedPersonsKycScreenerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyb/screener/RelatedPersonsKycScreenerTest.java
@@ -52,7 +52,8 @@ class RelatedPersonsKycScreenerTest {
             new SelfCertification(true, true, true),
             "EE",
             "Harju maakond, Tallinn, Pärnu mnt 1",
-            null);
+            null,
+            false);
 
     var result = screener.screen(data);
 
@@ -89,7 +90,8 @@ class RelatedPersonsKycScreenerTest {
             new SelfCertification(true, true, true),
             "EE",
             "Harju maakond, Tallinn, Pärnu mnt 1",
-            null);
+            null,
+            false);
 
     var result = screener.screen(data);
 
@@ -120,7 +122,8 @@ class RelatedPersonsKycScreenerTest {
             new SelfCertification(true, true, true),
             "EE",
             "Harju maakond, Tallinn, Pärnu mnt 1",
-            null);
+            null,
+            false);
 
     var result = screener.screen(data);
 
@@ -146,7 +149,8 @@ class RelatedPersonsKycScreenerTest {
             new SelfCertification(true, true, true),
             "EE",
             "Harju maakond, Tallinn, Pärnu mnt 1",
-            null);
+            null,
+            false);
 
     var result = screener.screen(data);
 

--- a/src/test/groovy/ee/tuleva/onboarding/kyb/screener/SelfCertificationScreenerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyb/screener/SelfCertificationScreenerTest.java
@@ -67,7 +67,8 @@ class SelfCertificationScreenerTest {
             null,
             "EE",
             "Harju maakond, Tallinn, Pärnu mnt 1",
-            null);
+            null,
+            false);
 
     var results = screener.screen(data);
 
@@ -102,6 +103,7 @@ class SelfCertificationScreenerTest {
         cert,
         "EE",
         "Harju maakond, Tallinn, Pärnu mnt 1",
-        null);
+        null,
+        false);
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/kyb/screener/SoleBoardMemberIsOwnerScreenerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyb/screener/SoleBoardMemberIsOwnerScreenerTest.java
@@ -37,7 +37,8 @@ class SoleBoardMemberIsOwnerScreenerTest {
             new SelfCertification(true, true, true),
             "EE",
             "Harju maakond, Tallinn, Pärnu mnt 1",
-            null);
+            null,
+            false);
 
     var result = screener.screen(data);
 
@@ -63,7 +64,8 @@ class SoleBoardMemberIsOwnerScreenerTest {
             new SelfCertification(true, true, true),
             "EE",
             "Harju maakond, Tallinn, Pärnu mnt 1",
-            null);
+            null,
+            false);
 
     var result = screener.screen(data);
 
@@ -89,7 +91,8 @@ class SoleBoardMemberIsOwnerScreenerTest {
             new SelfCertification(true, true, true),
             "EE",
             "Harju maakond, Tallinn, Pärnu mnt 1",
-            null);
+            null,
+            false);
 
     var result = screener.screen(data);
 
@@ -115,7 +118,8 @@ class SoleBoardMemberIsOwnerScreenerTest {
             new SelfCertification(true, true, true),
             "EE",
             "Harju maakond, Tallinn, Pärnu mnt 1",
-            null);
+            null,
+            false);
 
     var result = screener.screen(data);
 
@@ -136,7 +140,8 @@ class SoleBoardMemberIsOwnerScreenerTest {
             new SelfCertification(true, true, true),
             "EE",
             "Harju maakond, Tallinn, Pärnu mnt 1",
-            null);
+            null,
+            false);
 
     var result = screener.screen(data);
 

--- a/src/test/groovy/ee/tuleva/onboarding/kyb/screener/SoleMemberOwnershipScreenerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyb/screener/SoleMemberOwnershipScreenerTest.java
@@ -40,7 +40,8 @@ class SoleMemberOwnershipScreenerTest {
             new SelfCertification(true, true, true),
             "EE",
             "Harju maakond, Tallinn, Pärnu mnt 1",
-            null);
+            null,
+            false);
 
     var result = screener.screen(data);
 
@@ -75,7 +76,8 @@ class SoleMemberOwnershipScreenerTest {
             new SelfCertification(true, true, true),
             "EE",
             "Harju maakond, Tallinn, Pärnu mnt 1",
-            null);
+            null,
+            false);
 
     var result = screener.screen(data);
 


### PR DESCRIPTION
**Milestone M3** of the company AML risk-scoring rollout (issue TulevaEE/tuleva#78, Phase A). Self-contained spec: the rev-3 comment on tuleva#78 and the plan file in TulevaEE/tuleva#79.

> **Stacked on M2 (#1693)** — base is `aml-78-m2-company-age`, so this PR shows only M3's diff. It reuses `KybCheckType.isOnboardingGate()` introduced by M2's gate fix. Merge M2 first, then retarget this to `master`.

## Rule
Methodology rule (KKR): *"Kas juriidiline isik on vahetanud omanikku enne on-boardimist kunagi"* — has the company **ever changed owner before onboarding**. A company that changed hands before coming to us is an acquired-shell red flag (pairs with M2's company-age signal).

## Why now / what it replaces
The methodology notes this signal's data (`getCompanyRelationships` `endDate` history) was *"fetched but not used."* The existing `DATA_CHANGED` check inferred change from screening-to-screening diffs keyed by the **representative's personal code**, which contaminates a person who runs multiple companies. M3 reads the change from the **authoritative Äriregister relationship history** instead — per company, with dates.

## Change
- `OwnershipChangeDetector` flags a company when an **owner** (shareholder `OSAN` or beneficial owner) appears in the full history but is **not a current owner** — i.e. someone exited. A re-recorded same-person owner and **board-only** changes do not trigger it.
- The flag rides in `KybCompanyData` (computed in `LegalEntityScreener` from `getCompanyRelationships`, like M2's `foundingDate`); a new `OwnerChangeScreener` emits `KYB_OWNER_CHANGED`.
- **Risk signal, not a gate:** `OWNER_CHANGED` is `isOnboardingGate()=false`, so it's persisted and scored by M7 without rejecting the company (depends on the M2 fix).

## Tests (TDD)
- `OwnershipChangeDetectorTest` — exit detected; sole-owner no-change; same-person record split (not a false positive); beneficial-owner exit; board-only change ignored; empty history.
- `OwnerChangeScreenerTest` — emits failing/passing `OWNER_CHANGED`.
- `KybScreeningIntegrationTest` — a changed-owner company persists a failing `KYB_OWNER_CHANGED`.
- Green under `pg`/Testcontainers: `KybEndToEndTest` 28/28, `KybScreeningIntegrationTest` 6/6, + 149 kyb/aml unit tests, spotless.

## For Maria's sign-off (fine print of the rule)
- **Scope = owners only** — this is methodology **rule 16** (`planned_owner_changed_ever`, *"Omanikku vahetanud kunagi"*, status ⏳), which is owner-only by definition. Board-member changes are a **separate, already-active rule** — rule 5 `kkr_related_changed` (the existing `DATA_CHANGED` since-last-screening check, ✓) — **not** part of M3. So this is not a widen-to-board toggle; the two are distinct rules.
- **"Owner exited" = a former owner with no current owner relationship.** Same-person re-recording is excluded; a single ended owner-relationship with churn could still need refinement.
- One extra `getCompanyRelationships` SOAP call per screen/validate (could be deduplicated against the active-relationships fetch later).

Refs TulevaEE/tuleva#78.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
