### PR TITLE
Skip Slack alert on PEVA/RAVA DONE phase transition

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/investment/epis/PevaRavaPhaseUpdateJob.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/epis/PevaRavaPhaseUpdateJob.java
@@ -59,6 +59,13 @@ class PevaRavaPhaseUpdateJob {
           "PEVA/RAVA phase unchanged: phase={}, execDate={}", period.phase(), cycle.execDate());
       return;
     }
+    if (period.phase() == PevaRavaPhase.DONE) {
+      log.info(
+          "PEVA/RAVA cycle done, no notification: from={}, execDate={}",
+          storedPhase,
+          cycle.execDate());
+      return;
+    }
     log.info(
         "PEVA/RAVA phase transition: from={}, to={}, execDate={}",
         storedPhase,

--- a/src/main/java/ee/tuleva/onboarding/investment/epis/PevaRavaPhaseUpdateJob.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/epis/PevaRavaPhaseUpdateJob.java
@@ -2,6 +2,7 @@ package ee.tuleva.onboarding.investment.epis;
 
 import static ee.tuleva.onboarding.investment.JobRunSchedule.PEVA_RAVA_PHASE_UPDATE;
 import static ee.tuleva.onboarding.investment.JobRunSchedule.TIMEZONE;
+import static ee.tuleva.onboarding.investment.epis.PevaRavaPhase.DONE;
 import static ee.tuleva.onboarding.notification.OperationsNotificationService.Channel.INVESTMENT;
 
 import ee.tuleva.onboarding.investment.event.RunPevaRavaPhaseUpdateRequested;
@@ -59,7 +60,7 @@ class PevaRavaPhaseUpdateJob {
           "PEVA/RAVA phase unchanged: phase={}, execDate={}", period.phase(), cycle.execDate());
       return;
     }
-    if (period.phase() == PevaRavaPhase.DONE) {
+    if (period.phase() == DONE) {
       log.info(
           "PEVA/RAVA cycle done, no notification: from={}, execDate={}",
           storedPhase,

--- a/src/test/groovy/ee/tuleva/onboarding/investment/epis/PevaRavaPhaseUpdateJobTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/epis/PevaRavaPhaseUpdateJobTest.java
@@ -2,6 +2,7 @@ package ee.tuleva.onboarding.investment.epis;
 
 import static ee.tuleva.onboarding.investment.epis.PevaRavaPhase.ACTIVE;
 import static ee.tuleva.onboarding.investment.epis.PevaRavaPhase.DATA_VALID;
+import static ee.tuleva.onboarding.investment.epis.PevaRavaPhase.DONE;
 import static ee.tuleva.onboarding.investment.epis.PevaRavaPhase.TUK00_ACTIVE;
 import static ee.tuleva.onboarding.notification.OperationsNotificationService.Channel.INVESTMENT;
 import static org.mockito.BDDMockito.given;
@@ -79,6 +80,34 @@ class PevaRavaPhaseUpdateJobTest {
                 + "TUK75: D-aktiivne 2026-04-22, müügi tähtaeg 2026-04-27\n"
                 + "TUK00: D-aktiivne 2026-04-14, müügi tähtaeg 2026-04-23",
             INVESTMENT);
+  }
+
+  @Test
+  void persistsDonePhaseWithoutNotification() {
+    given(periodService.getCurrentPeriod(TODAY)).willReturn(Optional.of(period(DONE)));
+    given(cycleRepository.findByExecDate(EXEC_DATE)).willReturn(Optional.of(entity(ACTIVE)));
+
+    job.run();
+
+    verify(cycleRepository).save(entity(DONE));
+    verifyNoInteractions(notificationService);
+  }
+
+  @Test
+  void persistsDonePhaseWithoutNotificationOnFirstSight() {
+    given(periodService.getCurrentPeriod(TODAY)).willReturn(Optional.of(period(DONE)));
+    given(cycleRepository.findByExecDate(EXEC_DATE)).willReturn(Optional.empty());
+
+    job.run();
+
+    verify(cycleRepository)
+        .save(
+            PevaRavaCycleEntity.builder()
+                .lockDate(LOCK_DATE)
+                .execDate(EXEC_DATE)
+                .phase(DONE)
+                .build());
+    verifyNoInteractions(notificationService);
   }
 
   @Test


### PR DESCRIPTION
## What

`PevaRavaPhaseUpdateJob` now skips the INVESTMENT-channel Slack notification when the target phase is `DONE`, while still persisting the phase to the DB.

## Why

The `DONE` transition carries **no human action** — it just marks the cycle settled (exec + 3 business days). The liquidity-reservation logic in `TransactionInputService` already acts on the persisted phase (`phase != DONE` filter), so the state machine keeps working; only the non-actionable ping goes away.

It also produced a spurious `📅 PEVA/RAVA faasi muutus: uus tsükkel → DONE` message on 2026-06-15: the subsystem (PR #1696) went live mid-`DONE`-window (the May cycle settled ~7 May), so the first run found no stored phase and emitted a "transition" that was really just initialization.

This single change kills both: the deploy-init artifact (first-sight into `DONE` writes the row silently) and every routine `→ DONE` close.

## Preserved

The actionable transitions still alert: `→ DATA_VALID` (including the legitimate new-cycle lock-date ping), `→ TUK00_ACTIVE`, and `→ ACTIVE` — i.e. the ones that tell the desk the trade window is open and carry the sell-by deadlines.

## Tests

Added `persistsDonePhaseWithoutNotification` (normal `ACTIVE → DONE`) and `persistsDonePhaseWithoutNotificationOnFirstSight` (deploy-init case). Full `PevaRavaPhaseUpdateJobTest` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)