### PR TITLE
Make sure we delete old company party before adding a new one

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/company/CompanyPartyRepository.java
+++ b/src/main/java/ee/tuleva/onboarding/company/CompanyPartyRepository.java
@@ -4,6 +4,9 @@ import ee.tuleva.onboarding.party.PartyId;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface CompanyPartyRepository extends JpaRepository<CompanyParty, UUID> {
 
@@ -13,5 +16,7 @@ public interface CompanyPartyRepository extends JpaRepository<CompanyParty, UUID
   boolean existsByPartyCodeAndPartyTypeAndCompanyIdAndRelationshipType(
       String partyCode, PartyId.Type partyType, UUID companyId, RelationshipType relationshipType);
 
-  void deleteByCompanyId(UUID companyId);
+  @Modifying
+  @Query("DELETE FROM CompanyParty p WHERE p.companyId = :companyId")
+  void deleteByCompanyId(@Param("companyId") UUID companyId);
 }

--- a/src/test/groovy/ee/tuleva/onboarding/company/CompanyOnboardingEventListenerIntegrationTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/company/CompanyOnboardingEventListenerIntegrationTest.java
@@ -1,0 +1,73 @@
+package ee.tuleva.onboarding.company;
+
+import static ee.tuleva.onboarding.company.RelationshipType.BOARD_MEMBER;
+import static ee.tuleva.onboarding.kyb.KybCheckType.COMPANY_ACTIVE;
+import static ee.tuleva.onboarding.kyb.KybKycStatus.COMPLETED;
+import static ee.tuleva.onboarding.party.PartyId.Type.PERSON;
+import static java.math.BigDecimal.ZERO;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import ee.tuleva.onboarding.kyb.CompanyDto;
+import ee.tuleva.onboarding.kyb.KybCheck;
+import ee.tuleva.onboarding.kyb.KybCheckPerformedEvent;
+import ee.tuleva.onboarding.kyb.KybRelatedPerson;
+import ee.tuleva.onboarding.kyb.LegalForm;
+import ee.tuleva.onboarding.kyb.PersonalCode;
+import ee.tuleva.onboarding.kyb.RegistryCode;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+
+@DataJpaTest
+class CompanyOnboardingEventListenerIntegrationTest {
+
+  private static final String REGISTRY_CODE = "12345678";
+  private static final String PERSONAL_CODE = "38501010002";
+
+  @Autowired private CompanyRepository companyRepository;
+  @Autowired private CompanyPartyRepository companyPartyRepository;
+
+  private CompanyOnboardingEventListener listener;
+
+  @BeforeEach
+  void setUp() {
+    listener = new CompanyOnboardingEventListener(companyRepository, companyPartyRepository);
+  }
+
+  @Test
+  void reOnboardingSameCompanyReplacesPartiesWithoutViolatingUniqueConstraint() {
+    onboard();
+    companyPartyRepository.flush();
+
+    onboard();
+    companyPartyRepository.flush();
+
+    var company = companyRepository.findByRegistryCode(REGISTRY_CODE).orElseThrow();
+    var parties =
+        companyPartyRepository.findByPartyCodeAndPartyTypeAndRelationshipType(
+            PERSONAL_CODE, PERSON, BOARD_MEMBER);
+    assertThat(parties)
+        .extracting(
+            CompanyParty::getCompanyId,
+            CompanyParty::getPartyCode,
+            CompanyParty::getPartyType,
+            CompanyParty::getRelationshipType)
+        .containsExactly(tuple(company.getId(), PERSONAL_CODE, PERSON, BOARD_MEMBER));
+  }
+
+  private void onboard() {
+    var boardMember =
+        new KybRelatedPerson(new PersonalCode(PERSONAL_CODE), true, false, false, ZERO, COMPLETED);
+    listener.onKybCheckPerformed(
+        new KybCheckPerformedEvent(
+            this,
+            new CompanyDto(new RegistryCode(REGISTRY_CODE), "Test OÜ", "62011", LegalForm.OÜ),
+            new PersonalCode(PERSONAL_CODE),
+            List.of(boardMember),
+            List.of(new KybCheck(COMPANY_ACTIVE, true, Map.of()))));
+  }
+}


### PR DESCRIPTION
CompanyOnboardingEventListener.replaceParties() rebuilds a company's party rows by deleting them and re-inserting the current set, all inside one @Transactional method:

    companyPartyRepository.deleteByCompanyId(company.getId());
    ...forEach(companyPartyRepository::save);

deleteByCompanyId was a Spring Data *derived* delete. A derived delete does not issue SQL itself — it loads the matching entities and calls EntityManager.remove() on each, which only *schedules* the deletes in the persistence context. They are not flushed when the method returns; they sit in Hibernate's action queue until the transaction commits.

At flush time Hibernate does NOT execute SQL in the order the calls were made. It orders the action queue by operation type: inserts -> updates -> collection actions -> deletes (see ActionQueue.executeActions / OrderedActions). So even though the code deletes before it saves, Hibernate runs the INSERTs first and the DELETEs last within the same flush.

This causes duplicates that are now allowed by database constraints.