### PR TITLE
AML(#78) M4: capture company representation-right specialty (esindusõiguse erisus)

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/ariregister/AriregisterClient.java
+++ b/src/main/java/ee/tuleva/onboarding/ariregister/AriregisterClient.java
@@ -67,7 +67,7 @@ public class AriregisterClient {
         DETAILANDMED_FACTORY.createDetailandmedV6QueryAriregisterParool(properties.password()));
     query.setAriregistriKood(new BigInteger(registryCode));
     query.setYandmed(true);
-    query.setIandmed(false);
+    query.setIandmed(true);
     query.setKandmed(false);
     query.setDandmed(false);
     query.setMaarused(false);

--- a/src/main/java/ee/tuleva/onboarding/ariregister/CompanyDetail.java
+++ b/src/main/java/ee/tuleva/onboarding/ariregister/CompanyDetail.java
@@ -2,6 +2,7 @@ package ee.tuleva.onboarding.ariregister;
 
 import jakarta.annotation.Nullable;
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 import lombok.Value;
 
@@ -16,6 +17,7 @@ public class CompanyDetail {
   @Nullable CompanyAddress address;
   @Nullable String mainActivity;
   @Nullable String naceCode;
+  List<RepresentationRight> representationRights;
 
   public Optional<String> getStatus() {
     return Optional.ofNullable(status);

--- a/src/main/java/ee/tuleva/onboarding/ariregister/CompanyDetailMapper.java
+++ b/src/main/java/ee/tuleva/onboarding/ariregister/CompanyDetailMapper.java
@@ -1,10 +1,15 @@
 package ee.tuleva.onboarding.ariregister;
 
+import ee.tuleva.onboarding.ariregister.generated.detailandmed.DetailandmedV6EsindusoiguseEritingimus;
+import ee.tuleva.onboarding.ariregister.generated.detailandmed.DetailandmedV6EsindusoiguseEritingimused;
 import ee.tuleva.onboarding.ariregister.generated.detailandmed.DetailandmedV6Ettevotja;
+import ee.tuleva.onboarding.ariregister.generated.detailandmed.DetailandmedV6Isikuandmed;
 import ee.tuleva.onboarding.ariregister.generated.detailandmed.DetailandmedV6TeatatudTegevusala;
 import ee.tuleva.onboarding.ariregister.generated.detailandmed.DetailandmedV6Yldandmed;
 import ee.tuleva.onboarding.country.CountryCodes;
+import java.math.BigInteger;
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 class CompanyDetailMapper {
@@ -20,7 +25,30 @@ class CompanyDetailMapper {
         yldandmed.flatMap(CompanyDetailMapper::extractFoundingDate).orElse(null),
         yldandmed.flatMap(CompanyDetailMapper::extractCurrentAddress).orElse(null),
         mainActivityRecord.map(DetailandmedV6TeatatudTegevusala::getEmtakTekstina).orElse(null),
-        mainActivityRecord.map(DetailandmedV6TeatatudTegevusala::getNaceKood).orElse(null));
+        mainActivityRecord.map(DetailandmedV6TeatatudTegevusala::getNaceKood).orElse(null),
+        extractRepresentationRights(ettevotja));
+  }
+
+  private static List<RepresentationRight> extractRepresentationRights(
+      DetailandmedV6Ettevotja ettevotja) {
+    return Optional.ofNullable(ettevotja.getIsikuandmed())
+        .map(DetailandmedV6Isikuandmed::getEsindusoiguseEritingimused)
+        .map(DetailandmedV6EsindusoiguseEritingimused::getItem)
+        .orElseGet(List::of)
+        .stream()
+        .map(CompanyDetailMapper::toRepresentationRight)
+        .toList();
+  }
+
+  private static RepresentationRight toRepresentationRight(
+      DetailandmedV6EsindusoiguseEritingimus eritingimus) {
+    return new RepresentationRight(
+        eritingimus.getEsinduseTyyp(),
+        eritingimus.getEsinduseTyypTekstina(),
+        eritingimus.getEsinduseSisu(),
+        eritingimus.getAlgusKpv(),
+        eritingimus.getLoppKpv(),
+        Optional.ofNullable(eritingimus.getKirjeId()).map(BigInteger::longValue).orElse(null));
   }
 
   private static Optional<LocalDate> extractFoundingDate(DetailandmedV6Yldandmed yldandmed) {

--- a/src/main/java/ee/tuleva/onboarding/ariregister/RepresentationRight.java
+++ b/src/main/java/ee/tuleva/onboarding/ariregister/RepresentationRight.java
@@ -1,0 +1,12 @@
+package ee.tuleva.onboarding.ariregister;
+
+import jakarta.annotation.Nullable;
+import java.time.LocalDate;
+
+public record RepresentationRight(
+    @Nullable String type,
+    @Nullable String typeText,
+    @Nullable String content,
+    @Nullable LocalDate startDate,
+    @Nullable LocalDate endDate,
+    @Nullable Long entryId) {}

--- a/src/main/java/ee/tuleva/onboarding/company/CompanyOnboardingEventListener.java
+++ b/src/main/java/ee/tuleva/onboarding/company/CompanyOnboardingEventListener.java
@@ -4,6 +4,7 @@ import static ee.tuleva.onboarding.company.RelationshipType.*;
 import static ee.tuleva.onboarding.kyb.KybCheckPerformedEventOrder.ONBOARD_COMPANY;
 import static ee.tuleva.onboarding.party.PartyId.Type.PERSON;
 
+import ee.tuleva.onboarding.ariregister.RepresentationRight;
 import ee.tuleva.onboarding.kyb.KybCheck;
 import ee.tuleva.onboarding.kyb.KybCheckPerformedEvent;
 import ee.tuleva.onboarding.kyb.KybRelatedPerson;
@@ -22,6 +23,7 @@ public class CompanyOnboardingEventListener {
 
   private final CompanyRepository companyRepository;
   private final CompanyPartyRepository companyPartyRepository;
+  private final CompanyRepresentationRightRepository companyRepresentationRightRepository;
 
   @Order(ONBOARD_COMPANY)
   @EventListener
@@ -33,6 +35,7 @@ public class CompanyOnboardingEventListener {
             .orElseGet(() -> createCompany(event));
     if (allGateChecksPassed(event)) {
       replaceParties(company, event);
+      replaceRepresentationRights(company, event);
     }
   }
 
@@ -41,6 +44,26 @@ public class CompanyOnboardingEventListener {
     event.getRelatedPersons().stream()
         .flatMap(person -> toCompanyParties(person, company.getId()).stream())
         .forEach(companyPartyRepository::save);
+  }
+
+  private void replaceRepresentationRights(Company company, KybCheckPerformedEvent event) {
+    companyRepresentationRightRepository.deleteByCompanyId(company.getId());
+    event.getRepresentationRights().stream()
+        .map(right -> toCompanyRepresentationRight(right, company.getId()))
+        .forEach(companyRepresentationRightRepository::save);
+  }
+
+  private CompanyRepresentationRight toCompanyRepresentationRight(
+      RepresentationRight right, UUID companyId) {
+    return CompanyRepresentationRight.builder()
+        .companyId(companyId)
+        .entryId(right.entryId())
+        .representationType(right.type())
+        .representationTypeText(right.typeText())
+        .content(right.content())
+        .startDate(right.startDate())
+        .endDate(right.endDate())
+        .build();
   }
 
   private List<CompanyParty> toCompanyParties(KybRelatedPerson person, UUID companyId) {

--- a/src/main/java/ee/tuleva/onboarding/company/CompanyRepresentationRight.java
+++ b/src/main/java/ee/tuleva/onboarding/company/CompanyRepresentationRight.java
@@ -1,0 +1,50 @@
+package ee.tuleva.onboarding.company;
+
+import static jakarta.persistence.GenerationType.UUID;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.UUID;
+import lombok.*;
+
+@Entity
+@Table(name = "company_representation_right")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ToString
+public class CompanyRepresentationRight {
+
+  @Id
+  @GeneratedValue(strategy = UUID)
+  private UUID id;
+
+  @NotNull
+  @Column(nullable = false)
+  private UUID companyId;
+
+  private Long entryId;
+
+  private String representationType;
+
+  private String representationTypeText;
+
+  private String content;
+
+  private LocalDate startDate;
+
+  private LocalDate endDate;
+
+  @Column(nullable = false, updatable = false)
+  private Instant createdDate;
+
+  @PrePersist
+  void prePersist() {
+    if (createdDate == null) {
+      createdDate = Instant.now();
+    }
+  }
+}

--- a/src/main/java/ee/tuleva/onboarding/company/CompanyRepresentationRightRepository.java
+++ b/src/main/java/ee/tuleva/onboarding/company/CompanyRepresentationRightRepository.java
@@ -1,0 +1,13 @@
+package ee.tuleva.onboarding.company;
+
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CompanyRepresentationRightRepository
+    extends JpaRepository<CompanyRepresentationRight, UUID> {
+
+  List<CompanyRepresentationRight> findByCompanyId(UUID companyId);
+
+  void deleteByCompanyId(UUID companyId);
+}

--- a/src/main/java/ee/tuleva/onboarding/kyb/KybCheckPerformedEvent.java
+++ b/src/main/java/ee/tuleva/onboarding/kyb/KybCheckPerformedEvent.java
@@ -1,5 +1,6 @@
 package ee.tuleva.onboarding.kyb;
 
+import ee.tuleva.onboarding.ariregister.RepresentationRight;
 import java.util.List;
 import java.util.Objects;
 import lombok.Getter;
@@ -13,17 +14,20 @@ public class KybCheckPerformedEvent extends ApplicationEvent {
   private final PersonalCode personalCode;
   private final List<KybRelatedPerson> relatedPersons;
   private final List<KybCheck> checks;
+  private final List<RepresentationRight> representationRights;
 
   public KybCheckPerformedEvent(
       Object source,
       CompanyDto company,
       PersonalCode personalCode,
       List<KybRelatedPerson> relatedPersons,
-      List<KybCheck> checks) {
+      List<KybCheck> checks,
+      List<RepresentationRight> representationRights) {
     super(source);
     this.company = Objects.requireNonNull(company);
     this.personalCode = Objects.requireNonNull(personalCode);
     this.relatedPersons = Objects.requireNonNull(relatedPersons);
     this.checks = Objects.requireNonNull(checks);
+    this.representationRights = Objects.requireNonNull(representationRights);
   }
 }

--- a/src/main/java/ee/tuleva/onboarding/kyb/KybCompanyData.java
+++ b/src/main/java/ee/tuleva/onboarding/kyb/KybCompanyData.java
@@ -1,5 +1,6 @@
 package ee.tuleva.onboarding.kyb;
 
+import ee.tuleva.onboarding.ariregister.RepresentationRight;
 import jakarta.annotation.Nullable;
 import java.time.LocalDate;
 import java.util.List;
@@ -12,4 +13,5 @@ public record KybCompanyData(
     SelfCertification selfCertification,
     @Nullable String countryCode,
     @Nullable String fullAddress,
-    @Nullable LocalDate foundingDate) {}
+    @Nullable LocalDate foundingDate,
+    List<RepresentationRight> representationRights) {}

--- a/src/main/java/ee/tuleva/onboarding/kyb/KybCompanyDataMapper.java
+++ b/src/main/java/ee/tuleva/onboarding/kyb/KybCompanyDataMapper.java
@@ -41,6 +41,7 @@ class KybCompanyDataMapper {
         address.map(CompanyAddress::addressDetails).map(AddressDetails::countryCode).orElse(null);
     var fullAddress = address.map(CompanyAddress::fullAddress).orElse(null);
     var foundingDate = detail.getFoundingDate().orElse(null);
+    var representationRights = detail.getRepresentationRights();
 
     var companyDto =
         new CompanyDto(
@@ -72,7 +73,8 @@ class KybCompanyDataMapper {
         selfCertification,
         countryCode,
         fullAddress,
-        foundingDate);
+        foundingDate,
+        representationRights);
   }
 
   private KybRelatedPerson toRelatedPerson(

--- a/src/main/java/ee/tuleva/onboarding/kyb/KybScreeningService.java
+++ b/src/main/java/ee/tuleva/onboarding/kyb/KybScreeningService.java
@@ -33,7 +33,8 @@ public class KybScreeningService {
             companyData.company(),
             companyData.personalCode(),
             companyData.relatedPersons(),
-            results));
+            results,
+            companyData.representationRights()));
 
     return results;
   }

--- a/src/main/resources/db/migration/V1_221__company_representation_right.sql
+++ b/src/main/resources/db/migration/V1_221__company_representation_right.sql
@@ -1,0 +1,15 @@
+CREATE TABLE company_representation_right (
+    id uuid DEFAULT gen_random_uuid() PRIMARY KEY,
+    company_id uuid NOT NULL,
+    entry_id bigint,
+    representation_type text,
+    representation_type_text text,
+    content text,
+    start_date date,
+    end_date date,
+    created_date timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT fk_company_representation_right_company FOREIGN KEY (company_id) REFERENCES company (id),
+    CONSTRAINT uq_company_representation_right UNIQUE (company_id, entry_id)
+);
+
+CREATE INDEX idx_company_representation_right_company_id ON company_representation_right (company_id);

--- a/src/test/groovy/ee/tuleva/onboarding/aml/AmlKybCheckCompanyAttributionIntegrationTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/aml/AmlKybCheckCompanyAttributionIntegrationTest.java
@@ -104,6 +104,6 @@ public class AmlKybCheckCompanyAttributionIntegrationTest {
     var company = new CompanyDto(new RegistryCode(registryCode), "Test OÜ", "62011", LegalForm.OÜ);
     var relatedPersons = List.of(boardMemberOwner(personalCode, 100.0).build());
     return new KybCheckPerformedEvent(
-        this, company, new PersonalCode(personalCode), relatedPersons, checks);
+        this, company, new PersonalCode(personalCode), relatedPersons, checks, List.of());
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/aml/AmlKybCheckEventListenerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/aml/AmlKybCheckEventListenerTest.java
@@ -100,6 +100,7 @@ class AmlKybCheckEventListenerTest {
         company,
         new PersonalCode(personalCode),
         relatedPersons,
-        checks);
+        checks,
+        List.of());
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/ariregister/AriregisterClientTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/ariregister/AriregisterClientTest.java
@@ -127,7 +127,7 @@ class AriregisterClientTest {
         .andExpect(xpath("//ar:ariregister_kasutajanimi", NS).evaluatesTo("testuser"))
         .andExpect(xpath("//ar:ariregister_parool", NS).evaluatesTo("testpass"))
         .andExpect(xpath("//ar:yandmed", NS).evaluatesTo("true"))
-        .andExpect(xpath("//ar:iandmed", NS).evaluatesTo("false"))
+        .andExpect(xpath("//ar:iandmed", NS).evaluatesTo("true"))
         .andRespond(withPayload(detailandmedResponsePayload()));
 
     var result = client.getCompanyDetails("99000001");
@@ -144,6 +144,15 @@ class AriregisterClientTest {
                 "Pärnu mnt 123, 11313 Tallinn",
                 new AddressDetails("Pärnu mnt 123", "Tallinn", "11313", "EE")));
     assertThat(detail.getMainActivity()).contains("Fondide valitsemine");
+    assertThat(detail.getRepresentationRights())
+        .containsExactly(
+            new RepresentationRight(
+                "AINUESINDUS",
+                "Juhatuse liige esindab äriühingut ainuisikuliselt",
+                "Tehingute tegemiseks on nõutav nõukogu nõusolek",
+                LocalDate.of(2024, 9, 1),
+                LocalDate.of(2030, 12, 31),
+                12345L));
 
     mockServer.verify();
   }

--- a/src/test/groovy/ee/tuleva/onboarding/ariregister/CompanyDetailMapperTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/ariregister/CompanyDetailMapperTest.java
@@ -31,6 +31,7 @@ class CompanyDetailMapperTest {
                 "Pärnu mnt 1", new AddressDetails("Pärnu mnt 1", "Tallinn", "11313", "EE")));
     assertThat(result.getMainActivity()).contains("Fondide valitsemine");
     assertThat(result.getNaceCode()).contains("6630");
+    assertThat(result.getRepresentationRights()).isEmpty();
   }
 
   @Test
@@ -47,6 +48,35 @@ class CompanyDetailMapperTest {
     assertThat(result.getAddress()).isEmpty();
     assertThat(result.getMainActivity()).isEmpty();
     assertThat(result.getNaceCode()).isEmpty();
+    assertThat(result.getRepresentationRights()).isEmpty();
+  }
+
+  @Test
+  void mapsRepresentationRights() {
+    var ettevotja = ettevotjaWith(null);
+    ettevotja.setIsikuandmed(
+        isikuandmedWith(
+            eritingimus(
+                "AINUESINDUS",
+                "Juhatuse liige esindab äriühingut ainuisikuliselt",
+                "Tehingute tegemiseks on nõutav nõukogu nõusolek",
+                LocalDate.of(2023, 1, 15),
+                null,
+                12345),
+            eritingimus("YHISESINDUS", "Ühine esindusõigus", null, null, null, 67890)));
+
+    var result = CompanyDetailMapper.fromEttevotja(ettevotja);
+
+    assertThat(result.getRepresentationRights())
+        .containsExactly(
+            new RepresentationRight(
+                "AINUESINDUS",
+                "Juhatuse liige esindab äriühingut ainuisikuliselt",
+                "Tehingute tegemiseks on nõutav nõukogu nõusolek",
+                LocalDate.of(2023, 1, 15),
+                null,
+                12345L),
+            new RepresentationRight("YHISESINDUS", "Ühine esindusõigus", null, null, null, 67890L));
   }
 
   @Test
@@ -137,5 +167,33 @@ class CompanyDetailMapperTest {
     tegevusala.setOnPohitegevusala(main);
     tegevusalad.getItem().add(tegevusala);
     return tegevusalad;
+  }
+
+  private static DetailandmedV6Isikuandmed isikuandmedWith(
+      DetailandmedV6EsindusoiguseEritingimus... eritingimused) {
+    var container = new DetailandmedV6EsindusoiguseEritingimused();
+    for (var eritingimus : eritingimused) {
+      container.getItem().add(eritingimus);
+    }
+    var isikuandmed = new DetailandmedV6Isikuandmed();
+    isikuandmed.setEsindusoiguseEritingimused(container);
+    return isikuandmed;
+  }
+
+  private static DetailandmedV6EsindusoiguseEritingimus eritingimus(
+      String type,
+      String typeText,
+      String content,
+      LocalDate startDate,
+      LocalDate endDate,
+      int id) {
+    var eritingimus = new DetailandmedV6EsindusoiguseEritingimus();
+    eritingimus.setEsinduseTyyp(type);
+    eritingimus.setEsinduseTyypTekstina(typeText);
+    eritingimus.setEsinduseSisu(content);
+    eritingimus.setAlgusKpv(startDate);
+    eritingimus.setLoppKpv(endDate);
+    eritingimus.setKirjeId(BigInteger.valueOf(id));
+    return eritingimus;
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/company/CompanyOnboardingEventListenerIntegrationTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/company/CompanyOnboardingEventListenerIntegrationTest.java
@@ -28,12 +28,15 @@ class CompanyOnboardingEventListenerIntegrationTest {
 
   @Autowired private CompanyRepository companyRepository;
   @Autowired private CompanyPartyRepository companyPartyRepository;
+  @Autowired private CompanyRepresentationRightRepository companyRepresentationRightRepository;
 
   private CompanyOnboardingEventListener listener;
 
   @BeforeEach
   void setUp() {
-    listener = new CompanyOnboardingEventListener(companyRepository, companyPartyRepository);
+    listener =
+        new CompanyOnboardingEventListener(
+            companyRepository, companyPartyRepository, companyRepresentationRightRepository);
   }
 
   @Test
@@ -65,6 +68,7 @@ class CompanyOnboardingEventListenerIntegrationTest {
             new CompanyDto(new RegistryCode(REGISTRY_CODE), "Test OÜ", "62011", LegalForm.OÜ),
             new PersonalCode(PERSONAL_CODE),
             List.of(boardMember),
-            List.of(new KybCheck(COMPANY_ACTIVE, true, Map.of()))));
+            List.of(new KybCheck(COMPANY_ACTIVE, true, Map.of())),
+            List.of()));
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/company/CompanyOnboardingEventListenerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/company/CompanyOnboardingEventListenerTest.java
@@ -7,11 +7,14 @@ import static ee.tuleva.onboarding.kyb.KybTestFixtures.boardMemberOwner;
 import static ee.tuleva.onboarding.kyb.KybTestFixtures.shareholderOwner;
 import static ee.tuleva.onboarding.party.PartyId.Type.PERSON;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
+import ee.tuleva.onboarding.ariregister.RepresentationRight;
 import ee.tuleva.onboarding.kyb.*;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -22,8 +25,11 @@ class CompanyOnboardingEventListenerTest {
 
   private final CompanyRepository companyRepository = mock(CompanyRepository.class);
   private final CompanyPartyRepository companyPartyRepository = mock(CompanyPartyRepository.class);
+  private final CompanyRepresentationRightRepository companyRepresentationRightRepository =
+      mock(CompanyRepresentationRightRepository.class);
   private final CompanyOnboardingEventListener listener =
-      new CompanyOnboardingEventListener(companyRepository, companyPartyRepository);
+      new CompanyOnboardingEventListener(
+          companyRepository, companyPartyRepository, companyRepresentationRightRepository);
 
   private final CompanyDto company =
       new CompanyDto(new RegistryCode("12345678"), "Test OÜ", "62011", LegalForm.OÜ);
@@ -49,7 +55,8 @@ class CompanyOnboardingEventListenerTest {
             company,
             new PersonalCode("38501010001"),
             List.of(person1, person2, person3),
-            checks);
+            checks,
+            List.of());
     given(companyRepository.findByRegistryCode("12345678")).willReturn(Optional.empty());
     given(companyRepository.save(any(Company.class)))
         .willAnswer(invocation -> invocation.getArgument(0));
@@ -82,12 +89,59 @@ class CompanyOnboardingEventListenerTest {
   }
 
   @Test
+  void capturesRepresentationRightsWhenAllChecksPass() {
+    var existing =
+        Company.builder().id(java.util.UUID.randomUUID()).registryCode("12345678").build();
+    var checks = List.of(new KybCheck(COMPANY_ACTIVE, true, Map.of()));
+    var rights =
+        List.of(
+            new RepresentationRight(
+                "AINUESINDUS",
+                "Juhatuse liige esindab äriühingut ainuisikuliselt",
+                "Nõukogu nõusolek nõutav",
+                LocalDate.of(2023, 1, 15),
+                null,
+                12345L),
+            new RepresentationRight("YHISESINDUS", "Ühine esindusõigus", null, null, null, 67890L));
+    var event =
+        new KybCheckPerformedEvent(
+            this, company, new PersonalCode("38501010001"), List.of(person2), checks, rights);
+    given(companyRepository.findByRegistryCode("12345678")).willReturn(Optional.of(existing));
+
+    listener.onKybCheckPerformed(event);
+
+    var captor = ArgumentCaptor.forClass(CompanyRepresentationRight.class);
+    verify(companyRepresentationRightRepository).deleteByCompanyId(existing.getId());
+    verify(companyRepresentationRightRepository, times(2)).save(captor.capture());
+
+    assertThat(captor.getAllValues())
+        .extracting(
+            CompanyRepresentationRight::getCompanyId,
+            CompanyRepresentationRight::getEntryId,
+            CompanyRepresentationRight::getRepresentationType,
+            CompanyRepresentationRight::getRepresentationTypeText,
+            CompanyRepresentationRight::getContent,
+            CompanyRepresentationRight::getStartDate,
+            CompanyRepresentationRight::getEndDate)
+        .containsExactly(
+            tuple(
+                existing.getId(),
+                12345L,
+                "AINUESINDUS",
+                "Juhatuse liige esindab äriühingut ainuisikuliselt",
+                "Nõukogu nõusolek nõutav",
+                LocalDate.of(2023, 1, 15),
+                null),
+            tuple(existing.getId(), 67890L, "YHISESINDUS", "Ühine esindusõigus", null, null, null));
+  }
+
+  @Test
   void usesExistingCompanyIfAlreadyExists() {
     var existing = Company.builder().registryCode("12345678").name("Test OÜ").build();
     var checks = List.of(new KybCheck(COMPANY_ACTIVE, true, Map.of()));
     var event =
         new KybCheckPerformedEvent(
-            this, company, new PersonalCode("38501010001"), List.of(person2), checks);
+            this, company, new PersonalCode("38501010001"), List.of(person2), checks, List.of());
     given(companyRepository.findByRegistryCode("12345678")).willReturn(Optional.of(existing));
 
     listener.onKybCheckPerformed(event);
@@ -110,7 +164,7 @@ class CompanyOnboardingEventListenerTest {
             new KybCheck(DATA_CHANGED, true, Map.of()));
     var event =
         new KybCheckPerformedEvent(
-            this, company, new PersonalCode("38501010001"), List.of(person2), checks);
+            this, company, new PersonalCode("38501010001"), List.of(person2), checks, List.of());
     given(companyRepository.findByRegistryCode("12345678")).willReturn(Optional.of(existing));
 
     listener.onKybCheckPerformed(event);
@@ -135,7 +189,7 @@ class CompanyOnboardingEventListenerTest {
             new KybCheck(DATA_CHANGED, false, Map.of()));
     var event =
         new KybCheckPerformedEvent(
-            this, company, new PersonalCode("38501010001"), List.of(person1), checks);
+            this, company, new PersonalCode("38501010001"), List.of(person1), checks, List.of());
     given(companyRepository.findByRegistryCode("12345678")).willReturn(Optional.of(existing));
 
     listener.onKybCheckPerformed(event);
@@ -153,7 +207,7 @@ class CompanyOnboardingEventListenerTest {
             new KybCheck(DATA_CHANGED, false, Map.of()));
     var event =
         new KybCheckPerformedEvent(
-            this, company, new PersonalCode("38501010001"), List.of(person1), checks);
+            this, company, new PersonalCode("38501010001"), List.of(person1), checks, List.of());
     given(companyRepository.findByRegistryCode("12345678")).willReturn(Optional.empty());
     given(companyRepository.save(any(Company.class)))
         .willAnswer(invocation -> invocation.getArgument(0));
@@ -172,7 +226,7 @@ class CompanyOnboardingEventListenerTest {
             new KybCheck(COMPANY_AGE, false, Map.of()));
     var event =
         new KybCheckPerformedEvent(
-            this, company, new PersonalCode("38501010001"), List.of(person1), checks);
+            this, company, new PersonalCode("38501010001"), List.of(person1), checks, List.of());
     given(companyRepository.findByRegistryCode("12345678")).willReturn(Optional.empty());
     given(companyRepository.save(any(Company.class)))
         .willAnswer(invocation -> invocation.getArgument(0));
@@ -192,7 +246,7 @@ class CompanyOnboardingEventListenerTest {
             new KybCheck(DATA_CHANGED, false, Map.of()));
     var event =
         new KybCheckPerformedEvent(
-            this, company, new PersonalCode("38501010001"), List.of(person1), checks);
+            this, company, new PersonalCode("38501010001"), List.of(person1), checks, List.of());
     given(companyRepository.findByRegistryCode("12345678")).willReturn(Optional.empty());
     given(companyRepository.save(any(Company.class)))
         .willAnswer(invocation -> invocation.getArgument(0));
@@ -202,6 +256,8 @@ class CompanyOnboardingEventListenerTest {
     verify(companyRepository).save(any(Company.class));
     verify(companyPartyRepository, never()).save(any());
     verify(companyPartyRepository, never()).deleteByCompanyId(any());
+    verify(companyRepresentationRightRepository, never()).save(any());
+    verify(companyRepresentationRightRepository, never()).deleteByCompanyId(any());
   }
 
   @Test
@@ -218,7 +274,7 @@ class CompanyOnboardingEventListenerTest {
             new KybCheck(COMPANY_STRUCTURE, false, Map.of()));
     var event =
         new KybCheckPerformedEvent(
-            this, company, new PersonalCode("38501010001"), List.of(person1), checks);
+            this, company, new PersonalCode("38501010001"), List.of(person1), checks, List.of());
     given(companyRepository.findByRegistryCode("12345678")).willReturn(Optional.of(existing));
 
     listener.onKybCheckPerformed(event);
@@ -226,5 +282,7 @@ class CompanyOnboardingEventListenerTest {
     verify(companyRepository, never()).save(any());
     verify(companyPartyRepository, never()).save(any());
     verify(companyPartyRepository, never()).deleteByCompanyId(any());
+    verify(companyRepresentationRightRepository, never()).save(any());
+    verify(companyRepresentationRightRepository, never()).deleteByCompanyId(any());
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/company/CompanyRepresentationRightRepositoryTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/company/CompanyRepresentationRightRepositoryTest.java
@@ -1,0 +1,60 @@
+package ee.tuleva.onboarding.company;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+
+@DataJpaTest
+class CompanyRepresentationRightRepositoryTest {
+
+  @Autowired CompanyRepository companyRepository;
+  @Autowired CompanyRepresentationRightRepository repository;
+
+  @Test
+  void persistsAndFindsRepresentationRightsByCompany() {
+    var company =
+        companyRepository.save(Company.builder().registryCode("90000001").name("Test OÜ").build());
+
+    repository.save(
+        CompanyRepresentationRight.builder()
+            .companyId(company.getId())
+            .entryId(12345L)
+            .representationType("AINUESINDUS")
+            .representationTypeText("Juhatuse liige esindab äriühingut ainuisikuliselt")
+            .content("Tehingute tegemiseks on nõutav nõukogu nõusolek")
+            .startDate(LocalDate.of(2023, 1, 15))
+            .build());
+
+    var rights = repository.findByCompanyId(company.getId());
+
+    assertThat(rights)
+        .singleElement()
+        .satisfies(
+            right -> {
+              assertThat(right.getEntryId()).isEqualTo(12345L);
+              assertThat(right.getRepresentationType()).isEqualTo("AINUESINDUS");
+              assertThat(right.getRepresentationTypeText())
+                  .isEqualTo("Juhatuse liige esindab äriühingut ainuisikuliselt");
+              assertThat(right.getContent())
+                  .isEqualTo("Tehingute tegemiseks on nõutav nõukogu nõusolek");
+              assertThat(right.getStartDate()).isEqualTo(LocalDate.of(2023, 1, 15));
+              assertThat(right.getEndDate()).isNull();
+              assertThat(right.getCreatedDate()).isNotNull();
+            });
+  }
+
+  @Test
+  void deletesRepresentationRightsByCompany() {
+    var company =
+        companyRepository.save(Company.builder().registryCode("90000002").name("Other OÜ").build());
+    repository.save(
+        CompanyRepresentationRight.builder().companyId(company.getId()).entryId(1L).build());
+
+    repository.deleteByCompanyId(company.getId());
+
+    assertThat(repository.findByCompanyId(company.getId())).isEmpty();
+  }
+}

--- a/src/test/groovy/ee/tuleva/onboarding/kyb/KybCompanyDataMapperTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyb/KybCompanyDataMapperTest.java
@@ -57,7 +57,8 @@ class KybCompanyDataMapperTest {
             "Osaluse kaudu",
             "EST");
 
-    var detail = new CompanyDetail("Test OÜ", "12345678", "R", "OÜ", null, null, null, null);
+    var detail =
+        new CompanyDetail("Test OÜ", "12345678", "R", "OÜ", null, null, null, null, List.of());
 
     var result =
         mapper.toKybCompanyData(
@@ -110,7 +111,8 @@ class KybCompanyDataMapperTest {
             null,
             "EST");
 
-    var detail = new CompanyDetail("Test OÜ", "12345678", "R", "OÜ", null, null, null, null);
+    var detail =
+        new CompanyDetail("Test OÜ", "12345678", "R", "OÜ", null, null, null, null, List.of());
 
     var result =
         mapper.toKybCompanyData(detail, PERSONAL_CODE, List.of(person1, person2), SELF_CERT);
@@ -142,7 +144,8 @@ class KybCompanyDataMapperTest {
             "Osaluse kaudu",
             "EST");
 
-    var detail = new CompanyDetail("Test OÜ", "12345678", "R", "OÜ", null, null, null, null);
+    var detail =
+        new CompanyDetail("Test OÜ", "12345678", "R", "OÜ", null, null, null, null, List.of());
 
     var result = mapper.toKybCompanyData(detail, PERSONAL_CODE, List.of(relationship), SELF_CERT);
 
@@ -162,7 +165,8 @@ class KybCompanyDataMapperTest {
         new CompanyAddress(
             "Tartu maakond, Tartu linn, Paju 2",
             new AddressDetails("Paju 2", "Tartu linn", "50104", "EE"));
-    var detail = new CompanyDetail("Test OÜ", "12345678", "R", "OÜ", null, address, null, null);
+    var detail =
+        new CompanyDetail("Test OÜ", "12345678", "R", "OÜ", null, address, null, null, List.of());
 
     var result = mapper.toKybCompanyData(detail, PERSONAL_CODE, List.of(), SELF_CERT);
 
@@ -172,7 +176,8 @@ class KybCompanyDataMapperTest {
 
   @Test
   void mapsNullAddressToNullCountryCodeAndFullAddress() {
-    var detail = new CompanyDetail("Test OÜ", "12345678", "R", "OÜ", null, null, null, null);
+    var detail =
+        new CompanyDetail("Test OÜ", "12345678", "R", "OÜ", null, null, null, null, List.of());
 
     var result = mapper.toKybCompanyData(detail, PERSONAL_CODE, List.of(), SELF_CERT);
 
@@ -182,7 +187,8 @@ class KybCompanyDataMapperTest {
 
   @Test
   void mapsCompanyStatus() {
-    var detail = new CompanyDetail("Test OÜ", "12345678", "R", "OÜ", null, null, null, null);
+    var detail =
+        new CompanyDetail("Test OÜ", "12345678", "R", "OÜ", null, null, null, null, List.of());
 
     var result = mapper.toKybCompanyData(detail, PERSONAL_CODE, List.of(), SELF_CERT);
 
@@ -193,7 +199,15 @@ class KybCompanyDataMapperTest {
   void mapsFoundingDate() {
     var detail =
         new CompanyDetail(
-            "Test OÜ", "12345678", "R", "OÜ", LocalDate.of(2020, 1, 15), null, null, null);
+            "Test OÜ",
+            "12345678",
+            "R",
+            "OÜ",
+            LocalDate.of(2020, 1, 15),
+            null,
+            null,
+            null,
+            List.of());
 
     var result = mapper.toKybCompanyData(detail, PERSONAL_CODE, List.of(), SELF_CERT);
 
@@ -202,7 +216,8 @@ class KybCompanyDataMapperTest {
 
   @Test
   void mapsNullFoundingDateWhenAriregisterHasNone() {
-    var detail = new CompanyDetail("Test OÜ", "12345678", "R", "OÜ", null, null, null, null);
+    var detail =
+        new CompanyDetail("Test OÜ", "12345678", "R", "OÜ", null, null, null, null, List.of());
 
     var result = mapper.toKybCompanyData(detail, PERSONAL_CODE, List.of(), SELF_CERT);
 
@@ -240,7 +255,8 @@ class KybCompanyDataMapperTest {
             null,
             "GBR");
 
-    var detail = new CompanyDetail("Test OÜ", "12345678", "R", "OÜ", null, null, null, null);
+    var detail =
+        new CompanyDetail("Test OÜ", "12345678", "R", "OÜ", null, null, null, null, List.of());
 
     var result =
         mapper.toKybCompanyData(
@@ -255,7 +271,8 @@ class KybCompanyDataMapperTest {
 
   @Test
   void mapsKnownLegalFormTüh() {
-    var detail = new CompanyDetail("Test TÜH", "12345678", "R", "TÜH", null, null, null, null);
+    var detail =
+        new CompanyDetail("Test TÜH", "12345678", "R", "TÜH", null, null, null, null, List.of());
 
     var result = mapper.toKybCompanyData(detail, PERSONAL_CODE, List.of(), SELF_CERT);
 
@@ -264,7 +281,8 @@ class KybCompanyDataMapperTest {
 
   @Test
   void mapsUnknownLegalFormToOther() {
-    var detail = new CompanyDetail("Test XYZ", "12345678", "R", "XYZ", null, null, null, null);
+    var detail =
+        new CompanyDetail("Test XYZ", "12345678", "R", "XYZ", null, null, null, null, List.of());
 
     var result = mapper.toKybCompanyData(detail, PERSONAL_CODE, List.of(), SELF_CERT);
 
@@ -302,7 +320,8 @@ class KybCompanyDataMapperTest {
             null,
             "EST");
 
-    var detail = new CompanyDetail("Test OÜ", "12345678", "R", "OÜ", null, null, null, null);
+    var detail =
+        new CompanyDetail("Test OÜ", "12345678", "R", "OÜ", null, null, null, null, List.of());
 
     var result = mapper.toKybCompanyData(detail, PERSONAL_CODE, List.of(role1, role2), SELF_CERT);
 
@@ -319,7 +338,8 @@ class KybCompanyDataMapperTest {
         .thenReturn(true);
 
     var relationship = boardMemberRelationship("38501010002");
-    var detail = new CompanyDetail("Test OÜ", "12345678", "R", "OÜ", null, null, null, null);
+    var detail =
+        new CompanyDetail("Test OÜ", "12345678", "R", "OÜ", null, null, null, null, List.of());
 
     var result = mapper.toKybCompanyData(detail, PERSONAL_CODE, List.of(relationship), SELF_CERT);
 
@@ -336,7 +356,8 @@ class KybCompanyDataMapperTest {
         .thenReturn(true);
 
     var relationship = boardMemberRelationship("38501010002");
-    var detail = new CompanyDetail("Test OÜ", "12345678", "R", "OÜ", null, null, null, null);
+    var detail =
+        new CompanyDetail("Test OÜ", "12345678", "R", "OÜ", null, null, null, null, List.of());
 
     var result = mapper.toKybCompanyData(detail, PERSONAL_CODE, List.of(relationship), SELF_CERT);
 
@@ -346,7 +367,8 @@ class KybCompanyDataMapperTest {
   @Test
   void resolvesUnknownKycStatusWhenNoCheckExists() {
     var relationship = boardMemberRelationship("38501010002");
-    var detail = new CompanyDetail("Test OÜ", "12345678", "R", "OÜ", null, null, null, null);
+    var detail =
+        new CompanyDetail("Test OÜ", "12345678", "R", "OÜ", null, null, null, null, List.of());
 
     var result = mapper.toKybCompanyData(detail, PERSONAL_CODE, List.of(relationship), SELF_CERT);
 
@@ -356,7 +378,8 @@ class KybCompanyDataMapperTest {
   @Test
   void mapsNasdaqCsdShareholderRoleToShareholder() {
     var shareholder = nasdaqCsdShareholder("38501010002", "Jaan", "Tamm", new BigDecimal("100.00"));
-    var detail = new CompanyDetail("Test OÜ", "12345678", "R", "OÜ", null, null, null, null);
+    var detail =
+        new CompanyDetail("Test OÜ", "12345678", "R", "OÜ", null, null, null, null, List.of());
 
     var result = mapper.toKybCompanyData(detail, PERSONAL_CODE, List.of(shareholder), SELF_CERT);
 
@@ -373,7 +396,8 @@ class KybCompanyDataMapperTest {
   void mapsLegalEntityOwnerAsNonNaturalPerson() {
     var legalEntityOwner =
         legalEntityShareholder("90000002", "Holding OÜ", new BigDecimal("100.00"));
-    var detail = new CompanyDetail("Test OÜ", "12345678", "R", "OÜ", null, null, null, null);
+    var detail =
+        new CompanyDetail("Test OÜ", "12345678", "R", "OÜ", null, null, null, null, List.of());
 
     var result =
         mapper.toKybCompanyData(detail, PERSONAL_CODE, List.of(legalEntityOwner), SELF_CERT);

--- a/src/test/groovy/ee/tuleva/onboarding/kyb/KybEndToEndTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyb/KybEndToEndTest.java
@@ -212,7 +212,8 @@ class KybEndToEndTest {
             VALID_CERT,
             "EE",
             "Harju maakond, Tallinn, Pärnu mnt 1",
-            null);
+            null,
+            List.of());
 
     var results = kybScreeningService.screen(data);
 

--- a/src/test/groovy/ee/tuleva/onboarding/kyb/KybScreeningIntegrationTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyb/KybScreeningIntegrationTest.java
@@ -118,7 +118,8 @@ class KybScreeningIntegrationTest {
             new SelfCertification(true, true, true),
             "EE",
             "Harju maakond, Tallinn, Pärnu mnt 1",
-            null);
+            null,
+            List.of());
 
     var secondResults = kybScreeningService.screen(changedData);
 
@@ -191,7 +192,8 @@ class KybScreeningIntegrationTest {
             new SelfCertification(true, true, true),
             "EE",
             "Harju maakond, Tallinn, Pärnu mnt 1",
-            LocalDate.now(clock).minusMonths(1));
+            LocalDate.now(clock).minusMonths(1),
+            List.of());
 
     kybScreeningService.screen(data);
 

--- a/src/test/groovy/ee/tuleva/onboarding/kyb/KybTestFixtures.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyb/KybTestFixtures.java
@@ -224,7 +224,8 @@ public final class KybTestFixtures {
         selfCertification,
         "EE",
         "Harju maakond, Tallinn, Pärnu mnt 1",
-        null);
+        null,
+        List.of());
   }
 
   // A standard active OÜ with the given related persons (defaults for the fields screeners ignore).
@@ -255,7 +256,8 @@ public final class KybTestFixtures {
           LocalDate.of(2020, 1, 15),
           null,
           "Programmeerimine",
-          "62011");
+          "62011",
+          List.of());
 
   static List<CompanyRelationship> rule31PassRelationships() {
     return List.of(
@@ -423,7 +425,8 @@ public final class KybTestFixtures {
         LocalDate.of(2020, 1, 15),
         null,
         "Programmeerimine",
-        "62011");
+        "62011",
+        List.of());
   }
 
   static KybCompanyData rule34Pass() {
@@ -491,7 +494,8 @@ public final class KybTestFixtures {
         LocalDate.of(2020, 1, 15),
         null,
         "Krüptovarade teenused",
-        "64321");
+        "64321",
+        List.of());
   }
 
   static KybCompanyData rule41Pass() {
@@ -546,7 +550,8 @@ public final class KybTestFixtures {
         LocalDate.of(2020, 1, 15),
         null,
         "Programmeerimine",
-        "62011");
+        "62011",
+        List.of());
   }
 
   static KybCompanyData rule50Pass() {

--- a/src/test/groovy/ee/tuleva/onboarding/kyb/LegalEntityScreenerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyb/LegalEntityScreenerTest.java
@@ -86,7 +86,8 @@ class LegalEntityScreenerTest {
             SELF_CERT,
             "EE",
             "Harju maakond, Tallinn, Pärnu mnt 1",
-            null);
+            null,
+            List.of());
     given(kybCompanyDataMapper.toKybCompanyData(detail, PERSONAL_CODE, relationships, SELF_CERT))
         .willReturn(companyData);
     var checks = List.of(new KybCheck(KybCheckType.COMPANY_ACTIVE, true, Map.of()));
@@ -112,7 +113,8 @@ class LegalEntityScreenerTest {
             null,
             "EE",
             "Harju maakond, Tallinn, Pärnu mnt 1",
-            null);
+            null,
+            List.of());
     given(kybCompanyDataMapper.toKybCompanyData(detail, PERSONAL_CODE, relationships, null))
         .willReturn(companyData);
     var checks = List.of(new KybCheck(KybCheckType.COMPANY_ACTIVE, true, Map.of()));
@@ -145,7 +147,8 @@ class LegalEntityScreenerTest {
             SELF_CERT,
             "EE",
             "Harju maakond, Tallinn, Pärnu mnt 1",
-            null);
+            null,
+            List.of());
     given(
             kybCompanyDataMapper.toKybCompanyData(
                 detail, PERSONAL_CODE, List.of(boardMember), SELF_CERT))
@@ -193,6 +196,7 @@ class LegalEntityScreenerTest {
   }
 
   private static CompanyDetail sampleDetail() {
-    return new CompanyDetail("Test OÜ", REGISTRY_CODE, "R", "OÜ", null, null, null, null);
+    return new CompanyDetail(
+        "Test OÜ", REGISTRY_CODE, "R", "OÜ", null, null, null, null, List.of());
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/kyb/screener/CompanyActiveScreenerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyb/screener/CompanyActiveScreenerTest.java
@@ -46,6 +46,7 @@ class CompanyActiveScreenerTest {
         new SelfCertification(true, true, true),
         "EE",
         "Harju maakond, Tallinn, Pärnu mnt 1",
-        null);
+        null,
+        List.of());
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/kyb/screener/CompanyAgeScreenerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyb/screener/CompanyAgeScreenerTest.java
@@ -67,6 +67,7 @@ class CompanyAgeScreenerTest {
         new SelfCertification(true, true, true),
         "EE",
         "Harju maakond, Tallinn, Pärnu mnt 1",
-        foundingDate);
+        foundingDate,
+        List.of());
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/kyb/screener/CompanyLegalFormScreenerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyb/screener/CompanyLegalFormScreenerTest.java
@@ -58,6 +58,7 @@ class CompanyLegalFormScreenerTest {
         new SelfCertification(true, true, true),
         "EE",
         "Harju maakond, Tallinn, Pärnu mnt 1",
-        null);
+        null,
+        List.of());
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/kyb/screener/CompanyNaceScreenerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyb/screener/CompanyNaceScreenerTest.java
@@ -70,6 +70,7 @@ class CompanyNaceScreenerTest {
         new SelfCertification(true, true, true),
         "EE",
         "Harju maakond, Tallinn, Pärnu mnt 1",
-        null);
+        null,
+        List.of());
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/kyb/screener/CompanyRegisteredInEstoniaScreenerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyb/screener/CompanyRegisteredInEstoniaScreenerTest.java
@@ -69,6 +69,7 @@ class CompanyRegisteredInEstoniaScreenerTest {
         new SelfCertification(true, true, true),
         countryCode,
         fullAddress,
-        null);
+        null,
+        List.of());
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/kyb/screener/CompanySanctionScreenerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyb/screener/CompanySanctionScreenerTest.java
@@ -114,7 +114,8 @@ class CompanySanctionScreenerTest {
         new SelfCertification(true, true, true),
         "EE",
         "Harju maakond, Tallinn, Pärnu mnt 1",
-        null);
+        null,
+        List.of());
   }
 
   private MatchResponse emptyResponse() {

--- a/src/test/groovy/ee/tuleva/onboarding/kyb/survey/KybSurveyServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyb/survey/KybSurveyServiceTest.java
@@ -71,7 +71,8 @@ class KybSurveyServiceTest {
         null,
         new CompanyAddress("Tallinn", new AddressDetails(null, null, null, null)),
         "Fondide valitsemine",
-        "6630");
+        "6630",
+        List.of());
   }
 
   private void stubInitialValidation(
@@ -93,7 +94,8 @@ class KybSurveyServiceTest {
             java.time.LocalDate.of(2020, 1, 15),
             new CompanyAddress("Tallinn", new AddressDetails(null, null, null, null)),
             "Fondide valitsemine",
-            "6630");
+            "6630",
+            List.of());
     var relationships = sampleRelationships();
     stubInitialValidation(
         relationships,

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/LegalEntityOnboardingEventListenerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/LegalEntityOnboardingEventListenerTest.java
@@ -105,6 +105,6 @@ class LegalEntityOnboardingEventListenerTest {
 
   private KybCheckPerformedEvent eventWith(List<KybCheck> checks) {
     return new KybCheckPerformedEvent(
-        this, company, new PersonalCode("38501010001"), relatedPersons, checks);
+        this, company, new PersonalCode("38501010001"), relatedPersons, checks, List.of());
   }
 }

--- a/src/test/resources/ariregister/detailandmed_v2_response.xml
+++ b/src/test/resources/ariregister/detailandmed_v2_response.xml
@@ -50,6 +50,18 @@
             </ns1:item>
           </ns1:teatatud_tegevusalad>
         </ns1:yldandmed>
+        <ns1:isikuandmed>
+          <ns1:esindusoiguse_eritingimused>
+            <ns1:item>
+              <ns1:kirje_id>12345</ns1:kirje_id>
+              <ns1:esinduse_tyyp>AINUESINDUS</ns1:esinduse_tyyp>
+              <ns1:esinduse_tyyp_tekstina>Juhatuse liige esindab äriühingut ainuisikuliselt</ns1:esinduse_tyyp_tekstina>
+              <ns1:esinduse_sisu>Tehingute tegemiseks on nõutav nõukogu nõusolek</ns1:esinduse_sisu>
+              <ns1:algus_kpv>2024-09-01</ns1:algus_kpv>
+              <ns1:lopp_kpv>2030-12-31</ns1:lopp_kpv>
+            </ns1:item>
+          </ns1:esindusoiguse_eritingimused>
+        </ns1:isikuandmed>
       </ns1:item>
     </ns1:ettevotjad>
     <ns1:leitud_ettevotjate_arv>1</ns1:leitud_ettevotjate_arv>


### PR DESCRIPTION
## What & why

Milestone **M4** of the company AML-risk rollout (TulevaEE/tuleva#78).

Captures a company's **special representation-right conditions** (*eriliigiline esindusõigus* / *esindusõiguse erisus*) from the Äriregister and persists them per company, so the "Ettevõtte profiil" dashboard tab (M8) can show who may represent the company and under what conditions.

**Data capture only — NOT a scoring rule.** No `KybCheckType` / `AmlCheckType` / `KybScreener` is added, so M4 can never gate onboarding — consistent with the lesson from M2's *"treat company age as a risk signal, not an onboarding gate"*: risk/capture signals must not reject companies.

## Changes
- **Toggle:** `AriregisterClient.getCompanyDetails` now sends `iandmed=true` so the registry returns `isikuandmed`, where the special representation rights live. (M3 did not need this toggle; M4 owns it.)
- **Anti-corruption mapping:** new `RepresentationRight` domain record + `CompanyDetail.representationRights`, mapped from the JAXB `isikuandmed → esindusoiguse_eritingimused` chain in `CompanyDetailMapper`. No generated/JAXB types leak outside the ariregister module.
- **Persistence:** threaded through `KybCompanyData` + `KybCheckPerformedEvent` and persisted as `company_representation_right` rows in `CompanyOnboardingEventListener`, mirroring `company_party` (delete-then-insert on re-screening; inside the `allGateChecksPassed` branch).
- **Schema:** Flyway `V1_208` — `company_representation_right` (FK to `company`, indexed, unique on `(company_id, entry_id)` where `entry_id` = registry `kirje_id`).

## Tests
- `CompanyDetailMapperTest.mapsRepresentationRights` — capture from JAXB.
- `AriregisterClientTest.getCompanyDetails` — full round-trip through real JAXB unmarshalling (asserts `iandmed=true` + the captured right).
- `CompanyOnboardingEventListenerTest.capturesRepresentationRightsWhenAllChecksPass` + gating assertions (not persisted when a real gate check fails).
- `CompanyRepresentationRightRepositoryTest` — `@DataJpaTest` migration round-trip.

Green locally including the KYB `@SpringBootTest` integration tests on Postgres.

## ⚠️ Open question for compliance (Maria / Alar)
Should *esindusõiguse erisus* be **elevated from data-capture to an AML rule** (e.g. a `KYB_*` check feeding the risk score)? Per Sten's decision this PR is capture + profile display only; flagging for compliance to decide later.

## 📝 Doc note (not in this repo)
The plan/methodology in the monorepo (`work/sten/aml/plaanid/juriidilise-isiku-risk-rakendusplaan.md` §4 and `metoodika/company-risk-description.md`) currently says the esindusõiguse erisus is *"praegu Javas ei mappita"* — now stale. It should be updated to note M4 captures it into `company_representation_right` for profile display (rule status still open). I did not edit the monorepo because its checkout is on an unrelated feature branch with in-progress work; please apply on the correct branch.

## Migration number
`V1_208` (master max is `V1_207` from M1 #1691). Re-check & renumber above master max immediately before merge in case a racing PR claims it.

Sibling PRs: M1 #1691, M2 #1693, M3 #1694.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
