### PR TITLE
Exclude Yahoo from price data freshness check

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/comparisons/fundvalue/PriceDataFreshnessAlertJob.java
+++ b/src/main/java/ee/tuleva/onboarding/comparisons/fundvalue/PriceDataFreshnessAlertJob.java
@@ -111,7 +111,6 @@ public class PriceDataFreshnessAlertJob {
           .getEuronextParisStorageKey()
           .ifPresent(key -> map.put(key, new ProviderKey("EURONEXT", key)));
       map.put(ticker.getEodhdTicker(), new ProviderKey("EODHD", ticker.getEodhdTicker()));
-      map.put(ticker.getYahooTicker(), new ProviderKey("YAHOO", ticker.getYahooTicker()));
     }
     return map;
   }

--- a/src/test/groovy/ee/tuleva/onboarding/comparisons/fundvalue/PriceDataFreshnessAlertJobTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/comparisons/fundvalue/PriceDataFreshnessAlertJobTest.java
@@ -174,14 +174,14 @@ class PriceDataFreshnessAlertJobTest {
 
     Map<String, LocalDate> latestDates = buildAllFreshDates(tuesday);
     makeEodhdStale(latestDates, friday);
-    makeYahooStale(latestDates, friday);
+    makeXetraStale(latestDates, friday);
     when(fundValueRepository.findLatestDateByKeys(any())).thenReturn(latestDates);
 
     job.checkAfterIndexing();
 
     verify(notificationService)
         .sendMessage(
-            argThat((String msg) -> msg.contains("EODHD") && msg.contains("YAHOO")),
+            argThat((String msg) -> msg.contains("EODHD") && msg.contains("DEUTSCHE_BOERSE")),
             eq(INVESTMENT));
   }
 
@@ -257,8 +257,18 @@ class PriceDataFreshnessAlertJobTest {
     Set<String> providers = new HashSet<>();
     map.values().forEach(pk -> providers.add(pk.provider()));
 
-    assertThat(providers)
-        .containsExactlyInAnyOrder("DEUTSCHE_BOERSE", "EURONEXT", "EODHD", "YAHOO");
+    assertThat(providers).containsExactlyInAnyOrder("DEUTSCHE_BOERSE", "EURONEXT", "EODHD");
+  }
+
+  @Test
+  void buildKeyToProviderMap_excludesYahoo() {
+    List<FundTicker> etfTickers = PriceDataFreshnessAlertJob.getEtfTickers();
+    Map<String, PriceDataFreshnessAlertJob.ProviderKey> map =
+        PriceDataFreshnessAlertJob.buildKeyToProviderMap(etfTickers);
+
+    assertThat(map.values()).noneMatch(pk -> pk.provider().equals("YAHOO"));
+    assertThat(map.keySet())
+        .doesNotContainAnyElementsOf(etfTickers.stream().map(FundTicker::getYahooTicker).toList());
   }
 
   private void stubAllKeysWithDate(LocalDate date) {
@@ -281,10 +291,10 @@ class PriceDataFreshnessAlertJobTest {
     }
   }
 
-  private void makeYahooStale(Map<String, LocalDate> latestDates, LocalDate staleDate) {
+  private void makeXetraStale(Map<String, LocalDate> latestDates, LocalDate staleDate) {
     List<FundTicker> etfTickers = PriceDataFreshnessAlertJob.getEtfTickers();
     for (FundTicker ticker : etfTickers) {
-      latestDates.put(ticker.getYahooTicker(), staleDate);
+      ticker.getXetraStorageKey().ifPresent(key -> latestDates.put(key, staleDate));
     }
   }
 


### PR DESCRIPTION
## Problem

The `PriceDataFreshnessAlertJob` fired a false `PRICE DATA STALE` alert almost every morning:

```
PRICE DATA STALE — check before NAV calculation at 11:00, expectedDate=2026-06-16
  YAHOO: 21 instruments missing (SGAS.DE, SLMC.DE, SGAJ.DE, ESGM.DE, XRSM.DE, ...)
```

Yahoo EOD prices for European ETFs arrive late in the day, but the check runs hourly and alerts once per day starting from the first run at/after 07:00 Tallinn — before Yahoo has updated. At that point the exchange (Deutsche Börse / Euronext) and EODHD feeds already have the price, so NAV is fully ready and the alert is pure noise.

## Fix

Yahoo is the lowest-priority NAV fallback in `PriorityPriceProvider` (BLACKROCK → MORNINGSTAR → EODHD → DEUTSCHE_BOERSE → EURONEXT → YAHOO) and is already cross-checked hourly by `FundValueIntegrityChecker`. Its morning lag never blocks the 11:00 NAV run.

This drops the `YAHOO` key from `buildKeyToProviderMap`, so the freshness check only watches the NAV-critical sources: **DEUTSCHE_BOERSE, EURONEXT, EODHD**. A broken EODHD or exchange import still pages.

## Out of scope

The separate new-instrument case (a freshly-seeded ticker with no price history flagged as `DEUTSCHE_BOERSE` stale) is unaffected and can be handled in a follow-up.

## Tests

- Updated `multipleStaleProviders_singleMessage` to use a stale exchange feed instead of Yahoo
- Provider-set assertion no longer expects `YAHOO`
- Added `buildKeyToProviderMap_excludesYahoo`
- `PriceDataFreshnessAlertJobTest` green, Spotless clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)