### PR TITLE
Add Amundi MSCI World Screened UCITS ETF to FundTicker

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/comparisons/fundvalue/retrieval/FundTicker.java
+++ b/src/main/java/ee/tuleva/onboarding/comparisons/fundvalue/retrieval/FundTicker.java
@@ -103,6 +103,14 @@ public enum FundTicker {
       "USAS",
       null,
       BenchmarkCategory.EQUITY_DM),
+  AMUNDI_WORLD_SCREENED(
+      "WLSC.PA",
+      "WLSC.PA.EODHD",
+      "IE000QWCYQT0",
+      "Amundi MSCI World Screened UCITS ETF",
+      "WLSC",
+      null,
+      BenchmarkCategory.EQUITY_DM),
   AMUNDI_WORLD_EX_USA_SCREENED(
       "WLXU.DE",
       "WLXU.XETRA",

--- a/src/test/groovy/ee/tuleva/onboarding/comparisons/fundvalue/retrieval/FundTickerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/comparisons/fundvalue/retrieval/FundTickerTest.java
@@ -73,7 +73,8 @@ class FundTickerTest {
 
   @Test
   void getEuronextParisIsinsReturnsOnlyParisTradedEtfs() {
-    assertThat(getEuronextParisIsins()).containsExactlyInAnyOrder("IE000F60HVH9", "LU1708330318");
+    assertThat(getEuronextParisIsins())
+        .containsExactlyInAnyOrder("IE000F60HVH9", "IE000QWCYQT0", "LU1708330318");
   }
 
   @Test


### PR DESCRIPTION
## What

Register **Amundi MSCI World Screened UCITS ETF** (ISIN `IE000QWCYQT0`, Euronext Paris ticker `WLSC`) in the `FundTicker` enum so the system starts collecting and resolving its price data.

| Field | Value |
|---|---|
| Yahoo | `WLSC.PA` |
| EODHD | `WLSC.PA.EODHD` |
| ISIN | `IE000QWCYQT0` |
| Bloomberg | `WLSC` (BBG `WLSC FP`) |
| Benchmark category | `EQUITY_DM` |

## Why

Needed for price collection, NAV/position pricing, and tracking-difference once the fund is added to a model portfolio.

## How

Follows the existing `AMUNDI_USA_SCREENED` pattern for Euronext-Paris-listed funds (`.PA` / `.PA.EODHD`). No new code required — the instrument is automatically:
- **collected** by `EuronextValueRetriever` (stored `IE000QWCYQT0.XPAR`) and `EODHDValueRetriever` (stored `WLSC.PA.EODHD`),
- **resolved** by `PriorityPriceProvider` via its existing `EURONEXT` and `EODHD` feeds.

## Notes

- `FundTicker` is still the live source of truth (the `instrument_reference` DB table from #1655 is not yet merged). Once that lands, future instruments become an `INSERT` instead of a code change.
- The Euronext Paris listing trades in EUR while the fund's base currency is USD — identical to the existing `AMUNDI_USA_SCREENED` setup, so it inherits the proven path.

## Tests

- Updated `getEuronextParisIsinsReturnsOnlyParisTradedEtfs` to include the new ISIN.
- `FundTickerTest`, `EODHDValueRetrieverTest`, full `comparisons.fundvalue.*` and `investment.check.tracking.*` packages — all green. Spotless clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)