### PR TITLE
Add Xtrackers MSCI World Screened to TUK75/TUV100 model portfolio order

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/fund/TulevaFund.java
+++ b/src/main/java/ee/tuleva/onboarding/fund/TulevaFund.java
@@ -29,6 +29,7 @@ public enum TulevaFund {
           "IE00BFNM3G45",
           "IE00BFNM3D14",
           "IE00BFNM3L97",
+          "IE000I9HGDZ3",
           "IE00BKPTWY98")),
   TUK00(
       "TUK00",
@@ -59,6 +60,7 @@ public enum TulevaFund {
           "IE00BFNM3G45",
           "IE00BFNM3D14",
           "IE00BFNM3L97",
+          "IE000I9HGDZ3",
           "IE00BKPTWY98")),
   TKF100(
       "TKF100",


### PR DESCRIPTION
## What

Adds `IE000I9HGDZ3` (Xtrackers MSCI World Screened UCITS ETF) to the `modelPortfolioOrder` lists of **TUK75** and **TUV100**, positioned directly above the EM fund (`IE00BKPTWY98`).

## Why

The ETF joined both model portfolios in the 2026-06 switch (allocation/limit rows already in prod). `modelPortfolioOrder` controls only the **row ordering of the NAV report** — its sole consumer is `NavReportMapper.sortedSecurities()`. Without this entry the instrument would sort to the bottom of the report once held.

## Impact

- **No functional/behavioural change.** Not read by trade calc, limit checks, pricing, tracking difference, or settlement — only NAV-report display order.
- **No-op until the position is actually held** — `sortedSecurities()` only orders securities present in the report; an unheld ISIN is never looked up.
- Old regional ETFs (`IE00BFNM3G45/D14/L97`) kept in the list for the transition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)