### PR TITLE
Fix KYB false-rejection of Nasdaq-CSD-registered OÜs

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/kyb/KybCompanyDataMapper.java
+++ b/src/main/java/ee/tuleva/onboarding/kyb/KybCompanyDataMapper.java
@@ -1,6 +1,8 @@
 package ee.tuleva.onboarding.kyb;
 
 import static ee.tuleva.onboarding.aml.AmlCheckType.KYC_CHECK;
+import static ee.tuleva.onboarding.kyb.KybKycStatus.*;
+import static ee.tuleva.onboarding.kyb.KybRelationshipRoles.*;
 import static ee.tuleva.onboarding.time.ClockHolder.aYearAgo;
 
 import ee.tuleva.onboarding.aml.AmlCheckRepository;
@@ -20,8 +22,8 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 class KybCompanyDataMapper {
 
-  private static final String BOARD_MEMBER_ROLE = "JUHL";
-  private static final String SHAREHOLDER_ROLE = "OSAN";
+  private static final String NATURAL_PERSON_TYPE = "F"; // füüsiline isik (natural person)
+  private static final String LEGAL_ENTITY_TYPE = "J"; // juriidiline isik (legal entity)
 
   private final AmlCheckRepository amlCheckRepository;
 
@@ -75,8 +77,9 @@ class KybCompanyDataMapper {
 
   private KybRelatedPerson toRelatedPerson(
       @Nullable PersonalCode code, List<CompanyRelationship> roles) {
+    var naturalPerson = roles.stream().allMatch(r -> NATURAL_PERSON_TYPE.equals(r.personType()));
     var boardMember = roles.stream().anyMatch(r -> BOARD_MEMBER_ROLE.equals(r.roleCode()));
-    var shareholder = roles.stream().anyMatch(r -> SHAREHOLDER_ROLE.equals(r.roleCode()));
+    var shareholder = roles.stream().anyMatch(r -> SHAREHOLDER_ROLES.contains(r.roleCode()));
     var beneficialOwner = roles.stream().anyMatch(r -> r.controlMethod() != null);
     var ownershipPercent =
         roles.stream()
@@ -86,22 +89,23 @@ class KybCompanyDataMapper {
             .orElse(BigDecimal.ZERO);
     return new KybRelatedPerson(
         code,
+        naturalPerson,
         boardMember,
         shareholder,
         beneficialOwner,
         ownershipPercent,
-        code != null ? resolveKycStatus(code.value()) : KybKycStatus.UNKNOWN);
+        code != null ? resolveKycStatus(code.value()) : UNKNOWN);
   }
 
   private KybKycStatus resolveKycStatus(String personalCode) {
     if (amlCheckRepository.existsByPersonalCodeAndTypeAndSuccessAndCreatedTimeAfter(
         personalCode, KYC_CHECK, true, aYearAgo())) {
-      return KybKycStatus.COMPLETED;
+      return COMPLETED;
     }
     if (amlCheckRepository.existsByPersonalCodeAndTypeAndSuccessAndCreatedTimeAfter(
         personalCode, KYC_CHECK, false, aYearAgo())) {
-      return KybKycStatus.REJECTED;
+      return REJECTED;
     }
-    return KybKycStatus.UNKNOWN;
+    return UNKNOWN;
   }
 }

--- a/src/main/java/ee/tuleva/onboarding/kyb/KybRelatedPerson.java
+++ b/src/main/java/ee/tuleva/onboarding/kyb/KybRelatedPerson.java
@@ -1,10 +1,13 @@
 package ee.tuleva.onboarding.kyb;
 
 import java.math.BigDecimal;
+import lombok.Builder;
 import org.jspecify.annotations.Nullable;
 
+@Builder
 public record KybRelatedPerson(
     @Nullable PersonalCode personalCode,
+    boolean naturalPerson,
     boolean boardMember,
     boolean shareholder,
     boolean beneficialOwner,

--- a/src/main/java/ee/tuleva/onboarding/kyb/KybRelationshipRoles.java
+++ b/src/main/java/ee/tuleva/onboarding/kyb/KybRelationshipRoles.java
@@ -1,0 +1,29 @@
+package ee.tuleva.onboarding.kyb;
+
+import java.util.Set;
+
+final class KybRelationshipRoles {
+
+  static final String BOARD_MEMBER_ROLE = "JUHL"; // juhatuse liige (board member)
+  static final String NASDAQ_CSD_SHAREHOLDER_ROLE = "O"; // osanik (shares held in Nasdaq CSD)
+  static final String BUSINESS_REGISTRY_SHAREHOLDER_ROLE =
+      "OSAN"; // osanik (listed in the registry)
+  static final String BENEFICIAL_OWNER_ROLE = "W"; // tegelik kasusaaja (beneficial owner)
+
+  // Both codes mean osanik (shareholder): "O" when shares are in Nasdaq CSD, "OSAN" when they are
+  // listed directly in the business registry.
+  static final Set<String> SHAREHOLDER_ROLES =
+      Set.of(NASDAQ_CSD_SHAREHOLDER_ROLE, BUSINESS_REGISTRY_SHAREHOLDER_ROLE);
+
+  // The only roles an ownership rule models. Everything else (founders, the Nasdaq CSD share
+  // registrar ORP/ARP, prokurist, contact persons, liquidators, auditors, ...) is not a related
+  // person for screening.
+  static final Set<String> RELATED_PERSON_ROLES =
+      Set.of(
+          BOARD_MEMBER_ROLE,
+          NASDAQ_CSD_SHAREHOLDER_ROLE,
+          BUSINESS_REGISTRY_SHAREHOLDER_ROLE,
+          BENEFICIAL_OWNER_ROLE);
+
+  private KybRelationshipRoles() {}
+}

--- a/src/main/java/ee/tuleva/onboarding/kyb/LegalEntityScreener.java
+++ b/src/main/java/ee/tuleva/onboarding/kyb/LegalEntityScreener.java
@@ -1,5 +1,7 @@
 package ee.tuleva.onboarding.kyb;
 
+import static ee.tuleva.onboarding.kyb.KybRelationshipRoles.RELATED_PERSON_ROLES;
+
 import ee.tuleva.onboarding.ariregister.AriregisterClient;
 import ee.tuleva.onboarding.ariregister.CompanyDetail;
 import ee.tuleva.onboarding.ariregister.CompanyRelationship;
@@ -14,8 +16,6 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class LegalEntityScreener {
 
-  private static final String FOUNDER_ROLE = "A";
-
   private final AriregisterClient ariregisterClient;
   private final KybCompanyDataMapper kybCompanyDataMapper;
   private final KybScreeningService kybScreeningService;
@@ -26,7 +26,7 @@ public class LegalEntityScreener {
     return ariregisterClient
         .getActiveCompanyRelationships(registryCode, LocalDate.now(clock))
         .stream()
-        .filter(r -> !FOUNDER_ROLE.equals(r.roleCode()))
+        .filter(relationship -> RELATED_PERSON_ROLES.contains(relationship.roleCode()))
         .toList();
   }
 

--- a/src/main/java/ee/tuleva/onboarding/kyb/screener/CompanyStructureScreener.java
+++ b/src/main/java/ee/tuleva/onboarding/kyb/screener/CompanyStructureScreener.java
@@ -19,14 +19,32 @@ public class CompanyStructureScreener implements KybScreener {
     var persons = companyData.relatedPersons();
     boolean tooManyPersons = persons.size() > MAX_RELATED_PERSONS;
     boolean hasUnidentifiedPerson = persons.stream().anyMatch(p -> p.personalCode() == null);
-    boolean success = !tooManyPersons && !hasUnidentifiedPerson;
+    boolean hasNonNaturalPerson = persons.stream().anyMatch(p -> !p.naturalPerson());
+    boolean success =
+        !tooManyPersons
+            && !hasUnidentifiedPerson
+            && !hasNonNaturalPerson
+            && ownershipStructureSupported(persons);
 
     return List.of(new KybCheck(COMPANY_STRUCTURE, success, buildMetadata(persons)));
+  }
+
+  // Fail closed: only structures an ownership rule covers are supported — a sole member, or two
+  // members where at least one is a board member. Anything else (no related persons, or two
+  // non-board owners) would otherwise pass with no ownership rule ever firing.
+  private boolean ownershipStructureSupported(List<KybRelatedPerson> persons) {
+    long boardMembers = persons.stream().filter(KybRelatedPerson::boardMember).count();
+    return switch (persons.size()) {
+      case 1 -> true;
+      case 2 -> boardMembers >= 1;
+      default -> false;
+    };
   }
 
   private Map<String, Object> buildMetadata(List<KybRelatedPerson> persons) {
     return Map.of(
         "relatedPersonCount", persons.size(),
-        "allIdentified", persons.stream().noneMatch(p -> p.personalCode() == null));
+        "allIdentified", persons.stream().noneMatch(p -> p.personalCode() == null),
+        "allNatural", persons.stream().allMatch(KybRelatedPerson::naturalPerson));
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/aml/AmlKybCheckCompanyAttributionIntegrationTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/aml/AmlKybCheckCompanyAttributionIntegrationTest.java
@@ -2,6 +2,8 @@ package ee.tuleva.onboarding.aml;
 
 import static ee.tuleva.onboarding.kyb.KybCheckType.COMPANY_ACTIVE;
 import static ee.tuleva.onboarding.kyb.KybCheckType.COMPANY_STRUCTURE;
+import static ee.tuleva.onboarding.kyb.KybKycStatus.COMPLETED;
+import static ee.tuleva.onboarding.kyb.KybTestFixtures.boardMemberOwner;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
@@ -12,12 +14,9 @@ import ee.tuleva.onboarding.conversion.UserConversionService;
 import ee.tuleva.onboarding.kyb.CompanyDto;
 import ee.tuleva.onboarding.kyb.KybCheck;
 import ee.tuleva.onboarding.kyb.KybCheckPerformedEvent;
-import ee.tuleva.onboarding.kyb.KybKycStatus;
-import ee.tuleva.onboarding.kyb.KybRelatedPerson;
 import ee.tuleva.onboarding.kyb.LegalForm;
 import ee.tuleva.onboarding.kyb.PersonalCode;
 import ee.tuleva.onboarding.kyb.RegistryCode;
-import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
@@ -106,13 +105,7 @@ public class AmlKybCheckCompanyAttributionIntegrationTest {
     var company = new CompanyDto(new RegistryCode(registryCode), "Test OÜ", "62011", LegalForm.OÜ);
     var relatedPersons =
         List.of(
-            new KybRelatedPerson(
-                new PersonalCode(personalCode),
-                true,
-                true,
-                true,
-                BigDecimal.valueOf(100),
-                KybKycStatus.COMPLETED));
+            boardMemberOwner(new PersonalCode(personalCode), 100.0).kycStatus(COMPLETED).build());
     return new KybCheckPerformedEvent(
         this, company, new PersonalCode(personalCode), relatedPersons, checks);
   }

--- a/src/test/groovy/ee/tuleva/onboarding/aml/AmlKybCheckCompanyAttributionIntegrationTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/aml/AmlKybCheckCompanyAttributionIntegrationTest.java
@@ -2,7 +2,6 @@ package ee.tuleva.onboarding.aml;
 
 import static ee.tuleva.onboarding.kyb.KybCheckType.COMPANY_ACTIVE;
 import static ee.tuleva.onboarding.kyb.KybCheckType.COMPANY_STRUCTURE;
-import static ee.tuleva.onboarding.kyb.KybKycStatus.COMPLETED;
 import static ee.tuleva.onboarding.kyb.KybTestFixtures.boardMemberOwner;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -103,9 +102,7 @@ public class AmlKybCheckCompanyAttributionIntegrationTest {
   private KybCheckPerformedEvent screening(
       String registryCode, String personalCode, List<KybCheck> checks) {
     var company = new CompanyDto(new RegistryCode(registryCode), "Test OÜ", "62011", LegalForm.OÜ);
-    var relatedPersons =
-        List.of(
-            boardMemberOwner(new PersonalCode(personalCode), 100.0).kycStatus(COMPLETED).build());
+    var relatedPersons = List.of(boardMemberOwner(personalCode, 100.0).build());
     return new KybCheckPerformedEvent(
         this, company, new PersonalCode(personalCode), relatedPersons, checks);
   }

--- a/src/test/groovy/ee/tuleva/onboarding/aml/AmlKybCheckEventListenerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/aml/AmlKybCheckEventListenerTest.java
@@ -2,6 +2,8 @@ package ee.tuleva.onboarding.aml;
 
 import static ee.tuleva.onboarding.aml.AmlCheckType.*;
 import static ee.tuleva.onboarding.kyb.KybCheckType.*;
+import static ee.tuleva.onboarding.kyb.KybKycStatus.COMPLETED;
+import static ee.tuleva.onboarding.kyb.KybTestFixtures.boardMemberOwner;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
@@ -10,7 +12,6 @@ import static org.mockito.Mockito.verify;
 import ee.tuleva.onboarding.company.Company;
 import ee.tuleva.onboarding.company.CompanyRepository;
 import ee.tuleva.onboarding.kyb.*;
-import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -96,13 +97,7 @@ class AmlKybCheckEventListenerTest {
     var company = new CompanyDto(new RegistryCode(registryCode), "Test OÜ", "62011", LegalForm.OÜ);
     var relatedPersons =
         List.of(
-            new KybRelatedPerson(
-                new PersonalCode(personalCode),
-                true,
-                true,
-                true,
-                BigDecimal.valueOf(100),
-                KybKycStatus.COMPLETED));
+            boardMemberOwner(new PersonalCode(personalCode), 100.0).kycStatus(COMPLETED).build());
     return new KybCheckPerformedEvent(
         AmlKybCheckEventListenerTest.class,
         company,

--- a/src/test/groovy/ee/tuleva/onboarding/aml/AmlKybCheckEventListenerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/aml/AmlKybCheckEventListenerTest.java
@@ -2,7 +2,6 @@ package ee.tuleva.onboarding.aml;
 
 import static ee.tuleva.onboarding.aml.AmlCheckType.*;
 import static ee.tuleva.onboarding.kyb.KybCheckType.*;
-import static ee.tuleva.onboarding.kyb.KybKycStatus.COMPLETED;
 import static ee.tuleva.onboarding.kyb.KybTestFixtures.boardMemberOwner;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.BDDMockito.given;
@@ -95,9 +94,7 @@ class AmlKybCheckEventListenerTest {
   private static KybCheckPerformedEvent event(
       String registryCode, String personalCode, List<KybCheck> checks) {
     var company = new CompanyDto(new RegistryCode(registryCode), "Test OÜ", "62011", LegalForm.OÜ);
-    var relatedPersons =
-        List.of(
-            boardMemberOwner(new PersonalCode(personalCode), 100.0).kycStatus(COMPLETED).build());
+    var relatedPersons = List.of(boardMemberOwner(new PersonalCode(personalCode), 100.0).build());
     return new KybCheckPerformedEvent(
         AmlKybCheckEventListenerTest.class,
         company,

--- a/src/test/groovy/ee/tuleva/onboarding/company/CompanyOnboardingEventListenerIntegrationTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/company/CompanyOnboardingEventListenerIntegrationTest.java
@@ -2,8 +2,7 @@ package ee.tuleva.onboarding.company;
 
 import static ee.tuleva.onboarding.company.RelationshipType.BOARD_MEMBER;
 import static ee.tuleva.onboarding.kyb.KybCheckType.COMPANY_ACTIVE;
-import static ee.tuleva.onboarding.kyb.KybKycStatus.COMPLETED;
-import static ee.tuleva.onboarding.kyb.KybTestFixtures.kybPerson;
+import static ee.tuleva.onboarding.kyb.KybTestFixtures.boardMemberOnly;
 import static ee.tuleva.onboarding.party.PartyId.Type.PERSON;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
@@ -59,12 +58,7 @@ class CompanyOnboardingEventListenerIntegrationTest {
   }
 
   private void onboard() {
-    var boardMember =
-        kybPerson()
-            .personalCode(new PersonalCode(PERSONAL_CODE))
-            .boardMember(true)
-            .kycStatus(COMPLETED)
-            .build();
+    var boardMember = boardMemberOnly(PERSONAL_CODE).build();
     listener.onKybCheckPerformed(
         new KybCheckPerformedEvent(
             this,

--- a/src/test/groovy/ee/tuleva/onboarding/company/CompanyOnboardingEventListenerIntegrationTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/company/CompanyOnboardingEventListenerIntegrationTest.java
@@ -3,15 +3,14 @@ package ee.tuleva.onboarding.company;
 import static ee.tuleva.onboarding.company.RelationshipType.BOARD_MEMBER;
 import static ee.tuleva.onboarding.kyb.KybCheckType.COMPANY_ACTIVE;
 import static ee.tuleva.onboarding.kyb.KybKycStatus.COMPLETED;
+import static ee.tuleva.onboarding.kyb.KybTestFixtures.kybPerson;
 import static ee.tuleva.onboarding.party.PartyId.Type.PERSON;
-import static java.math.BigDecimal.ZERO;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
 import ee.tuleva.onboarding.kyb.CompanyDto;
 import ee.tuleva.onboarding.kyb.KybCheck;
 import ee.tuleva.onboarding.kyb.KybCheckPerformedEvent;
-import ee.tuleva.onboarding.kyb.KybRelatedPerson;
 import ee.tuleva.onboarding.kyb.LegalForm;
 import ee.tuleva.onboarding.kyb.PersonalCode;
 import ee.tuleva.onboarding.kyb.RegistryCode;
@@ -61,7 +60,11 @@ class CompanyOnboardingEventListenerIntegrationTest {
 
   private void onboard() {
     var boardMember =
-        new KybRelatedPerson(new PersonalCode(PERSONAL_CODE), true, false, false, ZERO, COMPLETED);
+        kybPerson()
+            .personalCode(new PersonalCode(PERSONAL_CODE))
+            .boardMember(true)
+            .kycStatus(COMPLETED)
+            .build();
     listener.onKybCheckPerformed(
         new KybCheckPerformedEvent(
             this,

--- a/src/test/groovy/ee/tuleva/onboarding/company/CompanyOnboardingEventListenerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/company/CompanyOnboardingEventListenerTest.java
@@ -2,6 +2,9 @@ package ee.tuleva.onboarding.company;
 
 import static ee.tuleva.onboarding.company.RelationshipType.*;
 import static ee.tuleva.onboarding.kyb.KybCheckType.*;
+import static ee.tuleva.onboarding.kyb.KybKycStatus.COMPLETED;
+import static ee.tuleva.onboarding.kyb.KybTestFixtures.boardMemberOwner;
+import static ee.tuleva.onboarding.kyb.KybTestFixtures.kybPerson;
 import static ee.tuleva.onboarding.party.PartyId.Type.PERSON;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -28,33 +31,20 @@ class CompanyOnboardingEventListenerTest {
 
   // board member + shareholder + beneficial owner
   private final KybRelatedPerson person1 =
-      new KybRelatedPerson(
-          new PersonalCode("38501010001"),
-          true,
-          true,
-          true,
-          BigDecimal.valueOf(50),
-          KybKycStatus.COMPLETED);
+      boardMemberOwner("38501010001", 50.0).kycStatus(COMPLETED).build();
 
   // board member only
   private final KybRelatedPerson person2 =
-      new KybRelatedPerson(
-          new PersonalCode("38501010002"),
-          true,
-          false,
-          false,
-          BigDecimal.ZERO,
-          KybKycStatus.COMPLETED);
+      kybPerson("38501010002").boardMember(true).kycStatus(COMPLETED).build();
 
   // shareholder + beneficial owner, not a board member
   private final KybRelatedPerson person3 =
-      new KybRelatedPerson(
-          new PersonalCode("38501010003"),
-          false,
-          true,
-          true,
-          BigDecimal.valueOf(50),
-          KybKycStatus.COMPLETED);
+      kybPerson("38501010003")
+          .shareholder(true)
+          .beneficialOwner(true)
+          .ownershipPercent(BigDecimal.valueOf(50))
+          .kycStatus(COMPLETED)
+          .build();
 
   @Test
   void createsCompanyAndAllPartyRelationshipsWhenAllChecksPass() {

--- a/src/test/groovy/ee/tuleva/onboarding/company/CompanyOnboardingEventListenerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/company/CompanyOnboardingEventListenerTest.java
@@ -2,9 +2,9 @@ package ee.tuleva.onboarding.company;
 
 import static ee.tuleva.onboarding.company.RelationshipType.*;
 import static ee.tuleva.onboarding.kyb.KybCheckType.*;
-import static ee.tuleva.onboarding.kyb.KybKycStatus.COMPLETED;
+import static ee.tuleva.onboarding.kyb.KybTestFixtures.boardMemberOnly;
 import static ee.tuleva.onboarding.kyb.KybTestFixtures.boardMemberOwner;
-import static ee.tuleva.onboarding.kyb.KybTestFixtures.kybPerson;
+import static ee.tuleva.onboarding.kyb.KybTestFixtures.shareholderOwner;
 import static ee.tuleva.onboarding.party.PartyId.Type.PERSON;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -12,7 +12,6 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
 import ee.tuleva.onboarding.kyb.*;
-import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -30,21 +29,13 @@ class CompanyOnboardingEventListenerTest {
       new CompanyDto(new RegistryCode("12345678"), "Test OÜ", "62011", LegalForm.OÜ);
 
   // board member + shareholder + beneficial owner
-  private final KybRelatedPerson person1 =
-      boardMemberOwner("38501010001", 50.0).kycStatus(COMPLETED).build();
+  private final KybRelatedPerson person1 = boardMemberOwner("38501010001", 50.0).build();
 
   // board member only
-  private final KybRelatedPerson person2 =
-      kybPerson("38501010002").boardMember(true).kycStatus(COMPLETED).build();
+  private final KybRelatedPerson person2 = boardMemberOnly("38501010002").build();
 
   // shareholder + beneficial owner, not a board member
-  private final KybRelatedPerson person3 =
-      kybPerson("38501010003")
-          .shareholder(true)
-          .beneficialOwner(true)
-          .ownershipPercent(BigDecimal.valueOf(50))
-          .kycStatus(COMPLETED)
-          .build();
+  private final KybRelatedPerson person3 = shareholderOwner("38501010003", 50.0).build();
 
   @Test
   void createsCompanyAndAllPartyRelationshipsWhenAllChecksPass() {

--- a/src/test/groovy/ee/tuleva/onboarding/kyb/KybCompanyDataMapperTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyb/KybCompanyDataMapperTest.java
@@ -1,6 +1,7 @@
 package ee.tuleva.onboarding.kyb;
 
 import static ee.tuleva.onboarding.kyb.CompanyStatus.R;
+import static ee.tuleva.onboarding.kyb.KybTestFixtures.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.mock;
@@ -69,8 +70,13 @@ class KybCompanyDataMapperTest {
     assertThat(result.selfCertification()).isEqualTo(SELF_CERT);
     assertThat(result.relatedPersons())
         .containsExactly(
-            new KybRelatedPerson(
-                PERSONAL_CODE, true, true, true, new BigDecimal("100.00"), KybKycStatus.UNKNOWN));
+            kybPerson()
+                .personalCode(PERSONAL_CODE)
+                .boardMember(true)
+                .shareholder(true)
+                .beneficialOwner(true)
+                .ownershipPercent(new BigDecimal("100.00"))
+                .build());
   }
 
   @Test
@@ -112,15 +118,11 @@ class KybCompanyDataMapperTest {
     assertThat(result.relatedPersons()).hasSize(2);
     assertThat(result.relatedPersons())
         .containsExactlyInAnyOrder(
-            new KybRelatedPerson(
-                PERSONAL_CODE, true, false, false, BigDecimal.ZERO, KybKycStatus.UNKNOWN),
-            new KybRelatedPerson(
-                new PersonalCode("49901010003"),
-                false,
-                true,
-                false,
-                new BigDecimal("50.00"),
-                KybKycStatus.UNKNOWN));
+            kybPerson().personalCode(PERSONAL_CODE).boardMember(true).build(),
+            kybPerson("49901010003")
+                .shareholder(true)
+                .ownershipPercent(new BigDecimal("50.00"))
+                .build());
   }
 
   @Test
@@ -146,8 +148,12 @@ class KybCompanyDataMapperTest {
 
     assertThat(result.relatedPersons())
         .containsExactly(
-            new KybRelatedPerson(
-                PERSONAL_CODE, false, true, true, new BigDecimal("75.00"), KybKycStatus.UNKNOWN));
+            kybPerson()
+                .personalCode(PERSONAL_CODE)
+                .shareholder(true)
+                .beneficialOwner(true)
+                .ownershipPercent(new BigDecimal("75.00"))
+                .build());
   }
 
   @Test
@@ -219,32 +225,32 @@ class KybCompanyDataMapperTest {
             null,
             null,
             "EST");
-    var withoutCode =
+    var foreignBoardMember =
         new CompanyRelationship(
-            "J",
-            "ARP",
-            "Aktsiaraamatu pidaja",
-            null,
-            "Nasdaq CSD SE",
-            null,
-            null,
+            "F",
+            "JUHL",
+            "Juhatuse liige",
+            "John",
+            "Smith",
             null,
             null,
             null,
             null,
-            null);
+            null,
+            null,
+            "GBR");
 
     var detail = new CompanyDetail("Test OÜ", "12345678", "R", "OÜ", null, null, null, null);
 
     var result =
-        mapper.toKybCompanyData(detail, PERSONAL_CODE, List.of(withCode, withoutCode), SELF_CERT);
+        mapper.toKybCompanyData(
+            detail, PERSONAL_CODE, List.of(withCode, foreignBoardMember), SELF_CERT);
 
     assertThat(result.relatedPersons()).hasSize(2);
     assertThat(result.relatedPersons())
         .containsExactlyInAnyOrder(
-            new KybRelatedPerson(
-                PERSONAL_CODE, true, false, false, BigDecimal.ZERO, KybKycStatus.UNKNOWN),
-            new KybRelatedPerson(null, false, false, false, BigDecimal.ZERO, KybKycStatus.UNKNOWN));
+            kybPerson().personalCode(PERSONAL_CODE).boardMember(true).build(),
+            kybPerson().personalCode(null).boardMember(true).build());
   }
 
   @Test
@@ -345,6 +351,40 @@ class KybCompanyDataMapperTest {
     var result = mapper.toKybCompanyData(detail, PERSONAL_CODE, List.of(relationship), SELF_CERT);
 
     assertThat(result.relatedPersons().getFirst().kycStatus()).isEqualTo(KybKycStatus.UNKNOWN);
+  }
+
+  @Test
+  void mapsNasdaqCsdShareholderRoleToShareholder() {
+    var shareholder = nasdaqCsdShareholder("38501010002", "Jaan", "Tamm", new BigDecimal("100.00"));
+    var detail = new CompanyDetail("Test OÜ", "12345678", "R", "OÜ", null, null, null, null);
+
+    var result = mapper.toKybCompanyData(detail, PERSONAL_CODE, List.of(shareholder), SELF_CERT);
+
+    assertThat(result.relatedPersons())
+        .containsExactly(
+            kybPerson()
+                .personalCode(PERSONAL_CODE)
+                .shareholder(true)
+                .ownershipPercent(new BigDecimal("100.00"))
+                .build());
+  }
+
+  @Test
+  void mapsLegalEntityOwnerAsNonNaturalPerson() {
+    var legalEntityOwner =
+        legalEntityShareholder("90000002", "Holding OÜ", new BigDecimal("100.00"));
+    var detail = new CompanyDetail("Test OÜ", "12345678", "R", "OÜ", null, null, null, null);
+
+    var result =
+        mapper.toKybCompanyData(detail, PERSONAL_CODE, List.of(legalEntityOwner), SELF_CERT);
+
+    assertThat(result.relatedPersons())
+        .containsExactly(
+            kybPerson("90000002")
+                .naturalPerson(false)
+                .shareholder(true)
+                .ownershipPercent(new BigDecimal("100.00"))
+                .build());
   }
 
   private CompanyRelationship boardMemberRelationship(String personalCode) {

--- a/src/test/groovy/ee/tuleva/onboarding/kyb/KybEndToEndTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyb/KybEndToEndTest.java
@@ -1,7 +1,10 @@
 package ee.tuleva.onboarding.kyb;
 
 import static ee.tuleva.onboarding.aml.AmlCheckType.*;
+import static ee.tuleva.onboarding.aml.AmlCheckType.KYC_CHECK;
 import static ee.tuleva.onboarding.kyb.KybCheckType.*;
+import static ee.tuleva.onboarding.kyb.KybKycStatus.COMPLETED;
+import static ee.tuleva.onboarding.kyb.KybKycStatus.REJECTED;
 import static ee.tuleva.onboarding.kyb.KybTestFixtures.*;
 import static ee.tuleva.onboarding.time.ClockHolder.aYearAgo;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -178,22 +181,20 @@ class KybEndToEndTest {
     amlCheckRepository.save(
         AmlCheck.builder()
             .personalCode(JAAN.value())
-            .type(AmlCheckType.KYC_CHECK)
+            .type(KYC_CHECK)
             .success(true)
             .metadata(Map.of())
             .build());
     amlCheckRepository.save(
         AmlCheck.builder()
             .personalCode(MARI.value())
-            .type(AmlCheckType.KYC_CHECK)
+            .type(KYC_CHECK)
             .success(false)
             .metadata(Map.of())
             .build());
 
-    var person1 =
-        person(JAAN, true, true, true, java.math.BigDecimal.valueOf(50), KybKycStatus.COMPLETED);
-    var person2 =
-        person(MARI, true, true, true, java.math.BigDecimal.valueOf(50), KybKycStatus.REJECTED);
+    var person1 = boardMemberOwner(JAAN, 50.0).kycStatus(COMPLETED).build();
+    var person2 = boardMemberOwner(MARI, 50.0).kycStatus(REJECTED).build();
     var data =
         new KybCompanyData(
             VALID_COMPANY,

--- a/src/test/groovy/ee/tuleva/onboarding/kyb/KybNasdaqCsdScreeningTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyb/KybNasdaqCsdScreeningTest.java
@@ -10,7 +10,6 @@ import static org.mockito.Mockito.mock;
 
 import ee.tuleva.onboarding.aml.AmlCheckRepository;
 import ee.tuleva.onboarding.ariregister.AriregisterClient;
-import ee.tuleva.onboarding.ariregister.CompanyDetail;
 import ee.tuleva.onboarding.ariregister.CompanyRelationship;
 import ee.tuleva.onboarding.kyb.screener.CompanyStructureScreener;
 import ee.tuleva.onboarding.kyb.screener.DualMemberOwnershipScreener;
@@ -97,7 +96,7 @@ class KybNasdaqCsdScreeningTest {
                 REGISTRY_CODE, LocalDate.now(FIXED_CLOCK)))
         .willReturn(relationships);
     given(ariregisterClient.getCompanyDetails(REGISTRY_CODE))
-        .willReturn(Optional.of(companyDetail()));
+        .willReturn(Optional.of(VALID_COMPANY_DETAIL));
   }
 
   private List<KybCheck> screenActive(PersonalCode owner) {
@@ -107,9 +106,5 @@ class KybNasdaqCsdScreeningTest {
 
   private static boolean success(List<KybCheck> checks, KybCheckType type) {
     return checks.stream().filter(c -> c.type() == type).findFirst().orElseThrow().success();
-  }
-
-  private static CompanyDetail companyDetail() {
-    return new CompanyDetail("Test OÜ", REGISTRY_CODE, "R", "OÜ", null, null, null, null);
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/kyb/KybNasdaqCsdScreeningTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyb/KybNasdaqCsdScreeningTest.java
@@ -1,0 +1,115 @@
+package ee.tuleva.onboarding.kyb;
+
+import static ee.tuleva.onboarding.kyb.KybCheckType.COMPANY_STRUCTURE;
+import static ee.tuleva.onboarding.kyb.KybCheckType.DUAL_MEMBER_OWNERSHIP;
+import static ee.tuleva.onboarding.kyb.KybCheckType.SOLE_MEMBER_OWNERSHIP;
+import static ee.tuleva.onboarding.kyb.KybTestFixtures.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import ee.tuleva.onboarding.aml.AmlCheckRepository;
+import ee.tuleva.onboarding.ariregister.AriregisterClient;
+import ee.tuleva.onboarding.ariregister.CompanyDetail;
+import ee.tuleva.onboarding.ariregister.CompanyRelationship;
+import ee.tuleva.onboarding.kyb.screener.CompanyStructureScreener;
+import ee.tuleva.onboarding.kyb.screener.DualMemberOwnershipScreener;
+import ee.tuleva.onboarding.kyb.screener.SoleBoardMemberIsOwnerScreener;
+import ee.tuleva.onboarding.kyb.screener.SoleMemberOwnershipScreener;
+import ee.tuleva.onboarding.kyb.survey.LatestKybSurveyInputs;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationEventPublisher;
+
+class KybNasdaqCsdScreeningTest {
+
+  private static final String REGISTRY_CODE = "12345678";
+  private static final Clock FIXED_CLOCK =
+      Clock.fixed(Instant.parse("2026-03-27T10:00:00Z"), ZoneId.of("Europe/Tallinn"));
+
+  private final AmlCheckRepository amlCheckRepository = mock(AmlCheckRepository.class);
+  private final AriregisterClient ariregisterClient = mock(AriregisterClient.class);
+  private final LatestKybSurveyInputs latestKybSurveyInputs = mock(LatestKybSurveyInputs.class);
+
+  private final KybCompanyDataMapper mapper = new KybCompanyDataMapper(amlCheckRepository);
+  private final KybScreeningService screeningService =
+      new KybScreeningService(
+          List.of(
+              new CompanyStructureScreener(),
+              new SoleMemberOwnershipScreener(),
+              new DualMemberOwnershipScreener(),
+              new SoleBoardMemberIsOwnerScreener()),
+          mock(KybDataChangeDetector.class),
+          mock(ApplicationEventPublisher.class));
+  private final LegalEntityScreener screener =
+      new LegalEntityScreener(
+          ariregisterClient, mapper, screeningService, latestKybSurveyInputs, FIXED_CLOCK);
+
+  @Test
+  void nasdaqCsdRegisteredSoleOwnerOuIsNotRejectedForStructureOrOwnership() {
+    givenRelationships(nasdaqCsdSoleOwnerRelationships(JAAN.value()));
+
+    var checks = screenActive(JAAN);
+
+    assertThat(success(checks, COMPANY_STRUCTURE)).isTrue();
+    assertThat(success(checks, SOLE_MEMBER_OWNERSHIP)).isTrue();
+  }
+
+  @Test
+  void legalEntityShareholderIsRejectedForStructure() {
+    givenRelationships(
+        List.of(
+            boardMember(JAAN.value(), "Jaan", "Tamm"),
+            legalEntityShareholder("90000002", "Holding OÜ", new BigDecimal("100.00"))));
+
+    var checks = screenActive(JAAN);
+
+    assertThat(success(checks, COMPANY_STRUCTURE)).isFalse();
+  }
+
+  @Test
+  void twoNasdaqCsdBoardMemberOwnersPassDualOwnership() {
+    givenRelationships(
+        List.of(
+            boardMember(JAAN.value(), "Jaan", "Tamm"),
+            nasdaqCsdShareholder(JAAN.value(), "Jaan", "Tamm", new BigDecimal("50.00")),
+            nasdaqBeneficialOwner(JAAN.value(), "Jaan", "Tamm"),
+            boardMember(MARI.value(), "Mari", "Kask"),
+            nasdaqCsdShareholder(MARI.value(), "Mari", "Kask", new BigDecimal("50.00")),
+            nasdaqBeneficialOwner(MARI.value(), "Mari", "Kask"),
+            shareRegistrar()));
+
+    var checks = screenActive(JAAN);
+
+    assertThat(success(checks, COMPANY_STRUCTURE)).isTrue();
+    assertThat(success(checks, DUAL_MEMBER_OWNERSHIP)).isTrue();
+  }
+
+  private void givenRelationships(List<CompanyRelationship> relationships) {
+    given(
+            ariregisterClient.getActiveCompanyRelationships(
+                REGISTRY_CODE, LocalDate.now(FIXED_CLOCK)))
+        .willReturn(relationships);
+    given(ariregisterClient.getCompanyDetails(REGISTRY_CODE))
+        .willReturn(Optional.of(companyDetail()));
+  }
+
+  private List<KybCheck> screenActive(PersonalCode owner) {
+    var relationships = screener.fetchActiveRelationships(REGISTRY_CODE);
+    return screener.validate(REGISTRY_CODE, owner, null, relationships).checks();
+  }
+
+  private static boolean success(List<KybCheck> checks, KybCheckType type) {
+    return checks.stream().filter(c -> c.type() == type).findFirst().orElseThrow().success();
+  }
+
+  private static CompanyDetail companyDetail() {
+    return new CompanyDetail("Test OÜ", REGISTRY_CODE, "R", "OÜ", null, null, null, null);
+  }
+}

--- a/src/test/groovy/ee/tuleva/onboarding/kyb/KybScreeningIntegrationTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyb/KybScreeningIntegrationTest.java
@@ -49,7 +49,7 @@ class KybScreeningIntegrationTest {
 
   @Test
   void singlePersonCompanyWithValidOwnershipAndCompletedKycCreatesSuccessfulChecks() {
-    var person = boardMemberOwner(PERSONAL_CODE, 100.0).kycStatus(COMPLETED).build();
+    var person = boardMemberOwner(PERSONAL_CODE, 100.0).build();
     var data = companyWith(person);
 
     var results = kybScreeningService.screen(data);
@@ -104,7 +104,7 @@ class KybScreeningIntegrationTest {
   @Test
   @SuppressWarnings("unchecked")
   void dataChangedCheckDetectsChangesOnRerun() {
-    var person = boardMemberOwner(PERSONAL_CODE, 100.0).kycStatus(COMPLETED).build();
+    var person = boardMemberOwner(PERSONAL_CODE, 100.0).build();
     var data = companyWith(person);
 
     kybScreeningService.screen(data);
@@ -155,7 +155,7 @@ class KybScreeningIntegrationTest {
 
   @Test
   void companyWithUnidentifiedRelatedPersonIsBlockedWithoutCrashing() {
-    var unidentified = boardMemberOwner((PersonalCode) null, 100.0).build();
+    var unidentified = boardMemberOwner((PersonalCode) null, 100.0).kycStatus(UNKNOWN).build();
     var data = companyWith(unidentified);
 
     var results = kybScreeningService.screen(data);
@@ -181,7 +181,7 @@ class KybScreeningIntegrationTest {
 
   @Test
   void companyFoundedLessThanAYearAgoCreatesFailingCompanyAgeCheck() {
-    var person = boardMemberOwner(PERSONAL_CODE, 100.0).kycStatus(COMPLETED).build();
+    var person = boardMemberOwner(PERSONAL_CODE, 100.0).build();
     var data =
         new KybCompanyData(
             new CompanyDto(new RegistryCode("12345678"), "Test OÜ", "62011", LegalForm.OÜ),

--- a/src/test/groovy/ee/tuleva/onboarding/kyb/KybScreeningIntegrationTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyb/KybScreeningIntegrationTest.java
@@ -3,6 +3,9 @@ package ee.tuleva.onboarding.kyb;
 import static ee.tuleva.onboarding.aml.AmlCheckType.*;
 import static ee.tuleva.onboarding.kyb.CompanyStatus.R;
 import static ee.tuleva.onboarding.kyb.KybKycStatus.*;
+import static ee.tuleva.onboarding.kyb.KybTestFixtures.boardMemberOwner;
+import static ee.tuleva.onboarding.kyb.KybTestFixtures.companyWith;
+import static ee.tuleva.onboarding.kyb.KybTestFixtures.kybPerson;
 import static ee.tuleva.onboarding.time.ClockHolder.aYearAgo;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -46,18 +49,8 @@ class KybScreeningIntegrationTest {
 
   @Test
   void singlePersonCompanyWithValidOwnershipAndCompletedKycCreatesSuccessfulChecks() {
-    var person =
-        new KybRelatedPerson(PERSONAL_CODE, true, true, true, BigDecimal.valueOf(100), COMPLETED);
-    var data =
-        new KybCompanyData(
-            new CompanyDto(new RegistryCode("12345678"), "Test OÜ", "62011", LegalForm.OÜ),
-            PERSONAL_CODE,
-            R,
-            List.of(person),
-            new SelfCertification(true, true, true),
-            "EE",
-            "Harju maakond, Tallinn, Pärnu mnt 1",
-            null);
+    var person = boardMemberOwner(PERSONAL_CODE, 100.0).kycStatus(COMPLETED).build();
+    var data = companyWith(person);
 
     var results = kybScreeningService.screen(data);
 
@@ -86,17 +79,14 @@ class KybScreeningIntegrationTest {
   @Test
   void singlePersonCompanyWithInvalidOwnershipCreatesFailedCheck() {
     var person =
-        new KybRelatedPerson(PERSONAL_CODE, true, true, false, BigDecimal.valueOf(100), COMPLETED);
-    var data =
-        new KybCompanyData(
-            new CompanyDto(new RegistryCode("12345678"), "Test OÜ", "62011", LegalForm.OÜ),
-            PERSONAL_CODE,
-            R,
-            List.of(person),
-            new SelfCertification(true, true, true),
-            "EE",
-            "Harju maakond, Tallinn, Pärnu mnt 1",
-            null);
+        kybPerson()
+            .personalCode(PERSONAL_CODE)
+            .boardMember(true)
+            .shareholder(true)
+            .ownershipPercent(BigDecimal.valueOf(100))
+            .kycStatus(COMPLETED)
+            .build();
+    var data = companyWith(person);
 
     var results = kybScreeningService.screen(data);
 
@@ -114,18 +104,8 @@ class KybScreeningIntegrationTest {
   @Test
   @SuppressWarnings("unchecked")
   void dataChangedCheckDetectsChangesOnRerun() {
-    var person =
-        new KybRelatedPerson(PERSONAL_CODE, true, true, true, BigDecimal.valueOf(100), COMPLETED);
-    var data =
-        new KybCompanyData(
-            new CompanyDto(new RegistryCode("12345678"), "Test OÜ", "62011", LegalForm.OÜ),
-            PERSONAL_CODE,
-            R,
-            List.of(person),
-            new SelfCertification(true, true, true),
-            "EE",
-            "Harju maakond, Tallinn, Pärnu mnt 1",
-            null);
+    var person = boardMemberOwner(PERSONAL_CODE, 100.0).kycStatus(COMPLETED).build();
+    var data = companyWith(person);
 
     kybScreeningService.screen(data);
 
@@ -154,18 +134,8 @@ class KybScreeningIntegrationTest {
 
   @Test
   void relatedPersonWithRejectedKycCreatesFailedKycCheck() {
-    var person =
-        new KybRelatedPerson(PERSONAL_CODE, true, true, true, BigDecimal.valueOf(100), REJECTED);
-    var data =
-        new KybCompanyData(
-            new CompanyDto(new RegistryCode("12345678"), "Test OÜ", "62011", LegalForm.OÜ),
-            PERSONAL_CODE,
-            R,
-            List.of(person),
-            new SelfCertification(true, true, true),
-            "EE",
-            "Harju maakond, Tallinn, Pärnu mnt 1",
-            null);
+    var person = boardMemberOwner(PERSONAL_CODE, 100.0).kycStatus(REJECTED).build();
+    var data = companyWith(person);
 
     var results = kybScreeningService.screen(data);
 
@@ -185,18 +155,8 @@ class KybScreeningIntegrationTest {
 
   @Test
   void companyWithUnidentifiedRelatedPersonIsBlockedWithoutCrashing() {
-    var unidentified =
-        new KybRelatedPerson(null, true, true, true, BigDecimal.valueOf(100), UNKNOWN);
-    var data =
-        new KybCompanyData(
-            new CompanyDto(new RegistryCode("12345678"), "Test OÜ", "62011", LegalForm.OÜ),
-            PERSONAL_CODE,
-            R,
-            List.of(unidentified),
-            new SelfCertification(true, true, true),
-            "EE",
-            "Harju maakond, Tallinn, Pärnu mnt 1",
-            null);
+    var unidentified = boardMemberOwner((PersonalCode) null, 100.0).build();
+    var data = companyWith(unidentified);
 
     var results = kybScreeningService.screen(data);
 
@@ -221,8 +181,7 @@ class KybScreeningIntegrationTest {
 
   @Test
   void companyFoundedLessThanAYearAgoCreatesFailingCompanyAgeCheck() {
-    var person =
-        new KybRelatedPerson(PERSONAL_CODE, true, true, true, BigDecimal.valueOf(100), COMPLETED);
+    var person = boardMemberOwner(PERSONAL_CODE, 100.0).kycStatus(COMPLETED).build();
     var data =
         new KybCompanyData(
             new CompanyDto(new RegistryCode("12345678"), "Test OÜ", "62011", LegalForm.OÜ),

--- a/src/test/groovy/ee/tuleva/onboarding/kyb/KybScreeningServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyb/KybScreeningServiceTest.java
@@ -3,7 +3,9 @@ package ee.tuleva.onboarding.kyb;
 import static ee.tuleva.onboarding.kyb.CompanyStatus.R;
 import static ee.tuleva.onboarding.kyb.KybCheckType.*;
 import static ee.tuleva.onboarding.kyb.KybKycStatus.COMPLETED;
-import static ee.tuleva.onboarding.kyb.KybKycStatus.UNKNOWN;
+import static ee.tuleva.onboarding.kyb.KybTestFixtures.boardMemberOwner;
+import static ee.tuleva.onboarding.kyb.KybTestFixtures.companyWith;
+import static ee.tuleva.onboarding.kyb.KybTestFixtures.kybPerson;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -63,19 +65,8 @@ class KybScreeningServiceTest {
 
   @Test
   void singlePersonCompanyRunsRules31And34() {
-    var person =
-        new KybRelatedPerson(
-            new PersonalCode("38501010001"), true, true, true, BigDecimal.valueOf(100), UNKNOWN);
-    var data =
-        new KybCompanyData(
-            new CompanyDto(new RegistryCode("12345678"), "Test OÜ", "62011", LegalForm.OÜ),
-            new PersonalCode("38501010001"),
-            R,
-            List.of(person),
-            new SelfCertification(true, true, true),
-            "EE",
-            "Harju maakond, Tallinn, Pärnu mnt 1",
-            null);
+    var person = boardMemberOwner("38501010001", 100.0).build();
+    var data = companyWith(person);
 
     var results = kybScreeningService.screen(data);
 
@@ -96,22 +87,9 @@ class KybScreeningServiceTest {
 
   @Test
   void twoPersonCompanyWithTwoBoardMembersRunsRules32And34() {
-    var person1 =
-        new KybRelatedPerson(
-            new PersonalCode("38501010001"), true, true, true, BigDecimal.valueOf(50), UNKNOWN);
-    var person2 =
-        new KybRelatedPerson(
-            new PersonalCode("38501010002"), true, true, true, BigDecimal.valueOf(50), UNKNOWN);
-    var data =
-        new KybCompanyData(
-            new CompanyDto(new RegistryCode("12345678"), "Test OÜ", "62011", LegalForm.OÜ),
-            new PersonalCode("38501010001"),
-            R,
-            List.of(person1, person2),
-            new SelfCertification(true, true, true),
-            "EE",
-            "Harju maakond, Tallinn, Pärnu mnt 1",
-            null);
+    var person1 = boardMemberOwner("38501010001", 50.0).build();
+    var person2 = boardMemberOwner("38501010002", 50.0).build();
+    var data = companyWith(person1, person2);
 
     var results = kybScreeningService.screen(data);
 
@@ -132,22 +110,14 @@ class KybScreeningServiceTest {
 
   @Test
   void twoPersonCompanyWithOneBoardMemberRunsRules33And34() {
-    var person1 =
-        new KybRelatedPerson(
-            new PersonalCode("38501010001"), true, true, true, BigDecimal.valueOf(50), UNKNOWN);
+    var person1 = boardMemberOwner("38501010001", 50.0).build();
     var person2 =
-        new KybRelatedPerson(
-            new PersonalCode("38501010002"), false, true, true, BigDecimal.valueOf(50), UNKNOWN);
-    var data =
-        new KybCompanyData(
-            new CompanyDto(new RegistryCode("12345678"), "Test OÜ", "62011", LegalForm.OÜ),
-            new PersonalCode("38501010001"),
-            R,
-            List.of(person1, person2),
-            new SelfCertification(true, true, true),
-            "EE",
-            "Harju maakond, Tallinn, Pärnu mnt 1",
-            null);
+        kybPerson("38501010002")
+            .shareholder(true)
+            .beneficialOwner(true)
+            .ownershipPercent(BigDecimal.valueOf(50))
+            .build();
+    var data = companyWith(person1, person2);
 
     var results = kybScreeningService.screen(data);
 
@@ -168,25 +138,10 @@ class KybScreeningServiceTest {
 
   @Test
   void threePersonCompanyHasAtLeastOneFailingCheck() {
-    var person1 =
-        new KybRelatedPerson(
-            new PersonalCode("38501010001"), true, true, true, BigDecimal.valueOf(40), COMPLETED);
-    var person2 =
-        new KybRelatedPerson(
-            new PersonalCode("38501010002"), true, true, true, BigDecimal.valueOf(30), COMPLETED);
-    var person3 =
-        new KybRelatedPerson(
-            new PersonalCode("38501010003"), true, true, true, BigDecimal.valueOf(30), COMPLETED);
-    var data =
-        new KybCompanyData(
-            new CompanyDto(new RegistryCode("12345678"), "Test OÜ", "62011", LegalForm.OÜ),
-            new PersonalCode("38501010001"),
-            R,
-            List.of(person1, person2, person3),
-            new SelfCertification(true, true, true),
-            "EE",
-            "Harju maakond, Tallinn, Pärnu mnt 1",
-            null);
+    var person1 = boardMemberOwner("38501010001", 40.0).kycStatus(COMPLETED).build();
+    var person2 = boardMemberOwner("38501010002", 30.0).kycStatus(COMPLETED).build();
+    var person3 = boardMemberOwner("38501010003", 30.0).kycStatus(COMPLETED).build();
+    var data = companyWith(person1, person2, person3);
 
     var results = kybScreeningService.screen(data);
 
@@ -195,9 +150,7 @@ class KybScreeningServiceTest {
 
   @Test
   void publishesKybCheckPerformedEvent() {
-    var person =
-        new KybRelatedPerson(
-            new PersonalCode("38501010001"), true, true, true, BigDecimal.valueOf(100), UNKNOWN);
+    var person = boardMemberOwner("38501010001", 100.0).build();
     var data =
         new KybCompanyData(
             new CompanyDto(new RegistryCode("12345678"), "Test OÜ", "62011", LegalForm.OÜ),
@@ -222,19 +175,8 @@ class KybScreeningServiceTest {
 
   @Test
   void validateReturnsScreenerResultsWithoutPublishingEvent() {
-    var person =
-        new KybRelatedPerson(
-            new PersonalCode("38501010001"), true, true, true, BigDecimal.valueOf(100), UNKNOWN);
-    var data =
-        new KybCompanyData(
-            new CompanyDto(new RegistryCode("12345678"), "Test OÜ", "62011", LegalForm.OÜ),
-            new PersonalCode("38501010001"),
-            R,
-            List.of(person),
-            new SelfCertification(true, true, true),
-            "EE",
-            "Harju maakond, Tallinn, Pärnu mnt 1",
-            null);
+    var person = boardMemberOwner("38501010001", 100.0).build();
+    var data = companyWith(person);
 
     var results = kybScreeningService.validate(data);
 

--- a/src/test/groovy/ee/tuleva/onboarding/kyb/KybScreeningServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyb/KybScreeningServiceTest.java
@@ -1,11 +1,10 @@
 package ee.tuleva.onboarding.kyb;
 
-import static ee.tuleva.onboarding.kyb.CompanyStatus.R;
 import static ee.tuleva.onboarding.kyb.KybCheckType.*;
-import static ee.tuleva.onboarding.kyb.KybKycStatus.COMPLETED;
+import static ee.tuleva.onboarding.kyb.KybTestFixtures.JAAN;
 import static ee.tuleva.onboarding.kyb.KybTestFixtures.boardMemberOwner;
 import static ee.tuleva.onboarding.kyb.KybTestFixtures.companyWith;
-import static ee.tuleva.onboarding.kyb.KybTestFixtures.kybPerson;
+import static ee.tuleva.onboarding.kyb.KybTestFixtures.shareholderOwner;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -25,7 +24,6 @@ import ee.tuleva.onboarding.kyb.screener.RelatedPersonsKycScreener;
 import ee.tuleva.onboarding.kyb.screener.SelfCertificationScreener;
 import ee.tuleva.onboarding.kyb.screener.SoleBoardMemberIsOwnerScreener;
 import ee.tuleva.onboarding.kyb.screener.SoleMemberOwnershipScreener;
-import java.math.BigDecimal;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -111,12 +109,7 @@ class KybScreeningServiceTest {
   @Test
   void twoPersonCompanyWithOneBoardMemberRunsRules33And34() {
     var person1 = boardMemberOwner("38501010001", 50.0).build();
-    var person2 =
-        kybPerson("38501010002")
-            .shareholder(true)
-            .beneficialOwner(true)
-            .ownershipPercent(BigDecimal.valueOf(50))
-            .build();
+    var person2 = shareholderOwner("38501010002", 50.0).build();
     var data = companyWith(person1, person2);
 
     var results = kybScreeningService.screen(data);
@@ -138,9 +131,9 @@ class KybScreeningServiceTest {
 
   @Test
   void threePersonCompanyHasAtLeastOneFailingCheck() {
-    var person1 = boardMemberOwner("38501010001", 40.0).kycStatus(COMPLETED).build();
-    var person2 = boardMemberOwner("38501010002", 30.0).kycStatus(COMPLETED).build();
-    var person3 = boardMemberOwner("38501010003", 30.0).kycStatus(COMPLETED).build();
+    var person1 = boardMemberOwner("38501010001", 40.0).build();
+    var person2 = boardMemberOwner("38501010002", 30.0).build();
+    var person3 = boardMemberOwner("38501010003", 30.0).build();
     var data = companyWith(person1, person2, person3);
 
     var results = kybScreeningService.screen(data);
@@ -150,17 +143,8 @@ class KybScreeningServiceTest {
 
   @Test
   void publishesKybCheckPerformedEvent() {
-    var person = boardMemberOwner("38501010001", 100.0).build();
-    var data =
-        new KybCompanyData(
-            new CompanyDto(new RegistryCode("12345678"), "Test OÜ", "62011", LegalForm.OÜ),
-            new PersonalCode("38501010001"),
-            R,
-            List.of(person),
-            new SelfCertification(true, true, true),
-            "EE",
-            "Harju maakond, Tallinn, Pärnu mnt 1",
-            null);
+    var person = boardMemberOwner(JAAN, 100.0).build();
+    var data = companyWith(person);
 
     var results = kybScreeningService.screen(data);
 
@@ -168,7 +152,7 @@ class KybScreeningServiceTest {
     verify(eventPublisher).publishEvent(captor.capture());
     var event = captor.getValue();
     assertThat(event.getCompany()).isEqualTo(data.company());
-    assertThat(event.getPersonalCode()).isEqualTo(new PersonalCode("38501010001"));
+    assertThat(event.getPersonalCode()).isEqualTo(JAAN);
     assertThat(event.getRelatedPersons()).isEqualTo(data.relatedPersons());
     assertThat(event.getChecks()).isEqualTo(results);
   }

--- a/src/test/groovy/ee/tuleva/onboarding/kyb/KybTestFixtures.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyb/KybTestFixtures.java
@@ -51,7 +51,34 @@ public final class KybTestFixtures {
         .boardMember(true)
         .shareholder(true)
         .beneficialOwner(true)
-        .ownershipPercent(BigDecimal.valueOf(ownershipPercent));
+        .ownershipPercent(BigDecimal.valueOf(ownershipPercent))
+        .kycStatus(COMPLETED);
+  }
+
+  // A shareholder and beneficial owner who is not a board member.
+  public static KybRelatedPerson.KybRelatedPersonBuilder shareholderOwner(
+      String personalCode, double ownershipPercent) {
+    return shareholderOwner(new PersonalCode(personalCode), ownershipPercent);
+  }
+
+  public static KybRelatedPerson.KybRelatedPersonBuilder shareholderOwner(
+      PersonalCode personalCode, double ownershipPercent) {
+    return kybPerson()
+        .personalCode(personalCode)
+        .shareholder(true)
+        .beneficialOwner(true)
+        .ownershipPercent(BigDecimal.valueOf(ownershipPercent))
+        .kycStatus(COMPLETED);
+  }
+
+  // A board member who is neither a shareholder nor a beneficial owner.
+  public static KybRelatedPerson.KybRelatedPersonBuilder boardMemberOnly(String personalCode) {
+    return boardMemberOnly(new PersonalCode(personalCode));
+  }
+
+  public static KybRelatedPerson.KybRelatedPersonBuilder boardMemberOnly(
+      PersonalCode personalCode) {
+    return kybPerson().personalCode(personalCode).boardMember(true).kycStatus(COMPLETED);
   }
 
   static CompanyRelationship boardMember(String personalCode, String firstName, String lastName) {
@@ -209,8 +236,14 @@ public final class KybTestFixtures {
     return companyData(VALID_COMPANY, JAAN, R, relatedPersons, VALID_CERT);
   }
 
+  // A standard active OÜ with a specific self-certification.
+  public static KybCompanyData companyWith(
+      SelfCertification selfCertification, KybRelatedPerson... relatedPersons) {
+    return companyData(VALID_COMPANY, JAAN, R, List.of(relatedPersons), selfCertification);
+  }
+
   // =====================================================================
-  // Rule 31: Single kybPerson OÜ — sole board member is 100% owner
+  // Rule 31: Single person OÜ — sole board member is 100% owner
   // =====================================================================
 
   static final CompanyDetail VALID_COMPANY_DETAIL =
@@ -237,7 +270,7 @@ public final class KybTestFixtures {
   }
 
   static KybCompanyData rule31Pass() {
-    var owner = boardMemberOwner(JAAN, 100.0).kycStatus(COMPLETED).build();
+    var owner = boardMemberOwner(JAAN, 100.0).build();
     return companyData(VALID_COMPANY, JAAN, R, List.of(owner), VALID_CERT);
   }
 
@@ -282,7 +315,7 @@ public final class KybTestFixtures {
   }
 
   // =====================================================================
-  // Rule 32: Two kybPerson OÜ — two board members are 100% owners
+  // Rule 32: Two person OÜ — two board members are 100% owners
   // =====================================================================
 
   static List<CompanyRelationship> rule32PassRelationships() {
@@ -302,14 +335,14 @@ public final class KybTestFixtures {
   }
 
   static KybCompanyData rule32Pass() {
-    var person1 = boardMemberOwner(JAAN, 50.0).kycStatus(COMPLETED).build();
-    var person2 = boardMemberOwner(MARI, 50.0).kycStatus(COMPLETED).build();
+    var person1 = boardMemberOwner(JAAN, 50.0).build();
+    var person2 = boardMemberOwner(MARI, 50.0).build();
     return companyData(VALID_COMPANY, JAAN, R, List.of(person1, person2), VALID_CERT);
   }
 
   static KybCompanyData rule32Fail_incompleteOwnership() {
-    var person1 = boardMemberOwner(JAAN, 30.0).kycStatus(COMPLETED).build();
-    var person2 = boardMemberOwner(MARI, 30.0).kycStatus(COMPLETED).build();
+    var person1 = boardMemberOwner(JAAN, 30.0).build();
+    var person2 = boardMemberOwner(MARI, 30.0).build();
     return companyData(VALID_COMPANY, JAAN, R, List.of(person1, person2), VALID_CERT);
   }
 
@@ -328,7 +361,7 @@ public final class KybTestFixtures {
   }
 
   // =====================================================================
-  // Rule 33: Two kybPerson OÜ — sole board member is one of two owners
+  // Rule 33: Two person OÜ — sole board member is one of two owners
   // =====================================================================
 
   static List<CompanyRelationship> rule33PassRelationships() {
@@ -345,28 +378,14 @@ public final class KybTestFixtures {
   }
 
   static KybCompanyData rule33Pass() {
-    var boardMember = boardMemberOwner(JAAN, 50.0).kycStatus(COMPLETED).build();
-    var otherOwner =
-        kybPerson()
-            .personalCode(MARI)
-            .shareholder(true)
-            .beneficialOwner(true)
-            .ownershipPercent(BigDecimal.valueOf(50))
-            .kycStatus(COMPLETED)
-            .build();
+    var boardMember = boardMemberOwner(JAAN, 50.0).build();
+    var otherOwner = shareholderOwner(MARI, 50.0).build();
     return companyData(VALID_COMPANY, JAAN, R, List.of(boardMember, otherOwner), VALID_CERT);
   }
 
   static KybCompanyData rule33Fail_boardMemberNotOwner() {
-    var boardMember = kybPerson().personalCode(JAAN).boardMember(true).kycStatus(COMPLETED).build();
-    var owner =
-        kybPerson()
-            .personalCode(MARI)
-            .shareholder(true)
-            .beneficialOwner(true)
-            .ownershipPercent(BigDecimal.valueOf(100))
-            .kycStatus(COMPLETED)
-            .build();
+    var boardMember = boardMemberOnly(JAAN).build();
+    var owner = shareholderOwner(MARI, 100.0).build();
     return companyData(VALID_COMPANY, JAAN, R, List.of(boardMember, owner), VALID_CERT);
   }
 
@@ -405,7 +424,7 @@ public final class KybTestFixtures {
   }
 
   static KybCompanyData rule34Fail_companyInLiquidation() {
-    var owner = boardMemberOwner(JAAN, 100.0).kycStatus(COMPLETED).build();
+    var owner = boardMemberOwner(JAAN, 100.0).build();
     return companyData(VALID_COMPANY, JAAN, L, List.of(owner), VALID_CERT);
   }
 
@@ -420,31 +439,31 @@ public final class KybTestFixtures {
   // 36: Not Estonian citizen or resident → KYC REJECTED
   // 37: High-risk country citizen → KYC REJECTED
   // 38: Estonian citizen lives in high-risk country → KYC REJECTED
-  // 39: Related kybPerson sanctioned → KYC REJECTED
+  // 39: Related person sanctioned → KYC REJECTED
   // 40: Not Estonian citizen but is resident → KYC UNKNOWN
   // =====================================================================
 
   static KybCompanyData rule36Fail_relatedPersonNotCitizen() {
-    var passedKyc = boardMemberOwner(JAAN, 50.0).kycStatus(COMPLETED).build();
+    var passedKyc = boardMemberOwner(JAAN, 50.0).build();
     var notCitizen = boardMemberOwner(MARI, 50.0).kycStatus(REJECTED).build();
     return companyData(VALID_COMPANY, JAAN, R, List.of(passedKyc, notCitizen), VALID_CERT);
   }
 
   static KybCompanyData rule37Fail_relatedPersonHighRiskCountry() {
-    var passedKyc = boardMemberOwner(JAAN, 50.0).kycStatus(COMPLETED).build();
+    var passedKyc = boardMemberOwner(JAAN, 50.0).build();
     var highRisk = boardMemberOwner(MARI, 50.0).kycStatus(REJECTED).build();
     return companyData(VALID_COMPANY, JAAN, R, List.of(passedKyc, highRisk), VALID_CERT);
   }
 
   static KybCompanyData rule39Fail_relatedPersonSanctioned() {
-    var passedKyc = boardMemberOwner(JAAN, 50.0).kycStatus(COMPLETED).build();
+    var passedKyc = boardMemberOwner(JAAN, 50.0).build();
     var sanctioned = boardMemberOwner(MARI, 50.0).kycStatus(REJECTED).build();
     return companyData(VALID_COMPANY, JAAN, R, List.of(passedKyc, sanctioned), VALID_CERT);
   }
 
   static KybCompanyData rule40Fail_relatedPersonNotCitizenButResident() {
-    var passedKyc = boardMemberOwner(JAAN, 50.0).kycStatus(COMPLETED).build();
-    var nonCitizenResident = boardMemberOwner(MARI, 50.0).build();
+    var passedKyc = boardMemberOwner(JAAN, 50.0).build();
+    var nonCitizenResident = boardMemberOwner(MARI, 50.0).kycStatus(UNKNOWN).build();
     return companyData(VALID_COMPANY, JAAN, R, List.of(passedKyc, nonCitizenResident), VALID_CERT);
   }
 
@@ -474,7 +493,7 @@ public final class KybTestFixtures {
 
   static KybCompanyData rule41Fail_highRiskNace() {
     var company = new CompanyDto(new RegistryCode("12345678"), "Crypto OÜ", "64321", OÜ);
-    var owner = boardMemberOwner(JAAN, 100.0).kycStatus(COMPLETED).build();
+    var owner = boardMemberOwner(JAAN, 100.0).build();
     return companyData(company, JAAN, R, List.of(owner), VALID_CERT);
   }
 
@@ -529,7 +548,7 @@ public final class KybTestFixtures {
 
   static KybCompanyData rule50Fail_notOÜ() {
     var company = new CompanyDto(new RegistryCode("12345678"), "Test AS", "62011", AS);
-    var owner = boardMemberOwner(JAAN, 100.0).kycStatus(COMPLETED).build();
+    var owner = boardMemberOwner(JAAN, 100.0).build();
     return companyData(company, JAAN, R, List.of(owner), VALID_CERT);
   }
 
@@ -542,7 +561,7 @@ public final class KybTestFixtures {
   }
 
   static KybCompanyData selfCertificationFail() {
-    var owner = boardMemberOwner(JAAN, 100.0).kycStatus(COMPLETED).build();
+    var owner = boardMemberOwner(JAAN, 100.0).build();
     var badCert = new SelfCertification(true, false, true);
     return companyData(VALID_COMPANY, JAAN, R, List.of(owner), badCert);
   }
@@ -561,16 +580,9 @@ public final class KybTestFixtures {
   }
 
   static KybCompanyData threeRelatedPersons() {
-    var person1 = boardMemberOwner(JAAN, 34.0).kycStatus(COMPLETED).build();
-    var person2 = boardMemberOwner(MARI, 33.0).kycStatus(COMPLETED).build();
-    var person3 =
-        kybPerson()
-            .personalCode(PEETER)
-            .shareholder(true)
-            .beneficialOwner(true)
-            .ownershipPercent(BigDecimal.valueOf(33))
-            .kycStatus(COMPLETED)
-            .build();
+    var person1 = boardMemberOwner(JAAN, 34.0).build();
+    var person2 = boardMemberOwner(MARI, 33.0).build();
+    var person3 = shareholderOwner(PEETER, 33.0).build();
     return companyData(VALID_COMPANY, JAAN, R, List.of(person1, person2, person3), VALID_CERT);
   }
 

--- a/src/test/groovy/ee/tuleva/onboarding/kyb/KybTestFixtures.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyb/KybTestFixtures.java
@@ -6,6 +6,7 @@ import static ee.tuleva.onboarding.kyb.KybCheckType.*;
 import static ee.tuleva.onboarding.kyb.KybKycStatus.*;
 import static ee.tuleva.onboarding.kyb.LegalForm.AS;
 import static ee.tuleva.onboarding.kyb.LegalForm.OÜ;
+import static java.math.BigDecimal.ZERO;
 
 import ee.tuleva.onboarding.ariregister.CompanyDetail;
 import ee.tuleva.onboarding.ariregister.CompanyRelationship;
@@ -29,15 +30,28 @@ public final class KybTestFixtures {
 
   static final SelfCertification VALID_CERT = new SelfCertification(true, true, true);
 
-  static KybRelatedPerson person(
-      PersonalCode code,
-      boolean boardMember,
-      boolean shareholder,
-      boolean beneficialOwner,
-      BigDecimal ownership,
-      KybKycStatus kycStatus) {
-    return new KybRelatedPerson(
-        code, boardMember, shareholder, beneficialOwner, ownership, kycStatus);
+  public static KybRelatedPerson.KybRelatedPersonBuilder kybPerson() {
+    return KybRelatedPerson.builder().naturalPerson(true).ownershipPercent(ZERO).kycStatus(UNKNOWN);
+  }
+
+  public static KybRelatedPerson.KybRelatedPersonBuilder kybPerson(String personalCode) {
+    return kybPerson().personalCode(new PersonalCode(personalCode));
+  }
+
+  // A board member who is also a shareholder and beneficial owner (the typical owner shape).
+  public static KybRelatedPerson.KybRelatedPersonBuilder boardMemberOwner(
+      String personalCode, double ownershipPercent) {
+    return boardMemberOwner(new PersonalCode(personalCode), ownershipPercent);
+  }
+
+  public static KybRelatedPerson.KybRelatedPersonBuilder boardMemberOwner(
+      PersonalCode personalCode, double ownershipPercent) {
+    return kybPerson()
+        .personalCode(personalCode)
+        .boardMember(true)
+        .shareholder(true)
+        .beneficialOwner(true)
+        .ownershipPercent(BigDecimal.valueOf(ownershipPercent));
   }
 
   static CompanyRelationship boardMember(String personalCode, String firstName, String lastName) {
@@ -90,6 +104,81 @@ public final class KybTestFixtures {
         "EST");
   }
 
+  static CompanyRelationship nasdaqCsdShareholder(
+      String personalCode, String firstName, String lastName, BigDecimal ownership) {
+    return new CompanyRelationship(
+        "F",
+        "O", // osanik (shares held in Nasdaq CSD as an "Omanikukonto")
+        "Osanik",
+        firstName,
+        lastName,
+        personalCode,
+        null,
+        LocalDate.of(2020, 6, 1),
+        null,
+        ownership,
+        null,
+        "EST");
+  }
+
+  static CompanyRelationship nasdaqBeneficialOwner(
+      String personalCode, String firstName, String lastName) {
+    return new CompanyRelationship(
+        "F",
+        "W", // tegelik kasusaaja (beneficial owner)
+        "Tegelik kasusaaja",
+        firstName,
+        lastName,
+        personalCode,
+        null,
+        LocalDate.of(2020, 6, 1),
+        null,
+        null,
+        "Otsene osalus",
+        "EST");
+  }
+
+  static CompanyRelationship shareRegistrar() {
+    return new CompanyRelationship(
+        "J", // juriidiline isik (legal entity)
+        "ORP", // osade registripidaja (Nasdaq CSD share registrar — not an owner)
+        "Osade registripidaja",
+        null,
+        "Nasdaq CSD SE",
+        null,
+        null,
+        LocalDate.of(2020, 6, 1),
+        null,
+        null,
+        null,
+        null);
+  }
+
+  static CompanyRelationship legalEntityShareholder(
+      String registryCode, String name, BigDecimal ownership) {
+    return new CompanyRelationship(
+        "J", // juriidiline isik (legal entity) — carries a registry code in the personal-code field
+        "OSAN",
+        "Osanik",
+        null,
+        name,
+        registryCode,
+        null,
+        LocalDate.of(2020, 6, 1),
+        null,
+        ownership,
+        null,
+        "EST");
+  }
+
+  static List<CompanyRelationship> nasdaqCsdSoleOwnerRelationships(String personalCode) {
+    return List.of(
+        boardMember(personalCode, "Jaan", "Tamm"),
+        nasdaqCsdShareholder(personalCode, "Jaan", "Tamm", new BigDecimal("100.00")),
+        nasdaqBeneficialOwner(personalCode, "Jaan", "Tamm"),
+        shareRegistrar());
+  }
+
   static KybCheck check(KybCheckType type, boolean success) {
     return new KybCheck(type, success, Map.of());
   }
@@ -111,8 +200,17 @@ public final class KybTestFixtures {
         null);
   }
 
+  // A standard active OÜ with the given related persons (defaults for the fields screeners ignore).
+  public static KybCompanyData companyWith(KybRelatedPerson... relatedPersons) {
+    return companyWith(List.of(relatedPersons));
+  }
+
+  public static KybCompanyData companyWith(List<KybRelatedPerson> relatedPersons) {
+    return companyData(VALID_COMPANY, JAAN, R, relatedPersons, VALID_CERT);
+  }
+
   // =====================================================================
-  // Rule 31: Single person OÜ — sole board member is 100% owner
+  // Rule 31: Single kybPerson OÜ — sole board member is 100% owner
   // =====================================================================
 
   static final CompanyDetail VALID_COMPANY_DETAIL =
@@ -139,12 +237,19 @@ public final class KybTestFixtures {
   }
 
   static KybCompanyData rule31Pass() {
-    var owner = person(JAAN, true, true, true, BigDecimal.valueOf(100), COMPLETED);
+    var owner = boardMemberOwner(JAAN, 100.0).kycStatus(COMPLETED).build();
     return companyData(VALID_COMPANY, JAAN, R, List.of(owner), VALID_CERT);
   }
 
   static KybCompanyData rule31Fail_notBeneficialOwner() {
-    var owner = person(JAAN, true, true, false, BigDecimal.valueOf(100), COMPLETED);
+    var owner =
+        kybPerson()
+            .personalCode(JAAN)
+            .boardMember(true)
+            .shareholder(true)
+            .ownershipPercent(BigDecimal.valueOf(100))
+            .kycStatus(COMPLETED)
+            .build();
     return companyData(VALID_COMPANY, JAAN, R, List.of(owner), VALID_CERT);
   }
 
@@ -177,7 +282,7 @@ public final class KybTestFixtures {
   }
 
   // =====================================================================
-  // Rule 32: Two person OÜ — two board members are 100% owners
+  // Rule 32: Two kybPerson OÜ — two board members are 100% owners
   // =====================================================================
 
   static List<CompanyRelationship> rule32PassRelationships() {
@@ -197,14 +302,14 @@ public final class KybTestFixtures {
   }
 
   static KybCompanyData rule32Pass() {
-    var person1 = person(JAAN, true, true, true, BigDecimal.valueOf(50), COMPLETED);
-    var person2 = person(MARI, true, true, true, BigDecimal.valueOf(50), COMPLETED);
+    var person1 = boardMemberOwner(JAAN, 50.0).kycStatus(COMPLETED).build();
+    var person2 = boardMemberOwner(MARI, 50.0).kycStatus(COMPLETED).build();
     return companyData(VALID_COMPANY, JAAN, R, List.of(person1, person2), VALID_CERT);
   }
 
   static KybCompanyData rule32Fail_incompleteOwnership() {
-    var person1 = person(JAAN, true, true, true, BigDecimal.valueOf(30), COMPLETED);
-    var person2 = person(MARI, true, true, true, BigDecimal.valueOf(30), COMPLETED);
+    var person1 = boardMemberOwner(JAAN, 30.0).kycStatus(COMPLETED).build();
+    var person2 = boardMemberOwner(MARI, 30.0).kycStatus(COMPLETED).build();
     return companyData(VALID_COMPANY, JAAN, R, List.of(person1, person2), VALID_CERT);
   }
 
@@ -223,7 +328,7 @@ public final class KybTestFixtures {
   }
 
   // =====================================================================
-  // Rule 33: Two person OÜ — sole board member is one of two owners
+  // Rule 33: Two kybPerson OÜ — sole board member is one of two owners
   // =====================================================================
 
   static List<CompanyRelationship> rule33PassRelationships() {
@@ -240,14 +345,28 @@ public final class KybTestFixtures {
   }
 
   static KybCompanyData rule33Pass() {
-    var boardMember = person(JAAN, true, true, true, BigDecimal.valueOf(50), COMPLETED);
-    var otherOwner = person(MARI, false, true, true, BigDecimal.valueOf(50), COMPLETED);
+    var boardMember = boardMemberOwner(JAAN, 50.0).kycStatus(COMPLETED).build();
+    var otherOwner =
+        kybPerson()
+            .personalCode(MARI)
+            .shareholder(true)
+            .beneficialOwner(true)
+            .ownershipPercent(BigDecimal.valueOf(50))
+            .kycStatus(COMPLETED)
+            .build();
     return companyData(VALID_COMPANY, JAAN, R, List.of(boardMember, otherOwner), VALID_CERT);
   }
 
   static KybCompanyData rule33Fail_boardMemberNotOwner() {
-    var boardMember = person(JAAN, true, false, false, BigDecimal.ZERO, COMPLETED);
-    var owner = person(MARI, false, true, true, BigDecimal.valueOf(100), COMPLETED);
+    var boardMember = kybPerson().personalCode(JAAN).boardMember(true).kycStatus(COMPLETED).build();
+    var owner =
+        kybPerson()
+            .personalCode(MARI)
+            .shareholder(true)
+            .beneficialOwner(true)
+            .ownershipPercent(BigDecimal.valueOf(100))
+            .kycStatus(COMPLETED)
+            .build();
     return companyData(VALID_COMPANY, JAAN, R, List.of(boardMember, owner), VALID_CERT);
   }
 
@@ -286,7 +405,7 @@ public final class KybTestFixtures {
   }
 
   static KybCompanyData rule34Fail_companyInLiquidation() {
-    var owner = person(JAAN, true, true, true, BigDecimal.valueOf(100), COMPLETED);
+    var owner = boardMemberOwner(JAAN, 100.0).kycStatus(COMPLETED).build();
     return companyData(VALID_COMPANY, JAAN, L, List.of(owner), VALID_CERT);
   }
 
@@ -301,31 +420,31 @@ public final class KybTestFixtures {
   // 36: Not Estonian citizen or resident → KYC REJECTED
   // 37: High-risk country citizen → KYC REJECTED
   // 38: Estonian citizen lives in high-risk country → KYC REJECTED
-  // 39: Related person sanctioned → KYC REJECTED
+  // 39: Related kybPerson sanctioned → KYC REJECTED
   // 40: Not Estonian citizen but is resident → KYC UNKNOWN
   // =====================================================================
 
   static KybCompanyData rule36Fail_relatedPersonNotCitizen() {
-    var passedKyc = person(JAAN, true, true, true, BigDecimal.valueOf(50), COMPLETED);
-    var notCitizen = person(MARI, true, true, true, BigDecimal.valueOf(50), REJECTED);
+    var passedKyc = boardMemberOwner(JAAN, 50.0).kycStatus(COMPLETED).build();
+    var notCitizen = boardMemberOwner(MARI, 50.0).kycStatus(REJECTED).build();
     return companyData(VALID_COMPANY, JAAN, R, List.of(passedKyc, notCitizen), VALID_CERT);
   }
 
   static KybCompanyData rule37Fail_relatedPersonHighRiskCountry() {
-    var passedKyc = person(JAAN, true, true, true, BigDecimal.valueOf(50), COMPLETED);
-    var highRisk = person(MARI, true, true, true, BigDecimal.valueOf(50), REJECTED);
+    var passedKyc = boardMemberOwner(JAAN, 50.0).kycStatus(COMPLETED).build();
+    var highRisk = boardMemberOwner(MARI, 50.0).kycStatus(REJECTED).build();
     return companyData(VALID_COMPANY, JAAN, R, List.of(passedKyc, highRisk), VALID_CERT);
   }
 
   static KybCompanyData rule39Fail_relatedPersonSanctioned() {
-    var passedKyc = person(JAAN, true, true, true, BigDecimal.valueOf(50), COMPLETED);
-    var sanctioned = person(MARI, true, true, true, BigDecimal.valueOf(50), REJECTED);
+    var passedKyc = boardMemberOwner(JAAN, 50.0).kycStatus(COMPLETED).build();
+    var sanctioned = boardMemberOwner(MARI, 50.0).kycStatus(REJECTED).build();
     return companyData(VALID_COMPANY, JAAN, R, List.of(passedKyc, sanctioned), VALID_CERT);
   }
 
   static KybCompanyData rule40Fail_relatedPersonNotCitizenButResident() {
-    var passedKyc = person(JAAN, true, true, true, BigDecimal.valueOf(50), COMPLETED);
-    var nonCitizenResident = person(MARI, true, true, true, BigDecimal.valueOf(50), UNKNOWN);
+    var passedKyc = boardMemberOwner(JAAN, 50.0).kycStatus(COMPLETED).build();
+    var nonCitizenResident = boardMemberOwner(MARI, 50.0).build();
     return companyData(VALID_COMPANY, JAAN, R, List.of(passedKyc, nonCitizenResident), VALID_CERT);
   }
 
@@ -355,7 +474,7 @@ public final class KybTestFixtures {
 
   static KybCompanyData rule41Fail_highRiskNace() {
     var company = new CompanyDto(new RegistryCode("12345678"), "Crypto OÜ", "64321", OÜ);
-    var owner = person(JAAN, true, true, true, BigDecimal.valueOf(100), COMPLETED);
+    var owner = boardMemberOwner(JAAN, 100.0).kycStatus(COMPLETED).build();
     return companyData(company, JAAN, R, List.of(owner), VALID_CERT);
   }
 
@@ -410,7 +529,7 @@ public final class KybTestFixtures {
 
   static KybCompanyData rule50Fail_notOÜ() {
     var company = new CompanyDto(new RegistryCode("12345678"), "Test AS", "62011", AS);
-    var owner = person(JAAN, true, true, true, BigDecimal.valueOf(100), COMPLETED);
+    var owner = boardMemberOwner(JAAN, 100.0).kycStatus(COMPLETED).build();
     return companyData(company, JAAN, R, List.of(owner), VALID_CERT);
   }
 
@@ -423,7 +542,7 @@ public final class KybTestFixtures {
   }
 
   static KybCompanyData selfCertificationFail() {
-    var owner = person(JAAN, true, true, true, BigDecimal.valueOf(100), COMPLETED);
+    var owner = boardMemberOwner(JAAN, 100.0).kycStatus(COMPLETED).build();
     var badCert = new SelfCertification(true, false, true);
     return companyData(VALID_COMPANY, JAAN, R, List.of(owner), badCert);
   }
@@ -442,9 +561,16 @@ public final class KybTestFixtures {
   }
 
   static KybCompanyData threeRelatedPersons() {
-    var person1 = person(JAAN, true, true, true, BigDecimal.valueOf(34), COMPLETED);
-    var person2 = person(MARI, true, true, true, BigDecimal.valueOf(33), COMPLETED);
-    var person3 = person(PEETER, false, true, true, BigDecimal.valueOf(33), COMPLETED);
+    var person1 = boardMemberOwner(JAAN, 34.0).kycStatus(COMPLETED).build();
+    var person2 = boardMemberOwner(MARI, 33.0).kycStatus(COMPLETED).build();
+    var person3 =
+        kybPerson()
+            .personalCode(PEETER)
+            .shareholder(true)
+            .beneficialOwner(true)
+            .ownershipPercent(BigDecimal.valueOf(33))
+            .kycStatus(COMPLETED)
+            .build();
     return companyData(VALID_COMPANY, JAAN, R, List.of(person1, person2, person3), VALID_CERT);
   }
 

--- a/src/test/groovy/ee/tuleva/onboarding/kyb/LegalEntityScreenerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyb/LegalEntityScreenerTest.java
@@ -43,18 +43,33 @@ class LegalEntityScreenerTest {
           FIXED_CLOCK);
 
   @Test
-  void fetchActiveRelationshipsExcludesFounders() {
+  void fetchActiveRelationshipsKeepsOnlyOwnershipAndControlRoles() {
     var boardMember = relationship("JUHL", "Jaan", "Tamm", "38501010002");
+    var registryShareholder = relationship("OSAN", "Peeter", "Osanik", "37601010003");
+    var nasdaqShareholder = relationship("O", "Mari", "Kask", "49001010001");
+    var beneficialOwner = relationship("W", "Jaan", "Tamm", "38501010002");
     var founder = relationship("A", "Mari", "Asutaja", "39901010001");
-    var shareholder = relationship("OSAN", "Peeter", "Osanik", "37601010003");
+    var shareRegistrar = relationship("ORP", "Nasdaq", "CSD", "90000003");
+    var stockRegistrar = relationship("ARP", "Nasdaq", "CSD", "90000004");
+    var prokurist = relationship("PROK", "Peeter", "Prokurist", "37601010003");
     given(
             ariregisterClient.getActiveCompanyRelationships(
                 REGISTRY_CODE, LocalDate.now(FIXED_CLOCK)))
-        .willReturn(List.of(boardMember, founder, shareholder));
+        .willReturn(
+            List.of(
+                boardMember,
+                registryShareholder,
+                nasdaqShareholder,
+                beneficialOwner,
+                founder,
+                shareRegistrar,
+                stockRegistrar,
+                prokurist));
 
     var result = screener.fetchActiveRelationships(REGISTRY_CODE);
 
-    assertThat(result).containsExactly(boardMember, shareholder);
+    assertThat(result)
+        .containsExactly(boardMember, registryShareholder, nasdaqShareholder, beneficialOwner);
   }
 
   @Test

--- a/src/test/groovy/ee/tuleva/onboarding/kyb/screener/CompanyNaceScreenerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyb/screener/CompanyNaceScreenerTest.java
@@ -3,10 +3,10 @@ package ee.tuleva.onboarding.kyb.screener;
 import static ee.tuleva.onboarding.kyb.CompanyStatus.R;
 import static ee.tuleva.onboarding.kyb.KybCheckType.HIGH_RISK_NACE;
 import static ee.tuleva.onboarding.kyb.KybKycStatus.COMPLETED;
+import static ee.tuleva.onboarding.kyb.KybTestFixtures.boardMemberOwner;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import ee.tuleva.onboarding.kyb.*;
-import java.math.BigDecimal;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -61,9 +61,7 @@ class CompanyNaceScreenerTest {
 
   private KybCompanyData companyWithNace(String naceCode) {
     var company = new CompanyDto(new RegistryCode("12345678"), "Test OÜ", naceCode, LegalForm.OÜ);
-    var person =
-        new KybRelatedPerson(
-            new PersonalCode("38501010001"), true, true, true, BigDecimal.valueOf(100), COMPLETED);
+    var person = boardMemberOwner("38501010001", 100.0).kycStatus(COMPLETED).build();
     return new KybCompanyData(
         company,
         new PersonalCode("38501010001"),

--- a/src/test/groovy/ee/tuleva/onboarding/kyb/screener/CompanyNaceScreenerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyb/screener/CompanyNaceScreenerTest.java
@@ -2,9 +2,9 @@ package ee.tuleva.onboarding.kyb.screener;
 
 import static ee.tuleva.onboarding.kyb.CompanyStatus.R;
 import static ee.tuleva.onboarding.kyb.KybCheckType.HIGH_RISK_NACE;
-import static ee.tuleva.onboarding.kyb.KybKycStatus.COMPLETED;
 import static ee.tuleva.onboarding.kyb.KybTestFixtures.boardMemberOwner;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 
 import ee.tuleva.onboarding.kyb.*;
 import java.util.List;
@@ -22,9 +22,9 @@ class CompanyNaceScreenerTest {
 
     var results = screener.screen(data);
 
-    assertThat(results).hasSize(1);
-    assertThat(results.getFirst().type()).isEqualTo(HIGH_RISK_NACE);
-    assertThat(results.getFirst().success()).isTrue();
+    assertThat(results)
+        .extracting(KybCheck::type, KybCheck::success)
+        .containsExactly(tuple(HIGH_RISK_NACE, true));
   }
 
   @ParameterizedTest
@@ -34,9 +34,9 @@ class CompanyNaceScreenerTest {
 
     var results = screener.screen(data);
 
-    assertThat(results).hasSize(1);
-    assertThat(results.getFirst().type()).isEqualTo(HIGH_RISK_NACE);
-    assertThat(results.getFirst().success()).isFalse();
+    assertThat(results)
+        .extracting(KybCheck::type, KybCheck::success)
+        .containsExactly(tuple(HIGH_RISK_NACE, false));
   }
 
   @Test
@@ -61,7 +61,7 @@ class CompanyNaceScreenerTest {
 
   private KybCompanyData companyWithNace(String naceCode) {
     var company = new CompanyDto(new RegistryCode("12345678"), "Test OÜ", naceCode, LegalForm.OÜ);
-    var person = boardMemberOwner("38501010001", 100.0).kycStatus(COMPLETED).build();
+    var person = boardMemberOwner("38501010001", 100.0).build();
     return new KybCompanyData(
         company,
         new PersonalCode("38501010001"),

--- a/src/test/groovy/ee/tuleva/onboarding/kyb/screener/CompanyRegisteredInEstoniaScreenerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyb/screener/CompanyRegisteredInEstoniaScreenerTest.java
@@ -2,10 +2,11 @@ package ee.tuleva.onboarding.kyb.screener;
 
 import static ee.tuleva.onboarding.kyb.CompanyStatus.R;
 import static ee.tuleva.onboarding.kyb.KybCheckType.COMPANY_REGISTERED_IN_ESTONIA;
+import static ee.tuleva.onboarding.kyb.KybKycStatus.COMPLETED;
+import static ee.tuleva.onboarding.kyb.KybTestFixtures.boardMemberOwner;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import ee.tuleva.onboarding.kyb.*;
-import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -60,14 +61,7 @@ class CompanyRegisteredInEstoniaScreenerTest {
   }
 
   private KybCompanyData companyWith(String countryCode, String fullAddress) {
-    var person =
-        new KybRelatedPerson(
-            new PersonalCode("38501010002"),
-            true,
-            true,
-            true,
-            BigDecimal.valueOf(100),
-            KybKycStatus.COMPLETED);
+    var person = boardMemberOwner("38501010002", 100.0).kycStatus(COMPLETED).build();
     return new KybCompanyData(
         new CompanyDto(new RegistryCode("12345678"), "Test OÜ", "62011", LegalForm.OÜ),
         new PersonalCode("38501010002"),

--- a/src/test/groovy/ee/tuleva/onboarding/kyb/screener/CompanyRegisteredInEstoniaScreenerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyb/screener/CompanyRegisteredInEstoniaScreenerTest.java
@@ -2,7 +2,6 @@ package ee.tuleva.onboarding.kyb.screener;
 
 import static ee.tuleva.onboarding.kyb.CompanyStatus.R;
 import static ee.tuleva.onboarding.kyb.KybCheckType.COMPANY_REGISTERED_IN_ESTONIA;
-import static ee.tuleva.onboarding.kyb.KybKycStatus.COMPLETED;
 import static ee.tuleva.onboarding.kyb.KybTestFixtures.boardMemberOwner;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -61,7 +60,7 @@ class CompanyRegisteredInEstoniaScreenerTest {
   }
 
   private KybCompanyData companyWith(String countryCode, String fullAddress) {
-    var person = boardMemberOwner("38501010002", 100.0).kycStatus(COMPLETED).build();
+    var person = boardMemberOwner("38501010002", 100.0).build();
     return new KybCompanyData(
         new CompanyDto(new RegistryCode("12345678"), "Test OÜ", "62011", LegalForm.OÜ),
         new PersonalCode("38501010002"),

--- a/src/test/groovy/ee/tuleva/onboarding/kyb/screener/CompanySanctionScreenerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyb/screener/CompanySanctionScreenerTest.java
@@ -3,7 +3,6 @@ package ee.tuleva.onboarding.kyb.screener;
 import static ee.tuleva.onboarding.kyb.CompanyStatus.R;
 import static ee.tuleva.onboarding.kyb.KybCheckType.COMPANY_PEP;
 import static ee.tuleva.onboarding.kyb.KybCheckType.COMPANY_SANCTION;
-import static ee.tuleva.onboarding.kyb.KybKycStatus.COMPLETED;
 import static ee.tuleva.onboarding.kyb.KybTestFixtures.boardMemberOwner;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -106,7 +105,7 @@ class CompanySanctionScreenerTest {
   }
 
   private KybCompanyData companyData() {
-    var person = boardMemberOwner("38501010001", 100.0).kycStatus(COMPLETED).build();
+    var person = boardMemberOwner("38501010001", 100.0).build();
     return new KybCompanyData(
         COMPANY,
         new PersonalCode("38501010001"),

--- a/src/test/groovy/ee/tuleva/onboarding/kyb/screener/CompanySanctionScreenerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyb/screener/CompanySanctionScreenerTest.java
@@ -4,6 +4,7 @@ import static ee.tuleva.onboarding.kyb.CompanyStatus.R;
 import static ee.tuleva.onboarding.kyb.KybCheckType.COMPANY_PEP;
 import static ee.tuleva.onboarding.kyb.KybCheckType.COMPANY_SANCTION;
 import static ee.tuleva.onboarding.kyb.KybKycStatus.COMPLETED;
+import static ee.tuleva.onboarding.kyb.KybTestFixtures.boardMemberOwner;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -12,7 +13,6 @@ import static org.mockito.Mockito.when;
 import ee.tuleva.onboarding.aml.sanctions.MatchResponse;
 import ee.tuleva.onboarding.aml.sanctions.PepAndSanctionCheckService;
 import ee.tuleva.onboarding.kyb.*;
-import java.math.BigDecimal;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import tools.jackson.databind.json.JsonMapper;
@@ -106,9 +106,7 @@ class CompanySanctionScreenerTest {
   }
 
   private KybCompanyData companyData() {
-    var person =
-        new KybRelatedPerson(
-            new PersonalCode("38501010001"), true, true, true, BigDecimal.valueOf(100), COMPLETED);
+    var person = boardMemberOwner("38501010001", 100.0).kycStatus(COMPLETED).build();
     return new KybCompanyData(
         COMPANY,
         new PersonalCode("38501010001"),

--- a/src/test/groovy/ee/tuleva/onboarding/kyb/screener/CompanyStructureScreenerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyb/screener/CompanyStructureScreenerTest.java
@@ -1,13 +1,12 @@
 package ee.tuleva.onboarding.kyb.screener;
 
-import static ee.tuleva.onboarding.kyb.CompanyStatus.R;
 import static ee.tuleva.onboarding.kyb.KybCheckType.COMPANY_STRUCTURE;
 import static ee.tuleva.onboarding.kyb.KybKycStatus.COMPLETED;
+import static ee.tuleva.onboarding.kyb.KybTestFixtures.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import ee.tuleva.onboarding.kyb.*;
 import java.math.BigDecimal;
-import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class CompanyStructureScreenerTest {
@@ -16,7 +15,7 @@ class CompanyStructureScreenerTest {
 
   @Test
   void singlePersonWithPersonalCodePasses() {
-    var data = companyWith(List.of(identifiedPerson()));
+    var data = companyWith(identifiedPerson());
 
     var result = screener.screen(data);
 
@@ -29,9 +28,8 @@ class CompanyStructureScreenerTest {
   void twoPersonsWithPersonalCodesPasses() {
     var data =
         companyWith(
-            List.of(
-                identifiedPerson(new PersonalCode("38501010002")),
-                identifiedPerson(new PersonalCode("49001010001"))));
+            identifiedPerson(new PersonalCode("38501010002")),
+            identifiedPerson(new PersonalCode("49001010001")));
 
     var result = screener.screen(data);
 
@@ -42,10 +40,9 @@ class CompanyStructureScreenerTest {
   void threePersonsFails() {
     var data =
         companyWith(
-            List.of(
-                identifiedPerson(new PersonalCode("38501010002")),
-                identifiedPerson(new PersonalCode("49001010001")),
-                identifiedPerson(new PersonalCode("37801010009"))));
+            identifiedPerson(new PersonalCode("38501010002")),
+            identifiedPerson(new PersonalCode("49001010001")),
+            identifiedPerson(new PersonalCode("37801010009")));
 
     var result = screener.screen(data);
 
@@ -55,8 +52,14 @@ class CompanyStructureScreenerTest {
   @Test
   void nullPersonalCodeFails() {
     var unidentified =
-        new KybRelatedPerson(null, false, true, true, BigDecimal.valueOf(50), COMPLETED);
-    var data = companyWith(List.of(identifiedPerson(), unidentified));
+        kybPerson()
+            .personalCode(null)
+            .shareholder(true)
+            .beneficialOwner(true)
+            .ownershipPercent(BigDecimal.valueOf(50))
+            .kycStatus(COMPLETED)
+            .build();
+    var data = companyWith(identifiedPerson(), unidentified);
 
     var result = screener.screen(data);
 
@@ -65,7 +68,7 @@ class CompanyStructureScreenerTest {
 
   @Test
   void metadataContainsRelatedPersonCount() {
-    var data = companyWith(List.of(identifiedPerson()));
+    var data = companyWith(identifiedPerson());
 
     var result = screener.screen(data);
 
@@ -74,23 +77,51 @@ class CompanyStructureScreenerTest {
         .containsEntry("allIdentified", true);
   }
 
+  @Test
+  void legalEntityRelatedPersonFails() {
+    var legalEntityOwner =
+        kybPerson("90000002")
+            .naturalPerson(false)
+            .shareholder(true)
+            .beneficialOwner(true)
+            .ownershipPercent(BigDecimal.valueOf(100))
+            .kycStatus(COMPLETED)
+            .build();
+    var data = companyWith(legalEntityOwner);
+
+    var result = screener.screen(data);
+
+    assertThat(result.getFirst().success()).isFalse();
+  }
+
+  @Test
+  void twoRelatedPersonsWithNoBoardMemberFails() {
+    var owner1 =
+        kybPerson("38501010002")
+            .shareholder(true)
+            .beneficialOwner(true)
+            .ownershipPercent(BigDecimal.valueOf(50))
+            .kycStatus(COMPLETED)
+            .build();
+    var owner2 =
+        kybPerson("49001010001")
+            .shareholder(true)
+            .beneficialOwner(true)
+            .ownershipPercent(BigDecimal.valueOf(50))
+            .kycStatus(COMPLETED)
+            .build();
+    var data = companyWith(owner1, owner2);
+
+    var result = screener.screen(data);
+
+    assertThat(result.getFirst().success()).isFalse();
+  }
+
   private KybRelatedPerson identifiedPerson() {
     return identifiedPerson(new PersonalCode("38501010002"));
   }
 
   private KybRelatedPerson identifiedPerson(PersonalCode code) {
-    return new KybRelatedPerson(code, true, true, true, BigDecimal.valueOf(100), COMPLETED);
-  }
-
-  private KybCompanyData companyWith(List<KybRelatedPerson> persons) {
-    return new KybCompanyData(
-        new CompanyDto(new RegistryCode("12345678"), "Test OÜ", "62011", LegalForm.OÜ),
-        new PersonalCode("38501010002"),
-        R,
-        persons,
-        new SelfCertification(true, true, true),
-        "EE",
-        "Harju maakond, Tallinn, Pärnu mnt 1",
-        null);
+    return boardMemberOwner(code, 100.0).kycStatus(COMPLETED).build();
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/kyb/screener/CompanyStructureScreenerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyb/screener/CompanyStructureScreenerTest.java
@@ -4,6 +4,7 @@ import static ee.tuleva.onboarding.kyb.KybCheckType.COMPANY_STRUCTURE;
 import static ee.tuleva.onboarding.kyb.KybKycStatus.COMPLETED;
 import static ee.tuleva.onboarding.kyb.KybTestFixtures.*;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 
 import ee.tuleva.onboarding.kyb.*;
 import java.math.BigDecimal;
@@ -19,17 +20,14 @@ class CompanyStructureScreenerTest {
 
     var result = screener.screen(data);
 
-    assertThat(result).hasSize(1);
-    assertThat(result.getFirst().type()).isEqualTo(COMPANY_STRUCTURE);
-    assertThat(result.getFirst().success()).isTrue();
+    assertThat(result)
+        .extracting(KybCheck::type, KybCheck::success)
+        .containsExactly(tuple(COMPANY_STRUCTURE, true));
   }
 
   @Test
   void twoPersonsWithPersonalCodesPasses() {
-    var data =
-        companyWith(
-            identifiedPerson(new PersonalCode("38501010002")),
-            identifiedPerson(new PersonalCode("49001010001")));
+    var data = companyWith(identifiedPerson("38501010002"), identifiedPerson("49001010001"));
 
     var result = screener.screen(data);
 
@@ -40,9 +38,9 @@ class CompanyStructureScreenerTest {
   void threePersonsFails() {
     var data =
         companyWith(
-            identifiedPerson(new PersonalCode("38501010002")),
-            identifiedPerson(new PersonalCode("49001010001")),
-            identifiedPerson(new PersonalCode("37801010009")));
+            identifiedPerson("38501010002"),
+            identifiedPerson("49001010001"),
+            identifiedPerson("37801010009"));
 
     var result = screener.screen(data);
 
@@ -96,20 +94,8 @@ class CompanyStructureScreenerTest {
 
   @Test
   void twoRelatedPersonsWithNoBoardMemberFails() {
-    var owner1 =
-        kybPerson("38501010002")
-            .shareholder(true)
-            .beneficialOwner(true)
-            .ownershipPercent(BigDecimal.valueOf(50))
-            .kycStatus(COMPLETED)
-            .build();
-    var owner2 =
-        kybPerson("49001010001")
-            .shareholder(true)
-            .beneficialOwner(true)
-            .ownershipPercent(BigDecimal.valueOf(50))
-            .kycStatus(COMPLETED)
-            .build();
+    var owner1 = shareholderOwner("38501010002", 50.0).build();
+    var owner2 = shareholderOwner("49001010001", 50.0).build();
     var data = companyWith(owner1, owner2);
 
     var result = screener.screen(data);
@@ -118,10 +104,10 @@ class CompanyStructureScreenerTest {
   }
 
   private KybRelatedPerson identifiedPerson() {
-    return identifiedPerson(new PersonalCode("38501010002"));
+    return identifiedPerson("38501010002");
   }
 
-  private KybRelatedPerson identifiedPerson(PersonalCode code) {
-    return boardMemberOwner(code, 100.0).kycStatus(COMPLETED).build();
+  private KybRelatedPerson identifiedPerson(String code) {
+    return boardMemberOwner(code, 100.0).build();
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/kyb/screener/DualMemberOwnershipScreenerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyb/screener/DualMemberOwnershipScreenerTest.java
@@ -1,19 +1,12 @@
 package ee.tuleva.onboarding.kyb.screener;
 
-import static ee.tuleva.onboarding.kyb.CompanyStatus.R;
 import static ee.tuleva.onboarding.kyb.KybCheckType.DUAL_MEMBER_OWNERSHIP;
-import static ee.tuleva.onboarding.kyb.KybKycStatus.UNKNOWN;
+import static ee.tuleva.onboarding.kyb.KybTestFixtures.boardMemberOwner;
+import static ee.tuleva.onboarding.kyb.KybTestFixtures.companyWith;
+import static ee.tuleva.onboarding.kyb.KybTestFixtures.kybPerson;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import ee.tuleva.onboarding.kyb.CompanyDto;
-import ee.tuleva.onboarding.kyb.KybCompanyData;
-import ee.tuleva.onboarding.kyb.KybRelatedPerson;
-import ee.tuleva.onboarding.kyb.LegalForm;
-import ee.tuleva.onboarding.kyb.PersonalCode;
-import ee.tuleva.onboarding.kyb.RegistryCode;
-import ee.tuleva.onboarding.kyb.SelfCertification;
 import java.math.BigDecimal;
-import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class DualMemberOwnershipScreenerTest {
@@ -22,22 +15,9 @@ class DualMemberOwnershipScreenerTest {
 
   @Test
   void twoBoardMembersBothShareholdersAndBeneficialOwnersWithFullOwnershipPasses() {
-    var person1 =
-        new KybRelatedPerson(
-            new PersonalCode("38501010001"), true, true, true, BigDecimal.valueOf(50), UNKNOWN);
-    var person2 =
-        new KybRelatedPerson(
-            new PersonalCode("38501010002"), true, true, true, BigDecimal.valueOf(50), UNKNOWN);
-    var data =
-        new KybCompanyData(
-            new CompanyDto(new RegistryCode("12345678"), "Test OÜ", "62011", LegalForm.OÜ),
-            new PersonalCode("38501010001"),
-            R,
-            List.of(person1, person2),
-            new SelfCertification(true, true, true),
-            "EE",
-            "Harju maakond, Tallinn, Pärnu mnt 1",
-            null);
+    var person1 = boardMemberOwner("38501010001", 50.0).build();
+    var person2 = boardMemberOwner("38501010002", 50.0).build();
+    var data = companyWith(person1, person2);
 
     var result = screener.screen(data);
 
@@ -48,22 +28,9 @@ class DualMemberOwnershipScreenerTest {
 
   @Test
   void twoBoardMembersWithTotalOwnershipLessThan100Fails() {
-    var person1 =
-        new KybRelatedPerson(
-            new PersonalCode("38501010001"), true, true, true, BigDecimal.valueOf(30), UNKNOWN);
-    var person2 =
-        new KybRelatedPerson(
-            new PersonalCode("38501010002"), true, true, true, BigDecimal.valueOf(30), UNKNOWN);
-    var data =
-        new KybCompanyData(
-            new CompanyDto(new RegistryCode("12345678"), "Test OÜ", "62011", LegalForm.OÜ),
-            new PersonalCode("38501010001"),
-            R,
-            List.of(person1, person2),
-            new SelfCertification(true, true, true),
-            "EE",
-            "Harju maakond, Tallinn, Pärnu mnt 1",
-            null);
+    var person1 = boardMemberOwner("38501010001", 30.0).build();
+    var person2 = boardMemberOwner("38501010002", 30.0).build();
+    var data = companyWith(person1, person2);
 
     var result = screener.screen(data);
 
@@ -74,22 +41,9 @@ class DualMemberOwnershipScreenerTest {
 
   @Test
   void twoBoardMembersWhereOneIsNotShareholderFails() {
-    var person1 =
-        new KybRelatedPerson(
-            new PersonalCode("38501010001"), true, true, true, BigDecimal.valueOf(100), UNKNOWN);
-    var person2 =
-        new KybRelatedPerson(
-            new PersonalCode("38501010002"), true, false, false, BigDecimal.ZERO, UNKNOWN);
-    var data =
-        new KybCompanyData(
-            new CompanyDto(new RegistryCode("12345678"), "Test OÜ", "62011", LegalForm.OÜ),
-            new PersonalCode("38501010001"),
-            R,
-            List.of(person1, person2),
-            new SelfCertification(true, true, true),
-            "EE",
-            "Harju maakond, Tallinn, Pärnu mnt 1",
-            null);
+    var person1 = boardMemberOwner("38501010001", 100.0).build();
+    var person2 = kybPerson("38501010002").boardMember(true).build();
+    var data = companyWith(person1, person2);
 
     var result = screener.screen(data);
 
@@ -100,22 +54,14 @@ class DualMemberOwnershipScreenerTest {
 
   @Test
   void doesNotApplyWhenOnlyOneBoardMemberOutOfTwoPersons() {
-    var person1 =
-        new KybRelatedPerson(
-            new PersonalCode("38501010001"), true, true, true, BigDecimal.valueOf(50), UNKNOWN);
+    var person1 = boardMemberOwner("38501010001", 50.0).build();
     var person2 =
-        new KybRelatedPerson(
-            new PersonalCode("38501010002"), false, true, true, BigDecimal.valueOf(50), UNKNOWN);
-    var data =
-        new KybCompanyData(
-            new CompanyDto(new RegistryCode("12345678"), "Test OÜ", "62011", LegalForm.OÜ),
-            new PersonalCode("38501010001"),
-            R,
-            List.of(person1, person2),
-            new SelfCertification(true, true, true),
-            "EE",
-            "Harju maakond, Tallinn, Pärnu mnt 1",
-            null);
+        kybPerson("38501010002")
+            .shareholder(true)
+            .beneficialOwner(true)
+            .ownershipPercent(BigDecimal.valueOf(50))
+            .build();
+    var data = companyWith(person1, person2);
 
     var result = screener.screen(data);
 
@@ -124,19 +70,8 @@ class DualMemberOwnershipScreenerTest {
 
   @Test
   void doesNotApplyWhenOnlyOneRelatedPerson() {
-    var person =
-        new KybRelatedPerson(
-            new PersonalCode("38501010001"), true, true, true, BigDecimal.valueOf(100), UNKNOWN);
-    var data =
-        new KybCompanyData(
-            new CompanyDto(new RegistryCode("12345678"), "Test OÜ", "62011", LegalForm.OÜ),
-            new PersonalCode("38501010001"),
-            R,
-            List.of(person),
-            new SelfCertification(true, true, true),
-            "EE",
-            "Harju maakond, Tallinn, Pärnu mnt 1",
-            null);
+    var person = boardMemberOwner("38501010001", 100.0).build();
+    var data = companyWith(person);
 
     var result = screener.screen(data);
 

--- a/src/test/groovy/ee/tuleva/onboarding/kyb/screener/DualMemberOwnershipScreenerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyb/screener/DualMemberOwnershipScreenerTest.java
@@ -1,12 +1,14 @@
 package ee.tuleva.onboarding.kyb.screener;
 
 import static ee.tuleva.onboarding.kyb.KybCheckType.DUAL_MEMBER_OWNERSHIP;
+import static ee.tuleva.onboarding.kyb.KybTestFixtures.boardMemberOnly;
 import static ee.tuleva.onboarding.kyb.KybTestFixtures.boardMemberOwner;
 import static ee.tuleva.onboarding.kyb.KybTestFixtures.companyWith;
-import static ee.tuleva.onboarding.kyb.KybTestFixtures.kybPerson;
+import static ee.tuleva.onboarding.kyb.KybTestFixtures.shareholderOwner;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 
-import java.math.BigDecimal;
+import ee.tuleva.onboarding.kyb.KybCheck;
 import org.junit.jupiter.api.Test;
 
 class DualMemberOwnershipScreenerTest {
@@ -21,9 +23,9 @@ class DualMemberOwnershipScreenerTest {
 
     var result = screener.screen(data);
 
-    assertThat(result).hasSize(1);
-    assertThat(result.getFirst().type()).isEqualTo(DUAL_MEMBER_OWNERSHIP);
-    assertThat(result.getFirst().success()).isTrue();
+    assertThat(result)
+        .extracting(KybCheck::type, KybCheck::success)
+        .containsExactly(tuple(DUAL_MEMBER_OWNERSHIP, true));
   }
 
   @Test
@@ -34,33 +36,28 @@ class DualMemberOwnershipScreenerTest {
 
     var result = screener.screen(data);
 
-    assertThat(result).hasSize(1);
-    assertThat(result.getFirst().type()).isEqualTo(DUAL_MEMBER_OWNERSHIP);
-    assertThat(result.getFirst().success()).isFalse();
+    assertThat(result)
+        .extracting(KybCheck::type, KybCheck::success)
+        .containsExactly(tuple(DUAL_MEMBER_OWNERSHIP, false));
   }
 
   @Test
   void twoBoardMembersWhereOneIsNotShareholderFails() {
     var person1 = boardMemberOwner("38501010001", 100.0).build();
-    var person2 = kybPerson("38501010002").boardMember(true).build();
+    var person2 = boardMemberOnly("38501010002").build();
     var data = companyWith(person1, person2);
 
     var result = screener.screen(data);
 
-    assertThat(result).hasSize(1);
-    assertThat(result.getFirst().type()).isEqualTo(DUAL_MEMBER_OWNERSHIP);
-    assertThat(result.getFirst().success()).isFalse();
+    assertThat(result)
+        .extracting(KybCheck::type, KybCheck::success)
+        .containsExactly(tuple(DUAL_MEMBER_OWNERSHIP, false));
   }
 
   @Test
   void doesNotApplyWhenOnlyOneBoardMemberOutOfTwoPersons() {
     var person1 = boardMemberOwner("38501010001", 50.0).build();
-    var person2 =
-        kybPerson("38501010002")
-            .shareholder(true)
-            .beneficialOwner(true)
-            .ownershipPercent(BigDecimal.valueOf(50))
-            .build();
+    var person2 = shareholderOwner("38501010002", 50.0).build();
     var data = companyWith(person1, person2);
 
     var result = screener.screen(data);

--- a/src/test/groovy/ee/tuleva/onboarding/kyb/screener/RelatedPersonsKycScreenerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyb/screener/RelatedPersonsKycScreenerTest.java
@@ -50,7 +50,7 @@ class RelatedPersonsKycScreenerTest {
   @Test
   @SuppressWarnings("unchecked")
   void failureMetadataContainsIncompletePersons() {
-    var completed = boardMemberOwner("38501010001", 50.0).kycStatus(COMPLETED).build();
+    var completed = boardMemberOwner("38501010001", 50.0).build();
     var rejected = boardMemberOwner("38501010002", 50.0).kycStatus(REJECTED).build();
     var data = companyWith(completed, rejected);
 
@@ -68,7 +68,7 @@ class RelatedPersonsKycScreenerTest {
   @Test
   @SuppressWarnings("unchecked")
   void handlesNullPersonalCodeInMetadata() {
-    var withCode = boardMemberOwner("38501010001", 100.0).build();
+    var withCode = boardMemberOwner("38501010001", 100.0).kycStatus(UNKNOWN).build();
     var withoutCode = kybPerson().personalCode(null).build();
     var data = companyWith(withCode, withoutCode);
 
@@ -87,7 +87,7 @@ class RelatedPersonsKycScreenerTest {
 
   @Test
   void successMetadataHasNoIncompletePersons() {
-    var person = boardMemberOwner("38501010001", 100.0).kycStatus(COMPLETED).build();
+    var person = boardMemberOwner("38501010001", 100.0).build();
     var data = companyWith(person);
 
     var result = screener.screen(data);

--- a/src/test/groovy/ee/tuleva/onboarding/kyb/screener/RelatedPersonsKycScreenerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyb/screener/RelatedPersonsKycScreenerTest.java
@@ -1,20 +1,14 @@
 package ee.tuleva.onboarding.kyb.screener;
 
-import static ee.tuleva.onboarding.kyb.CompanyStatus.R;
 import static ee.tuleva.onboarding.kyb.KybCheckType.RELATED_PERSONS_KYC;
 import static ee.tuleva.onboarding.kyb.KybKycStatus.*;
+import static ee.tuleva.onboarding.kyb.KybTestFixtures.boardMemberOwner;
+import static ee.tuleva.onboarding.kyb.KybTestFixtures.companyWith;
+import static ee.tuleva.onboarding.kyb.KybTestFixtures.kybPerson;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import ee.tuleva.onboarding.kyb.CompanyDto;
 import ee.tuleva.onboarding.kyb.KybCheck;
-import ee.tuleva.onboarding.kyb.KybCompanyData;
 import ee.tuleva.onboarding.kyb.KybKycStatus;
-import ee.tuleva.onboarding.kyb.KybRelatedPerson;
-import ee.tuleva.onboarding.kyb.LegalForm;
-import ee.tuleva.onboarding.kyb.PersonalCode;
-import ee.tuleva.onboarding.kyb.RegistryCode;
-import ee.tuleva.onboarding.kyb.SelfCertification;
-import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -32,26 +26,9 @@ class RelatedPersonsKycScreenerTest {
   void checksAllRelatedPersonsKycStatus(List<KybKycStatus> statuses, boolean expectedSuccess) {
     var persons =
         statuses.stream()
-            .map(
-                status ->
-                    new KybRelatedPerson(
-                        new PersonalCode("38501010001"),
-                        true,
-                        true,
-                        true,
-                        BigDecimal.valueOf(100),
-                        status))
+            .map(status -> boardMemberOwner("38501010001", 100.0).kycStatus(status).build())
             .toList();
-    var data =
-        new KybCompanyData(
-            new CompanyDto(new RegistryCode("12345678"), "Test OÜ", "62011", LegalForm.OÜ),
-            new PersonalCode("38501010001"),
-            R,
-            persons,
-            new SelfCertification(true, true, true),
-            "EE",
-            "Harju maakond, Tallinn, Pärnu mnt 1",
-            null);
+    var data = companyWith(persons);
 
     var result = screener.screen(data);
 
@@ -73,22 +50,9 @@ class RelatedPersonsKycScreenerTest {
   @Test
   @SuppressWarnings("unchecked")
   void failureMetadataContainsIncompletePersons() {
-    var completed =
-        new KybRelatedPerson(
-            new PersonalCode("38501010001"), true, true, true, BigDecimal.valueOf(50), COMPLETED);
-    var rejected =
-        new KybRelatedPerson(
-            new PersonalCode("38501010002"), true, true, true, BigDecimal.valueOf(50), REJECTED);
-    var data =
-        new KybCompanyData(
-            new CompanyDto(new RegistryCode("12345678"), "Test OÜ", "62011", LegalForm.OÜ),
-            new PersonalCode("38501010001"),
-            R,
-            List.of(completed, rejected),
-            new SelfCertification(true, true, true),
-            "EE",
-            "Harju maakond, Tallinn, Pärnu mnt 1",
-            null);
+    var completed = boardMemberOwner("38501010001", 50.0).kycStatus(COMPLETED).build();
+    var rejected = boardMemberOwner("38501010002", 50.0).kycStatus(REJECTED).build();
+    var data = companyWith(completed, rejected);
 
     var result = screener.screen(data);
 
@@ -104,20 +68,9 @@ class RelatedPersonsKycScreenerTest {
   @Test
   @SuppressWarnings("unchecked")
   void handlesNullPersonalCodeInMetadata() {
-    var withCode =
-        new KybRelatedPerson(
-            new PersonalCode("38501010001"), true, true, true, BigDecimal.valueOf(100), UNKNOWN);
-    var withoutCode = new KybRelatedPerson(null, false, false, false, BigDecimal.ZERO, UNKNOWN);
-    var data =
-        new KybCompanyData(
-            new CompanyDto(new RegistryCode("12345678"), "Test OÜ", "62011", LegalForm.OÜ),
-            new PersonalCode("38501010001"),
-            R,
-            List.of(withCode, withoutCode),
-            new SelfCertification(true, true, true),
-            "EE",
-            "Harju maakond, Tallinn, Pärnu mnt 1",
-            null);
+    var withCode = boardMemberOwner("38501010001", 100.0).build();
+    var withoutCode = kybPerson().personalCode(null).build();
+    var data = companyWith(withCode, withoutCode);
 
     var result = screener.screen(data);
 
@@ -134,19 +87,8 @@ class RelatedPersonsKycScreenerTest {
 
   @Test
   void successMetadataHasNoIncompletePersons() {
-    var person =
-        new KybRelatedPerson(
-            new PersonalCode("38501010001"), true, true, true, BigDecimal.valueOf(100), COMPLETED);
-    var data =
-        new KybCompanyData(
-            new CompanyDto(new RegistryCode("12345678"), "Test OÜ", "62011", LegalForm.OÜ),
-            new PersonalCode("38501010001"),
-            R,
-            List.of(person),
-            new SelfCertification(true, true, true),
-            "EE",
-            "Harju maakond, Tallinn, Pärnu mnt 1",
-            null);
+    var person = boardMemberOwner("38501010001", 100.0).kycStatus(COMPLETED).build();
+    var data = companyWith(person);
 
     var result = screener.screen(data);
 

--- a/src/test/groovy/ee/tuleva/onboarding/kyb/screener/SelfCertificationScreenerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyb/screener/SelfCertificationScreenerTest.java
@@ -1,13 +1,12 @@
 package ee.tuleva.onboarding.kyb.screener;
 
-import static ee.tuleva.onboarding.kyb.CompanyStatus.R;
 import static ee.tuleva.onboarding.kyb.KybCheckType.SELF_CERTIFICATION;
-import static ee.tuleva.onboarding.kyb.KybKycStatus.COMPLETED;
 import static ee.tuleva.onboarding.kyb.KybTestFixtures.boardMemberOwner;
+import static ee.tuleva.onboarding.kyb.KybTestFixtures.companyWith;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 
 import ee.tuleva.onboarding.kyb.*;
-import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class SelfCertificationScreenerTest {
@@ -20,9 +19,9 @@ class SelfCertificationScreenerTest {
 
     var results = screener.screen(data);
 
-    assertThat(results).hasSize(1);
-    assertThat(results.getFirst().type()).isEqualTo(SELF_CERTIFICATION);
-    assertThat(results.getFirst().success()).isTrue();
+    assertThat(results)
+        .extracting(KybCheck::type, KybCheck::success)
+        .containsExactly(tuple(SELF_CERTIFICATION, true));
   }
 
   @Test
@@ -54,18 +53,8 @@ class SelfCertificationScreenerTest {
 
   @Test
   void nullCertificationFails() {
-    var company = new CompanyDto(new RegistryCode("12345678"), "Test OÜ", "62011", LegalForm.OÜ);
-    var person = boardMemberOwner("38501010001", 100.0).kycStatus(COMPLETED).build();
     var data =
-        new KybCompanyData(
-            company,
-            new PersonalCode("38501010001"),
-            R,
-            List.of(person),
-            null,
-            "EE",
-            "Harju maakond, Tallinn, Pärnu mnt 1",
-            null);
+        companyWith((SelfCertification) null, boardMemberOwner("38501010001", 100.0).build());
 
     var results = screener.screen(data);
 
@@ -87,17 +76,8 @@ class SelfCertificationScreenerTest {
 
   private KybCompanyData companyWithCertification(
       boolean operatesInEstonia, boolean notSanctioned, boolean noHighRiskActivity) {
-    var company = new CompanyDto(new RegistryCode("12345678"), "Test OÜ", "62011", LegalForm.OÜ);
-    var person = boardMemberOwner("38501010001", 100.0).kycStatus(COMPLETED).build();
-    var cert = new SelfCertification(operatesInEstonia, notSanctioned, noHighRiskActivity);
-    return new KybCompanyData(
-        company,
-        new PersonalCode("38501010001"),
-        R,
-        List.of(person),
-        cert,
-        "EE",
-        "Harju maakond, Tallinn, Pärnu mnt 1",
-        null);
+    return companyWith(
+        new SelfCertification(operatesInEstonia, notSanctioned, noHighRiskActivity),
+        boardMemberOwner("38501010001", 100.0).build());
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/kyb/screener/SelfCertificationScreenerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyb/screener/SelfCertificationScreenerTest.java
@@ -3,10 +3,10 @@ package ee.tuleva.onboarding.kyb.screener;
 import static ee.tuleva.onboarding.kyb.CompanyStatus.R;
 import static ee.tuleva.onboarding.kyb.KybCheckType.SELF_CERTIFICATION;
 import static ee.tuleva.onboarding.kyb.KybKycStatus.COMPLETED;
+import static ee.tuleva.onboarding.kyb.KybTestFixtures.boardMemberOwner;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import ee.tuleva.onboarding.kyb.*;
-import java.math.BigDecimal;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
@@ -55,9 +55,7 @@ class SelfCertificationScreenerTest {
   @Test
   void nullCertificationFails() {
     var company = new CompanyDto(new RegistryCode("12345678"), "Test OÜ", "62011", LegalForm.OÜ);
-    var person =
-        new KybRelatedPerson(
-            new PersonalCode("38501010001"), true, true, true, BigDecimal.valueOf(100), COMPLETED);
+    var person = boardMemberOwner("38501010001", 100.0).kycStatus(COMPLETED).build();
     var data =
         new KybCompanyData(
             company,
@@ -90,9 +88,7 @@ class SelfCertificationScreenerTest {
   private KybCompanyData companyWithCertification(
       boolean operatesInEstonia, boolean notSanctioned, boolean noHighRiskActivity) {
     var company = new CompanyDto(new RegistryCode("12345678"), "Test OÜ", "62011", LegalForm.OÜ);
-    var person =
-        new KybRelatedPerson(
-            new PersonalCode("38501010001"), true, true, true, BigDecimal.valueOf(100), COMPLETED);
+    var person = boardMemberOwner("38501010001", 100.0).kycStatus(COMPLETED).build();
     var cert = new SelfCertification(operatesInEstonia, notSanctioned, noHighRiskActivity);
     return new KybCompanyData(
         company,

--- a/src/test/groovy/ee/tuleva/onboarding/kyb/screener/SoleBoardMemberIsOwnerScreenerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyb/screener/SoleBoardMemberIsOwnerScreenerTest.java
@@ -1,19 +1,13 @@
 package ee.tuleva.onboarding.kyb.screener;
 
-import static ee.tuleva.onboarding.kyb.CompanyStatus.R;
 import static ee.tuleva.onboarding.kyb.KybCheckType.SOLE_BOARD_MEMBER_IS_OWNER;
-import static ee.tuleva.onboarding.kyb.KybKycStatus.UNKNOWN;
+import static ee.tuleva.onboarding.kyb.KybTestFixtures.boardMemberOwner;
+import static ee.tuleva.onboarding.kyb.KybTestFixtures.companyWith;
+import static ee.tuleva.onboarding.kyb.KybTestFixtures.kybPerson;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import ee.tuleva.onboarding.kyb.CompanyDto;
-import ee.tuleva.onboarding.kyb.KybCompanyData;
-import ee.tuleva.onboarding.kyb.KybRelatedPerson;
-import ee.tuleva.onboarding.kyb.LegalForm;
 import ee.tuleva.onboarding.kyb.PersonalCode;
-import ee.tuleva.onboarding.kyb.RegistryCode;
-import ee.tuleva.onboarding.kyb.SelfCertification;
 import java.math.BigDecimal;
-import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class SoleBoardMemberIsOwnerScreenerTest {
@@ -22,22 +16,14 @@ class SoleBoardMemberIsOwnerScreenerTest {
 
   @Test
   void soleBoardMemberWhoIsShareholderAndBeneficialOwnerPasses() {
-    var boardMember =
-        new KybRelatedPerson(
-            new PersonalCode("38501010001"), true, true, true, BigDecimal.valueOf(50), UNKNOWN);
+    var boardMember = boardMemberOwner("38501010001", 50.0).build();
     var otherPerson =
-        new KybRelatedPerson(
-            new PersonalCode("38501010002"), false, true, true, BigDecimal.valueOf(50), UNKNOWN);
-    var data =
-        new KybCompanyData(
-            new CompanyDto(new RegistryCode("12345678"), "Test OÜ", "62011", LegalForm.OÜ),
-            new PersonalCode("38501010001"),
-            R,
-            List.of(boardMember, otherPerson),
-            new SelfCertification(true, true, true),
-            "EE",
-            "Harju maakond, Tallinn, Pärnu mnt 1",
-            null);
+        kybPerson("38501010002")
+            .shareholder(true)
+            .beneficialOwner(true)
+            .ownershipPercent(BigDecimal.valueOf(50))
+            .build();
+    var data = companyWith(boardMember, otherPerson);
 
     var result = screener.screen(data);
 
@@ -48,22 +34,14 @@ class SoleBoardMemberIsOwnerScreenerTest {
 
   @Test
   void soleBoardMemberWhoIsNotShareholderFails() {
-    var boardMember =
-        new KybRelatedPerson(
-            new PersonalCode("38501010001"), true, false, false, BigDecimal.ZERO, UNKNOWN);
+    var boardMember = kybPerson("38501010001").boardMember(true).build();
     var owner =
-        new KybRelatedPerson(
-            new PersonalCode("38501010002"), false, true, true, BigDecimal.valueOf(100), UNKNOWN);
-    var data =
-        new KybCompanyData(
-            new CompanyDto(new RegistryCode("12345678"), "Test OÜ", "62011", LegalForm.OÜ),
-            new PersonalCode("38501010001"),
-            R,
-            List.of(boardMember, owner),
-            new SelfCertification(true, true, true),
-            "EE",
-            "Harju maakond, Tallinn, Pärnu mnt 1",
-            null);
+        kybPerson("38501010002")
+            .shareholder(true)
+            .beneficialOwner(true)
+            .ownershipPercent(BigDecimal.valueOf(100))
+            .build();
+    var data = companyWith(boardMember, owner);
 
     var result = screener.screen(data);
 
@@ -75,21 +53,18 @@ class SoleBoardMemberIsOwnerScreenerTest {
   @Test
   void soleBoardMemberWhoIsShareholderButNotBeneficialOwnerFails() {
     var boardMember =
-        new KybRelatedPerson(
-            new PersonalCode("38501010001"), true, true, false, BigDecimal.valueOf(50), UNKNOWN);
+        kybPerson("38501010001")
+            .boardMember(true)
+            .shareholder(true)
+            .ownershipPercent(BigDecimal.valueOf(50))
+            .build();
     var otherPerson =
-        new KybRelatedPerson(
-            new PersonalCode("38501010002"), false, true, true, BigDecimal.valueOf(50), UNKNOWN);
-    var data =
-        new KybCompanyData(
-            new CompanyDto(new RegistryCode("12345678"), "Test OÜ", "62011", LegalForm.OÜ),
-            new PersonalCode("38501010001"),
-            R,
-            List.of(boardMember, otherPerson),
-            new SelfCertification(true, true, true),
-            "EE",
-            "Harju maakond, Tallinn, Pärnu mnt 1",
-            null);
+        kybPerson("38501010002")
+            .shareholder(true)
+            .beneficialOwner(true)
+            .ownershipPercent(BigDecimal.valueOf(50))
+            .build();
+    var data = companyWith(boardMember, otherPerson);
 
     var result = screener.screen(data);
 
@@ -100,20 +75,14 @@ class SoleBoardMemberIsOwnerScreenerTest {
 
   @Test
   void handlesNullPersonalCodeForSoleBoardMember() {
-    var boardMember = new KybRelatedPerson(null, true, true, true, BigDecimal.valueOf(50), UNKNOWN);
+    var boardMember = boardMemberOwner((PersonalCode) null, 50.0).build();
     var otherPerson =
-        new KybRelatedPerson(
-            new PersonalCode("38501010002"), false, true, true, BigDecimal.valueOf(50), UNKNOWN);
-    var data =
-        new KybCompanyData(
-            new CompanyDto(new RegistryCode("12345678"), "Test OÜ", "62011", LegalForm.OÜ),
-            new PersonalCode("38501010001"),
-            R,
-            List.of(boardMember, otherPerson),
-            new SelfCertification(true, true, true),
-            "EE",
-            "Harju maakond, Tallinn, Pärnu mnt 1",
-            null);
+        kybPerson("38501010002")
+            .shareholder(true)
+            .beneficialOwner(true)
+            .ownershipPercent(BigDecimal.valueOf(50))
+            .build();
+    var data = companyWith(boardMember, otherPerson);
 
     var result = screener.screen(data);
 
@@ -125,22 +94,9 @@ class SoleBoardMemberIsOwnerScreenerTest {
 
   @Test
   void doesNotApplyWhenTwoBoardMembers() {
-    var person1 =
-        new KybRelatedPerson(
-            new PersonalCode("38501010001"), true, true, true, BigDecimal.valueOf(50), UNKNOWN);
-    var person2 =
-        new KybRelatedPerson(
-            new PersonalCode("38501010002"), true, true, true, BigDecimal.valueOf(50), UNKNOWN);
-    var data =
-        new KybCompanyData(
-            new CompanyDto(new RegistryCode("12345678"), "Test OÜ", "62011", LegalForm.OÜ),
-            new PersonalCode("38501010001"),
-            R,
-            List.of(person1, person2),
-            new SelfCertification(true, true, true),
-            "EE",
-            "Harju maakond, Tallinn, Pärnu mnt 1",
-            null);
+    var person1 = boardMemberOwner("38501010001", 50.0).build();
+    var person2 = boardMemberOwner("38501010002", 50.0).build();
+    var data = companyWith(person1, person2);
 
     var result = screener.screen(data);
 
@@ -149,19 +105,8 @@ class SoleBoardMemberIsOwnerScreenerTest {
 
   @Test
   void doesNotApplyWhenOnlyOneRelatedPerson() {
-    var person =
-        new KybRelatedPerson(
-            new PersonalCode("38501010001"), true, true, true, BigDecimal.valueOf(100), UNKNOWN);
-    var data =
-        new KybCompanyData(
-            new CompanyDto(new RegistryCode("12345678"), "Test OÜ", "62011", LegalForm.OÜ),
-            new PersonalCode("38501010001"),
-            R,
-            List.of(person),
-            new SelfCertification(true, true, true),
-            "EE",
-            "Harju maakond, Tallinn, Pärnu mnt 1",
-            null);
+    var person = boardMemberOwner("38501010001", 100.0).build();
+    var data = companyWith(person);
 
     var result = screener.screen(data);
 

--- a/src/test/groovy/ee/tuleva/onboarding/kyb/screener/SoleBoardMemberIsOwnerScreenerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyb/screener/SoleBoardMemberIsOwnerScreenerTest.java
@@ -1,11 +1,15 @@
 package ee.tuleva.onboarding.kyb.screener;
 
 import static ee.tuleva.onboarding.kyb.KybCheckType.SOLE_BOARD_MEMBER_IS_OWNER;
+import static ee.tuleva.onboarding.kyb.KybTestFixtures.boardMemberOnly;
 import static ee.tuleva.onboarding.kyb.KybTestFixtures.boardMemberOwner;
 import static ee.tuleva.onboarding.kyb.KybTestFixtures.companyWith;
 import static ee.tuleva.onboarding.kyb.KybTestFixtures.kybPerson;
+import static ee.tuleva.onboarding.kyb.KybTestFixtures.shareholderOwner;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 
+import ee.tuleva.onboarding.kyb.KybCheck;
 import ee.tuleva.onboarding.kyb.PersonalCode;
 import java.math.BigDecimal;
 import org.junit.jupiter.api.Test;
@@ -17,37 +21,27 @@ class SoleBoardMemberIsOwnerScreenerTest {
   @Test
   void soleBoardMemberWhoIsShareholderAndBeneficialOwnerPasses() {
     var boardMember = boardMemberOwner("38501010001", 50.0).build();
-    var otherPerson =
-        kybPerson("38501010002")
-            .shareholder(true)
-            .beneficialOwner(true)
-            .ownershipPercent(BigDecimal.valueOf(50))
-            .build();
+    var otherPerson = shareholderOwner("38501010002", 50.0).build();
     var data = companyWith(boardMember, otherPerson);
 
     var result = screener.screen(data);
 
-    assertThat(result).hasSize(1);
-    assertThat(result.getFirst().type()).isEqualTo(SOLE_BOARD_MEMBER_IS_OWNER);
-    assertThat(result.getFirst().success()).isTrue();
+    assertThat(result)
+        .extracting(KybCheck::type, KybCheck::success)
+        .containsExactly(tuple(SOLE_BOARD_MEMBER_IS_OWNER, true));
   }
 
   @Test
   void soleBoardMemberWhoIsNotShareholderFails() {
-    var boardMember = kybPerson("38501010001").boardMember(true).build();
-    var owner =
-        kybPerson("38501010002")
-            .shareholder(true)
-            .beneficialOwner(true)
-            .ownershipPercent(BigDecimal.valueOf(100))
-            .build();
+    var boardMember = boardMemberOnly("38501010001").build();
+    var owner = shareholderOwner("38501010002", 100.0).build();
     var data = companyWith(boardMember, owner);
 
     var result = screener.screen(data);
 
-    assertThat(result).hasSize(1);
-    assertThat(result.getFirst().type()).isEqualTo(SOLE_BOARD_MEMBER_IS_OWNER);
-    assertThat(result.getFirst().success()).isFalse();
+    assertThat(result)
+        .extracting(KybCheck::type, KybCheck::success)
+        .containsExactly(tuple(SOLE_BOARD_MEMBER_IS_OWNER, false));
   }
 
   @Test
@@ -58,37 +52,27 @@ class SoleBoardMemberIsOwnerScreenerTest {
             .shareholder(true)
             .ownershipPercent(BigDecimal.valueOf(50))
             .build();
-    var otherPerson =
-        kybPerson("38501010002")
-            .shareholder(true)
-            .beneficialOwner(true)
-            .ownershipPercent(BigDecimal.valueOf(50))
-            .build();
+    var otherPerson = shareholderOwner("38501010002", 50.0).build();
     var data = companyWith(boardMember, otherPerson);
 
     var result = screener.screen(data);
 
-    assertThat(result).hasSize(1);
-    assertThat(result.getFirst().type()).isEqualTo(SOLE_BOARD_MEMBER_IS_OWNER);
-    assertThat(result.getFirst().success()).isFalse();
+    assertThat(result)
+        .extracting(KybCheck::type, KybCheck::success)
+        .containsExactly(tuple(SOLE_BOARD_MEMBER_IS_OWNER, false));
   }
 
   @Test
   void handlesNullPersonalCodeForSoleBoardMember() {
     var boardMember = boardMemberOwner((PersonalCode) null, 50.0).build();
-    var otherPerson =
-        kybPerson("38501010002")
-            .shareholder(true)
-            .beneficialOwner(true)
-            .ownershipPercent(BigDecimal.valueOf(50))
-            .build();
+    var otherPerson = shareholderOwner("38501010002", 50.0).build();
     var data = companyWith(boardMember, otherPerson);
 
     var result = screener.screen(data);
 
-    assertThat(result).hasSize(1);
-    assertThat(result.getFirst().type()).isEqualTo(SOLE_BOARD_MEMBER_IS_OWNER);
-    assertThat(result.getFirst().success()).isTrue();
+    assertThat(result)
+        .extracting(KybCheck::type, KybCheck::success)
+        .containsExactly(tuple(SOLE_BOARD_MEMBER_IS_OWNER, true));
     assertThat(result.getFirst().metadata()).doesNotContainKey("boardMemberPersonalCode");
   }
 

--- a/src/test/groovy/ee/tuleva/onboarding/kyb/screener/SoleMemberOwnershipScreenerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyb/screener/SoleMemberOwnershipScreenerTest.java
@@ -5,7 +5,9 @@ import static ee.tuleva.onboarding.kyb.KybTestFixtures.boardMemberOwner;
 import static ee.tuleva.onboarding.kyb.KybTestFixtures.companyWith;
 import static ee.tuleva.onboarding.kyb.KybTestFixtures.kybPerson;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 
+import ee.tuleva.onboarding.kyb.KybCheck;
 import ee.tuleva.onboarding.kyb.PersonalCode;
 import java.math.BigDecimal;
 import java.util.stream.Stream;
@@ -54,9 +56,9 @@ class SoleMemberOwnershipScreenerTest {
 
     var result = screener.screen(data);
 
-    assertThat(result).hasSize(1);
-    assertThat(result.getFirst().type()).isEqualTo(SOLE_MEMBER_OWNERSHIP);
-    assertThat(result.getFirst().success()).isTrue();
+    assertThat(result)
+        .extracting(KybCheck::type, KybCheck::success)
+        .containsExactly(tuple(SOLE_MEMBER_OWNERSHIP, true));
     assertThat(result.getFirst().metadata()).doesNotContainKey("personalCode");
   }
 

--- a/src/test/groovy/ee/tuleva/onboarding/kyb/screener/SoleMemberOwnershipScreenerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyb/screener/SoleMemberOwnershipScreenerTest.java
@@ -1,19 +1,13 @@
 package ee.tuleva.onboarding.kyb.screener;
 
-import static ee.tuleva.onboarding.kyb.CompanyStatus.R;
 import static ee.tuleva.onboarding.kyb.KybCheckType.SOLE_MEMBER_OWNERSHIP;
-import static ee.tuleva.onboarding.kyb.KybKycStatus.UNKNOWN;
+import static ee.tuleva.onboarding.kyb.KybTestFixtures.boardMemberOwner;
+import static ee.tuleva.onboarding.kyb.KybTestFixtures.companyWith;
+import static ee.tuleva.onboarding.kyb.KybTestFixtures.kybPerson;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import ee.tuleva.onboarding.kyb.CompanyDto;
-import ee.tuleva.onboarding.kyb.KybCompanyData;
-import ee.tuleva.onboarding.kyb.KybRelatedPerson;
-import ee.tuleva.onboarding.kyb.LegalForm;
 import ee.tuleva.onboarding.kyb.PersonalCode;
-import ee.tuleva.onboarding.kyb.RegistryCode;
-import ee.tuleva.onboarding.kyb.SelfCertification;
 import java.math.BigDecimal;
-import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -29,18 +23,13 @@ class SoleMemberOwnershipScreenerTest {
   void singlePersonOwnership(
       boolean board, boolean share, boolean beneficial, BigDecimal ownership, boolean expected) {
     var person =
-        new KybRelatedPerson(
-            new PersonalCode("38501010001"), board, share, beneficial, ownership, UNKNOWN);
-    var data =
-        new KybCompanyData(
-            new CompanyDto(new RegistryCode("12345678"), "Test OÜ", "62011", LegalForm.OÜ),
-            new PersonalCode("38501010001"),
-            R,
-            List.of(person),
-            new SelfCertification(true, true, true),
-            "EE",
-            "Harju maakond, Tallinn, Pärnu mnt 1",
-            null);
+        kybPerson("38501010001")
+            .boardMember(board)
+            .shareholder(share)
+            .beneficialOwner(beneficial)
+            .ownershipPercent(ownership)
+            .build();
+    var data = companyWith(person);
 
     var result = screener.screen(data);
 
@@ -60,17 +49,8 @@ class SoleMemberOwnershipScreenerTest {
 
   @Test
   void handlesNullPersonalCode() {
-    var person = new KybRelatedPerson(null, true, true, true, BigDecimal.valueOf(100), UNKNOWN);
-    var data =
-        new KybCompanyData(
-            new CompanyDto(new RegistryCode("12345678"), "Test OÜ", "62011", LegalForm.OÜ),
-            new PersonalCode("38501010001"),
-            R,
-            List.of(person),
-            new SelfCertification(true, true, true),
-            "EE",
-            "Harju maakond, Tallinn, Pärnu mnt 1",
-            null);
+    var person = boardMemberOwner((PersonalCode) null, 100.0).build();
+    var data = companyWith(person);
 
     var result = screener.screen(data);
 
@@ -82,22 +62,9 @@ class SoleMemberOwnershipScreenerTest {
 
   @Test
   void doesNotApplyWhenMultipleRelatedPersons() {
-    var person1 =
-        new KybRelatedPerson(
-            new PersonalCode("38501010001"), true, true, true, BigDecimal.valueOf(50), UNKNOWN);
-    var person2 =
-        new KybRelatedPerson(
-            new PersonalCode("38501010002"), true, true, true, BigDecimal.valueOf(50), UNKNOWN);
-    var data =
-        new KybCompanyData(
-            new CompanyDto(new RegistryCode("12345678"), "Test OÜ", "62011", LegalForm.OÜ),
-            new PersonalCode("38501010001"),
-            R,
-            List.of(person1, person2),
-            new SelfCertification(true, true, true),
-            "EE",
-            "Harju maakond, Tallinn, Pärnu mnt 1",
-            null);
+    var person1 = boardMemberOwner("38501010001", 50.0).build();
+    var person2 = boardMemberOwner("38501010002", 50.0).build();
+    var data = companyWith(person1, person2);
 
     var result = screener.screen(data);
 

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/LegalEntityOnboardingEventListenerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/LegalEntityOnboardingEventListenerTest.java
@@ -6,10 +6,7 @@ import static ee.tuleva.onboarding.party.PartyId.Type.LEGAL_ENTITY;
 import static ee.tuleva.onboarding.savings.fund.SavingsFundOnboardingStatus.COMPLETED;
 import static ee.tuleva.onboarding.savings.fund.SavingsFundOnboardingStatus.REJECTED;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import ee.tuleva.onboarding.kyb.*;
 import java.util.List;

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/LegalEntityOnboardingEventListenerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/LegalEntityOnboardingEventListenerTest.java
@@ -1,6 +1,7 @@
 package ee.tuleva.onboarding.savings.fund;
 
 import static ee.tuleva.onboarding.kyb.KybCheckType.*;
+import static ee.tuleva.onboarding.kyb.KybTestFixtures.boardMemberOwner;
 import static ee.tuleva.onboarding.party.PartyId.Type.LEGAL_ENTITY;
 import static ee.tuleva.onboarding.savings.fund.SavingsFundOnboardingStatus.COMPLETED;
 import static ee.tuleva.onboarding.savings.fund.SavingsFundOnboardingStatus.REJECTED;
@@ -11,7 +12,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import ee.tuleva.onboarding.kyb.*;
-import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -28,14 +28,7 @@ class LegalEntityOnboardingEventListenerTest {
       new CompanyDto(new RegistryCode("12345678"), "Test OÜ", "62011", LegalForm.OÜ);
 
   private final List<KybRelatedPerson> relatedPersons =
-      List.of(
-          new KybRelatedPerson(
-              new PersonalCode("38501010001"),
-              true,
-              true,
-              true,
-              BigDecimal.valueOf(100),
-              KybKycStatus.COMPLETED));
+      List.of(boardMemberOwner("38501010001", 100.0).kycStatus(KybKycStatus.COMPLETED).build());
 
   @Test
   void setsStatusCompletedWhenAllChecksPass() {


### PR DESCRIPTION
Removing the company whitelist exposed two latent KYB mapper bugs for OÜs whose shares are held in Nasdaq CSD, plus two over-acceptance gaps:

- Allowlist owner/control roles in LegalEntityScreener (JUHL, O, OSAN, W) instead of "everything except founder" — drops the phantom ORP share registrar that was counted as an unidentified related person
- Match shareholder from role O (Nasdaq CSD) as well as OSAN (registry)
- Reject legal-entity owners via a naturalPerson flag: they carry a registry code in the personal-code field, so the null-code check missed them
- Fail closed in CompanyStructureScreener when no ownership rule covers the structure

Migrate KYB test fixtures to Lombok builders with reusable kybPerson()/boardMemberOwner()/companyWith() helpers, and add KybNasdaqCsdScreeningTest covering the Nasdaq-CSD ownership shapes.