### PR TITLE
Add Xtrackers MSCI World Screened UCITS ETF to FundTicker

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/comparisons/fundvalue/retrieval/FundTicker.java
+++ b/src/main/java/ee/tuleva/onboarding/comparisons/fundvalue/retrieval/FundTicker.java
@@ -47,6 +47,14 @@ public enum FundTicker {
       "XRSM",
       null,
       BenchmarkCategory.EQUITY_DM),
+  XTRACKERS_WORLD_SCREENED(
+      "XWSC.DE",
+      "XWSC.XETRA",
+      "IE000I9HGDZ3",
+      "Xtrackers MSCI World Screened UCITS ETF 1C",
+      "XWSC",
+      null,
+      BenchmarkCategory.EQUITY_DM),
   XTRACKERS_CANADA_ESG_SCREENED(
       "D5BH.DE",
       "D5BH.XETRA",

--- a/src/test/groovy/ee/tuleva/onboarding/comparisons/fundvalue/retrieval/FundTickerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/comparisons/fundvalue/retrieval/FundTickerTest.java
@@ -54,6 +54,7 @@ class FundTickerTest {
             "IE00BFNM3L97",
             "IE00BMDBMY19",
             "IE00BJZ2DC62",
+            "IE000I9HGDZ3",
             "LU0476289540",
             "IE000O58J820",
             "LU1291099718",


### PR DESCRIPTION
## What

Registers **Xtrackers MSCI World Screened UCITS ETF 1C** (`IE000I9HGDZ3`, `XWSC.DE` / `XWSC.XETRA`, Bloomberg `XWSC`) as a `FundTicker` entry, modelled on `XTRACKERS_USA_ESG_SCREENED`.

## Why

The instrument needs to be known to the pricing and trade pipeline. Adding the enum row wires it into:

- **EODHD** price retrieval (`XWSC.XETRA`)
- **Yahoo** + **Deutsche Börse/Xetra** retrieval (`.XETRA` suffix → `getXetraIsins`, `ISIN.XETR` storage key)
- Price resolution gate (`findByIsin` in `PriorityPriceProvider` / `PositionPriceResolver`)
- SEB trade-settlement parsing (`findByTicker` / `findByBloombergTicker`)
- Tracking difference against the **EQUITY_DM** benchmark (MSCI World = developed markets)

`Provider.XTRACKERS` (domicile IRELAND) already exists and matches the Ireland-domiciled ISIN.

## Not in scope (done separately as DB/governance data, no deploy)

- `investment_model_portfolio_allocation` — fund, target weight, provider
- `investment_position_limit` / `investment_provider_limit`
- `instrument_ocf_rates` / `investment_custody_fee_instrument_type`

## Tests

- Added `IE000I9HGDZ3` to `FundTickerTest.getXetraIsinsReturnsOnlyXetraTradedEtfs` (only list-coupled test; other retriever tests scale off `FundTicker.values()`).
- `FundTickerTest`, `EODHDValueRetrieverTest`, `DeutscheBoerseValueRetrieverTest` green; Spotless clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)