### PR TITLE
Avoid concurrent insertions of party

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/ledger/LedgerAccountService.java
+++ b/src/main/java/ee/tuleva/onboarding/ledger/LedgerAccountService.java
@@ -8,7 +8,9 @@ import ee.tuleva.onboarding.ledger.LedgerAccount.AccountType;
 import ee.tuleva.onboarding.ledger.LedgerAccount.AssetType;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.simple.JdbcClient;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -16,18 +18,31 @@ import org.springframework.stereotype.Service;
 class LedgerAccountService {
 
   private final LedgerAccountRepository ledgerAccountRepository;
+  private final JdbcClient jdbcClient;
 
   LedgerAccount createUserAccount(LedgerParty owner, UserAccount userAccount) {
-    var ledgerAccount =
-        LedgerAccount.builder()
-            .owner(owner)
-            .name(userAccount.name())
-            .purpose(USER_ACCOUNT)
-            .assetType(userAccount.getAssetType())
-            .accountType(userAccount.getAccountType())
-            .build();
+    insertUserAccountIfAbsent(owner, userAccount);
+    return findUserAccount(owner, userAccount).orElseThrow();
+  }
 
-    return ledgerAccountRepository.save(ledgerAccount);
+  void insertUserAccountIfAbsent(LedgerParty owner, UserAccount userAccount) {
+    jdbcClient
+        .sql(
+            """
+            INSERT INTO ledger.account (id, owner_party_id, name, purpose, account_type, asset_type)
+            VALUES (:id, :ownerPartyId, :name,
+                    CAST(:purpose AS ledger.account_purpose),
+                    CAST(:accountType AS ledger.account_type),
+                    CAST(:assetType AS ledger.asset_type))
+            ON CONFLICT DO NOTHING
+            """)
+        .param("id", UUID.randomUUID())
+        .param("ownerPartyId", owner.getId())
+        .param("name", userAccount.name())
+        .param("purpose", USER_ACCOUNT.name())
+        .param("accountType", userAccount.getAccountType().name())
+        .param("assetType", userAccount.getAssetType().name())
+        .update();
   }
 
   public Optional<LedgerAccount> findUserAccount(LedgerParty owner, UserAccount userAccount) {

--- a/src/main/java/ee/tuleva/onboarding/ledger/LedgerPartyService.java
+++ b/src/main/java/ee/tuleva/onboarding/ledger/LedgerPartyService.java
@@ -1,8 +1,8 @@
 package ee.tuleva.onboarding.ledger;
 
 import ee.tuleva.onboarding.ledger.LedgerParty.PartyType;
-import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.jdbc.core.simple.JdbcClient;
 import org.springframework.stereotype.Service;
@@ -18,27 +18,26 @@ class LedgerPartyService {
     return getParty(ownerId, partyType)
         .orElseGet(
             () -> {
-              acquirePartyLock(partyType, ownerId);
-              return getParty(ownerId, partyType).orElseGet(() -> createParty(ownerId, partyType));
+              insertPartyIfAbsent(ownerId, partyType);
+              return getParty(ownerId, partyType).orElseThrow();
             });
-  }
-
-  LedgerParty createParty(String ownerId, PartyType partyType) {
-    var ledgerParty =
-        LedgerParty.builder().partyType(partyType).ownerId(ownerId).details(Map.of()).build();
-
-    return ledgerPartyRepository.save(ledgerParty);
   }
 
   public Optional<LedgerParty> getParty(String ownerId, PartyType partyType) {
     return Optional.ofNullable(ledgerPartyRepository.findByOwnerIdAndPartyType(ownerId, partyType));
   }
 
-  private void acquirePartyLock(PartyType partyType, String ownerId) {
+  void insertPartyIfAbsent(String ownerId, PartyType partyType) {
     jdbcClient
-        .sql("SELECT pg_advisory_xact_lock(:key)")
-        .param("key", (long) (partyType.name() + ":" + ownerId).hashCode())
-        .query((rs, rowNum) -> 0)
-        .optional();
+        .sql(
+            """
+            INSERT INTO ledger.party (id, party_type, owner_id, details)
+            VALUES (:id, CAST(:partyType AS ledger.party_type), :ownerId, '{}')
+            ON CONFLICT DO NOTHING
+            """)
+        .param("id", UUID.randomUUID())
+        .param("partyType", partyType.name())
+        .param("ownerId", ownerId)
+        .update();
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/ledger/LedgerAccountServiceIntegrationTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/ledger/LedgerAccountServiceIntegrationTest.java
@@ -1,0 +1,65 @@
+package ee.tuleva.onboarding.ledger;
+
+import static ee.tuleva.onboarding.ledger.LedgerParty.PartyType.LEGAL_ENTITY;
+import static ee.tuleva.onboarding.ledger.UserAccount.SUBSCRIPTIONS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.simple.JdbcClient;
+
+@DataJpaTest
+@Import({LedgerAccountService.class, LedgerPartyService.class})
+class LedgerAccountServiceIntegrationTest {
+
+  @Autowired LedgerAccountService ledgerAccountService;
+  @Autowired LedgerPartyService ledgerPartyService;
+  @Autowired JdbcClient jdbcClient;
+
+  @Test
+  void createUserAccount_createsAccountWhenAbsent() {
+    LedgerParty party = ledgerPartyService.getOrCreate("20000001", LEGAL_ENTITY);
+
+    LedgerAccount account = ledgerAccountService.createUserAccount(party, SUBSCRIPTIONS);
+
+    assertThat(account.getName()).isEqualTo(SUBSCRIPTIONS.name());
+    assertThat(account.getOwner().getId()).isEqualTo(party.getId());
+    assertThat(accountCount(party, SUBSCRIPTIONS)).isEqualTo(1);
+  }
+
+  @Test
+  void createUserAccount_returnsExistingAccountWithoutCreatingDuplicate() {
+    LedgerParty party = ledgerPartyService.getOrCreate("20000002", LEGAL_ENTITY);
+
+    LedgerAccount first = ledgerAccountService.createUserAccount(party, SUBSCRIPTIONS);
+    LedgerAccount second = ledgerAccountService.createUserAccount(party, SUBSCRIPTIONS);
+
+    assertThat(second.getId()).isEqualTo(first.getId());
+    assertThat(accountCount(party, SUBSCRIPTIONS)).isEqualTo(1);
+  }
+
+  @Test
+  void insertUserAccountIfAbsent_isNoOpWhenAccountAlreadyExists() {
+    LedgerParty party = ledgerPartyService.getOrCreate("20000003", LEGAL_ENTITY);
+    ledgerAccountService.createUserAccount(party, SUBSCRIPTIONS);
+
+    assertThatCode(() -> ledgerAccountService.insertUserAccountIfAbsent(party, SUBSCRIPTIONS))
+        .doesNotThrowAnyException();
+
+    assertThat(accountCount(party, SUBSCRIPTIONS)).isEqualTo(1);
+  }
+
+  private long accountCount(LedgerParty owner, UserAccount userAccount) {
+    return jdbcClient
+        .sql(
+            "SELECT count(*) FROM ledger.account"
+                + " WHERE owner_party_id = :ownerPartyId AND name = :name")
+        .param("ownerPartyId", owner.getId())
+        .param("name", userAccount.name())
+        .query(Long.class)
+        .single();
+  }
+}

--- a/src/test/groovy/ee/tuleva/onboarding/ledger/LedgerAccountServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/ledger/LedgerAccountServiceTest.java
@@ -10,11 +10,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.simple.JdbcClient;
 
 @ExtendWith(MockitoExtension.class)
 class LedgerAccountServiceTest {
 
   @Mock private LedgerAccountRepository ledgerAccountRepository;
+  @Mock private JdbcClient jdbcClient;
 
   @InjectMocks private LedgerAccountService ledgerAccountService;
 

--- a/src/test/groovy/ee/tuleva/onboarding/ledger/LedgerPartyConcurrencyIntegrationTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/ledger/LedgerPartyConcurrencyIntegrationTest.java
@@ -1,0 +1,118 @@
+package ee.tuleva.onboarding.ledger;
+
+import static ee.tuleva.onboarding.ledger.LedgerParty.PartyType.LEGAL_ENTITY;
+import static ee.tuleva.onboarding.ledger.UserAccount.SUBSCRIPTIONS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.simple.JdbcClient;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@SpringBootTest
+@TestPropertySource(properties = "spring.datasource.hikari.maximum-pool-size=20")
+class LedgerPartyConcurrencyIntegrationTest {
+
+  @Autowired LedgerService ledgerService;
+  @Autowired JdbcClient jdbcClient;
+  @Autowired DataSource dataSource;
+  @Autowired PlatformTransactionManager transactionManager;
+
+  @Test
+  void concurrentGetPartyAccountForSameOwner_createsExactlyOnePartyAndAccount() throws Exception {
+    assumeTrue(isPostgres(), "The get-or-create race only reproduces on PostgreSQL");
+
+    String ownerId = "conc-" + UUID.randomUUID();
+    int threads = 16;
+    TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);
+    ExecutorService pool = Executors.newFixedThreadPool(threads);
+    CyclicBarrier barrier = new CyclicBarrier(threads);
+    List<Throwable> errors = new CopyOnWriteArrayList<>();
+    List<Future<?>> futures = new ArrayList<>();
+
+    long parties;
+    long accounts;
+    try {
+      for (int i = 0; i < threads; i++) {
+        futures.add(
+            pool.submit(
+                () -> {
+                  try {
+                    barrier.await();
+                    transactionTemplate.executeWithoutResult(
+                        status ->
+                            ledgerService.getPartyAccount(ownerId, LEGAL_ENTITY, SUBSCRIPTIONS));
+                  } catch (Throwable t) {
+                    errors.add(t);
+                  }
+                  return null;
+                }));
+      }
+      for (Future<?> future : futures) {
+        future.get(60, SECONDS);
+      }
+      parties = partyCount(ownerId);
+      accounts = accountCount(ownerId);
+    } finally {
+      pool.shutdownNow();
+      deleteParty(ownerId);
+    }
+
+    assertThat(errors).isEmpty();
+    assertThat(parties).isEqualTo(1);
+    assertThat(accounts).isEqualTo(1);
+  }
+
+  private boolean isPostgres() throws SQLException {
+    try (var connection = dataSource.getConnection()) {
+      return connection.getMetaData().getDatabaseProductName().toLowerCase().contains("postgresql");
+    }
+  }
+
+  private long partyCount(String ownerId) {
+    return jdbcClient
+        .sql("SELECT count(*) FROM ledger.party WHERE owner_id = :ownerId")
+        .param("ownerId", ownerId)
+        .query(Long.class)
+        .single();
+  }
+
+  private long accountCount(String ownerId) {
+    return jdbcClient
+        .sql(
+            "SELECT count(*) FROM ledger.account a"
+                + " JOIN ledger.party p ON p.id = a.owner_party_id"
+                + " WHERE p.owner_id = :ownerId")
+        .param("ownerId", ownerId)
+        .query(Long.class)
+        .single();
+  }
+
+  private void deleteParty(String ownerId) {
+    jdbcClient
+        .sql(
+            "DELETE FROM ledger.account WHERE owner_party_id IN"
+                + " (SELECT id FROM ledger.party WHERE owner_id = :ownerId)")
+        .param("ownerId", ownerId)
+        .update();
+    jdbcClient
+        .sql("DELETE FROM ledger.party WHERE owner_id = :ownerId")
+        .param("ownerId", ownerId)
+        .update();
+  }
+}

--- a/src/test/groovy/ee/tuleva/onboarding/ledger/LedgerPartyServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/ledger/LedgerPartyServiceTest.java
@@ -1,71 +1,70 @@
 package ee.tuleva.onboarding.ledger;
 
+import static ee.tuleva.onboarding.ledger.LedgerParty.PartyType.LEGAL_ENTITY;
 import static ee.tuleva.onboarding.ledger.LedgerParty.PartyType.PERSON;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.*;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
-import java.util.Map;
-import java.util.Optional;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.jdbc.core.simple.JdbcClient;
 
-@ExtendWith(MockitoExtension.class)
+@DataJpaTest
+@Import(LedgerPartyService.class)
 class LedgerPartyServiceTest {
 
-  @Mock private LedgerPartyRepository ledgerPartyRepository;
-  @Mock private JdbcClient jdbcClient;
-  @Mock private JdbcClient.StatementSpec statementSpec;
-  @Mock private JdbcClient.MappedQuerySpec<Object> mappedQuerySpec;
-  @InjectMocks private LedgerPartyService ledgerPartyService;
-
-  final String ownerId = "38812121215";
-  final LedgerParty existingParty =
-      LedgerParty.builder().partyType(PERSON).ownerId(ownerId).details(Map.of()).build();
+  @Autowired LedgerPartyService ledgerPartyService;
+  @Autowired JdbcClient jdbcClient;
 
   @Test
-  void getOrCreate_returnsExistingParty() {
-    given(ledgerPartyRepository.findByOwnerIdAndPartyType(ownerId, PERSON))
-        .willReturn(existingParty);
+  void getOrCreate_createsPartyWhenAbsent() {
+    LedgerParty party = ledgerPartyService.getOrCreate("10000001", LEGAL_ENTITY);
 
-    assertThat(ledgerPartyService.getOrCreate(ownerId, PERSON)).isEqualTo(existingParty);
-
-    verify(ledgerPartyRepository, never()).save(any());
+    assertThat(party.getOwnerId()).isEqualTo("10000001");
+    assertThat(party.getPartyType()).isEqualTo(LEGAL_ENTITY);
+    assertThat(party.getDetails()).isEmpty();
+    assertThat(partyCount("10000001", LEGAL_ENTITY)).isEqualTo(1);
   }
 
   @Test
-  void getOrCreate_createsPartyWhenNotFound() {
-    given(ledgerPartyRepository.findByOwnerIdAndPartyType(ownerId, PERSON)).willReturn(null);
-    given(ledgerPartyRepository.save(any())).willReturn(existingParty);
-    stubAdvisoryLock();
+  void getOrCreate_returnsExistingPartyWithoutCreatingDuplicate() {
+    LedgerParty first = ledgerPartyService.getOrCreate("10000002", LEGAL_ENTITY);
+    LedgerParty second = ledgerPartyService.getOrCreate("10000002", LEGAL_ENTITY);
 
-    assertThat(ledgerPartyService.getOrCreate(ownerId, PERSON)).isEqualTo(existingParty);
-
-    verify(ledgerPartyRepository).save(any());
+    assertThat(second.getId()).isEqualTo(first.getId());
+    assertThat(partyCount("10000002", LEGAL_ENTITY)).isEqualTo(1);
   }
 
   @Test
-  void getOrCreate_returnsExistingPartyAfterLockWhenCreatedByConcurrentThread() {
-    given(ledgerPartyRepository.findByOwnerIdAndPartyType(ownerId, PERSON))
-        .willReturn(null)
-        .willReturn(existingParty);
-    stubAdvisoryLock();
+  void insertPartyIfAbsent_isNoOpWhenPartyAlreadyExists() {
+    ledgerPartyService.getOrCreate("10000003", LEGAL_ENTITY);
 
-    assertThat(ledgerPartyService.getOrCreate(ownerId, PERSON)).isEqualTo(existingParty);
+    assertThatCode(() -> ledgerPartyService.insertPartyIfAbsent("10000003", LEGAL_ENTITY))
+        .doesNotThrowAnyException();
 
-    verify(ledgerPartyRepository, never()).save(any());
+    assertThat(partyCount("10000003", LEGAL_ENTITY)).isEqualTo(1);
   }
 
-  @SuppressWarnings("unchecked")
-  private void stubAdvisoryLock() {
-    given(jdbcClient.sql(contains("pg_advisory_xact_lock"))).willReturn(statementSpec);
-    given(statementSpec.param(eq("key"), anyLong())).willReturn(statementSpec);
-    given(statementSpec.query(any(org.springframework.jdbc.core.RowMapper.class)))
-        .willReturn(mappedQuerySpec);
-    given(mappedQuerySpec.optional()).willReturn(Optional.empty());
+  @Test
+  void getOrCreate_separatesPartyTypesForSameOwnerId() {
+    LedgerParty person = ledgerPartyService.getOrCreate("10000004", PERSON);
+    LedgerParty legalEntity = ledgerPartyService.getOrCreate("10000004", LEGAL_ENTITY);
+
+    assertThat(person.getId()).isNotEqualTo(legalEntity.getId());
+    assertThat(partyCount("10000004", PERSON)).isEqualTo(1);
+    assertThat(partyCount("10000004", LEGAL_ENTITY)).isEqualTo(1);
+  }
+
+  private long partyCount(String ownerId, LedgerParty.PartyType partyType) {
+    return jdbcClient
+        .sql(
+            "SELECT count(*) FROM ledger.party WHERE owner_id = :ownerId"
+                + " AND party_type = CAST(:partyType AS ledger.party_type)")
+        .param("ownerId", ownerId)
+        .param("partyType", partyType.name())
+        .query(Long.class)
+        .single();
   }
 }


### PR DESCRIPTION
The transactions endpoint and the savings-fund statement endpoint both lazily create the ledger party for a first-time investor via LedgerPartyService.getOrCreate. When a dashboard load fires both concurrently for a not-yet-created party, both insert the same (party_type, owner_id) and one fails with:

  duplicate key value violates unique constraint "ux_party_type_owner"

The previous guard (pg_advisory_xact_lock + double-checked re-read) did not prevent this. An advisory xact lock is held only until its transaction ends, so it serializes callers only while they hold it across their INSERT. getTransactions is @Transactional and does; but SavingsFundStatementService.getAccountStatement is not, so there each statement is its own transaction and the lock is released the instant its SELECT returns -- before the re-check and INSERT. That path holds no lock across the write, so it never excluded the transactional path.

Replace the lock with an idempotent upsert that does not depend on holding a lock across the write: INSERT ... ON CONFLICT DO NOTHING, then re-fetch. This is correct regardless of transaction vs autocommit, connection sharing, or isolation level. Apply the same pattern to the account path (ux_account_owner_name), which would otherwise surface the same race once the party stopped failing.

Verified on both engines: H2 @DataJpaTest idempotency tests (default ./gradlew test) and a 16-thread LedgerPartyConcurrencyIntegrationTest on real PostgreSQL (gated by assumeTrue(isPostgres()), SPRING_PROFILES_ACTIVE=pg,test).