### PR TITLE
Transaction registry: integrity-defect & regulatory remediation (D1–D10, N1–N8, R1–R3/R5/R6, GP1–GP7)

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/investment/epis/EpisReportSummary.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/epis/EpisReportSummary.java
@@ -58,6 +58,11 @@ public class EpisReportSummary {
   @JdbcTypeCode(JSON)
   private Map<String, Object> data = Map.of();
 
+  @NotNull
+  @Builder.Default
+  @Column(name = "complete")
+  private Boolean complete = true;
+
   private Instant createdAt;
 
   @PrePersist

--- a/src/main/java/ee/tuleva/onboarding/investment/epis/EpisReportSummaryRepository.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/epis/EpisReportSummaryRepository.java
@@ -15,6 +15,8 @@ public interface EpisReportSummaryRepository extends JpaRepository<EpisReportSum
   Optional<EpisReportSummary> findTopByReportTypeAndFundOrderByReportDateDescIdDesc(
       ReportType reportType, TulevaFund fund);
 
+  Optional<EpisReportSummary> findByReportIdAndFund(Long reportId, TulevaFund fund);
+
   List<EpisReportSummary> findByReportId(Long reportId);
 
   @Modifying(flushAutomatically = true, clearAutomatically = true)

--- a/src/main/java/ee/tuleva/onboarding/investment/epis/PevaRavaFlowService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/epis/PevaRavaFlowService.java
@@ -5,15 +5,12 @@ import static ee.tuleva.onboarding.investment.config.InvestmentParameter.PEVA_RA
 import static ee.tuleva.onboarding.investment.config.InvestmentParameter.PEVA_RAVA_TRADE_BUFFER_PERCENT;
 import static ee.tuleva.onboarding.investment.config.InvestmentParameter.PEVA_RAVA_TRADE_ROUNDING_STEP;
 import static ee.tuleva.onboarding.investment.epis.SummaryData.number;
-import static ee.tuleva.onboarding.investment.report.ReportType.R17_PEVA;
-import static ee.tuleva.onboarding.investment.report.ReportType.R21_RAVA;
 import static java.math.BigDecimal.ONE;
 import static java.math.BigDecimal.ZERO;
 import static java.math.RoundingMode.CEILING;
 
 import ee.tuleva.onboarding.fund.TulevaFund;
 import ee.tuleva.onboarding.investment.config.InvestmentParameterRepository;
-import ee.tuleva.onboarding.investment.report.ReportType;
 import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.LocalDate;
@@ -22,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.Nullable;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -35,6 +33,8 @@ public class PevaRavaFlowService {
   private final EpisReportSummaryRepository summaryRepository;
   private final OwnFundNavProvider ownFundNavProvider;
   private final InvestmentParameterRepository parameterRepository;
+  private final PevaRavaCycleRepository cycleRepository;
+  private final PevaRavaPeriodService periodService;
   private final Clock clock;
 
   public Map<TulevaFund, PevaRavaFlows> calculateFlows() {
@@ -50,8 +50,12 @@ public class PevaRavaFlowService {
   }
 
   private Optional<PevaRavaFlows> calculateFlows(TulevaFund fund, LocalDate asOfDate) {
-    Optional<EpisReportSummary> r17 = latestSummary(R17_PEVA, fund);
-    Optional<EpisReportSummary> r21 = latestSummary(R21_RAVA, fund);
+    Optional<PevaRavaCycleEntity> activeCycle = activeCycle(asOfDate);
+    if (activeCycle.isEmpty()) {
+      return Optional.empty();
+    }
+    Optional<EpisReportSummary> r17 = summaryForReport(activeCycle.get().getR17ReportId(), fund);
+    Optional<EpisReportSummary> r21 = summaryForReport(activeCycle.get().getR21ReportId(), fund);
     if (r17.isEmpty() && r21.isEmpty()) {
       return Optional.empty();
     }
@@ -117,8 +121,16 @@ public class PevaRavaFlowService {
     }
   }
 
-  private Optional<EpisReportSummary> latestSummary(ReportType reportType, TulevaFund fund) {
-    return summaryRepository.findTopByReportTypeAndFundOrderByReportDateDescIdDesc(
-        reportType, fund);
+  private Optional<PevaRavaCycleEntity> activeCycle(LocalDate asOfDate) {
+    return periodService
+        .getCurrentPeriod(asOfDate)
+        .flatMap(period -> cycleRepository.findByExecDate(period.cycle().execDate()));
+  }
+
+  private Optional<EpisReportSummary> summaryForReport(@Nullable Long reportId, TulevaFund fund) {
+    if (reportId == null) {
+      return Optional.empty();
+    }
+    return summaryRepository.findByReportIdAndFund(reportId, fund);
   }
 }

--- a/src/main/java/ee/tuleva/onboarding/investment/epis/R45ReportService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/epis/R45ReportService.java
@@ -5,13 +5,16 @@ import static ee.tuleva.onboarding.investment.epis.SummaryData.number;
 import static ee.tuleva.onboarding.investment.epis.parser.EpisCsvParser.findDate;
 import static ee.tuleva.onboarding.investment.epis.parser.EpisCsvParser.findValue;
 import static ee.tuleva.onboarding.investment.report.ReportType.R45;
+import static ee.tuleva.onboarding.notification.OperationsNotificationService.Channel.INVESTMENT;
 
 import ee.tuleva.onboarding.fund.TulevaFund;
 import ee.tuleva.onboarding.investment.epis.parser.EpisCsvParser;
 import ee.tuleva.onboarding.investment.epis.parser.R45ParseResult;
 import ee.tuleva.onboarding.investment.epis.parser.R45ReportParser;
+import ee.tuleva.onboarding.investment.epis.parser.R45UnvaluedRow;
 import ee.tuleva.onboarding.investment.report.InvestmentReport;
 import ee.tuleva.onboarding.investment.report.InvestmentReportRepository;
+import ee.tuleva.onboarding.notification.OperationsNotificationService;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -21,6 +24,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.Nullable;
@@ -40,6 +45,7 @@ public class R45ReportService {
   private final OwnFundNavProvider ownFundNavProvider;
   private final R45ReportParser r45ReportParser;
   private final EpisCsvParser csvParser;
+  private final OperationsNotificationService notificationService;
 
   @Transactional
   public Map<TulevaFund, R45Result> processAndStore(Long reportId) {
@@ -56,11 +62,16 @@ public class R45ReportService {
     String csv = rawCsv(report);
     LocalDate reportDate = report.getReportDate();
     R45ParseResult parsed = r45ReportParser.parse(csv, reportDate, fallbackNavsByIsin(reportDate));
+    Set<String> incompleteFundCodes =
+        parsed.unvaluedRows().stream()
+            .map(R45UnvaluedRow::fundCode)
+            .collect(Collectors.toUnmodifiableSet());
     if (!parsed.unvaluedRows().isEmpty()) {
       log.warn(
           "R45 rows without NAV could not be valued: reportId={}, unvaluedRows={}",
           reportId,
           parsed.unvaluedRows());
+      notificationService.sendMessage(unvaluedAlertMessage(reportId, parsed), INVESTMENT);
     }
     Map<String, List<LocalDate>> redRowDates = redRowSettlementDatesByFundCode(csv);
 
@@ -72,7 +83,14 @@ public class R45ReportService {
     summaryRepository.deleteByReportId(reportId);
     summaryRepository.saveAll(
         results.entrySet().stream()
-            .map(entry -> toSummary(report, entry.getKey(), entry.getValue(), redRowDates))
+            .map(
+                entry ->
+                    toSummary(
+                        report,
+                        entry.getKey(),
+                        entry.getValue(),
+                        redRowDates,
+                        !incompleteFundCodes.contains(entry.getKey().getCode())))
             .toList());
     return results;
   }
@@ -93,6 +111,12 @@ public class R45ReportService {
     return flows;
   }
 
+  public List<TulevaFund> getIncompleteFunds() {
+    return Arrays.stream(TulevaFund.values())
+        .filter(fund -> latestSummary(fund).map(summary -> !summary.getComplete()).orElse(false))
+        .toList();
+  }
+
   public List<LocalDate> getLatestRedRowSettlementDates(TulevaFund fund) {
     return latestSummary(fund)
         .map(summary -> dates(summary.getData(), "redRowSettlementDates"))
@@ -107,13 +131,15 @@ public class R45ReportService {
       InvestmentReport report,
       TulevaFund fund,
       R45Result result,
-      Map<String, List<LocalDate>> redRowDates) {
+      Map<String, List<LocalDate>> redRowDates,
+      boolean complete) {
     return EpisReportSummary.builder()
         .reportId(report.getId())
         .reportType(R45)
         .reportDate(report.getReportDate())
         .fund(fund)
         .fundIsin(fund.getIsin())
+        .complete(complete)
         .data(
             Map.of(
                 "inflowEur", result.inflowEur(),
@@ -124,6 +150,19 @@ public class R45ReportService {
                         .map(LocalDate::toString)
                         .toList()))
         .build();
+  }
+
+  private static String unvaluedAlertMessage(Long reportId, R45ParseResult parsed) {
+    StringBuilder message =
+        new StringBuilder(
+            "⚠️ R45 ridu ilma NAV-ita ei saanud hinnata (vooge blokeeritud kuni NAV lisatakse): reportId=%s"
+                .formatted(reportId));
+    for (R45UnvaluedRow row : parsed.unvaluedRows()) {
+      message.append(
+          "\n%s %s: %s osakut, ISIN %s"
+              .formatted(row.fundCode(), row.transactionType(), row.units(), row.isin()));
+    }
+    return message.toString();
   }
 
   private Map<String, List<LocalDate>> redRowSettlementDatesByFundCode(String csv) {

--- a/src/main/java/ee/tuleva/onboarding/investment/portfolio/FundLimit.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/portfolio/FundLimit.java
@@ -1,5 +1,6 @@
 package ee.tuleva.onboarding.investment.portfolio;
 
+import static ee.tuleva.onboarding.time.ClockHolder.clock;
 import static jakarta.persistence.EnumType.STRING;
 
 import ee.tuleva.onboarding.fund.TulevaFund;
@@ -52,6 +53,8 @@ public class FundLimit {
 
   @PrePersist
   protected void onCreate() {
-    createdAt = Instant.now();
+    if (createdAt == null) {
+      createdAt = clock().instant();
+    }
   }
 }

--- a/src/main/java/ee/tuleva/onboarding/investment/portfolio/ModelPortfolioAllocationRepository.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/portfolio/ModelPortfolioAllocationRepository.java
@@ -13,8 +13,9 @@ public interface ModelPortfolioAllocationRepository
   List<ModelPortfolioAllocation> findByFundAndEffectiveDate(
       TulevaFund fund, LocalDate effectiveDate);
 
-  Optional<ModelPortfolioAllocation> findFirstByIsinAndProviderIsNotNullOrderByEffectiveDateDesc(
-      String isin);
+  Optional<ModelPortfolioAllocation>
+      findFirstByIsinAndProviderIsNotNullAndEffectiveDateLessThanEqualOrderByEffectiveDateDesc(
+          String isin, LocalDate effectiveDate);
 
   // Snapshot semantics: a model portfolio is versioned as a whole, so all allocations on a given
   // effective date form one indivisible version. Returns every row from the single newest

--- a/src/main/java/ee/tuleva/onboarding/investment/report/InvestmentReportService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/report/InvestmentReportService.java
@@ -3,6 +3,7 @@ package ee.tuleva.onboarding.investment.report;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.util.List;
@@ -20,6 +21,7 @@ public class InvestmentReportService {
 
   private final InvestmentReportRepository repository;
   private final CsvToJsonConverter csvConverter;
+  private final Clock clock;
 
   @Transactional
   public InvestmentReport saveReport(
@@ -57,7 +59,7 @@ public class InvestmentReportService {
             .reportDate(reportDate)
             .rawData(rawData)
             .metadata(metadata)
-            .createdAt(Instant.now())
+            .createdAt(Instant.now(clock))
             .build();
 
     log.info(

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/BatchStatus.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/BatchStatus.java
@@ -3,5 +3,6 @@ package ee.tuleva.onboarding.investment.transaction;
 public enum BatchStatus {
   AWAITING_CONFIRMATION,
   CONFIRMED,
-  SENT
+  SENT,
+  CANCELLED
 }

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/CancelTransactionBatchRequest.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/CancelTransactionBatchRequest.java
@@ -1,0 +1,7 @@
+package ee.tuleva.onboarding.investment.transaction;
+
+import jakarta.validation.constraints.NotBlank;
+import org.jspecify.annotations.NullMarked;
+
+@NullMarked
+public record CancelTransactionBatchRequest(@NotBlank String reason) {}

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/FtConfirmation.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/FtConfirmation.java
@@ -3,6 +3,8 @@ package ee.tuleva.onboarding.investment.transaction;
 import static ee.tuleva.onboarding.investment.transaction.FtConfirmationType.CANCELLATION;
 import static ee.tuleva.onboarding.investment.transaction.FtConfirmationType.NORMAL;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import ee.tuleva.onboarding.fund.TulevaFund;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -19,12 +21,34 @@ public record FtConfirmation(
     @NotNull BigDecimal quantity,
     @NotNull BigDecimal grossPrice,
     FtConfirmationType type,
-    @Nullable String account) {
+    @Nullable String account,
+    boolean suppressed) {
 
   public FtConfirmation {
     if (type == null) {
       type = NORMAL;
     }
+  }
+
+  @JsonCreator
+  public FtConfirmation(
+      @JsonProperty("fund") TulevaFund fund,
+      @JsonProperty("isin") String isin,
+      @JsonProperty("tradeDate") LocalDate tradeDate,
+      @JsonProperty("quantity") BigDecimal quantity,
+      @JsonProperty("grossPrice") BigDecimal grossPrice,
+      @JsonProperty("type") @Nullable FtConfirmationType type,
+      @JsonProperty("account") @Nullable String account,
+      @JsonProperty("suppressed") @Nullable Boolean suppressed) {
+    this(
+        fund,
+        isin,
+        tradeDate,
+        quantity,
+        grossPrice,
+        type,
+        account,
+        Boolean.TRUE.equals(suppressed));
   }
 
   public FtConfirmation(
@@ -33,7 +57,18 @@ public record FtConfirmation(
       LocalDate tradeDate,
       BigDecimal quantity,
       BigDecimal grossPrice) {
-    this(fund, isin, tradeDate, quantity, grossPrice, NORMAL, null);
+    this(fund, isin, tradeDate, quantity, grossPrice, NORMAL, null, false);
+  }
+
+  public FtConfirmation(
+      TulevaFund fund,
+      String isin,
+      LocalDate tradeDate,
+      BigDecimal quantity,
+      BigDecimal grossPrice,
+      FtConfirmationType type,
+      @Nullable String account) {
+    this(fund, isin, tradeDate, quantity, grossPrice, type, account, false);
   }
 
   public boolean isCancellation() {

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/FtConfirmation.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/FtConfirmation.java
@@ -1,11 +1,15 @@
 package ee.tuleva.onboarding.investment.transaction;
 
+import static ee.tuleva.onboarding.investment.transaction.FtConfirmationType.CANCELLATION;
+import static ee.tuleva.onboarding.investment.transaction.FtConfirmationType.NORMAL;
+
 import ee.tuleva.onboarding.fund.TulevaFund;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 @NullMarked
 public record FtConfirmation(
@@ -13,4 +17,35 @@ public record FtConfirmation(
     @NotBlank String isin,
     @NotNull LocalDate tradeDate,
     @NotNull BigDecimal quantity,
-    @NotNull BigDecimal grossPrice) {}
+    @NotNull BigDecimal grossPrice,
+    FtConfirmationType type,
+    @Nullable String account) {
+
+  public FtConfirmation {
+    if (type == null) {
+      type = NORMAL;
+    }
+  }
+
+  public FtConfirmation(
+      TulevaFund fund,
+      String isin,
+      LocalDate tradeDate,
+      BigDecimal quantity,
+      BigDecimal grossPrice) {
+    this(fund, isin, tradeDate, quantity, grossPrice, NORMAL, null);
+  }
+
+  public boolean isCancellation() {
+    return type == CANCELLATION;
+  }
+
+  public String cancellationSignature() {
+    return String.join(
+        "|",
+        isin,
+        account == null ? "" : account,
+        tradeDate.toString(),
+        grossPrice.toPlainString());
+  }
+}

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/FtConfirmationType.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/FtConfirmationType.java
@@ -3,11 +3,7 @@ package ee.tuleva.onboarding.investment.transaction;
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked
-public enum FtVerificationStatus {
-  OK,
-  ERROR,
-  PENDING_EXECUTION,
-  PENDING_NAV,
-  CANCELLED,
-  AMBIGUOUS
+public enum FtConfirmationType {
+  NORMAL,
+  CANCELLATION
 }

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/FtVerificationStatus.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/FtVerificationStatus.java
@@ -9,5 +9,6 @@ public enum FtVerificationStatus {
   PENDING_EXECUTION,
   PENDING_NAV,
   CANCELLED,
-  AMBIGUOUS
+  AMBIGUOUS,
+  IGNORED
 }

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/SettlementDateCalculator.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/SettlementDateCalculator.java
@@ -25,15 +25,31 @@ public class SettlementDateCalculator {
 
   public LocalDate calculateSettlementDate(
       LocalDate tradeDate, InstrumentType instrumentType, String isin) {
+    int businessDays =
+        switch (instrumentType) {
+          case ETF -> ETF_SETTLEMENT_BUSINESS_DAYS;
+          case FUND -> FUND_SETTLEMENT_BUSINESS_DAYS;
+        };
+    return addBusinessDays(tradeDate, instrumentType, isin, businessDays);
+  }
+
+  public LocalDate addBusinessDays(
+      LocalDate tradeDate, InstrumentType instrumentType, String isin, int businessDays) {
+    return calendarFor(instrumentType, isin, tradeDate).addBusinessDays(tradeDate, businessDays);
+  }
+
+  private TradingCalendar calendarFor(
+      InstrumentType instrumentType, String isin, LocalDate tradeDate) {
     return switch (instrumentType) {
-      case ETF -> target2Calendar.addBusinessDays(tradeDate, ETF_SETTLEMENT_BUSINESS_DAYS);
-      case FUND -> fundCalendar(isin).addBusinessDays(tradeDate, FUND_SETTLEMENT_BUSINESS_DAYS);
+      case ETF -> target2Calendar;
+      case FUND -> fundCalendar(isin, tradeDate);
     };
   }
 
-  private TradingCalendar fundCalendar(String isin) {
+  private TradingCalendar fundCalendar(String isin, LocalDate tradeDate) {
     return allocationRepository
-        .findFirstByIsinAndProviderIsNotNullOrderByEffectiveDateDesc(isin)
+        .findFirstByIsinAndProviderIsNotNullAndEffectiveDateLessThanEqualOrderByEffectiveDateDesc(
+            isin, tradeDate)
         .map(ModelPortfolioAllocation::getProvider)
         .map(Provider::getDomicile)
         .map(domicileCalendar::forDomicile)

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionAdminService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionAdminService.java
@@ -6,6 +6,7 @@ import static org.springframework.http.HttpStatus.NOT_FOUND;
 import ee.tuleva.onboarding.fund.TulevaFund;
 import java.math.BigDecimal;
 import java.time.Clock;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.Base64;
@@ -18,6 +19,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
 @Slf4j
@@ -29,6 +31,7 @@ class TransactionAdminService {
   private final TransactionCommandRepository commandRepository;
   private final TransactionBatchRepository batchRepository;
   private final TransactionOrderRepository orderRepository;
+  private final TransactionAuditEventRepository auditEventRepository;
   private final TransactionPreparationService preparationService;
   private final Clock clock;
 
@@ -78,7 +81,7 @@ class TransactionAdminService {
                 TransactionBatchResponse.from(batch, orderRepository.findByBatchId(batch.getId())));
   }
 
-  TransactionBatchResponse confirmAndFinalize(Long id) {
+  TransactionBatchResponse confirmAndFinalize(Long id, String actor) {
     TransactionBatch batch =
         batchRepository
             .findById(id)
@@ -90,10 +93,60 @@ class TransactionAdminService {
       throw new ResponseStatusException(
           CONFLICT, "Batch not awaiting confirmation: id=" + id + ", status=" + batch.getStatus());
     }
-    log.info("Admin confirmed transaction batch: id={}", id);
+    log.info("Admin confirmed transaction batch: id={}, actor={}", id, actor);
     batch.setStatus(BatchStatus.CONFIRMED);
+    batch.setConfirmedBy(actor);
+    batch.setConfirmedAt(Instant.now(clock));
     preparationService.finalizeConfirmedBatch(batch);
     return TransactionBatchResponse.from(batch, orderRepository.findByBatchId(batch.getId()));
+  }
+
+  @Transactional
+  TransactionBatchResponse cancelBatch(Long id, String reason, String actor) {
+    TransactionBatch batch =
+        batchRepository
+            .findById(id)
+            .orElseThrow(
+                () ->
+                    new ResponseStatusException(
+                        NOT_FOUND, "Transaction batch not found: id=" + id));
+    List<TransactionOrder> orders = orderRepository.findByBatchId(batch.getId());
+    if (orders.stream().anyMatch(TransactionAdminService::isInMarket)) {
+      throw new ResponseStatusException(
+          CONFLICT,
+          "Batch has orders past SENT and cannot be cancelled: id="
+              + id
+              + ", status="
+              + batch.getStatus());
+    }
+    Instant now = Instant.now(clock);
+    log.info("Admin cancelled transaction batch: id={}, actor={}, reason={}", id, actor, reason);
+    batch.setStatus(BatchStatus.CANCELLED);
+    batch.setCancellationReason(reason);
+    batch.setCancelledBy(actor);
+    batch.setCancelledAt(now);
+    batchRepository.save(batch);
+
+    orders.stream()
+        .filter(order -> order.getOrderStatus() != OrderStatus.CANCELLED)
+        .forEach(order -> order.setOrderStatus(OrderStatus.CANCELLED));
+    orderRepository.saveAll(orders);
+
+    auditEventRepository.save(
+        TransactionAuditEvent.builder()
+            .batch(batch)
+            .eventType("BATCH_CANCELLED")
+            .actor(actor)
+            .createdAt(now)
+            .payload(Map.of("reason", reason, "actor", actor, "orderCount", orders.size()))
+            .build());
+
+    return TransactionBatchResponse.from(batch, orders);
+  }
+
+  private static boolean isInMarket(TransactionOrder order) {
+    return order.getOrderStatus() == OrderStatus.EXECUTED
+        || order.getOrderStatus() == OrderStatus.SETTLED;
   }
 
   Optional<byte[]> exportFile(Long id, String type) {

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionBatch.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionBatch.java
@@ -53,6 +53,16 @@ public class TransactionBatch {
 
   private Instant createdAt;
 
+  private String confirmedBy;
+
+  private Instant confirmedAt;
+
+  private String cancellationReason;
+
+  private String cancelledBy;
+
+  private Instant cancelledAt;
+
   @PrePersist
   protected void onCreate() {
     if (createdAt == null) {

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionCommandController.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionCommandController.java
@@ -99,13 +99,33 @@ public class TransactionCommandController {
 
   @PostMapping("/transaction-batches/{id}/confirm")
   public TransactionBatchResponse confirmBatch(
-      @RequestHeader("X-Admin-Token") String token, @PathVariable Long id) {
+      @RequestHeader("X-Admin-Token") String token,
+      @RequestHeader(name = "X-Admin-Actor", required = false, defaultValue = "admin") String actor,
+      @PathVariable Long id) {
 
     validateToken(token);
 
-    log.info("Admin triggered transaction batch confirmation: id={}", id);
+    log.info("Admin triggered transaction batch confirmation: id={}, actor={}", id, actor);
 
-    return adminService.confirmAndFinalize(id);
+    return adminService.confirmAndFinalize(id, actor);
+  }
+
+  @PostMapping("/transaction-batches/{id}/cancel")
+  public TransactionBatchResponse cancelBatch(
+      @RequestHeader("X-Admin-Token") String token,
+      @RequestHeader(name = "X-Admin-Actor", required = false, defaultValue = "admin") String actor,
+      @PathVariable Long id,
+      @Valid @RequestBody CancelTransactionBatchRequest request) {
+
+    validateToken(token);
+
+    log.info(
+        "Admin triggered transaction batch cancellation: id={}, actor={}, reason={}",
+        id,
+        actor,
+        request.reason());
+
+    return adminService.cancelBatch(id, request.reason(), actor);
   }
 
   @GetMapping("/transaction-batches/{id}/exports/{type}")

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionCommandJob.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionCommandJob.java
@@ -3,6 +3,8 @@ package ee.tuleva.onboarding.investment.transaction;
 import static ee.tuleva.onboarding.investment.JobRunSchedule.*;
 
 import ee.tuleva.onboarding.investment.event.RunTransactionCommandRequested;
+import java.time.Clock;
+import java.time.Instant;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
@@ -22,6 +24,7 @@ public class TransactionCommandJob {
   private final TransactionBatchRepository batchRepository;
   private final TransactionPreparationService preparationService;
   private final ApplicationEventPublisher eventPublisher;
+  private final Clock clock;
 
   @Scheduled(cron = TRANSACTION_COMMAND, zone = TIMEZONE)
   @SchedulerLock(name = "TransactionCommandJob", lockAtMostFor = "5m", lockAtLeastFor = "30s")
@@ -50,6 +53,10 @@ public class TransactionCommandJob {
         preparationService.processCommand(command);
       } catch (Exception e) {
         log.error("Unexpected error processing command: id={}", command.getId(), e);
+        command.setStatus(CommandStatus.FAILED);
+        command.setErrorMessage(e.getMessage());
+        command.setProcessedAt(Instant.now(clock));
+        commandRepository.save(command);
       }
     }
   }

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionExecutionRepository.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionExecutionRepository.java
@@ -14,6 +14,8 @@ public interface TransactionExecutionRepository extends JpaRepository<Transactio
 
   Optional<TransactionExecution> findByBrokerTransactionId(String brokerTransactionId);
 
+  List<TransactionExecution> findAllByBrokerTransactionId(String brokerTransactionId);
+
   List<TransactionExecution> findByOrderIdIn(Collection<Long> orderIds);
 
   // Half-open range [fromInclusive, toExclusive) so a trade-date window

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionInputService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionInputService.java
@@ -326,6 +326,12 @@ public class TransactionInputService {
   }
 
   private BigDecimal getR45Net(TulevaFund fund) {
+    if (r45ReportService.getIncompleteFunds().contains(fund)) {
+      throw new IllegalStateException(
+          "R45 summary incomplete: fund="
+              + fund
+              + ", reason=unvalued R45 rows missing NAV, action=supply NAV and reprocess R45");
+    }
     R45Result result = r45ReportService.getLatestFlows().get(fund);
     return result == null ? ZERO : result.netEur();
   }

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionPreparationService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionPreparationService.java
@@ -8,6 +8,7 @@ import ee.tuleva.onboarding.comparisons.fundvalue.ResolvedPrice;
 import ee.tuleva.onboarding.investment.portfolio.ModelPortfolioAllocation;
 import ee.tuleva.onboarding.investment.portfolio.ModelPortfolioAllocationRepository;
 import ee.tuleva.onboarding.investment.transaction.calculation.TradeCalculationEngine;
+import ee.tuleva.onboarding.investment.transaction.export.CustodianOrderEmailSender;
 import ee.tuleva.onboarding.investment.transaction.export.GoogleDriveProperties;
 import ee.tuleva.onboarding.investment.transaction.export.TransactionExportService;
 import ee.tuleva.onboarding.investment.transaction.export.TransactionExportUploader;
@@ -49,6 +50,7 @@ public class TransactionPreparationService {
   private final ApplicationEventPublisher eventPublisher;
   private final GoogleDriveProperties driveProperties;
   @Nullable private final TransactionExportUploader exportUploader;
+  private final CustodianOrderEmailSender custodianOrderEmailSender;
   private final Clock clock;
 
   @Transactional
@@ -88,7 +90,7 @@ public class TransactionPreparationService {
               .createdAt(Instant.now(clock))
               .payload(
                   Map.of(
-                      "input", serializeInput(input),
+                      "input", serializeInput(input, command.getManualAdjustments()),
                       "output", serializeTrades(result.trades()),
                       "summary",
                           Map.of(
@@ -191,11 +193,13 @@ public class TransactionPreparationService {
       byte[] sebFundXlsx,
       byte[] sebEtfXlsx,
       byte[] ftEtfXlsx) {
-    Map<String, String> driveFileUrls =
-        uploadExportsToDrive(batch, timestamp, sebFundXlsx, sebEtfXlsx, ftEtfXlsx);
+    var exports =
+        Map.of("sebFundXlsx", sebFundXlsx, "sebEtfXlsx", sebEtfXlsx, "ftEtfXlsx", ftEtfXlsx);
+    Map<String, String> driveFileUrls = uploadExportsToDrive(batch, timestamp, exports);
     if (!driveFileUrls.isEmpty()) {
       persistDriveFileUrls(batch, driveFileUrls);
     }
+    custodianOrderEmailSender.send(batch.getFund(), timestamp, exports);
     eventPublisher.publishEvent(
         new BatchFinalizedEvent(batch.getId(), orderCount, tradeDate.toString(), driveFileUrls));
   }
@@ -283,7 +287,8 @@ public class TransactionPreparationService {
     return instrumentType == InstrumentType.FUND && transactionType == TransactionType.BUY;
   }
 
-  static Map<String, Object> serializeInput(FundTransactionInput input) {
+  static Map<String, Object> serializeInput(
+      FundTransactionInput input, Map<String, Object> manualAdjustments) {
     return Map.ofEntries(
         Map.entry(
             "positions",
@@ -317,7 +322,8 @@ public class TransactionPreparationService {
                             Map.of(
                                 "softLimit", entry.getValue().softLimit().toPlainString(),
                                 "hardLimit", entry.getValue().hardLimit().toPlainString())))),
-        Map.entry("fastSellIsins", List.copyOf(input.fastSellIsins())));
+        Map.entry("fastSellIsins", List.copyOf(input.fastSellIsins())),
+        Map.entry("manualAdjustments", Map.copyOf(manualAdjustments)));
   }
 
   static List<Map<String, Object>> serializeTrades(List<TradeCalculation> trades) {
@@ -342,17 +348,11 @@ public class TransactionPreparationService {
   }
 
   private Map<String, String> uploadExportsToDrive(
-      TransactionBatch batch,
-      Instant timestamp,
-      byte[] sebFundXlsx,
-      byte[] sebEtfXlsx,
-      byte[] ftEtfXlsx) {
+      TransactionBatch batch, Instant timestamp, Map<String, byte[]> exports) {
     if (!driveProperties.enabled() || exportUploader == null) {
       return Map.of();
     }
     try {
-      var exports =
-          Map.of("sebFundXlsx", sebFundXlsx, "sebEtfXlsx", sebEtfXlsx, "ftEtfXlsx", ftEtfXlsx);
       return exportUploader.uploadExports(
           driveProperties.rootFolderId(), batch.getFund(), timestamp, exports);
     } catch (Exception e) {

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionPreparationService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionPreparationService.java
@@ -28,6 +28,8 @@ import org.jspecify.annotations.Nullable;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 @Slf4j
 @Service
@@ -159,12 +161,6 @@ public class TransactionPreparationService {
     updatedMetadata.put("sebFundXlsx", encodeExport(sebFundXlsx));
     updatedMetadata.put("sebEtfXlsx", encodeExport(sebEtfXlsx));
     updatedMetadata.put("ftEtfXlsx", encodeExport(ftEtfXlsx));
-
-    Map<String, String> driveFileUrls =
-        uploadExportsToDrive(batch, now, sebFundXlsx, sebEtfXlsx, ftEtfXlsx);
-    if (!driveFileUrls.isEmpty()) {
-      updatedMetadata.put("driveFileUrls", driveFileUrls);
-    }
     batch.setMetadata(updatedMetadata);
 
     batch.setStatus(BatchStatus.SENT);
@@ -179,10 +175,50 @@ public class TransactionPreparationService {
             .payload(Map.of("tradeDate", tradeDate.toString(), "orderCount", orders.size()))
             .build());
 
-    eventPublisher.publishEvent(
-        new BatchFinalizedEvent(batch.getId(), orders.size(), tradeDate.toString(), driveFileUrls));
+    runAfterCommit(
+        () ->
+            publishExportsToDrive(
+                batch, now, tradeDate, orders.size(), sebFundXlsx, sebEtfXlsx, ftEtfXlsx));
 
     log.info("Batch finalized: id={}, orderCount={}", batch.getId(), orders.size());
+  }
+
+  private void publishExportsToDrive(
+      TransactionBatch batch,
+      Instant timestamp,
+      LocalDate tradeDate,
+      int orderCount,
+      byte[] sebFundXlsx,
+      byte[] sebEtfXlsx,
+      byte[] ftEtfXlsx) {
+    Map<String, String> driveFileUrls =
+        uploadExportsToDrive(batch, timestamp, sebFundXlsx, sebEtfXlsx, ftEtfXlsx);
+    if (!driveFileUrls.isEmpty()) {
+      persistDriveFileUrls(batch, driveFileUrls);
+    }
+    eventPublisher.publishEvent(
+        new BatchFinalizedEvent(batch.getId(), orderCount, tradeDate.toString(), driveFileUrls));
+  }
+
+  void persistDriveFileUrls(TransactionBatch batch, Map<String, String> driveFileUrls) {
+    Map<String, Object> updatedMetadata = new HashMap<>(batch.getMetadata());
+    updatedMetadata.put("driveFileUrls", driveFileUrls);
+    batch.setMetadata(updatedMetadata);
+    batchRepository.save(batch);
+  }
+
+  private void runAfterCommit(Runnable action) {
+    if (TransactionSynchronizationManager.isSynchronizationActive()) {
+      TransactionSynchronizationManager.registerSynchronization(
+          new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+              action.run();
+            }
+          });
+    } else {
+      action.run();
+    }
   }
 
   private List<TransactionOrder> createOrders(

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/calculation/TradeCalculationEngine.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/calculation/TradeCalculationEngine.java
@@ -220,12 +220,95 @@ public class TradeCalculationEngine {
 
     boolean anyOverSoftLimit = filteredScores.stream().anyMatch(score -> score.compareTo(ZERO) > 0);
     List<BigDecimal> finalScores = anyOverSoftLimit ? filteredScores : standardScores;
-    List<BigDecimal> distributed =
-        distributeAmountWithThreshold(
-            finalScores, targetSellAmount, input.minTransactionThreshold());
+
+    List<BigDecimal> distributed = distributeSellWithCap(input, finalScores, targetSellAmount);
 
     return distributed.stream()
         .map(value -> value.compareTo(ZERO) == 0 ? ZERO : value.negate())
+        .toList();
+  }
+
+  private List<BigDecimal> distributeSellWithCap(
+      FundTransactionInput input, List<BigDecimal> initialScores, BigDecimal targetSellAmount) {
+    int size = input.positions().size();
+    BigDecimal threshold = input.minTransactionThreshold();
+
+    BigDecimal totalSellableMarketValue =
+        input.positions().stream().map(PositionSnapshot::marketValue).reduce(ZERO, BigDecimal::add);
+    if (targetSellAmount.subtract(totalSellableMarketValue).compareTo(new BigDecimal("0.01")) > 0) {
+      throw new IllegalStateException(
+          "Insufficient liquidity to satisfy sell: fund="
+              + input.fund()
+              + ", targetSellAmount="
+              + targetSellAmount
+              + ", sellableMarketValue="
+              + totalSellableMarketValue);
+    }
+
+    BigDecimal[] allocations = new BigDecimal[size];
+    boolean[] capped = new boolean[size];
+    for (int i = 0; i < size; i++) {
+      allocations[i] = ZERO;
+    }
+
+    List<BigDecimal> scores = new ArrayList<>(initialScores);
+    BigDecimal remainingNeed = targetSellAmount;
+
+    for (int iteration = 0; iteration < MAX_ITERATIONS; iteration++) {
+      if (remainingNeed.compareTo(new BigDecimal("0.01")) <= 0) {
+        break;
+      }
+
+      List<BigDecimal> roundScores =
+          IntStream.range(0, size).mapToObj(i -> capped[i] ? ZERO : scores.get(i)).toList();
+      BigDecimal roundThreshold = threshold;
+      if (roundScores.stream().allMatch(s -> s.compareTo(ZERO) == 0)) {
+        roundScores = remainingMarketValueScores(input, allocations, capped);
+        roundThreshold = ZERO;
+        if (roundScores.stream().allMatch(s -> s.compareTo(ZERO) == 0)) {
+          break;
+        }
+      }
+
+      List<BigDecimal> round =
+          distributeAmountWithThreshold(roundScores, remainingNeed, roundThreshold);
+
+      boolean newlyCapped = false;
+      for (int i = 0; i < size; i++) {
+        if (capped[i]) {
+          continue;
+        }
+        BigDecimal proposed = allocations[i].add(round.get(i));
+        BigDecimal marketValue = input.positions().get(i).marketValue();
+        if (proposed.compareTo(marketValue) >= 0) {
+          allocations[i] = marketValue;
+          capped[i] = true;
+          newlyCapped = true;
+        } else {
+          allocations[i] = proposed;
+        }
+      }
+
+      BigDecimal allocated =
+          IntStream.range(0, size).mapToObj(i -> allocations[i]).reduce(ZERO, BigDecimal::add);
+      remainingNeed = targetSellAmount.subtract(allocated);
+
+      if (!newlyCapped) {
+        break;
+      }
+    }
+
+    return List.of(allocations);
+  }
+
+  private List<BigDecimal> remainingMarketValueScores(
+      FundTransactionInput input, BigDecimal[] allocations, boolean[] capped) {
+    return IntStream.range(0, input.positions().size())
+        .mapToObj(
+            i ->
+                capped[i]
+                    ? ZERO
+                    : input.positions().get(i).marketValue().subtract(allocations[i]).max(ZERO))
         .toList();
   }
 
@@ -289,8 +372,14 @@ public class TradeCalculationEngine {
     BigDecimal threshold = input.minTransactionThreshold();
     BigDecimal thresholdTolerance = threshold.subtract(new BigDecimal("0.01"));
     List<Integer> active = new ArrayList<>(bucketIndices);
+    Map<Integer, BigDecimal> filled = new HashMap<>();
+    BigDecimal remaining = amount;
 
     for (int iteration = 0; iteration < MAX_ITERATIONS && !active.isEmpty(); iteration++) {
+      if (remaining.compareTo(new BigDecimal("0.01")) <= 0) {
+        break;
+      }
+
       Map<Integer, BigDecimal> scores = new HashMap<>();
       BigDecimal totalScore = ZERO;
       for (int i : active) {
@@ -303,40 +392,67 @@ public class TradeCalculationEngine {
       if (totalScore.compareTo(new BigDecimal("0.01")) < 0) {
         totalScore = ZERO;
         for (int i : active) {
-          BigDecimal marketValue = input.positions().get(i).marketValue();
-          scores.put(i, marketValue);
-          totalScore = totalScore.add(marketValue);
+          BigDecimal headroom = headroom(input, filled, i);
+          scores.put(i, headroom);
+          totalScore = totalScore.add(headroom);
         }
       }
       if (totalScore.compareTo(ZERO) == 0) {
-        return;
+        break;
       }
 
       Map<Integer, BigDecimal> allocations = new HashMap<>();
+      List<Integer> cappedIndices = new ArrayList<>();
+      for (int i : active) {
+        BigDecimal headroom = headroom(input, filled, i);
+        BigDecimal allocation =
+            scores.get(i).multiply(remaining).divide(totalScore, SCALE, HALF_UP);
+        if (allocation.compareTo(headroom) >= 0) {
+          allocation = headroom;
+          cappedIndices.add(i);
+        }
+        allocations.put(i, allocation);
+      }
+
+      if (!cappedIndices.isEmpty()) {
+        for (int i : cappedIndices) {
+          filled.merge(i, allocations.get(i), BigDecimal::add);
+          remaining = remaining.subtract(allocations.get(i));
+          active.remove(Integer.valueOf(i));
+        }
+        continue;
+      }
+
       BigDecimal minAllocation = null;
       int minIndex = -1;
       for (int i : active) {
-        BigDecimal allocation =
-            scores
-                .get(i)
-                .multiply(amount)
-                .divide(totalScore, SCALE, HALF_UP)
-                .min(input.positions().get(i).marketValue());
-        allocations.put(i, allocation);
-        if (minAllocation == null || allocation.compareTo(minAllocation) < 0) {
-          minAllocation = allocation;
+        BigDecimal total = filled.getOrDefault(i, ZERO).add(allocations.get(i));
+        if (minAllocation == null || total.compareTo(minAllocation) < 0) {
+          minAllocation = total;
           minIndex = i;
         }
       }
 
       if (minAllocation != null && minAllocation.compareTo(thresholdTolerance) >= 0) {
         for (int i : active) {
-          results[i] = allocations.get(i).negate();
+          filled.merge(i, allocations.get(i), BigDecimal::add);
         }
-        return;
+        break;
       }
       active.remove(Integer.valueOf(minIndex));
     }
+
+    filled.forEach((i, value) -> results[i] = value.negate());
+  }
+
+  private BigDecimal headroom(
+      FundTransactionInput input, Map<Integer, BigDecimal> filled, int index) {
+    return input
+        .positions()
+        .get(index)
+        .marketValue()
+        .subtract(filled.getOrDefault(index, ZERO))
+        .max(ZERO);
   }
 
   private List<BigDecimal> normalizedTargetValues(FundTransactionInput input) {
@@ -541,7 +657,8 @@ public class TradeCalculationEngine {
     return input
         .grossPortfolioValue()
         .subtract(input.cashBuffer())
-        .subtract(input.liabilities().abs());
+        .subtract(input.liabilities())
+        .add(input.receivables());
   }
 
   private Map<String, BigDecimal> buildWeightMap(List<ModelWeight> modelWeights) {

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/export/CustodianOrderEmailProperties.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/export/CustodianOrderEmailProperties.java
@@ -1,0 +1,17 @@
+package ee.tuleva.onboarding.investment.transaction.export;
+
+import java.util.List;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("transaction-registry.custodian-order-email")
+public record CustodianOrderEmailProperties(boolean enabled, List<String> to, List<String> cc) {
+
+  public CustodianOrderEmailProperties {
+    to = to == null ? List.of() : List.copyOf(to);
+    cc = cc == null ? List.of() : List.copyOf(cc);
+  }
+
+  boolean isSendable() {
+    return enabled && !to.isEmpty();
+  }
+}

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/export/CustodianOrderEmailSender.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/export/CustodianOrderEmailSender.java
@@ -1,0 +1,50 @@
+package ee.tuleva.onboarding.investment.transaction.export;
+
+import ee.tuleva.onboarding.fund.TulevaFund;
+import ee.tuleva.onboarding.notification.email.EmailService;
+import java.time.Instant;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CustodianOrderEmailSender {
+
+  private final CustodianOrderEmailProperties properties;
+  private final CustodianOrderMessageFactory messageFactory;
+  private final EmailService emailService;
+
+  public boolean send(TulevaFund fund, Instant timestamp, Map<String, byte[]> exports) {
+    if (!properties.isSendable()) {
+      log.info(
+          "Custodian order email not sent (inert): enabled={}, recipients={}, fund={}",
+          properties.enabled(),
+          properties.to().size(),
+          fund);
+      return false;
+    }
+    boolean hasContent =
+        exports.values().stream().anyMatch(bytes -> bytes != null && bytes.length > 0);
+    if (!hasContent) {
+      log.warn("Custodian order email not sent: no export content, fund={}", fund);
+      return false;
+    }
+
+    var message = messageFactory.create(fund, timestamp, exports);
+    boolean sent = emailService.sendSystemEmail(message);
+    if (sent) {
+      log.info(
+          "Custodian order email sent: fund={}, to={}, cc={}, attachments={}",
+          fund,
+          properties.to(),
+          properties.cc(),
+          message.getAttachments().size());
+    } else {
+      log.error("Custodian order email failed: fund={}, to={}", fund, properties.to());
+    }
+    return sent;
+  }
+}

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/export/CustodianOrderMessageFactory.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/export/CustodianOrderMessageFactory.java
@@ -1,0 +1,94 @@
+package ee.tuleva.onboarding.investment.transaction.export;
+
+import static com.microtripit.mandrillapp.lutung.view.MandrillMessage.Recipient.Type.CC;
+import static com.microtripit.mandrillapp.lutung.view.MandrillMessage.Recipient.Type.TO;
+
+import com.microtripit.mandrillapp.lutung.view.MandrillMessage;
+import com.microtripit.mandrillapp.lutung.view.MandrillMessage.MessageContent;
+import com.microtripit.mandrillapp.lutung.view.MandrillMessage.Recipient;
+import ee.tuleva.onboarding.fund.TulevaFund;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+class CustodianOrderMessageFactory {
+
+  private static final String XLSX_MIME_TYPE =
+      "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+
+  private static final DateTimeFormatter TIMESTAMP =
+      DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH_mm_ss").withZone(ZoneOffset.UTC);
+  private static final DateTimeFormatter SUBJECT_DATE =
+      DateTimeFormatter.ofPattern("dd.MM.yyyy").withZone(ZoneOffset.UTC);
+
+  private static final Map<String, String> FILE_NAME_PATTERNS =
+      Map.of(
+          "sebFundXlsx", "SEB_%s_indeksfondid_%s.xlsx",
+          "sebEtfXlsx", "SEB_%s_ETF_tehingud_%s.xlsx",
+          "ftEtfXlsx", "FT_%s_ETF_orders_%s.xlsx");
+
+  private final CustodianOrderEmailProperties properties;
+
+  MandrillMessage create(TulevaFund fund, Instant timestamp, Map<String, byte[]> exports) {
+    var message = new MandrillMessage();
+    message.setFromEmail("funds@tuleva.ee");
+    message.setFromName("Tuleva");
+    message.setSubject(
+        fund.getCode() + " ostu-/müügikorraldused " + SUBJECT_DATE.format(timestamp));
+    message.setHtml(
+        """
+        <p>Tere,</p>
+        <p>Manuses on %s fondi ostu-/müügikorralduste failid.</p>
+        <p>See on automaatne kiri.</p>
+        <p>Parimat,<br>Tuleva robot</p>
+        """
+            .formatted(fund.getCode()));
+    message.setPreserveRecipients(true);
+    message.setTo(buildRecipients());
+    message.setAttachments(buildAttachments(fund, timestamp, exports));
+    return message;
+  }
+
+  private List<Recipient> buildRecipients() {
+    List<Recipient> recipients = new ArrayList<>();
+    for (String to : properties.to()) {
+      var recipient = new Recipient();
+      recipient.setEmail(to);
+      recipient.setType(TO);
+      recipients.add(recipient);
+    }
+    for (String cc : properties.cc()) {
+      var recipient = new Recipient();
+      recipient.setEmail(cc);
+      recipient.setType(CC);
+      recipients.add(recipient);
+    }
+    return recipients;
+  }
+
+  private List<MessageContent> buildAttachments(
+      TulevaFund fund, Instant timestamp, Map<String, byte[]> exports) {
+    var fileTimestamp = TIMESTAMP.format(timestamp);
+    List<MessageContent> attachments = new ArrayList<>();
+    FILE_NAME_PATTERNS.forEach(
+        (exportKey, namePattern) -> {
+          var content = exports.get(exportKey);
+          if (content != null && content.length > 0) {
+            var attachment = new MessageContent();
+            attachment.setName(namePattern.formatted(fund.getCode(), fileTimestamp));
+            attachment.setType(XLSX_MIME_TYPE);
+            attachment.setContent(Base64.getEncoder().encodeToString(content));
+            attachments.add(attachment);
+          }
+        });
+    return attachments;
+  }
+}

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/export/GoogleDriveConfiguration.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/export/GoogleDriveConfiguration.java
@@ -8,7 +8,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.web.client.RestClient;
 
 @Configuration
-@EnableConfigurationProperties(GoogleDriveProperties.class)
+@EnableConfigurationProperties({GoogleDriveProperties.class, CustodianOrderEmailProperties.class})
 class GoogleDriveConfiguration {
 
   @Bean

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/export/TransactionExportService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/export/TransactionExportService.java
@@ -114,8 +114,14 @@ public class TransactionExportService {
         row.createCell(9).setCellValue(order.getTransactionType() == BUY ? "SUBS" : "REDP");
         row.createCell(12).setCellValue(labelsByIsin.getOrDefault(order.getInstrumentIsin(), ""));
         row.createCell(13).setCellValue(order.getInstrumentIsin());
-        if (order.getOrderAmount() != null) {
-          row.createCell(16).setCellValue(order.getOrderAmount().doubleValue());
+        if (order.getTransactionType() == BUY) {
+          if (order.getOrderAmount() != null) {
+            row.createCell(16).setCellValue(order.getOrderAmount().doubleValue());
+          }
+        } else {
+          if (order.getOrderQuantity() != null) {
+            row.createCell(14).setCellValue(order.getOrderQuantity().doubleValue());
+          }
         }
       }
 

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationAuditRecorder.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationAuditRecorder.java
@@ -32,6 +32,10 @@ class FtConfirmationAuditRecorder {
     payload.put("tradeDate", confirmation.tradeDate().toString());
     payload.put("quantity", confirmation.quantity().toPlainString());
     payload.put("grossPrice", confirmation.grossPrice().toPlainString());
+    payload.put("type", confirmation.type().name());
+    if (confirmation.account() != null) {
+      payload.put("account", confirmation.account());
+    }
     payload.put("quantityStatus", result.quantityStatus().name());
     payload.put("priceStatus", result.priceStatus().name());
     payload.put("details", result.details());

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationVerificationService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationVerificationService.java
@@ -1,10 +1,13 @@
 package ee.tuleva.onboarding.investment.transaction.ingest;
 
+import static ee.tuleva.onboarding.investment.transaction.FtVerificationStatus.AMBIGUOUS;
+import static ee.tuleva.onboarding.investment.transaction.FtVerificationStatus.CANCELLED;
 import static ee.tuleva.onboarding.investment.transaction.FtVerificationStatus.ERROR;
 import static ee.tuleva.onboarding.investment.transaction.FtVerificationStatus.OK;
 import static ee.tuleva.onboarding.investment.transaction.FtVerificationStatus.PENDING_EXECUTION;
 import static ee.tuleva.onboarding.investment.transaction.FtVerificationStatus.PENDING_NAV;
 import static java.util.Comparator.comparing;
+import static java.util.stream.Collectors.toList;
 
 import ee.tuleva.onboarding.comparisons.fundvalue.PositionPriceResolver;
 import ee.tuleva.onboarding.comparisons.fundvalue.ResolvedPrice;
@@ -22,6 +25,7 @@ import java.time.Clock;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -53,8 +57,8 @@ public class FtConfirmationVerificationService {
   private BigDecimal priceTolerance = DEFAULT_PRICE_TOLERANCE;
 
   public Optional<FtConfirmationResult> verify(FtConfirmation confirmation) {
-    Optional<TransactionOrder> orderOpt = findOrder(confirmation);
-    if (orderOpt.isEmpty()) {
+    List<TransactionOrder> candidates = candidateOrders(confirmation);
+    if (candidates.isEmpty()) {
       log.warn(
           "No order found for FT confirmation: fund={}, isin={}, tradeDate={}",
           confirmation.fund(),
@@ -62,33 +66,85 @@ public class FtConfirmationVerificationService {
           confirmation.tradeDate());
       return Optional.empty();
     }
-    TransactionOrder order = orderOpt.get();
+
+    OrderSelection selection = selectOrder(confirmation, candidates);
+    TransactionOrder order = selection.order();
 
     Map<String, String> details = new LinkedHashMap<>();
     details.put("orderUuid", order.getOrderUuid().toString());
 
+    if (confirmation.isCancellation()) {
+      return cancel(confirmation, order, details);
+    }
+
+    if (selection.ambiguous()) {
+      details.put("ambiguousOrderCount", String.valueOf(selection.matchCount()));
+      return result(confirmation, order, AMBIGUOUS, AMBIGUOUS, details);
+    }
+
     FtVerificationStatus quantityStatus = checkQuantity(confirmation, order, details);
     FtVerificationStatus priceStatus = checkPrice(confirmation, details);
+    return result(confirmation, order, quantityStatus, priceStatus, details);
+  }
 
+  private Optional<FtConfirmationResult> cancel(
+      FtConfirmation confirmation, TransactionOrder order, Map<String, String> details) {
+    details.put("cancellationSignature", confirmation.cancellationSignature());
+    return result(confirmation, order, CANCELLED, CANCELLED, details);
+  }
+
+  private Optional<FtConfirmationResult> result(
+      FtConfirmation confirmation,
+      TransactionOrder order,
+      FtVerificationStatus quantityStatus,
+      FtVerificationStatus priceStatus,
+      Map<String, String> details) {
     FtConfirmationResult result =
         new FtConfirmationResult(quantityStatus, priceStatus, Map.copyOf(details));
     auditRecorder.recordVerified(order, confirmation, result);
     log.info(
-        "FT confirmation verified: orderUuid={}, isin={}, tradeDate={}, quantityStatus={}, priceStatus={}",
+        "FT confirmation verified: orderUuid={}, isin={}, tradeDate={}, type={}, quantityStatus={}, priceStatus={}",
         order.getOrderUuid(),
         confirmation.isin(),
         confirmation.tradeDate(),
+        confirmation.type(),
         quantityStatus,
         priceStatus);
     return Optional.of(result);
   }
 
-  private Optional<TransactionOrder> findOrder(FtConfirmation confirmation) {
+  private List<TransactionOrder> candidateOrders(FtConfirmation confirmation) {
     return orderRepository.findByInstrumentIsin(confirmation.isin()).stream()
         .filter(order -> order.getFund() == confirmation.fund())
         .filter(order -> hasTradeDate(order, confirmation.tradeDate()))
-        .min(comparing(TransactionOrder::getId));
+        .collect(toList());
   }
+
+  private OrderSelection selectOrder(
+      FtConfirmation confirmation, List<TransactionOrder> candidates) {
+    if (candidates.size() == 1) {
+      return new OrderSelection(candidates.get(0), false, 1);
+    }
+    List<TransactionOrder> quantityMatches =
+        candidates.stream()
+            .filter(order -> order.getOrderQuantity() != null)
+            .filter(
+                order -> withinQuantityTolerance(confirmation.quantity(), order.getOrderQuantity()))
+            .collect(toList());
+    if (quantityMatches.size() == 1) {
+      return new OrderSelection(quantityMatches.get(0), false, 1);
+    }
+    if (quantityMatches.size() > 1) {
+      return new OrderSelection(oldest(quantityMatches), true, quantityMatches.size());
+    }
+    return new OrderSelection(oldest(candidates), false, candidates.size());
+  }
+
+  private static TransactionOrder oldest(List<TransactionOrder> orders) {
+    return orders.stream().min(comparing(TransactionOrder::getId)).orElseThrow();
+  }
+
+  private record OrderSelection(TransactionOrder order, boolean ambiguous, int matchCount) {}
 
   private static boolean hasTradeDate(TransactionOrder order, LocalDate tradeDate) {
     return order.getOrderTimestamp() != null

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationVerificationService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationVerificationService.java
@@ -3,6 +3,7 @@ package ee.tuleva.onboarding.investment.transaction.ingest;
 import static ee.tuleva.onboarding.investment.transaction.FtVerificationStatus.AMBIGUOUS;
 import static ee.tuleva.onboarding.investment.transaction.FtVerificationStatus.CANCELLED;
 import static ee.tuleva.onboarding.investment.transaction.FtVerificationStatus.ERROR;
+import static ee.tuleva.onboarding.investment.transaction.FtVerificationStatus.IGNORED;
 import static ee.tuleva.onboarding.investment.transaction.FtVerificationStatus.OK;
 import static ee.tuleva.onboarding.investment.transaction.FtVerificationStatus.PENDING_EXECUTION;
 import static ee.tuleva.onboarding.investment.transaction.FtVerificationStatus.PENDING_NAV;
@@ -22,6 +23,7 @@ import ee.tuleva.onboarding.investment.transaction.TransactionOrder;
 import ee.tuleva.onboarding.investment.transaction.TransactionOrderRepository;
 import java.math.BigDecimal;
 import java.time.Clock;
+import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.LinkedHashMap;
@@ -57,6 +59,11 @@ public class FtConfirmationVerificationService {
   private BigDecimal priceTolerance = DEFAULT_PRICE_TOLERANCE;
 
   public Optional<FtConfirmationResult> verify(FtConfirmation confirmation) {
+    Optional<FtConfirmationResult> ignored = ignoredResult(confirmation);
+    if (ignored.isPresent()) {
+      return ignored;
+    }
+
     List<TransactionOrder> candidates = candidateOrders(confirmation);
     if (candidates.isEmpty()) {
       log.warn(
@@ -85,6 +92,31 @@ public class FtConfirmationVerificationService {
     FtVerificationStatus quantityStatus = checkQuantity(confirmation, order, details);
     FtVerificationStatus priceStatus = checkPrice(confirmation, details);
     return result(confirmation, order, quantityStatus, priceStatus, details);
+  }
+
+  private Optional<FtConfirmationResult> ignoredResult(FtConfirmation confirmation) {
+    if (confirmation.suppressed()) {
+      return ignored(confirmation, "manually suppressed false positive");
+    }
+    if (isWeekend(confirmation.tradeDate())) {
+      return ignored(confirmation, "weekend trade date: " + confirmation.tradeDate());
+    }
+    return Optional.empty();
+  }
+
+  private Optional<FtConfirmationResult> ignored(FtConfirmation confirmation, String reason) {
+    log.info(
+        "FT confirmation ignored: fund={}, isin={}, tradeDate={}, reason={}",
+        confirmation.fund(),
+        confirmation.isin(),
+        confirmation.tradeDate(),
+        reason);
+    return Optional.of(new FtConfirmationResult(IGNORED, IGNORED, Map.of("ignoreReason", reason)));
+  }
+
+  private static boolean isWeekend(LocalDate date) {
+    DayOfWeek day = date.getDayOfWeek();
+    return day == DayOfWeek.SATURDAY || day == DayOfWeek.SUNDAY;
   }
 
   private Optional<FtConfirmationResult> cancel(

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/QuantityAmountMismatchAlertListener.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/QuantityAmountMismatchAlertListener.java
@@ -6,8 +6,9 @@ import ee.tuleva.onboarding.notification.OperationsNotificationService;
 import ee.tuleva.onboarding.notification.email.EmailService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 
 @Slf4j
 @Component
@@ -18,9 +19,19 @@ class QuantityAmountMismatchAlertListener {
   private final EmailService emailService;
   private final OperationsNotificationService notificationService;
 
-  @EventListener
+  // Fire after the reconcile transaction commits so a Slack/email failure can never roll back
+  // persisted reconciliation state; fallbackExecution lets it still run outside a transaction.
+  @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
   public void onQuantityAmountMismatch(QuantityAmountMismatchEvent event) {
-    notificationService.sendMessage(buildSlackMessage(event), INVESTMENT);
+    try {
+      notificationService.sendMessage(buildSlackMessage(event), INVESTMENT);
+    } catch (RuntimeException e) {
+      log.error(
+          "Failed to send quantity/amount mismatch Slack alert: reportDate={}, orderId={}",
+          event.reportDate(),
+          event.order().getId(),
+          e);
+    }
 
     var subject = "[HOIATUS] Tehingute koguse/summa lahknevused – " + event.reportDate();
     var body = buildBody(event);

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/ReconciliationAuditRecorder.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/ReconciliationAuditRecorder.java
@@ -17,6 +17,7 @@ import org.springframework.stereotype.Component;
 class ReconciliationAuditRecorder {
 
   static final String EXECUTION_MATCHED = "EXECUTION_MATCHED";
+  static final String EXECUTION_UPDATED = "EXECUTION_UPDATED";
   static final String UNMATCHED_SEB_TRANSACTION = "UNMATCHED_SEB_TRANSACTION";
   static final String QUANTITY_AMOUNT_MISMATCH = "QUANTITY_AMOUNT_MISMATCH";
   static final String SETTLEMENT_DETECTED = "SETTLEMENT_DETECTED";
@@ -30,6 +31,18 @@ class ReconciliationAuditRecorder {
   void recordExecutionMatched(
       TransactionOrder order, SebPendingTransactionRow row, LocalDate reportDate) {
     save(EXECUTION_MATCHED, order, rowPayload(row, reportDate));
+  }
+
+  void recordExecutionUpdated(
+      TransactionOrder order,
+      SebPendingTransactionRow row,
+      LocalDate reportDate,
+      Map<String, Object> before,
+      Map<String, Object> after) {
+    Map<String, Object> payload = rowPayload(row, reportDate);
+    payload.put("before", before);
+    payload.put("after", after);
+    save(EXECUTION_UPDATED, order, payload);
   }
 
   void recordUnmatched(SebPendingTransactionRow row, LocalDate reportDate) {

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/SebPendingTransactionExtractor.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/SebPendingTransactionExtractor.java
@@ -1,10 +1,9 @@
 package ee.tuleva.onboarding.investment.transaction.ingest;
 
 import ee.tuleva.onboarding.investment.report.InvestmentReport;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
-import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
@@ -12,27 +11,40 @@ import org.springframework.stereotype.Component;
 @Component
 class SebPendingTransactionExtractor {
 
-  List<SebPendingTransactionRow> extract(InvestmentReport report) {
-    return report.getRawData().stream()
-        .filter(SebPendingTransactionExtractor::hasContent)
-        .flatMap(SebPendingTransactionExtractor::parseSafely)
-        .filter(Objects::nonNull)
-        .toList();
+  // A content row that fails strict parsing is dropped from the typed rows but still counted as
+  // malformed. Settlement-by-absence must not run on an incomplete report: a dropped order would
+  // look "absent" and be falsely settled (see detectSettlementsByAbsence).
+  record ExtractionResult(List<SebPendingTransactionRow> rows, int malformedCount) {
+    boolean isComplete() {
+      return malformedCount == 0;
+    }
   }
 
-  private static Stream<SebPendingTransactionRow> parseSafely(Map<String, Object> raw) {
-    try {
-      return Stream.of(SebPendingTransactionRow.fromRawData(raw));
-    } catch (RuntimeException e) {
-      log.warn(
-          "Skipping malformed SEB pending transaction row: clientRef={}, ourRef={}, isin={},"
-              + " reason={}",
-          raw.get("Client ref"),
-          raw.get("Our ref"),
-          raw.get("ISIN"),
-          e.getMessage());
-      return Stream.empty();
+  ExtractionResult extractWithDiagnostics(InvestmentReport report) {
+    List<SebPendingTransactionRow> rows = new ArrayList<>();
+    int malformedCount = 0;
+    for (Map<String, Object> raw : report.getRawData()) {
+      if (!hasContent(raw)) {
+        continue;
+      }
+      try {
+        rows.add(SebPendingTransactionRow.fromRawData(raw));
+      } catch (RuntimeException e) {
+        malformedCount++;
+        log.warn(
+            "Skipping malformed SEB pending transaction row: clientRef={}, ourRef={}, isin={},"
+                + " reason={}",
+            raw.get("Client ref"),
+            raw.get("Our ref"),
+            raw.get("ISIN"),
+            e.getMessage());
+      }
     }
+    return new ExtractionResult(List.copyOf(rows), malformedCount);
+  }
+
+  List<SebPendingTransactionRow> extract(InvestmentReport report) {
+    return extractWithDiagnostics(report).rows();
   }
 
   private static boolean hasContent(Map<String, Object> raw) {

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/SebPendingTransactionReconciliationService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/SebPendingTransactionReconciliationService.java
@@ -1,6 +1,10 @@
 package ee.tuleva.onboarding.investment.transaction.ingest;
 
+import static ee.tuleva.onboarding.investment.report.ReportProvider.SEB;
+import static ee.tuleva.onboarding.investment.report.ReportType.PENDING_TRANSACTIONS;
+
 import ee.tuleva.onboarding.investment.report.InvestmentReport;
+import ee.tuleva.onboarding.investment.report.InvestmentReportService;
 import ee.tuleva.onboarding.investment.transaction.OrderStatus;
 import ee.tuleva.onboarding.investment.transaction.OrderVenue;
 import ee.tuleva.onboarding.investment.transaction.TransactionExecution;
@@ -14,6 +18,7 @@ import java.time.LocalDate;
 import java.time.ZoneOffset;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
@@ -39,16 +44,20 @@ public class SebPendingTransactionReconciliationService {
   private final ReconciliationAuditRecorder auditRecorder;
   private final TransactionSettlementRepository settlementRepository;
   private final TransactionSettlementService settlementService;
+  private final InvestmentReportService reportService;
 
   @Transactional
   public void reconcile(InvestmentReport report) {
-    var rows = extractor.extract(report);
+    SebPendingTransactionExtractor.ExtractionResult extraction =
+        extractor.extractWithDiagnostics(report);
+    List<SebPendingTransactionRow> rows = extraction.rows();
     LocalDate reportDate = report.getReportDate();
     TransactionMatchingProperties matchingProperties = matchingPolicy.current();
     log.info(
-        "Reconciling SEB pending transactions: reportDate={}, rowCount={}",
+        "Reconciling SEB pending transactions: reportDate={}, rowCount={}, malformedCount={}",
         reportDate,
-        rows.size());
+        rows.size(),
+        extraction.malformedCount());
 
     int matched = 0;
     int unmatched = 0;
@@ -91,9 +100,16 @@ public class SebPendingTransactionReconciliationService {
         handleSettledOrderReappearance(order, settlement.get(), row, reportDate);
         continue;
       }
-      quantityAmountValidator
-          .validate(order, row, matchingProperties)
-          .ifPresent(mismatch -> reportMismatch(mismatch.withReportDate(reportDate), row));
+      Optional<QuantityAmountMismatchEvent> mismatch =
+          quantityAmountValidator.validate(order, row, matchingProperties);
+      if (mismatch.isPresent()) {
+        // Quarantine: a divergent fill (partial fill, price/qty error) must not be silently
+        // absorbed as EXECUTED. Flag it for manual handling and leave the order in its
+        // pre-execution status; it still counts as present so it is not settled by absence.
+        reportMismatch(mismatch.get().withReportDate(reportDate), row);
+        matched++;
+        continue;
+      }
       if (upsert(row, order, reportDate)) {
         matched++;
       }
@@ -105,7 +121,8 @@ public class SebPendingTransactionReconciliationService {
         matched,
         unmatched);
 
-    detectSettlementsByAbsence(reportDate, rows.size(), matched, presentOrderIds);
+    detectSettlementsByAbsence(
+        reportDate, rows.size(), matched, presentOrderIds, extraction.isComplete());
   }
 
   private void reportMismatch(QuantityAmountMismatchEvent event, SebPendingTransactionRow row) {
@@ -127,10 +144,24 @@ public class SebPendingTransactionReconciliationService {
     if (row.ourRef() == null) {
       return Optional.empty();
     }
-    return executionRepository
-        .findByBrokerTransactionId(row.ourRef())
+    return uniqueExecutionByBrokerRef(row.ourRef())
         .map(TransactionExecution::getOrderId)
         .flatMap(orderRepository::findById);
+  }
+
+  // The broker_transaction_id index is not unique (H2/PG-portable schema), so a duplicate broker
+  // ref must be refused rather than resolved to an arbitrary execution (would silently mislink).
+  private Optional<TransactionExecution> uniqueExecutionByBrokerRef(String brokerRef) {
+    List<TransactionExecution> matches =
+        executionRepository.findAllByBrokerTransactionId(brokerRef);
+    if (matches.size() > 1) {
+      log.error(
+          "Refusing ambiguous broker-ref match: brokerTransactionId={}, executionCount={}",
+          brokerRef,
+          matches.size());
+      return Optional.empty();
+    }
+    return matches.stream().findFirst();
   }
 
   private boolean upsert(
@@ -139,16 +170,17 @@ public class SebPendingTransactionReconciliationService {
       return false;
     }
     Optional<TransactionExecution> existing = executionRepository.findByOrderId(order.getId());
-    TransactionExecution execution =
-        existing
-            .map(
-                e -> {
-                  executionMapper.applyTo(e, row, order);
-                  return e;
-                })
-            .orElseGet(() -> executionMapper.toExecution(row, order));
-    executionRepository.save(execution);
-    if (existing.isEmpty()) {
+    if (existing.isPresent()) {
+      TransactionExecution execution = existing.get();
+      Map<String, Object> before = executionMapper.snapshot(execution);
+      executionMapper.applyTo(execution, row, order);
+      executionRepository.save(execution);
+      Map<String, Object> after = executionMapper.snapshot(execution);
+      if (!before.equals(after)) {
+        auditRecorder.recordExecutionUpdated(order, row, reportDate, before, after);
+      }
+    } else {
+      executionRepository.save(executionMapper.toExecution(row, order));
       auditRecorder.recordExecutionMatched(order, row, reportDate);
     }
 
@@ -177,7 +209,11 @@ public class SebPendingTransactionReconciliationService {
   }
 
   private void detectSettlementsByAbsence(
-      LocalDate reportDate, int rowCount, int matched, Set<Long> presentOrderIds) {
+      LocalDate reportDate,
+      int rowCount,
+      int matched,
+      Set<Long> presentOrderIds,
+      boolean reportComplete) {
     if (rowCount == 0) {
       log.info("Skipping settlement detection on empty report: reportDate={}", reportDate);
       return;
@@ -190,12 +226,32 @@ public class SebPendingTransactionReconciliationService {
           rowCount);
       return;
     }
+    if (!reportComplete) {
+      // A dropped malformed row could make a still-pending order look absent → false settlement.
+      log.warn(
+          "Skipping settlement detection, report had malformed rows: reportDate={}", reportDate);
+      return;
+    }
+    if (!isLatestReport(reportDate)) {
+      // A lookback/backfill replay of an older report must not flip an order SETTLED out of order:
+      // a newer report may still show it pending.
+      log.info("Skipping settlement detection on non-latest report: reportDate={}", reportDate);
+      return;
+    }
     orderRepository.findByOrderStatusIn(List.of(OrderStatus.EXECUTED)).stream()
         .filter(order -> order.getOrderVenue() == OrderVenue.SEB)
         .filter(order -> !presentOrderIds.contains(order.getId()))
         .filter(order -> !settlementRepository.existsByOrderId(order.getId()))
         .filter(order -> executedBefore(order, reportDate))
         .forEach(order -> settleByAbsence(order, reportDate));
+  }
+
+  private boolean isLatestReport(LocalDate reportDate) {
+    return reportService
+        .getLatestReport(SEB, PENDING_TRANSACTIONS)
+        .map(InvestmentReport::getReportDate)
+        .map(latest -> !reportDate.isBefore(latest))
+        .orElse(true);
   }
 
   private boolean executedBefore(TransactionOrder order, LocalDate reportDate) {
@@ -218,8 +274,7 @@ public class SebPendingTransactionReconciliationService {
   private Set<Long> referencedOrderIds(SebPendingTransactionRow row) {
     Set<Long> orderIds = new HashSet<>();
     if (row.ourRef() != null) {
-      executionRepository
-          .findByBrokerTransactionId(row.ourRef())
+      uniqueExecutionByBrokerRef(row.ourRef())
           .map(TransactionExecution::getOrderId)
           .ifPresent(orderIds::add);
     }
@@ -237,8 +292,7 @@ public class SebPendingTransactionReconciliationService {
     if (row.ourRef() == null) {
       return false;
     }
-    Optional<TransactionExecution> byBrokerId =
-        executionRepository.findByBrokerTransactionId(row.ourRef());
+    Optional<TransactionExecution> byBrokerId = uniqueExecutionByBrokerRef(row.ourRef());
     if (byBrokerId.isEmpty()) {
       return false;
     }

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/SettlementCheckJob.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/SettlementCheckJob.java
@@ -10,11 +10,11 @@ import static java.util.stream.Collectors.toSet;
 
 import ee.tuleva.onboarding.deadline.PublicHolidays;
 import ee.tuleva.onboarding.fund.TulevaFund;
-import ee.tuleva.onboarding.investment.calendar.Target2Calendar;
 import ee.tuleva.onboarding.investment.event.RunOverdueSettlementRequested;
 import ee.tuleva.onboarding.investment.report.InvestmentReport;
 import ee.tuleva.onboarding.investment.report.InvestmentReportService;
 import ee.tuleva.onboarding.investment.transaction.InstrumentType;
+import ee.tuleva.onboarding.investment.transaction.SettlementDateCalculator;
 import ee.tuleva.onboarding.investment.transaction.TransactionExecution;
 import ee.tuleva.onboarding.investment.transaction.TransactionExecutionRepository;
 import ee.tuleva.onboarding.investment.transaction.TransactionOrder;
@@ -61,7 +61,7 @@ class SettlementCheckJob {
 
   private final Clock clock;
   private final PublicHolidays publicHolidays;
-  private final Target2Calendar target2Calendar;
+  private final SettlementDateCalculator settlementDateCalculator;
   private final TransactionOrderRepository orderRepository;
   private final TransactionExecutionRepository executionRepository;
   private final InvestmentReportService reportService;
@@ -188,8 +188,9 @@ class SettlementCheckJob {
     if (order.getOrderTimestamp() == null || order.getInstrumentType() == null) {
       return null;
     }
-    return target2Calendar.addBusinessDays(
-        orderDate(order), thresholdFor(order.getInstrumentType()));
+    InstrumentType instrumentType = order.getInstrumentType();
+    return settlementDateCalculator.addBusinessDays(
+        orderDate(order), instrumentType, order.getInstrumentIsin(), thresholdFor(instrumentType));
   }
 
   private @Nullable LocalDate executedDeadline(

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/TransactionExecutionMapper.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/TransactionExecutionMapper.java
@@ -2,6 +2,8 @@ package ee.tuleva.onboarding.investment.transaction.ingest;
 
 import ee.tuleva.onboarding.investment.transaction.TransactionExecution;
 import ee.tuleva.onboarding.investment.transaction.TransactionOrder;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -28,5 +30,24 @@ class TransactionExecutionMapper {
     execution.setSource(SOURCE_SEB_OOTEL);
     execution.setModifiedBy(MODIFIED_BY_SEB_RECONCILIATION);
     return execution;
+  }
+
+  // Captures the mutable SEB-sourced fields so an in-place update can be delta-audited
+  // (Art 16: no silent alteration of a transaction record).
+  Map<String, Object> snapshot(TransactionExecution execution) {
+    Map<String, Object> snapshot = new LinkedHashMap<>();
+    snapshot.put("brokerTransactionId", asString(execution.getBrokerTransactionId()));
+    snapshot.put("executionTimestamp", asString(execution.getExecutionTimestamp()));
+    snapshot.put("executedQuantity", asString(execution.getExecutedQuantity()));
+    snapshot.put("unitPrice", asString(execution.getUnitPrice()));
+    snapshot.put("totalConsideration", asString(execution.getTotalConsideration()));
+    snapshot.put("settlementAmount", asString(execution.getSettlementAmount()));
+    snapshot.put("commissionAmount", asString(execution.getCommissionAmount()));
+    snapshot.put("actualSettlementDate", asString(execution.getActualSettlementDate()));
+    return snapshot;
+  }
+
+  private static String asString(Object value) {
+    return value == null ? null : value.toString();
   }
 }

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/portfolio/CostBasisCalculator.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/portfolio/CostBasisCalculator.java
@@ -44,20 +44,14 @@ public class CostBasisCalculator {
             qty.signum() == 0
                 ? BigDecimal.ZERO
                 : totalCost.divide(qty, AVG_UNIT_COST_SCALE, RoundingMode.HALF_UP);
+        if (execQty.compareTo(qty) > 0) {
+          throw new IllegalStateException(
+              String.format(
+                  "Cost-basis oversell: fund=%s, isin=%s, asOfDate=%s, heldQty=%s, sellQty=%s",
+                  fundIsin, instrumentIsin, asOfDate, qty, execQty));
+        }
         totalCost = totalCost.subtract(avgBefore.multiply(execQty));
         qty = qty.subtract(execQty);
-        if (qty.signum() < 0) {
-          log.warn(
-              "SELL clamped to zero: fundIsin={}, instrumentIsin={}, asOfDate={}, sellQty={},"
-                  + " priorQty={}",
-              fundIsin,
-              instrumentIsin,
-              asOfDate,
-              execQty,
-              priorQty);
-          qty = BigDecimal.ZERO;
-          totalCost = BigDecimal.ZERO;
-        }
       }
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -191,6 +191,12 @@ transaction-registry:
       - funds@tuleva.ee
     cc:
       - taavi.pertman@tuleva.ee
+  # Outbound order notification to the custodian (SEB trustee). Inert by default:
+  # disabled and with no recipients, so nothing is sent until explicitly configured.
+  custodian-order-email:
+    enabled: ${TRANSACTION_REGISTRY_CUSTODIAN_ORDER_EMAIL_ENABLED:false}
+    to: ${TRANSACTION_REGISTRY_CUSTODIAN_ORDER_EMAIL_TO:}
+    cc: ${TRANSACTION_REGISTRY_CUSTODIAN_ORDER_EMAIL_CC:}
   settlement-check:
     # How far back the daily settlement check scans SENT/EXECUTED orders. Bounds the
     # scan because orders never transition to SETTLED, so the EXECUTED backlog grows.

--- a/src/main/resources/db/migration/V1_217__epis_report_summary_complete.sql
+++ b/src/main/resources/db/migration/V1_217__epis_report_summary_complete.sql
@@ -1,0 +1,2 @@
+ALTER TABLE epis_report_summary
+    ADD COLUMN complete boolean NOT NULL DEFAULT true;

--- a/src/main/resources/db/migration/V1_218__add_batch_operator_attribution_and_cancellation.sql
+++ b/src/main/resources/db/migration/V1_218__add_batch_operator_attribution_and_cancellation.sql
@@ -1,0 +1,14 @@
+ALTER TABLE investment_transaction_batch
+    ADD COLUMN confirmed_by text;
+
+ALTER TABLE investment_transaction_batch
+    ADD COLUMN confirmed_at timestamptz;
+
+ALTER TABLE investment_transaction_batch
+    ADD COLUMN cancellation_reason text;
+
+ALTER TABLE investment_transaction_batch
+    ADD COLUMN cancelled_by text;
+
+ALTER TABLE investment_transaction_batch
+    ADD COLUMN cancelled_at timestamptz;

--- a/src/main/resources/db/migration/V1_219__settlement_delays_view.sql
+++ b/src/main/resources/db/migration/V1_219__settlement_delays_view.sql
@@ -1,0 +1,18 @@
+CREATE OR REPLACE VIEW v_settlement_delays AS
+SELECT
+    o.id AS order_id,
+    o.order_uuid AS order_uuid,
+    o.fund_code AS fund_code,
+    o.instrument_isin AS instrument_isin,
+    o.transaction_type AS transaction_type,
+    o.order_status AS order_status,
+    o.expected_settlement_date AS expected_settlement_date,
+    s.report_date AS actual_settlement_date,
+    s.settled_at AS settled_at,
+    CASE
+        WHEN o.expected_settlement_date IS NULL THEN NULL
+        WHEN s.report_date <= o.expected_settlement_date THEN TRUE
+        ELSE FALSE
+    END AS settled_on_time
+FROM investment_transaction_order o
+JOIN transaction_settlement s ON s.order_id = o.id;

--- a/src/test/groovy/ee/tuleva/onboarding/investment/epis/EpisReportIngestionServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/epis/EpisReportIngestionServiceTest.java
@@ -73,6 +73,9 @@ class EpisReportIngestionServiceTest {
 
   @MockitoBean private FundNavQueryService fundNavQueryService;
 
+  @MockitoBean
+  private ee.tuleva.onboarding.notification.OperationsNotificationService notificationService;
+
   private static final String R17_CSV =
       """
       Seisuga: 01.08.2026;;;;;;;

--- a/src/test/groovy/ee/tuleva/onboarding/investment/epis/PevaRavaFlowServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/epis/PevaRavaFlowServiceTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.mock;
 
 import ee.tuleva.onboarding.fund.TulevaFund;
 import ee.tuleva.onboarding.investment.config.InvestmentParameterRepository;
+import ee.tuleva.onboarding.investment.report.ReportType;
 import ee.tuleva.onboarding.savings.fund.nav.FundNavQueryService;
 import java.math.BigDecimal;
 import java.time.Clock;
@@ -29,12 +30,18 @@ class PevaRavaFlowServiceTest {
 
   private static final LocalDate AS_OF_DATE = LocalDate.of(2026, 8, 14);
   private static final LocalDate NAV_DATE = LocalDate.of(2026, 8, 13);
+  private static final LocalDate LOCK_DATE = LocalDate.of(2026, 7, 31);
+  private static final LocalDate EXEC_DATE = LocalDate.of(2026, 9, 1);
+  private static final long R17_REPORT_ID = 17L;
+  private static final long R21_REPORT_ID = 21L;
 
   private final EpisReportSummaryRepository summaryRepository =
       mock(EpisReportSummaryRepository.class);
   private final FundNavQueryService fundNavQueryService = mock(FundNavQueryService.class);
   private final InvestmentParameterRepository parameterRepository =
       mock(InvestmentParameterRepository.class);
+  private final PevaRavaCycleRepository cycleRepository = mock(PevaRavaCycleRepository.class);
+  private final PevaRavaPeriodService periodService = mock(PevaRavaPeriodService.class);
   private final Clock clock =
       Clock.fixed(Instant.parse("2026-08-14T10:00:00Z"), ZoneId.of("Europe/Tallinn"));
 
@@ -43,10 +50,13 @@ class PevaRavaFlowServiceTest {
           summaryRepository,
           new OwnFundNavProvider(fundNavQueryService),
           parameterRepository,
+          cycleRepository,
+          periodService,
           clock);
 
   @Test
   void calculatesFlowsFromUnitsAndLatestNav() {
+    givenActiveCycle(R17_REPORT_ID, R21_REPORT_ID);
     givenSummaries(TUK75, Map.of("pikUnits", 10000, "switchingNetUnits", -5000), 20000);
     givenNav(TUK75, "0.80");
     givenParameters(TUK75, "500000");
@@ -70,6 +80,7 @@ class PevaRavaFlowServiceTest {
 
   @Test
   void switchingSurplusReducesLiquidityButNotBelowPik() {
+    givenActiveCycle(R17_REPORT_ID, R21_REPORT_ID);
     givenSummaries(TUK00, Map.of("pikUnits", 1000, "switchingNetUnits", 3000), 2000);
     givenNav(TUK00, "0.70");
     givenParameters(TUK00, "200000");
@@ -92,9 +103,15 @@ class PevaRavaFlowServiceTest {
 
   @Test
   void missingR21IsTreatedAsZeroRava() {
-    given(summaryRepository.findTopByReportTypeAndFundOrderByReportDateDescIdDesc(R17_PEVA, TUK75))
+    givenActiveCycle(R17_REPORT_ID, null);
+    given(summaryRepository.findByReportIdAndFund(R17_REPORT_ID, TUK75))
         .willReturn(
-            Optional.of(summary(TUK75, Map.of("pikUnits", 10000, "switchingNetUnits", -5000))));
+            Optional.of(
+                summary(
+                    R17_PEVA,
+                    R17_REPORT_ID,
+                    TUK75,
+                    Map.of("pikUnits", 10000, "switchingNetUnits", -5000))));
     givenNav(TUK75, "0.80");
     givenParameters(TUK75, "500000");
 
@@ -115,12 +132,44 @@ class PevaRavaFlowServiceTest {
   }
 
   @Test
-  void omitsFundWithoutAnySummaries() {
+  void usesActiveCycleR21NotNewerCrossCycleSummary() {
+    givenActiveCycle(R17_REPORT_ID, R21_REPORT_ID);
+    given(summaryRepository.findByReportIdAndFund(R17_REPORT_ID, TUK75))
+        .willReturn(
+            Optional.of(
+                summary(
+                    R17_PEVA,
+                    R17_REPORT_ID,
+                    TUK75,
+                    Map.of("pikUnits", 10000, "switchingNetUnits", -5000))));
+    given(summaryRepository.findByReportIdAndFund(R21_REPORT_ID, TUK75))
+        .willReturn(
+            Optional.of(summary(R21_RAVA, R21_REPORT_ID, TUK75, Map.of("ravaUnits", 20000))));
+    givenNav(TUK75, "0.80");
+    givenParameters(TUK75, "500000");
+
+    Map<TulevaFund, PevaRavaFlows> flows = service.calculateFlows();
+
+    assertThat(flows.get(TUK75).ravaEur()).isEqualByComparingTo("16000");
+  }
+
+  @Test
+  void omitsFundWhenNoActiveCycleExists() {
+    given(periodService.getCurrentPeriod(AS_OF_DATE)).willReturn(Optional.empty());
+
+    assertThat(service.calculateFlows()).isEmpty();
+  }
+
+  @Test
+  void omitsFundWhenCycleHasNoLinkedReports() {
+    givenActiveCycle(null, null);
+
     assertThat(service.calculateFlows()).isEmpty();
   }
 
   @Test
   void throwsWhenNavMissing() {
+    givenActiveCycle(R17_REPORT_ID, R21_REPORT_ID);
     givenSummaries(TUK75, Map.of("pikUnits", 10000, "switchingNetUnits", 0), 0);
 
     assertThatThrownBy(service::calculateFlows).isInstanceOf(IllegalStateException.class);
@@ -128,6 +177,7 @@ class PevaRavaFlowServiceTest {
 
   @Test
   void throwsWhenNavOutOfReasonableRange() {
+    givenActiveCycle(R17_REPORT_ID, R21_REPORT_ID);
     givenSummaries(TUK75, Map.of("pikUnits", 10000, "switchingNetUnits", 0), 0);
     givenNav(TUK75, "12.00");
 
@@ -136,17 +186,33 @@ class PevaRavaFlowServiceTest {
 
   @Test
   void throwsWhenEurAmountsAreImplausiblyLarge() {
+    givenActiveCycle(R17_REPORT_ID, R21_REPORT_ID);
     givenSummaries(TUK75, Map.of("pikUnits", 900000000, "switchingNetUnits", 0), 0);
     givenNav(TUK75, "0.80");
 
     assertThatThrownBy(service::calculateFlows).isInstanceOf(IllegalStateException.class);
   }
 
+  private void givenActiveCycle(Long r17ReportId, Long r21ReportId) {
+    PevaRavaCycle cycle = new PevaRavaCycle(LOCK_DATE, EXEC_DATE);
+    given(periodService.getCurrentPeriod(AS_OF_DATE))
+        .willReturn(Optional.of(new PevaRavaPeriod(PevaRavaPhase.ACTIVE, cycle, null, null)));
+    PevaRavaCycleEntity entity =
+        PevaRavaCycleEntity.builder()
+            .lockDate(LOCK_DATE)
+            .execDate(EXEC_DATE)
+            .r17ReportId(r17ReportId)
+            .r21ReportId(r21ReportId)
+            .build();
+    given(cycleRepository.findByExecDate(EXEC_DATE)).willReturn(Optional.of(entity));
+  }
+
   private void givenSummaries(TulevaFund fund, Map<String, Object> r17Data, int ravaUnits) {
-    given(summaryRepository.findTopByReportTypeAndFundOrderByReportDateDescIdDesc(R17_PEVA, fund))
-        .willReturn(Optional.of(summary(fund, r17Data)));
-    given(summaryRepository.findTopByReportTypeAndFundOrderByReportDateDescIdDesc(R21_RAVA, fund))
-        .willReturn(Optional.of(summary(fund, Map.of("ravaUnits", ravaUnits))));
+    given(summaryRepository.findByReportIdAndFund(R17_REPORT_ID, fund))
+        .willReturn(Optional.of(summary(R17_PEVA, R17_REPORT_ID, fund, r17Data)));
+    given(summaryRepository.findByReportIdAndFund(R21_REPORT_ID, fund))
+        .willReturn(
+            Optional.of(summary(R21_RAVA, R21_REPORT_ID, fund, Map.of("ravaUnits", ravaUnits))));
   }
 
   private void givenNav(TulevaFund fund, String nav) {
@@ -167,10 +233,11 @@ class PevaRavaFlowServiceTest {
         .willReturn(new BigDecimal("1000"));
   }
 
-  private EpisReportSummary summary(TulevaFund fund, Map<String, Object> data) {
+  private EpisReportSummary summary(
+      ReportType reportType, Long reportId, TulevaFund fund, Map<String, Object> data) {
     return EpisReportSummary.builder()
-        .reportId(1L)
-        .reportType(R17_PEVA)
+        .reportId(reportId)
+        .reportType(reportType)
         .reportDate(AS_OF_DATE)
         .fund(fund)
         .fundIsin(fund.getIsin())

--- a/src/test/groovy/ee/tuleva/onboarding/investment/epis/R45ReportServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/epis/R45ReportServiceTest.java
@@ -5,10 +5,15 @@ import static ee.tuleva.onboarding.fund.TulevaFund.TUK75;
 import static ee.tuleva.onboarding.fund.TulevaFund.TUV100;
 import static ee.tuleva.onboarding.investment.report.ReportProvider.EPIS;
 import static ee.tuleva.onboarding.investment.report.ReportType.R45;
+import static ee.tuleva.onboarding.notification.OperationsNotificationService.Channel.INVESTMENT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import ee.tuleva.onboarding.fund.TulevaFund;
@@ -16,6 +21,7 @@ import ee.tuleva.onboarding.investment.epis.parser.EpisCsvParser;
 import ee.tuleva.onboarding.investment.epis.parser.R45ReportParser;
 import ee.tuleva.onboarding.investment.report.InvestmentReport;
 import ee.tuleva.onboarding.investment.report.InvestmentReportRepository;
+import ee.tuleva.onboarding.notification.OperationsNotificationService;
 import ee.tuleva.onboarding.savings.fund.nav.FundNavQueryService;
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -34,6 +40,8 @@ class R45ReportServiceTest {
   private final EpisReportSummaryRepository summaryRepository =
       mock(EpisReportSummaryRepository.class);
   private final FundNavQueryService fundNavQueryService = mock(FundNavQueryService.class);
+  private final OperationsNotificationService notificationService =
+      mock(OperationsNotificationService.class);
 
   private final R45ReportService service =
       new R45ReportService(
@@ -41,7 +49,8 @@ class R45ReportServiceTest {
           summaryRepository,
           new OwnFundNavProvider(fundNavQueryService),
           new R45ReportParser(new EpisCsvParser()),
-          new EpisCsvParser());
+          new EpisCsvParser(),
+          notificationService);
 
   @Test
   void processAndStoreReplacesSummariesWithFlowsAndRedRowSettlementDates() {
@@ -95,6 +104,36 @@ class R45ReportServiceTest {
                         new BigDecimal("-400.00"),
                         "redRowSettlementDates",
                         List.of("2026-08-18", "2026-08-25")))));
+    verify(notificationService, never()).sendMessage(any(), any());
+  }
+
+  @Test
+  void marksSummaryIncompleteAndAlertsWhenRowHasNoNav() {
+    String csv =
+        """
+        Tehtud: 14.08.2026;;;;;
+        Tehingu liik;ISIN;NAV;Osakuid;Summa;Täitmise kuupäev
+        RED;EE3600109435;0;1000,000;0;18.08.2026
+        """;
+    givenStoredReport(csv);
+
+    service.processAndStore(REPORT_ID);
+
+    verify(summaryRepository)
+        .saveAll(
+            List.of(
+                incompleteSummary(
+                    TUK75,
+                    Map.of(
+                        "inflowEur",
+                        BigDecimal.ZERO,
+                        "outflowEur",
+                        BigDecimal.ZERO,
+                        "netEur",
+                        BigDecimal.ZERO,
+                        "redRowSettlementDates",
+                        List.of("2026-08-18")))));
+    verify(notificationService).sendMessage(contains("EE3600109435"), eq(INVESTMENT));
   }
 
   @Test
@@ -207,5 +246,11 @@ class R45ReportServiceTest {
         .fundIsin(fund.getIsin())
         .data(data)
         .build();
+  }
+
+  private EpisReportSummary incompleteSummary(TulevaFund fund, Map<String, Object> data) {
+    EpisReportSummary summary = summary(fund, data);
+    summary.setComplete(false);
+    return summary;
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/investment/portfolio/ModelPortfolioAllocationRepositoryTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/portfolio/ModelPortfolioAllocationRepositoryTest.java
@@ -140,7 +140,7 @@ class ModelPortfolioAllocationRepositoryTest {
   }
 
   @Test
-  void findFirstByIsin_returnsLatestAllocationWithProvider() {
+  void findFirstByIsinAsOf_returnsLatestAllocationWithProviderOnOrBeforeDate() {
     entityManager.persist(
         ModelPortfolioAllocation.builder()
             .effectiveDate(LocalDate.of(2025, 3, 1))
@@ -157,23 +157,42 @@ class ModelPortfolioAllocationRepositoryTest {
             .weight(new BigDecimal("0.174"))
             .provider(XTRACKERS)
             .build());
+    // Future-dated allocation that must NOT affect resolution for an earlier as-of date.
     entityManager.persist(
         ModelPortfolioAllocation.builder()
             .effectiveDate(LocalDate.of(2026, 3, 1))
             .fund(TUK75)
             .isin("IE00BJZ2DC62")
             .weight(new BigDecimal("0.20"))
+            .provider(ISHARES)
             .build());
     entityManager.flush();
 
-    var latestWithProvider =
-        repository.findFirstByIsinAndProviderIsNotNullOrderByEffectiveDateDesc("IE00BJZ2DC62");
+    var asOfMidPeriod =
+        repository
+            .findFirstByIsinAndProviderIsNotNullAndEffectiveDateLessThanEqualOrderByEffectiveDateDesc(
+                "IE00BJZ2DC62", LocalDate.of(2026, 1, 15));
+    var asOfAfterFuture =
+        repository
+            .findFirstByIsinAndProviderIsNotNullAndEffectiveDateLessThanEqualOrderByEffectiveDateDesc(
+                "IE00BJZ2DC62", LocalDate.of(2026, 6, 1));
+    var asOfBeforeAny =
+        repository
+            .findFirstByIsinAndProviderIsNotNullAndEffectiveDateLessThanEqualOrderByEffectiveDateDesc(
+                "IE00BJZ2DC62", LocalDate.of(2025, 1, 1));
     var unknownIsin =
-        repository.findFirstByIsinAndProviderIsNotNullOrderByEffectiveDateDesc("XX0000000000");
+        repository
+            .findFirstByIsinAndProviderIsNotNullAndEffectiveDateLessThanEqualOrderByEffectiveDateDesc(
+                "XX0000000000", LocalDate.of(2026, 1, 15));
 
-    assertThat(latestWithProvider.orElseThrow().getProvider()).isEqualTo(XTRACKERS);
-    assertThat(latestWithProvider.orElseThrow().getEffectiveDate())
-        .isEqualTo(LocalDate.of(2025, 12, 1));
+    // As of 2026-01-15 the future 2026-03-01 allocation is excluded; latest effective is
+    // 2025-12-01.
+    assertThat(asOfMidPeriod.orElseThrow().getProvider()).isEqualTo(XTRACKERS);
+    assertThat(asOfMidPeriod.orElseThrow().getEffectiveDate()).isEqualTo(LocalDate.of(2025, 12, 1));
+    // As of 2026-06-01 the future allocation is now in scope and wins.
+    assertThat(asOfAfterFuture.orElseThrow().getEffectiveDate())
+        .isEqualTo(LocalDate.of(2026, 3, 1));
+    assertThat(asOfBeforeAny).isEmpty();
     assertThat(unknownIsin).isEmpty();
   }
 

--- a/src/test/groovy/ee/tuleva/onboarding/investment/report/InvestmentReportServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/report/InvestmentReportServiceTest.java
@@ -11,7 +11,10 @@ import static org.mockito.Mockito.when;
 
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
+import java.time.Clock;
+import java.time.Instant;
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -25,8 +28,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class InvestmentReportServiceTest {
 
+  private static final Instant NOW = Instant.parse("2026-01-15T09:00:00Z");
+
   @Mock private InvestmentReportRepository repository;
   @Spy private CsvToJsonConverter csvConverter = new CsvToJsonConverter();
+  @Spy private Clock clock = Clock.fixed(NOW, ZoneId.of("Europe/Tallinn"));
   @InjectMocks private InvestmentReportService service;
 
   @Test
@@ -60,7 +66,7 @@ class InvestmentReportServiceTest {
     assertThat(result.getRawData()).hasSize(1);
     assertThat(result.getRawData().getFirst().get("col1")).isEqualTo("val1");
     assertThat(result.getMetadata().get("filename")).isEqualTo("test.csv");
-    assertThat(result.getCreatedAt()).isNotNull();
+    assertThat(result.getCreatedAt()).isEqualTo(NOW);
   }
 
   @Test

--- a/src/test/groovy/ee/tuleva/onboarding/investment/report/ReportImportJobTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/report/ReportImportJobTest.java
@@ -44,7 +44,8 @@ class ReportImportJobTest {
 
   @BeforeEach
   void setUp() {
-    reportService = new InvestmentReportService(reportRepository, new CsvToJsonConverter());
+    reportService =
+        new InvestmentReportService(reportRepository, new CsvToJsonConverter(), FIXED_CLOCK);
     job =
         new ReportImportJob(
             List.of(source),

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/FairAllocationInvariantTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/FairAllocationInvariantTest.java
@@ -1,0 +1,107 @@
+package ee.tuleva.onboarding.investment.transaction;
+
+import static ee.tuleva.onboarding.fund.TulevaFund.TKF100;
+import static ee.tuleva.onboarding.fund.TulevaFund.TUV100;
+import static ee.tuleva.onboarding.investment.transaction.TransactionMode.BUY;
+import static java.math.BigDecimal.ZERO;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ee.tuleva.onboarding.investment.transaction.calculation.TradeCalculationEngine;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Fair-allocation invariant for the trade calculation engine (R6).
+ *
+ * <p><b>Regulatory basis:</b> Directive 2010/43/EU art 28 (order aggregation and allocation)
+ * obliges fair allocation only where orders for different clients/funds are aggregated into a
+ * single pool. Tuleva's calculation engine computes each fund independently from that fund's own
+ * inputs — there is no cross-fund aggregation pool — so the art 28 obligation is not triggered by
+ * construction.
+ *
+ * <p>This test pins that invariant so a future change introducing cross-fund pooling fails here:
+ *
+ * <ul>
+ *   <li>{@link TradeCalculationEngine#calculate} consumes a single {@link FundTransactionInput} for
+ *       one fund and yields a {@link FundCalculationResult} for exactly that fund.
+ *   <li>The trades produced reference only the input fund's own positions — feeding two funds whose
+ *       ISIN universes overlap produces two independent results, neither aware of the other's free
+ *       cash, positions, or limits.
+ *   <li>A {@link TransactionBatch} carries exactly one {@code fund} (no collection of funds).
+ * </ul>
+ */
+class FairAllocationInvariantTest {
+
+  private final TradeCalculationEngine engine = new TradeCalculationEngine();
+
+  @Test
+  void calculationResultIsScopedToTheSingleInputFund() {
+    var result = engine.calculate(singleFundInput(TUV100, "IE00A"), BUY);
+
+    assertThat(result.fund()).isEqualTo(TUV100);
+    assertThat(result.input().fund()).isEqualTo(TUV100);
+  }
+
+  @Test
+  void twoFundsSharingAnIsinAreComputedIndependentlyWithNoCrossFundPooling() {
+    String sharedIsin = "IE00SHARED";
+
+    var firstFundInput = singleFundInput(TUV100, sharedIsin);
+    var secondFundInput = singleFundInput(TKF100, sharedIsin);
+
+    var firstResult = engine.calculate(firstFundInput, BUY);
+    var secondResult = engine.calculate(secondFundInput, BUY);
+
+    assertThat(firstResult.fund()).isEqualTo(TUV100);
+    assertThat(secondResult.fund()).isEqualTo(TKF100);
+
+    assertThat(tradedIsins(firstResult)).containsExactly(sharedIsin);
+    assertThat(tradedIsins(secondResult)).containsExactly(sharedIsin);
+
+    // No pooling: each fund allocates only its own free cash, independent of the other fund.
+    assertThat(totalTraded(firstResult)).isEqualByComparingTo(firstFundInput.freeCash());
+    assertThat(totalTraded(secondResult)).isEqualByComparingTo(secondFundInput.freeCash());
+  }
+
+  @Test
+  void everyOrderAndItsBatchCarryExactlyOneAndTheSameFund() {
+    var batch = TransactionBatch.builder().fund(TUV100).createdBy("system").build();
+
+    var order = TransactionOrder.builder().batch(batch).fund(batch.getFund()).build();
+
+    assertThat(order.getFund()).isEqualTo(batch.getFund());
+    assertThat(order.getBatch().getFund()).isEqualTo(TUV100);
+  }
+
+  private static FundTransactionInput singleFundInput(
+      ee.tuleva.onboarding.fund.TulevaFund fund, String isin) {
+    return FundTransactionInput.builder()
+        .fund(fund)
+        .positions(List.of(new PositionSnapshot(isin, new BigDecimal("500000"))))
+        .modelWeights(List.of(new ModelWeight(isin, new BigDecimal("1.00"))))
+        .grossPortfolioValue(new BigDecimal("1000000"))
+        .cashBuffer(new BigDecimal("50000"))
+        .liabilities(ZERO)
+        .freeCash(new BigDecimal("100000"))
+        .minTransactionThreshold(new BigDecimal("5000"))
+        .positionLimits(Map.of())
+        .fastSellIsins(Set.of())
+        .build();
+  }
+
+  private static List<String> tradedIsins(FundCalculationResult result) {
+    return result.trades().stream()
+        .filter(trade -> trade.tradeAmount().compareTo(ZERO) != 0)
+        .map(TradeCalculation::isin)
+        .toList();
+  }
+
+  private static BigDecimal totalTraded(FundCalculationResult result) {
+    return result.trades().stream()
+        .map(TradeCalculation::tradeAmount)
+        .reduce(ZERO, BigDecimal::add);
+  }
+}

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/SettlementDateCalculatorTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/SettlementDateCalculatorTest.java
@@ -6,6 +6,8 @@ import static ee.tuleva.onboarding.investment.portfolio.Provider.ISHARES;
 import static ee.tuleva.onboarding.investment.transaction.InstrumentType.ETF;
 import static ee.tuleva.onboarding.investment.transaction.InstrumentType.FUND;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 
 import ee.tuleva.onboarding.investment.calendar.DomicileCalendar;
@@ -99,18 +101,39 @@ class SettlementDateCalculatorTest {
 
   @Test
   void fund_unresolvableIsinFallsBackToTarget2() {
-    given(
-            allocationRepository.findFirstByIsinAndProviderIsNotNullOrderByEffectiveDateDesc(
-                UNKNOWN_ISIN))
-        .willReturn(Optional.empty());
     LocalDate beforeStPatricksDay = LocalDate.of(2026, 3, 12);
+    given(
+            allocationRepository
+                .findFirstByIsinAndProviderIsNotNullAndEffectiveDateLessThanEqualOrderByEffectiveDateDesc(
+                    UNKNOWN_ISIN, beforeStPatricksDay))
+        .willReturn(Optional.empty());
 
     assertThat(calculator().calculateSettlementDate(beforeStPatricksDay, FUND, UNKNOWN_ISIN))
         .isEqualTo(LocalDate.of(2026, 3, 19));
   }
 
+  @Test
+  void fund_futureDatedAllocationDoesNotAffectEarlierTradeDate() {
+    LocalDate tradeDate = LocalDate.of(2026, 3, 12);
+    // A future-dated allocation (effectiveDate after the trade date) must not be resolved as the
+    // provider for this trade. The as-of-bounded finder returns empty, so we fall back to TARGET2.
+    given(
+            allocationRepository
+                .findFirstByIsinAndProviderIsNotNullAndEffectiveDateLessThanEqualOrderByEffectiveDateDesc(
+                    IRISH_FUND_ISIN, tradeDate))
+        .willReturn(Optional.empty());
+
+    // If the future allocation leaked in, the Irish calendar would skip St Patrick's Day and push
+    // settlement to 2026-03-20; with TARGET2 fallback it settles 2026-03-19.
+    assertThat(calculator().calculateSettlementDate(tradeDate, FUND, IRISH_FUND_ISIN))
+        .isEqualTo(LocalDate.of(2026, 3, 19));
+  }
+
   private void givenProvider(String isin, Provider provider) {
-    given(allocationRepository.findFirstByIsinAndProviderIsNotNullOrderByEffectiveDateDesc(isin))
+    given(
+            allocationRepository
+                .findFirstByIsinAndProviderIsNotNullAndEffectiveDateLessThanEqualOrderByEffectiveDateDesc(
+                    eq(isin), any()))
         .willReturn(
             Optional.of(ModelPortfolioAllocation.builder().isin(isin).provider(provider).build()));
   }

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionAdminServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionAdminServiceTest.java
@@ -13,6 +13,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.never;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.BDDMockito.willAnswer;
 
@@ -47,6 +48,7 @@ class TransactionAdminServiceTest {
   @Mock private TransactionCommandRepository commandRepository;
   @Mock private TransactionBatchRepository batchRepository;
   @Mock private TransactionOrderRepository orderRepository;
+  @Mock private TransactionAuditEventRepository auditEventRepository;
   @Mock private TransactionPreparationService preparationService;
 
   @InjectMocks private TransactionAdminService service;
@@ -246,10 +248,12 @@ class TransactionAdminServiceTest {
         .finalizeConfirmedBatch(batch);
     given(orderRepository.findByBatchId(10L)).willReturn(List.of());
 
-    TransactionBatchResponse response = service.confirmAndFinalize(10L);
+    TransactionBatchResponse response = service.confirmAndFinalize(10L, "operator-7");
 
     then(preparationService).should().finalizeConfirmedBatch(batch);
     assertThat(response.status()).isEqualTo(BatchStatus.SENT);
+    assertThat(batch.getConfirmedBy()).isEqualTo("operator-7");
+    assertThat(batch.getConfirmedAt()).isEqualTo(Instant.parse("2026-06-11T09:00:00Z"));
   }
 
   @Test
@@ -266,7 +270,7 @@ class TransactionAdminServiceTest {
         .finalizeConfirmedBatch(batch);
     given(orderRepository.findByBatchId(10L)).willReturn(List.of());
 
-    service.confirmAndFinalize(10L);
+    service.confirmAndFinalize(10L, "admin");
 
     then(preparationService).should().finalizeConfirmedBatch(batch);
   }
@@ -275,7 +279,7 @@ class TransactionAdminServiceTest {
   void confirmAndFinalize_unknownBatch_throwsNotFound() {
     given(batchRepository.findById(999L)).willReturn(Optional.empty());
 
-    assertThatThrownBy(() -> service.confirmAndFinalize(999L))
+    assertThatThrownBy(() -> service.confirmAndFinalize(999L, "admin"))
         .isInstanceOf(ResponseStatusException.class)
         .extracting(e -> ((ResponseStatusException) e).getStatusCode().value())
         .isEqualTo(404);
@@ -285,11 +289,78 @@ class TransactionAdminServiceTest {
   void confirmAndFinalize_alreadySentBatch_throwsConflict() {
     given(batchRepository.findById(10L)).willReturn(Optional.of(batch(10L, BatchStatus.SENT)));
 
-    assertThatThrownBy(() -> service.confirmAndFinalize(10L))
+    assertThatThrownBy(() -> service.confirmAndFinalize(10L, "admin"))
         .isInstanceOf(ResponseStatusException.class)
         .extracting(e -> ((ResponseStatusException) e).getStatusCode().value())
         .isEqualTo(409);
     then(preparationService).shouldHaveNoInteractions();
+  }
+
+  @Test
+  void cancelBatch_cancelsBatchAndNotYetExecutedOrdersAndWritesAudit() {
+    TransactionBatch batch = batch(10L, AWAITING_CONFIRMATION);
+    TransactionOrder pendingOrder = order(100L, batch);
+    pendingOrder.setOrderStatus(OrderStatus.PENDING);
+    TransactionOrder sentOrder = order(101L, batch);
+    sentOrder.setOrderStatus(OrderStatus.SENT);
+    given(batchRepository.findById(10L)).willReturn(Optional.of(batch));
+    given(orderRepository.findByBatchId(10L)).willReturn(List.of(pendingOrder, sentOrder));
+
+    TransactionBatchResponse response = service.cancelBatch(10L, "duplicate batch", "operator-7");
+
+    assertThat(response.status()).isEqualTo(BatchStatus.CANCELLED);
+    assertThat(batch.getStatus()).isEqualTo(BatchStatus.CANCELLED);
+    assertThat(batch.getCancellationReason()).isEqualTo("duplicate batch");
+    assertThat(batch.getCancelledBy()).isEqualTo("operator-7");
+    assertThat(batch.getCancelledAt()).isEqualTo(Instant.parse("2026-06-11T09:00:00Z"));
+    assertThat(pendingOrder.getOrderStatus()).isEqualTo(OrderStatus.CANCELLED);
+    assertThat(sentOrder.getOrderStatus()).isEqualTo(OrderStatus.CANCELLED);
+
+    then(batchRepository).should().save(batch);
+    then(orderRepository).should().saveAll(List.of(pendingOrder, sentOrder));
+    then(batchRepository).should(never()).delete(any());
+    then(orderRepository).should(never()).deleteAll(any());
+    then(auditEventRepository)
+        .should()
+        .save(
+            TransactionAuditEvent.builder()
+                .batch(batch)
+                .eventType("BATCH_CANCELLED")
+                .actor("operator-7")
+                .createdAt(Instant.parse("2026-06-11T09:00:00Z"))
+                .payload(
+                    Map.of("reason", "duplicate batch", "actor", "operator-7", "orderCount", 2))
+                .build());
+  }
+
+  @Test
+  void cancelBatch_withExecutedOrder_throwsConflictAndMutatesNothing() {
+    TransactionBatch batch = batch(10L, BatchStatus.SENT);
+    TransactionOrder executedOrder = order(100L, batch);
+    executedOrder.setOrderStatus(OrderStatus.EXECUTED);
+    given(batchRepository.findById(10L)).willReturn(Optional.of(batch));
+    given(orderRepository.findByBatchId(10L)).willReturn(List.of(executedOrder));
+
+    assertThatThrownBy(() -> service.cancelBatch(10L, "duplicate batch", "operator-7"))
+        .isInstanceOf(ResponseStatusException.class)
+        .extracting(e -> ((ResponseStatusException) e).getStatusCode().value())
+        .isEqualTo(409);
+
+    assertThat(batch.getStatus()).isEqualTo(BatchStatus.SENT);
+    assertThat(executedOrder.getOrderStatus()).isEqualTo(OrderStatus.EXECUTED);
+    then(batchRepository).should(never()).save(any());
+    then(orderRepository).should(never()).saveAll(any());
+    then(auditEventRepository).shouldHaveNoInteractions();
+  }
+
+  @Test
+  void cancelBatch_unknownBatch_throwsNotFound() {
+    given(batchRepository.findById(999L)).willReturn(Optional.empty());
+
+    assertThatThrownBy(() -> service.cancelBatch(999L, "duplicate batch", "admin"))
+        .isInstanceOf(ResponseStatusException.class)
+        .extracting(e -> ((ResponseStatusException) e).getStatusCode().value())
+        .isEqualTo(404);
   }
 
   @Test

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionBatchRepositoryIT.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionBatchRepositoryIT.java
@@ -36,6 +36,38 @@ class TransactionBatchRepositoryIT {
     assertThat(batchRepository.findFirstByFundOrderByCreatedAtDesc(TUK00)).isEmpty();
   }
 
+  @Test
+  void confirmationAndCancellationColumnsRoundTrip() {
+    TransactionBatch batch =
+        batchRepository.save(
+            TransactionBatch.builder()
+                .fund(TUK75)
+                .status(BatchStatus.CANCELLED)
+                .createdBy("system")
+                .createdAt(Instant.parse("2026-06-11T09:00:00Z"))
+                .confirmedBy("operator-7")
+                .confirmedAt(Instant.parse("2026-06-11T09:05:00Z"))
+                .cancellationReason("duplicate batch")
+                .cancelledBy("operator-9")
+                .cancelledAt(Instant.parse("2026-06-11T09:10:00Z"))
+                .metadata(Map.of())
+                .build());
+
+    assertThat(batchRepository.findById(batch.getId()))
+        .get()
+        .satisfies(
+            persisted -> {
+              assertThat(persisted.getStatus()).isEqualTo(BatchStatus.CANCELLED);
+              assertThat(persisted.getConfirmedBy()).isEqualTo("operator-7");
+              assertThat(persisted.getConfirmedAt())
+                  .isEqualTo(Instant.parse("2026-06-11T09:05:00Z"));
+              assertThat(persisted.getCancellationReason()).isEqualTo("duplicate batch");
+              assertThat(persisted.getCancelledBy()).isEqualTo("operator-9");
+              assertThat(persisted.getCancelledAt())
+                  .isEqualTo(Instant.parse("2026-06-11T09:10:00Z"));
+            });
+  }
+
   private TransactionBatch persistBatch(TulevaFund fund, Instant createdAt) {
     return batchRepository.save(
         TransactionBatch.builder()

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionCommandControllerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionCommandControllerTest.java
@@ -10,6 +10,7 @@ import static ee.tuleva.onboarding.investment.transaction.OrderVenue.SEB;
 import static ee.tuleva.onboarding.investment.transaction.TransactionMode.REBALANCE;
 import static ee.tuleva.onboarding.investment.transaction.TransactionType.BUY;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
 import static org.springframework.http.HttpStatus.CONFLICT;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
@@ -231,7 +232,7 @@ class TransactionCommandControllerTest {
 
   @Test
   void confirmBatch_finalizesAndReturnsBatch() throws Exception {
-    given(adminService.confirmAndFinalize(10L)).willReturn(batchResponse());
+    given(adminService.confirmAndFinalize(10L, "admin")).willReturn(batchResponse());
 
     mockMvc
         .perform(
@@ -244,8 +245,23 @@ class TransactionCommandControllerTest {
   }
 
   @Test
+  void confirmBatch_passesAdminActorToService() throws Exception {
+    given(adminService.confirmAndFinalize(10L, "operator-7")).willReturn(batchResponse());
+
+    mockMvc
+        .perform(
+            post("/admin/transaction-batches/10/confirm")
+                .with(csrf())
+                .header("X-Admin-Token", "valid-token")
+                .header("X-Admin-Actor", "operator-7"))
+        .andExpect(status().isOk());
+
+    then(adminService).should().confirmAndFinalize(10L, "operator-7");
+  }
+
+  @Test
   void confirmBatch_notAwaitingConfirmation_returnsConflict() throws Exception {
-    given(adminService.confirmAndFinalize(10L))
+    given(adminService.confirmAndFinalize(10L, "admin"))
         .willThrow(
             new ResponseStatusException(
                 CONFLICT, "Batch not awaiting confirmation: id=10, status=SENT"));
@@ -256,6 +272,81 @@ class TransactionCommandControllerTest {
                 .with(csrf())
                 .header("X-Admin-Token", "valid-token"))
         .andExpect(status().isConflict());
+  }
+
+  @Test
+  void cancelBatch_withReasonAndActor_invokesServiceAndReturnsBatch() throws Exception {
+    given(adminService.cancelBatch(10L, "duplicate batch", "operator-7"))
+        .willReturn(batchResponse());
+
+    mockMvc
+        .perform(
+            post("/admin/transaction-batches/10/cancel")
+                .with(csrf())
+                .header("X-Admin-Token", "valid-token")
+                .header("X-Admin-Actor", "operator-7")
+                .contentType(APPLICATION_JSON)
+                .content(
+                    """
+                    {"reason": "duplicate batch"}
+                    """))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").value(10));
+
+    then(adminService).should().cancelBatch(10L, "duplicate batch", "operator-7");
+  }
+
+  @Test
+  void cancelBatch_withoutActor_defaultsToAdmin() throws Exception {
+    given(adminService.cancelBatch(10L, "duplicate batch", "admin")).willReturn(batchResponse());
+
+    mockMvc
+        .perform(
+            post("/admin/transaction-batches/10/cancel")
+                .with(csrf())
+                .header("X-Admin-Token", "valid-token")
+                .contentType(APPLICATION_JSON)
+                .content(
+                    """
+                    {"reason": "duplicate batch"}
+                    """))
+        .andExpect(status().isOk());
+
+    then(adminService).should().cancelBatch(10L, "duplicate batch", "admin");
+  }
+
+  @Test
+  void cancelBatch_blankReason_returnsBadRequest() throws Exception {
+    mockMvc
+        .perform(
+            post("/admin/transaction-batches/10/cancel")
+                .with(csrf())
+                .header("X-Admin-Token", "valid-token")
+                .contentType(APPLICATION_JSON)
+                .content(
+                    """
+                    {"reason": "  "}
+                    """))
+        .andExpect(status().isBadRequest());
+
+    then(adminService).shouldHaveNoInteractions();
+  }
+
+  @Test
+  void cancelBatch_invalidToken_returnsUnauthorized() throws Exception {
+    mockMvc
+        .perform(
+            post("/admin/transaction-batches/10/cancel")
+                .with(csrf())
+                .header("X-Admin-Token", "wrong-token")
+                .contentType(APPLICATION_JSON)
+                .content(
+                    """
+                    {"reason": "duplicate batch"}
+                    """))
+        .andExpect(status().isUnauthorized());
+
+    then(adminService).shouldHaveNoInteractions();
   }
 
   @Test

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionCommandJobTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionCommandJobTest.java
@@ -2,18 +2,22 @@ package ee.tuleva.onboarding.investment.transaction;
 
 import static ee.tuleva.onboarding.fund.TulevaFund.TUV100;
 import static ee.tuleva.onboarding.investment.transaction.BatchStatus.CONFIRMED;
+import static ee.tuleva.onboarding.investment.transaction.CommandStatus.FAILED;
 import static ee.tuleva.onboarding.investment.transaction.CommandStatus.PENDING;
 import static ee.tuleva.onboarding.investment.transaction.CommandStatus.PROCESSING;
 import static ee.tuleva.onboarding.investment.transaction.TransactionMode.BUY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
+import java.time.Clock;
+import java.time.Instant;
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
@@ -26,7 +30,17 @@ class TransactionCommandJobTest {
   @Mock private TransactionPreparationService preparationService;
   @Mock private ApplicationEventPublisher eventPublisher;
 
-  @InjectMocks private TransactionCommandJob job;
+  private final Clock clock =
+      Clock.fixed(Instant.parse("2026-01-15T10:00:00Z"), ZoneId.of("Europe/Tallinn"));
+
+  private TransactionCommandJob job;
+
+  @BeforeEach
+  void setUp() {
+    job =
+        new TransactionCommandJob(
+            commandRepository, batchRepository, preparationService, eventPublisher, clock);
+  }
 
   @Test
   void processCommands_picksPendingCommandsAndProcesses() {
@@ -107,6 +121,28 @@ class TransactionCommandJobTest {
 
     verify(preparationService).processCommand(command1);
     verify(preparationService).processCommand(command2);
+  }
+
+  @Test
+  void processCommands_onUnexpectedException_marksCommandFailed() {
+    var command =
+        TransactionCommand.builder()
+            .id(1L)
+            .fund(TUV100)
+            .mode(BUY)
+            .asOfDate(LocalDate.of(2026, 1, 15))
+            .manualAdjustments(Map.of())
+            .status(PENDING)
+            .build();
+
+    when(commandRepository.findByStatus(PENDING)).thenReturn(List.of(command));
+    doThrow(new RuntimeException("Boom")).when(preparationService).processCommand(command);
+
+    job.processCommands();
+
+    assertThat(command.getStatus()).isEqualTo(FAILED);
+    assertThat(command.getErrorMessage()).isEqualTo("Boom");
+    assertThat(command.getProcessedAt()).isEqualTo(Instant.parse("2026-01-15T10:00:00Z"));
   }
 
   @Test

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionInputServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionInputServiceTest.java
@@ -916,6 +916,16 @@ class TransactionInputServiceTest {
   }
 
   @Test
+  void gatherInput_r45SummaryIncomplete_throwsToBlockTradeSizing() {
+    stubEmptyBaseline(TUV100);
+    given(r45ReportService.getIncompleteFunds()).willReturn(List.of(TUV100));
+
+    assertThatThrownBy(() -> service.gatherInput(TUV100, AS_OF_DATE, Map.of()))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("R45 summary incomplete");
+  }
+
+  @Test
   void gatherInput_r45NetOutflowCombinesWithManualAdjustments() {
     stubEmptyBaseline(TUV100);
     given(r45ReportService.getLatestFlows())

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionPreparationServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionPreparationServiceTest.java
@@ -30,12 +30,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 @ExtendWith(MockitoExtension.class)
 class TransactionPreparationServiceTest {
@@ -56,6 +59,13 @@ class TransactionPreparationServiceTest {
   @Mock private Clock clock;
 
   @InjectMocks private TransactionPreparationService service;
+
+  @AfterEach
+  void clearSynchronization() {
+    if (TransactionSynchronizationManager.isSynchronizationActive()) {
+      TransactionSynchronizationManager.clearSynchronization();
+    }
+  }
 
   @Test
   void processCommand_createsBatchAndOrders() {
@@ -694,5 +704,63 @@ class TransactionPreparationServiceTest {
 
     assertThat(batch.getMetadata()).containsKey("driveFileUrls");
     verify(exportUploader).uploadExports(eq("root-folder-id"), eq(TUV100), any(), any());
+  }
+
+  @Test
+  void finalizeConfirmedBatch_uploadsToDriveOnlyAfterCommit() {
+    when(clock.instant()).thenReturn(Instant.parse("2026-01-15T10:00:00Z"));
+    when(clock.getZone()).thenReturn(ZoneId.of("Europe/Tallinn"));
+
+    var batch =
+        TransactionBatch.builder()
+            .id(1L)
+            .fund(TUV100)
+            .status(CONFIRMED)
+            .createdBy("system")
+            .metadata(new HashMap<>(Map.of("commandId", 1L)))
+            .build();
+
+    var order =
+        TransactionOrder.builder()
+            .batch(batch)
+            .fund(TUV100)
+            .instrumentIsin("IE00A")
+            .transactionType(TransactionType.BUY)
+            .instrumentType(InstrumentType.ETF)
+            .orderAmount(new BigDecimal("100000"))
+            .orderVenue(OrderVenue.SEB)
+            .orderStatus(OrderStatus.PENDING)
+            .build();
+
+    given(orderRepository.findByBatchId(batch.getId())).willReturn(List.of(order));
+    given(settlementDateCalculator.calculateSettlementDate(any(), any(), any()))
+        .willReturn(LocalDate.of(2026, 1, 19));
+    given(
+            modelPortfolioAllocationRepository.findLatestByFundAsOf(
+                TUV100, LocalDate.of(2026, 1, 15)))
+        .willReturn(List.of());
+    given(exportService.generateOrdersExport(any())).willReturn(new byte[] {1});
+    given(exportService.generateSebFundExport(any(), any())).willReturn(new byte[] {2});
+    given(exportService.generateSebEtfExport(any(), any())).willReturn(new byte[] {3});
+    given(exportService.generateFtEtfExport(any(), any(), any())).willReturn(new byte[] {4});
+    given(driveProperties.enabled()).willReturn(true);
+    given(driveProperties.rootFolderId()).willReturn("root-folder-id");
+    given(exportUploader.uploadExports(any(), any(), any(), any()))
+        .willReturn(Map.of("sebFundXlsx", "https://drive.google.com/file1"));
+
+    TransactionSynchronizationManager.initSynchronization();
+
+    service.finalizeConfirmedBatch(batch);
+
+    verifyNoInteractions(exportUploader);
+    verify(eventPublisher, never()).publishEvent(any(BatchFinalizedEvent.class));
+
+    var synchronizations = TransactionSynchronizationManager.getSynchronizations();
+    assertThat(synchronizations).hasSize(1);
+    synchronizations.forEach(TransactionSynchronization::afterCommit);
+
+    verify(exportUploader).uploadExports(eq("root-folder-id"), eq(TUV100), any(), any());
+    assertThat(batch.getMetadata()).containsKey("driveFileUrls");
+    verify(eventPublisher).publishEvent(any(BatchFinalizedEvent.class));
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionPreparationServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionPreparationServiceTest.java
@@ -17,6 +17,7 @@ import ee.tuleva.onboarding.comparisons.fundvalue.ResolvedPrice;
 import ee.tuleva.onboarding.investment.portfolio.ModelPortfolioAllocation;
 import ee.tuleva.onboarding.investment.portfolio.ModelPortfolioAllocationRepository;
 import ee.tuleva.onboarding.investment.transaction.calculation.TradeCalculationEngine;
+import ee.tuleva.onboarding.investment.transaction.export.CustodianOrderEmailSender;
 import ee.tuleva.onboarding.investment.transaction.export.GoogleDriveProperties;
 import ee.tuleva.onboarding.investment.transaction.export.TransactionExportService;
 import ee.tuleva.onboarding.investment.transaction.export.TransactionExportUploader;
@@ -55,6 +56,7 @@ class TransactionPreparationServiceTest {
   @Mock private ApplicationEventPublisher eventPublisher;
   @Mock private GoogleDriveProperties driveProperties;
   @Mock private TransactionExportUploader exportUploader;
+  @Mock private CustodianOrderEmailSender custodianOrderEmailSender;
   @Mock private PositionPriceResolver positionPriceResolver;
   @Mock private Clock clock;
 
@@ -128,6 +130,76 @@ class TransactionPreparationServiceTest {
   }
 
   @Test
+  void processCommand_persistsManualAdjustmentsInCalculationSnapshot() {
+    var manualAdjustments = Map.<String, Object>of("IE00A", "25000");
+    var command =
+        TransactionCommand.builder()
+            .id(8L)
+            .fund(TUV100)
+            .mode(BUY)
+            .asOfDate(LocalDate.of(2026, 1, 15))
+            .manualAdjustments(manualAdjustments)
+            .status(PROCESSING)
+            .build();
+
+    var input =
+        FundTransactionInput.builder()
+            .fund(TUV100)
+            .positions(List.of(new PositionSnapshot("IE00A", new BigDecimal("500000"))))
+            .modelWeights(List.of(new ModelWeight("IE00A", new BigDecimal("1.00"))))
+            .grossPortfolioValue(new BigDecimal("1000000"))
+            .cashBuffer(new BigDecimal("50000"))
+            .liabilities(ZERO)
+            .freeCash(new BigDecimal("100000"))
+            .minTransactionThreshold(new BigDecimal("5000"))
+            .positionLimits(Map.of())
+            .fastSellIsins(Set.of())
+            .build();
+
+    var trades =
+        List.of(
+            new TradeCalculation(
+                "IE00A", new BigDecimal("100000"), new BigDecimal("0.60"), LimitStatus.OK));
+
+    var calculationResult = new FundCalculationResult(TUV100, BUY, input, trades);
+
+    given(inputService.gatherInput(TUV100, command.getAsOfDate(), manualAdjustments))
+        .willReturn(input);
+    given(calculationEngine.calculate(input, BUY)).willReturn(calculationResult);
+    given(batchRepository.save(any(TransactionBatch.class)))
+        .willAnswer(
+            invocation -> {
+              TransactionBatch batch = invocation.getArgument(0);
+              batch.setId(1L);
+              return batch;
+            });
+
+    service.processCommand(command);
+
+    var expectedEvent =
+        TransactionAuditEvent.builder()
+            .eventType("CALCULATION_COMPLETED")
+            .actor("system")
+            .createdAt(Instant.now(clock))
+            .payload(
+                Map.of(
+                    "input", TransactionPreparationService.serializeInput(input, manualAdjustments),
+                    "output", TransactionPreparationService.serializeTrades(trades),
+                    "summary",
+                        Map.of(
+                            "fund", TUV100.name(),
+                            "mode", BUY.name(),
+                            "tradeCount", 1)))
+            .build();
+    verify(auditEventRepository)
+        .save(
+            argThat(
+                event ->
+                    "CALCULATION_COMPLETED".equals(event.getEventType())
+                        && event.getPayload().equals(expectedEvent.getPayload())));
+  }
+
+  @Test
   void serializeInput_serializesAllFieldsToPlainStrings() {
     var input =
         FundTransactionInput.builder()
@@ -147,7 +219,9 @@ class TransactionPreparationServiceTest {
             .fastSellIsins(Set.of("IE00A"))
             .build();
 
-    var result = TransactionPreparationService.serializeInput(input);
+    var manualAdjustments = Map.<String, Object>of("IE00A", "10000");
+
+    var result = TransactionPreparationService.serializeInput(input, manualAdjustments);
 
     assertThat(result).containsEntry("grossPortfolioValue", "1000000");
     assertThat(result).containsEntry("freeCash", "100000");
@@ -159,6 +233,7 @@ class TransactionPreparationServiceTest {
     assertThat(result).containsKey("modelWeights");
     assertThat(result).containsKey("positionLimits");
     assertThat(result).containsKey("fastSellIsins");
+    assertThat(result).containsEntry("manualAdjustments", manualAdjustments);
   }
 
   @Test
@@ -753,6 +828,7 @@ class TransactionPreparationServiceTest {
     service.finalizeConfirmedBatch(batch);
 
     verifyNoInteractions(exportUploader);
+    verifyNoInteractions(custodianOrderEmailSender);
     verify(eventPublisher, never()).publishEvent(any(BatchFinalizedEvent.class));
 
     var synchronizations = TransactionSynchronizationManager.getSynchronizations();
@@ -761,6 +837,7 @@ class TransactionPreparationServiceTest {
 
     verify(exportUploader).uploadExports(eq("root-folder-id"), eq(TUV100), any(), any());
     assertThat(batch.getMetadata()).containsKey("driveFileUrls");
+    verify(custodianOrderEmailSender).send(eq(TUV100), any(), any());
     verify(eventPublisher).publishEvent(any(BatchFinalizedEvent.class));
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionRegistryControllerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionRegistryControllerTest.java
@@ -215,6 +215,48 @@ class TransactionRegistryControllerTest {
   }
 
   @Test
+  void ftConfirmation_suppressed_passesSuppressedFlag() throws Exception {
+    given(
+            ftConfirmationVerificationService.verify(
+                new FtConfirmation(
+                    TUK75,
+                    "IE000F60HVH9",
+                    LocalDate.parse("2026-06-08"),
+                    new BigDecimal("40434"),
+                    new BigDecimal("10.09"),
+                    FtConfirmationType.NORMAL,
+                    null,
+                    true)))
+        .willReturn(
+            Optional.of(
+                new FtConfirmationResult(
+                    FtVerificationStatus.IGNORED,
+                    FtVerificationStatus.IGNORED,
+                    Map.of("ignoreReason", "manually suppressed false positive"))));
+
+    mockMvc
+        .perform(
+            post("/admin/transaction-registry/ft-confirmation")
+                .with(csrf())
+                .header("X-Admin-Token", "valid-token")
+                .contentType("application/json")
+                .content(
+                    """
+                    {
+                      "fund": "TUK75",
+                      "isin": "IE000F60HVH9",
+                      "tradeDate": "2026-06-08",
+                      "quantity": 40434,
+                      "grossPrice": 10.09,
+                      "suppressed": true
+                    }
+                    """))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.quantityStatus").value("IGNORED"))
+        .andExpect(jsonPath("$.priceStatus").value("IGNORED"));
+  }
+
+  @Test
   void ftConfirmation_orderNotFound_returnsNotFound() throws Exception {
     given(ftConfirmationVerificationService.verify(any())).willReturn(Optional.empty());
 

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionRegistryControllerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionRegistryControllerTest.java
@@ -173,6 +173,48 @@ class TransactionRegistryControllerTest {
   }
 
   @Test
+  void ftConfirmation_cancellation_passesTypeAndAccount() throws Exception {
+    given(
+            ftConfirmationVerificationService.verify(
+                new FtConfirmation(
+                    TUK75,
+                    "IE000F60HVH9",
+                    LocalDate.parse("2026-06-08"),
+                    new BigDecimal("40434"),
+                    new BigDecimal("10.09"),
+                    FtConfirmationType.CANCELLATION,
+                    "FT-ACC")))
+        .willReturn(
+            Optional.of(
+                new FtConfirmationResult(
+                    FtVerificationStatus.CANCELLED,
+                    FtVerificationStatus.CANCELLED,
+                    Map.of("cancellationSignature", "sig"))));
+
+    mockMvc
+        .perform(
+            post("/admin/transaction-registry/ft-confirmation")
+                .with(csrf())
+                .header("X-Admin-Token", "valid-token")
+                .contentType("application/json")
+                .content(
+                    """
+                    {
+                      "fund": "TUK75",
+                      "isin": "IE000F60HVH9",
+                      "tradeDate": "2026-06-08",
+                      "quantity": 40434,
+                      "grossPrice": 10.09,
+                      "type": "CANCELLATION",
+                      "account": "FT-ACC"
+                    }
+                    """))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.quantityStatus").value("CANCELLED"))
+        .andExpect(jsonPath("$.priceStatus").value("CANCELLED"));
+  }
+
+  @Test
   void ftConfirmation_orderNotFound_returnsNotFound() throws Exception {
     given(ftConfirmationVerificationService.verify(any())).willReturn(Optional.empty());
 

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionRegistryRetentionGuardTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionRegistryRetentionGuardTest.java
@@ -1,0 +1,148 @@
+package ee.tuleva.onboarding.investment.transaction;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Locale;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider;
+import org.springframework.core.type.filter.AssignableTypeFilter;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.Repository;
+import org.springframework.util.ClassUtils;
+
+/**
+ * Codified retention guard for the transaction registry (R5).
+ *
+ * <p><b>Regulatory basis:</b> transaction registry records must be retained for at least 5 years
+ * (Art 16 record-keeping; Tuleva sisekord 04/11). Retention is currently met only by the
+ * <i>absence</i> of any purge/erasure path against the registry tables:
+ *
+ * <ul>
+ *   <li>{@code investment_transaction_batch} ({@link TransactionBatch})
+ *   <li>{@code investment_transaction_order} ({@link TransactionOrder})
+ *   <li>{@code investment_transaction_execution} ({@link TransactionExecution})
+ *   <li>{@code investment_transaction_command} ({@link TransactionCommand})
+ *   <li>{@code investment_transaction_audit_event} ({@link TransactionAuditEvent})
+ *   <li>{@code transaction_settlement} ({@link TransactionSettlement})
+ *   <li>{@code investment_portfolio_cost_basis} (portfolio cost-basis ledger)
+ * </ul>
+ *
+ * <p>This guard pins that absence. It scans every Spring Data {@link Repository} declared in the
+ * transaction module and fails if one introduces a deletion path:
+ *
+ * <ul>
+ *   <li>a derived delete-style method ({@code deleteBy*} / {@code removeBy*}), or
+ *   <li>a {@code @Query}/{@code @Modifying} carrying a {@code DELETE} against a registry table.
+ * </ul>
+ *
+ * <p>The {@code delete*} methods inherited from {@code JpaRepository} are intentionally out of
+ * scope: they exist on every repository but are not called against these tables (no production code
+ * references them today). A regression that adds a purge would have to declare one of the patterns
+ * above (which fails this test) or wire an inherited {@code delete*} call (which review must
+ * catch); either way the retention obligation stops being silent and becomes self-documenting here.
+ */
+class TransactionRegistryRetentionGuardTest {
+
+  private static final String TRANSACTION_PACKAGE = "ee.tuleva.onboarding.investment.transaction";
+
+  private static final Pattern DELETE_AGAINST_REGISTRY =
+      Pattern.compile(
+          "delete\\s+(from\\s+)?(investment_transaction\\w*|transaction_settlement"
+              + "|investment_portfolio_cost_basis|transactionbatch|transactionorder"
+              + "|transactionexecution|transactioncommand|transactionauditevent"
+              + "|transactionsettlement|portfoliocostbasis|portfoliobaseline)",
+          Pattern.CASE_INSENSITIVE);
+
+  private final List<Class<?>> transactionRepositories = findTransactionRepositories();
+
+  @Test
+  void transactionRepositoriesAreDiscovered() {
+    assertThat(transactionRepositories)
+        .as("transaction module Spring Data repositories")
+        .extracting(Class::getSimpleName)
+        .contains(
+            "TransactionOrderRepository",
+            "TransactionExecutionRepository",
+            "TransactionBatchRepository",
+            "TransactionCommandRepository",
+            "TransactionAuditEventRepository",
+            "TransactionSettlementRepository",
+            "PortfolioCostBasisRepository");
+  }
+
+  @Test
+  void noTransactionRepositoryDeclaresADerivedDeleteOrRemoveMethod() {
+    List<String> offenders =
+        transactionRepositories.stream()
+            .flatMap(repository -> List.of(repository.getDeclaredMethods()).stream())
+            .filter(method -> isDeleteOrRemoveDerivedMethod(method.getName()))
+            .map(TransactionRegistryRetentionGuardTest::describe)
+            .toList();
+
+    assertThat(offenders)
+        .as(
+            "transaction registry repositories must not declare derived delete/remove methods "
+                + "(Art 16 / sisekord 04/11 >=5-year retention)")
+        .isEmpty();
+  }
+
+  @Test
+  void noTransactionRepositoryDeclaresADeleteQueryAgainstRegistryTables() {
+    List<String> offenders =
+        transactionRepositories.stream()
+            .flatMap(repository -> List.of(repository.getDeclaredMethods()).stream())
+            .filter(TransactionRegistryRetentionGuardTest::isDeletingQuery)
+            .map(TransactionRegistryRetentionGuardTest::describe)
+            .toList();
+
+    assertThat(offenders)
+        .as(
+            "no @Query/@Modifying may target a registry table with DELETE "
+                + "(Art 16 / sisekord 04/11 >=5-year retention)")
+        .isEmpty();
+  }
+
+  private static List<Class<?>> findTransactionRepositories() {
+    var scanner =
+        new ClassPathScanningCandidateComponentProvider(false) {
+          @Override
+          protected boolean isCandidateComponent(
+              org.springframework.beans.factory.annotation.AnnotatedBeanDefinition definition) {
+            return definition.getMetadata().isInterface();
+          }
+        };
+    scanner.addIncludeFilter(new AssignableTypeFilter(Repository.class));
+    return scanner.findCandidateComponents(TRANSACTION_PACKAGE).stream()
+        .map(BeanDefinition::getBeanClassName)
+        .<Class<?>>map(
+            name ->
+                ClassUtils.resolveClassName(
+                    name, TransactionRegistryRetentionGuardTest.class.getClassLoader()))
+        .filter(Class::isInterface)
+        .filter(Repository.class::isAssignableFrom)
+        .toList();
+  }
+
+  private static boolean isDeleteOrRemoveDerivedMethod(String methodName) {
+    String lower = methodName.toLowerCase(Locale.ROOT);
+    return lower.startsWith("deleteby") || lower.startsWith("removeby");
+  }
+
+  private static boolean isDeletingQuery(Method method) {
+    Query query = method.getAnnotation(Query.class);
+    if (query != null && DELETE_AGAINST_REGISTRY.matcher(query.value()).find()) {
+      return true;
+    }
+    return method.isAnnotationPresent(Modifying.class)
+        && isDeleteOrRemoveDerivedMethod(method.getName());
+  }
+
+  private static String describe(Method method) {
+    return method.getDeclaringClass().getSimpleName() + "#" + method.getName();
+  }
+}

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionRegistryViewsIT.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionRegistryViewsIT.java
@@ -107,6 +107,40 @@ class TransactionRegistryViewsIT {
   }
 
   @Test
+  void settlementDelays_exposesExpectedAndActualDatesAndOnTimeFlag() {
+    TransactionOrder onTime = persistOrder(EXECUTED, LocalDate.now().minusDays(5), "100");
+    persistExecution(onTime, "100.0000");
+    persistSettlement(onTime, LocalDate.now().minusDays(5));
+    TransactionOrder late = persistOrder(EXECUTED, LocalDate.now().minusDays(5), "200");
+    persistExecution(late, "200.0000");
+    persistSettlement(late, LocalDate.now().minusDays(2));
+    TransactionOrder unsettled = persistOrder(EXECUTED, LocalDate.now().minusDays(3), "300");
+    persistExecution(unsettled, "300.0000");
+    entityManager.flush();
+
+    Map<String, Object> onTimeRow = settlementDelayRow(onTime);
+    assertThat(onTimeRow.get("order_uuid")).isEqualTo(onTime.getOrderUuid());
+    assertThat(onTimeRow.get("fund_code")).isEqualTo("TUK75");
+    assertThat(((java.sql.Date) onTimeRow.get("expected_settlement_date")).toLocalDate())
+        .isEqualTo(LocalDate.now().minusDays(5));
+    assertThat(((java.sql.Date) onTimeRow.get("actual_settlement_date")).toLocalDate())
+        .isEqualTo(LocalDate.now().minusDays(5));
+    assertThat(onTimeRow.get("settled_on_time")).isEqualTo(true);
+
+    Map<String, Object> lateRow = settlementDelayRow(late);
+    assertThat(((java.sql.Date) lateRow.get("actual_settlement_date")).toLocalDate())
+        .isEqualTo(LocalDate.now().minusDays(2));
+    assertThat(lateRow.get("settled_on_time")).isEqualTo(false);
+
+    List<Map<String, Object>> rows =
+        jdbcClient.sql("select order_id from v_settlement_delays").query().listOfRows();
+    assertThat(rows)
+        .extracting(row -> row.get("order_id"))
+        .contains(onTime.getId(), late.getId())
+        .doesNotContain(unsettled.getId());
+  }
+
+  @Test
   void overdueOrders_includesSentOrdersPastExpectedSettlementWithoutExecution() {
     TransactionOrder overdue = persistOrder(SENT, LocalDate.now().minusDays(2), "100");
     TransactionOrder sentButExecuted = persistOrder(SENT, LocalDate.now().minusDays(2), "100");
@@ -230,6 +264,17 @@ class TransactionRegistryViewsIT {
         .singleRow();
   }
 
+  private Map<String, Object> settlementDelayRow(TransactionOrder order) {
+    return jdbcClient
+        .sql(
+            "select order_id, order_uuid, fund_code, expected_settlement_date,"
+                + " actual_settlement_date, settled_on_time from v_settlement_delays"
+                + " where order_id = ?")
+        .param(order.getId())
+        .query()
+        .singleRow();
+  }
+
   private Map<String, Object> reconciliationRow(TransactionOrder order) {
     return jdbcClient
         .sql(
@@ -281,11 +326,15 @@ class TransactionRegistryViewsIT {
   }
 
   private TransactionSettlement persistSettlement(TransactionOrder order) {
+    return persistSettlement(order, LocalDate.now().minusDays(1));
+  }
+
+  private TransactionSettlement persistSettlement(TransactionOrder order, LocalDate reportDate) {
     return settlementRepository.save(
         TransactionSettlement.builder()
             .orderId(order.getId())
-            .settledAt(Instant.parse("2026-05-13T07:00:00Z"))
-            .reportDate(LocalDate.now().minusDays(1))
+            .settledAt(reportDate.atStartOfDay(java.time.ZoneOffset.UTC).toInstant())
+            .reportDate(reportDate)
             .build());
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/calculation/TradeCalculationEngineTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/calculation/TradeCalculationEngineTest.java
@@ -5,6 +5,7 @@ import static ee.tuleva.onboarding.investment.transaction.LimitStatus.*;
 import static ee.tuleva.onboarding.investment.transaction.TransactionMode.*;
 import static java.math.BigDecimal.ZERO;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import ee.tuleva.onboarding.investment.transaction.*;
 import java.math.BigDecimal;
@@ -765,6 +766,141 @@ class TradeCalculationEngineTest {
         result.trades().stream().map(TradeCalculation::tradeAmount).reduce(ZERO, BigDecimal::add);
     assertThat(totalBuy)
         .isCloseTo(new BigDecimal("12000"), org.assertj.core.data.Offset.offset(BigDecimal.ONE));
+  }
+
+  @Test
+  void buy_includesReceivablesInTargetBaseForScoring() {
+    var input =
+        FundTransactionInput.builder()
+            .fund(TUV100)
+            .positions(
+                List.of(
+                    new PositionSnapshot("IE00A", new BigDecimal("90000")),
+                    new PositionSnapshot("IE00B", new BigDecimal("80000"))))
+            .modelWeights(
+                List.of(
+                    new ModelWeight("IE00A", new BigDecimal("0.50")),
+                    new ModelWeight("IE00B", new BigDecimal("0.50"))))
+            .grossPortfolioValue(new BigDecimal("170000"))
+            .cashBuffer(ZERO)
+            .liabilities(ZERO)
+            .receivables(new BigDecimal("60000"))
+            .freeCash(new BigDecimal("20000"))
+            .minTransactionThreshold(new BigDecimal("5000"))
+            .positionLimits(Map.of())
+            .fastSellIsins(Set.of())
+            .build();
+
+    var result = engine.calculate(input, BUY);
+
+    var tradeA =
+        result.trades().stream().filter(t -> t.isin().equals("IE00A")).findFirst().orElseThrow();
+    var tradeB =
+        result.trades().stream().filter(t -> t.isin().equals("IE00B")).findFirst().orElseThrow();
+
+    assertThat(tradeA.tradeAmount()).isGreaterThan(ZERO);
+    assertThat(tradeB.tradeAmount()).isGreaterThan(tradeA.tradeAmount());
+
+    BigDecimal totalBuy =
+        result.trades().stream().map(TradeCalculation::tradeAmount).reduce(ZERO, BigDecimal::add);
+    assertThat(totalBuy)
+        .isCloseTo(new BigDecimal("20000"), org.assertj.core.data.Offset.offset(BigDecimal.ONE));
+  }
+
+  @Test
+  void sellFast_redistributesMarketValueCapShortfallWithinFastBucket() {
+    var input =
+        FundTransactionInput.builder()
+            .fund(TUV100)
+            .positions(
+                List.of(
+                    new PositionSnapshot("IE00SMALL", new BigDecimal("10000")),
+                    new PositionSnapshot("IE00BIG", new BigDecimal("100000"))))
+            .modelWeights(
+                List.of(
+                    new ModelWeight("IE00SMALL", ZERO),
+                    new ModelWeight("IE00BIG", new BigDecimal("0.50"))))
+            .grossPortfolioValue(new BigDecimal("1000000"))
+            .cashBuffer(ZERO)
+            .liabilities(ZERO)
+            .freeCash(new BigDecimal("-15000"))
+            .minTransactionThreshold(new BigDecimal("5000"))
+            .positionLimits(Map.of())
+            .fastSellIsins(Set.of("IE00SMALL", "IE00BIG"))
+            .build();
+
+    var result = engine.calculate(input, SELL_FAST);
+
+    var smallTrade =
+        result.trades().stream()
+            .filter(t -> t.isin().equals("IE00SMALL"))
+            .findFirst()
+            .orElseThrow();
+    assertThat(smallTrade.tradeAmount()).isGreaterThanOrEqualTo(new BigDecimal("-10000"));
+
+    BigDecimal totalSold =
+        result.trades().stream().map(TradeCalculation::tradeAmount).reduce(ZERO, BigDecimal::add);
+    assertThat(totalSold).isEqualByComparingTo(new BigDecimal("-15000"));
+  }
+
+  @Test
+  void sell_neverSellsAnyPositionBeyondItsMarketValue() {
+    var input =
+        FundTransactionInput.builder()
+            .fund(TUV100)
+            .positions(
+                List.of(
+                    new PositionSnapshot("IE00OVER", new BigDecimal("40000")),
+                    new PositionSnapshot("IE00ATTARGET", new BigDecimal("100000"))))
+            .modelWeights(
+                List.of(
+                    new ModelWeight("IE00OVER", ZERO),
+                    new ModelWeight("IE00ATTARGET", new BigDecimal("1.00"))))
+            .grossPortfolioValue(new BigDecimal("1000000"))
+            .cashBuffer(ZERO)
+            .liabilities(ZERO)
+            .freeCash(new BigDecimal("-44000"))
+            .minTransactionThreshold(new BigDecimal("5000"))
+            .positionLimits(Map.of())
+            .fastSellIsins(Set.of())
+            .build();
+
+    var result = engine.calculate(input, SELL);
+
+    var overTrade =
+        result.trades().stream().filter(t -> t.isin().equals("IE00OVER")).findFirst().orElseThrow();
+    assertThat(overTrade.tradeAmount()).isGreaterThanOrEqualTo(new BigDecimal("-40000"));
+
+    BigDecimal totalSold =
+        result.trades().stream().map(TradeCalculation::tradeAmount).reduce(ZERO, BigDecimal::add);
+    assertThat(totalSold).isEqualByComparingTo(new BigDecimal("-44000"));
+  }
+
+  @Test
+  void sell_failsWhenTotalSellNeedExceedsSellableMarketValue() {
+    var input =
+        FundTransactionInput.builder()
+            .fund(TUV100)
+            .positions(
+                List.of(
+                    new PositionSnapshot("IE00A", new BigDecimal("40000")),
+                    new PositionSnapshot("IE00B", new BigDecimal("30000"))))
+            .modelWeights(
+                List.of(
+                    new ModelWeight("IE00A", new BigDecimal("0.50")),
+                    new ModelWeight("IE00B", new BigDecimal("0.50"))))
+            .grossPortfolioValue(new BigDecimal("1000000"))
+            .cashBuffer(ZERO)
+            .liabilities(ZERO)
+            .freeCash(new BigDecimal("-90000"))
+            .minTransactionThreshold(new BigDecimal("5000"))
+            .positionLimits(Map.of())
+            .fastSellIsins(Set.of())
+            .build();
+
+    assertThatThrownBy(() -> engine.calculate(input, SELL))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Insufficient liquidity");
   }
 
   @Test

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/export/CustodianOrderEmailSenderTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/export/CustodianOrderEmailSenderTest.java
@@ -1,0 +1,93 @@
+package ee.tuleva.onboarding.investment.transaction.export;
+
+import static ee.tuleva.onboarding.fund.TulevaFund.TUV100;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import com.microtripit.mandrillapp.lutung.view.MandrillMessage;
+import ee.tuleva.onboarding.notification.email.EmailService;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CustodianOrderEmailSenderTest {
+
+  private static final Instant TIMESTAMP = Instant.parse("2026-01-15T10:00:00Z");
+
+  @Mock private EmailService emailService;
+
+  @Test
+  void send_buildsMessageAndSendsWhenEnabledAndConfigured() {
+    var properties =
+        new CustodianOrderEmailProperties(
+            true, List.of("trustee@seb.ee"), List.of("funds@tuleva.ee"));
+    var factory = new CustodianOrderMessageFactory(properties);
+    var sender = new CustodianOrderEmailSender(properties, factory, emailService);
+    given(emailService.sendSystemEmail(any())).willReturn(true);
+
+    var message = factory.create(TUV100, TIMESTAMP, Map.of("sebFundXlsx", new byte[] {1, 2}));
+
+    boolean sent = sender.send(TUV100, TIMESTAMP, Map.of("sebFundXlsx", new byte[] {1, 2}));
+
+    assertThat(sent).isTrue();
+    verify(emailService).sendSystemEmail(messageMatching(message));
+  }
+
+  @Test
+  void send_doesNothingWhenDisabled() {
+    var properties =
+        new CustodianOrderEmailProperties(
+            false, List.of("trustee@seb.ee"), List.of("funds@tuleva.ee"));
+    var sender =
+        new CustodianOrderEmailSender(
+            properties, new CustodianOrderMessageFactory(properties), emailService);
+
+    boolean sent = sender.send(TUV100, TIMESTAMP, Map.of("sebFundXlsx", new byte[] {1}));
+
+    assertThat(sent).isFalse();
+    verifyNoInteractions(emailService);
+  }
+
+  @Test
+  void send_doesNothingWhenNoRecipientsConfigured() {
+    var properties = new CustodianOrderEmailProperties(true, List.of(), List.of());
+    var sender =
+        new CustodianOrderEmailSender(
+            properties, new CustodianOrderMessageFactory(properties), emailService);
+
+    boolean sent = sender.send(TUV100, TIMESTAMP, Map.of("sebFundXlsx", new byte[] {1}));
+
+    assertThat(sent).isFalse();
+    verifyNoInteractions(emailService);
+  }
+
+  @Test
+  void send_doesNothingWhenAllExportsEmpty() {
+    var properties = new CustodianOrderEmailProperties(true, List.of("trustee@seb.ee"), List.of());
+    var sender =
+        new CustodianOrderEmailSender(
+            properties, new CustodianOrderMessageFactory(properties), emailService);
+
+    boolean sent = sender.send(TUV100, TIMESTAMP, Map.of());
+
+    assertThat(sent).isFalse();
+    verify(emailService, never()).sendSystemEmail(any());
+  }
+
+  private static MandrillMessage messageMatching(MandrillMessage expected) {
+    return org.mockito.ArgumentMatchers.argThat(
+        actual ->
+            actual.getSubject().equals(expected.getSubject())
+                && actual.getTo().size() == expected.getTo().size()
+                && actual.getAttachments().size() == expected.getAttachments().size());
+  }
+}

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/export/CustodianOrderMessageFactoryTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/export/CustodianOrderMessageFactoryTest.java
@@ -1,0 +1,74 @@
+package ee.tuleva.onboarding.investment.transaction.export;
+
+import static com.microtripit.mandrillapp.lutung.view.MandrillMessage.Recipient.Type.CC;
+import static com.microtripit.mandrillapp.lutung.view.MandrillMessage.Recipient.Type.TO;
+import static ee.tuleva.onboarding.fund.TulevaFund.TUV100;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.microtripit.mandrillapp.lutung.view.MandrillMessage.MessageContent;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class CustodianOrderMessageFactoryTest {
+
+  private static final Instant TIMESTAMP = Instant.parse("2026-01-15T10:00:00Z");
+
+  private final CustodianOrderEmailProperties properties =
+      new CustodianOrderEmailProperties(
+          true, List.of("trustee@seb.ee"), List.of("funds@tuleva.ee"));
+  private final CustodianOrderMessageFactory factory = new CustodianOrderMessageFactory(properties);
+
+  @Test
+  void create_setsFromSubjectAndRecipients() {
+    var message = factory.create(TUV100, TIMESTAMP, Map.of("sebFundXlsx", new byte[] {1, 2}));
+
+    assertThat(message.getFromEmail()).isEqualTo("funds@tuleva.ee");
+    assertThat(message.getFromName()).isEqualTo("Tuleva");
+    assertThat(message.getSubject()).contains("TUV100");
+    assertThat(message.getTo()).hasSize(2);
+    assertThat(message.getTo().get(0).getEmail()).isEqualTo("trustee@seb.ee");
+    assertThat(message.getTo().get(0).getType()).isEqualTo(TO);
+    assertThat(message.getTo().get(1).getEmail()).isEqualTo("funds@tuleva.ee");
+    assertThat(message.getTo().get(1).getType()).isEqualTo(CC);
+  }
+
+  @Test
+  void create_attachesAllNonEmptyExportWorkbooks() {
+    var message =
+        factory.create(
+            TUV100,
+            TIMESTAMP,
+            Map.of(
+                "sebFundXlsx", new byte[] {1, 2},
+                "sebEtfXlsx", new byte[] {3, 4},
+                "ftEtfXlsx", new byte[] {5, 6}));
+
+    assertThat(message.getAttachments())
+        .hasSize(3)
+        .extracting(MessageContent::getName)
+        .anySatisfy(name -> assertThat(name).contains("SEB").contains("TUV100").endsWith(".xlsx"))
+        .anySatisfy(name -> assertThat(name).contains("FT").contains("TUV100").endsWith(".xlsx"));
+    assertThat(message.getAttachments())
+        .allSatisfy(
+            attachment ->
+                assertThat(attachment.getType())
+                    .isEqualTo(
+                        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"));
+  }
+
+  @Test
+  void create_skipsEmptyExportBytes() {
+    var message =
+        factory.create(
+            TUV100,
+            TIMESTAMP,
+            Map.of(
+                "sebFundXlsx", new byte[] {1, 2},
+                "sebEtfXlsx", new byte[0],
+                "ftEtfXlsx", new byte[0]));
+
+    assertThat(message.getAttachments()).hasSize(1);
+  }
+}

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/export/TransactionExportServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/export/TransactionExportServiceTest.java
@@ -133,6 +133,23 @@ class TransactionExportServiceTest {
   }
 
   @Test
+  void generateSebFundExport_redpRowCarriesQuantityNotTransactionSum() throws Exception {
+    var batch = buildBatch();
+    var sellOrder =
+        buildOrder(batch, TUV100, "LU00FUND", SELL, FUND, SEB, new BigDecimal("30000"), 2400L);
+
+    byte[] xlsx =
+        service.generateSebFundExport(List.of(sellOrder), Map.of("LU00FUND", "SEB Fund X"));
+
+    try (var workbook = WorkbookFactory.create(new ByteArrayInputStream(xlsx))) {
+      var dataRow = workbook.getSheetAt(0).getRow(3);
+      assertThat(dataRow.getCell(9).getStringCellValue()).isEqualTo("REDP");
+      assertThat(dataRow.getCell(14).getNumericCellValue()).isEqualTo(2400.0);
+      assertThat(dataRow.getCell(16)).isNull();
+    }
+  }
+
+  @Test
   void generateSebEtfExport_filtersSebEtfOrdersAndFormatsCorrectly() throws Exception {
     var batch = buildBatch();
 

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationAuditRecorderTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationAuditRecorderTest.java
@@ -1,6 +1,8 @@
 package ee.tuleva.onboarding.investment.transaction.ingest;
 
 import static ee.tuleva.onboarding.fund.TulevaFund.TUK75;
+import static ee.tuleva.onboarding.investment.transaction.FtConfirmationType.CANCELLATION;
+import static ee.tuleva.onboarding.investment.transaction.FtVerificationStatus.CANCELLED;
 import static ee.tuleva.onboarding.investment.transaction.FtVerificationStatus.ERROR;
 import static ee.tuleva.onboarding.investment.transaction.FtVerificationStatus.OK;
 import static ee.tuleva.onboarding.investment.transaction.InstrumentType.ETF;
@@ -73,9 +75,60 @@ class FtConfirmationAuditRecorderTest {
                         "tradeDate", "2026-06-08",
                         "quantity", "40434",
                         "grossPrice", "10.09",
+                        "type", "NORMAL",
                         "quantityStatus", "OK",
                         "priceStatus", "ERROR",
                         "details", Map.of("orderQuantity", "40434", "priceDeltaPercent", "0.12")))
+                .createdAt(NOW)
+                .build());
+  }
+
+  @Test
+  void recordVerified_cancellation_recordsTypeAndAccount() {
+    TransactionOrder order =
+        TransactionOrder.builder()
+            .id(42L)
+            .fund(TUK75)
+            .instrumentIsin("IE000F60HVH9")
+            .transactionType(BUY)
+            .instrumentType(ETF)
+            .orderQuantity(new BigDecimal("40434"))
+            .orderVenue(OrderVenue.FT)
+            .orderUuid(ORDER_UUID)
+            .build();
+    FtConfirmation confirmation =
+        new FtConfirmation(
+            TUK75,
+            "IE000F60HVH9",
+            LocalDate.parse("2026-06-08"),
+            new BigDecimal("40434"),
+            new BigDecimal("10.09"),
+            CANCELLATION,
+            "FT-ACC");
+    FtConfirmationResult result =
+        new FtConfirmationResult(CANCELLED, CANCELLED, Map.of("cancellationSignature", "sig"));
+
+    new FtConfirmationAuditRecorder(auditEventRepository, Clock.fixed(NOW, ZoneOffset.UTC))
+        .recordVerified(order, confirmation, result);
+
+    verify(auditEventRepository)
+        .save(
+            TransactionAuditEvent.builder()
+                .orderId(42L)
+                .eventType("FT_CONFIRMATION_VERIFIED")
+                .actor("admin")
+                .payload(
+                    Map.of(
+                        "fund", "TUK75",
+                        "isin", "IE000F60HVH9",
+                        "tradeDate", "2026-06-08",
+                        "quantity", "40434",
+                        "grossPrice", "10.09",
+                        "type", "CANCELLATION",
+                        "account", "FT-ACC",
+                        "quantityStatus", "CANCELLED",
+                        "priceStatus", "CANCELLED",
+                        "details", Map.of("cancellationSignature", "sig")))
                 .createdAt(NOW)
                 .build());
   }

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationVerificationServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationVerificationServiceTest.java
@@ -6,6 +6,7 @@ import static ee.tuleva.onboarding.investment.transaction.FtConfirmationType.CAN
 import static ee.tuleva.onboarding.investment.transaction.FtVerificationStatus.AMBIGUOUS;
 import static ee.tuleva.onboarding.investment.transaction.FtVerificationStatus.CANCELLED;
 import static ee.tuleva.onboarding.investment.transaction.FtVerificationStatus.ERROR;
+import static ee.tuleva.onboarding.investment.transaction.FtVerificationStatus.IGNORED;
 import static ee.tuleva.onboarding.investment.transaction.FtVerificationStatus.OK;
 import static ee.tuleva.onboarding.investment.transaction.FtVerificationStatus.PENDING_EXECUTION;
 import static ee.tuleva.onboarding.investment.transaction.FtVerificationStatus.PENDING_NAV;
@@ -328,6 +329,45 @@ class FtConfirmationVerificationServiceTest {
     assertThat(result.quantityStatus()).isEqualTo(AMBIGUOUS);
     assertThat(result.priceStatus()).isEqualTo(AMBIGUOUS);
     assertThat(result.details()).containsEntry("ambiguousOrderCount", "2");
+  }
+
+  @Test
+  void weekendTradeDate_returnsIgnored_noMismatch() {
+    LocalDate saturday = LocalDate.of(2026, 6, 6); // Saturday
+    FtConfirmation weekendConfirmation =
+        new FtConfirmation(TUK75, ISIN, saturday, new BigDecimal("40434"), new BigDecimal("10.09"));
+
+    FtConfirmationResult result =
+        service(DAY_AFTER_TRADE).verify(weekendConfirmation).orElseThrow();
+
+    assertThat(result.quantityStatus()).isEqualTo(IGNORED);
+    assertThat(result.priceStatus()).isEqualTo(IGNORED);
+    assertThat(result.details()).containsEntry("ignoreReason", "weekend trade date: " + saturday);
+    verifyNoInteractions(orderRepository, executionRepository, positionPriceResolver);
+    verifyNoInteractions(auditRecorder);
+  }
+
+  @Test
+  void suppressedConfirmation_returnsIgnored_noMismatch() {
+    FtConfirmation suppressed =
+        new FtConfirmation(
+            TUK75,
+            ISIN,
+            TRADE_DATE,
+            new BigDecimal("40434"),
+            new BigDecimal("10.09"),
+            ee.tuleva.onboarding.investment.transaction.FtConfirmationType.NORMAL,
+            null,
+            true);
+
+    FtConfirmationResult result = service(DAY_AFTER_TRADE).verify(suppressed).orElseThrow();
+
+    assertThat(result.quantityStatus()).isEqualTo(IGNORED);
+    assertThat(result.priceStatus()).isEqualTo(IGNORED);
+    assertThat(result.details())
+        .containsEntry("ignoreReason", "manually suppressed false positive");
+    verifyNoInteractions(orderRepository, executionRepository, positionPriceResolver);
+    verifyNoInteractions(auditRecorder);
   }
 
   private FtConfirmation confirmation() {

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationVerificationServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationVerificationServiceTest.java
@@ -2,6 +2,9 @@ package ee.tuleva.onboarding.investment.transaction.ingest;
 
 import static ee.tuleva.onboarding.fund.TulevaFund.TUK00;
 import static ee.tuleva.onboarding.fund.TulevaFund.TUK75;
+import static ee.tuleva.onboarding.investment.transaction.FtConfirmationType.CANCELLATION;
+import static ee.tuleva.onboarding.investment.transaction.FtVerificationStatus.AMBIGUOUS;
+import static ee.tuleva.onboarding.investment.transaction.FtVerificationStatus.CANCELLED;
 import static ee.tuleva.onboarding.investment.transaction.FtVerificationStatus.ERROR;
 import static ee.tuleva.onboarding.investment.transaction.FtVerificationStatus.OK;
 import static ee.tuleva.onboarding.investment.transaction.FtVerificationStatus.PENDING_EXECUTION;
@@ -262,12 +265,88 @@ class FtConfirmationVerificationServiceTest {
     verify(auditRecorder).recordVerified(order, confirmation, result);
   }
 
+  @Test
+  void cancellationConfirmation_marksMatchingTradeCancelled_noMismatchError() {
+    TransactionOrder order = order(new BigDecimal("40434"));
+    given(orderRepository.findByInstrumentIsin(ISIN)).willReturn(List.of(order));
+
+    FtConfirmationResult result =
+        service(DAY_AFTER_TRADE).verify(cancellationConfirmation()).orElseThrow();
+
+    assertThat(result.quantityStatus()).isEqualTo(CANCELLED);
+    assertThat(result.priceStatus()).isEqualTo(CANCELLED);
+    assertThat(result.details())
+        .containsEntry("orderUuid", ORDER_UUID.toString())
+        .containsEntry("cancellationSignature", ISIN + "|FT-ACC|" + TRADE_DATE + "|10.09");
+  }
+
+  @Test
+  void cancellationConfirmation_recordsAuditEvent() {
+    TransactionOrder order = order(new BigDecimal("40434"));
+    given(orderRepository.findByInstrumentIsin(ISIN)).willReturn(List.of(order));
+    FtConfirmation confirmation = cancellationConfirmation();
+
+    FtConfirmationResult result = service(DAY_AFTER_TRADE).verify(confirmation).orElseThrow();
+
+    verify(auditRecorder).recordVerified(order, confirmation, result);
+  }
+
+  @Test
+  void cancellationConfirmation_orderNotFound_returnsEmpty() {
+    given(orderRepository.findByInstrumentIsin(ISIN)).willReturn(List.of());
+
+    Optional<FtConfirmationResult> result =
+        service(DAY_AFTER_TRADE).verify(cancellationConfirmation());
+
+    assertThat(result).isEmpty();
+    verifyNoInteractions(auditRecorder);
+  }
+
+  @Test
+  void normalConfirmation_picksOrderMatchingQuantityNotOldest() {
+    TransactionOrder oldest = order(10L, new BigDecimal("99999"));
+    TransactionOrder matching = order(42L, new BigDecimal("40434"));
+    given(orderRepository.findByInstrumentIsin(ISIN)).willReturn(List.of(oldest, matching));
+    given(executionRepository.findByOrderId(42L))
+        .willReturn(Optional.of(execution(new BigDecimal("40434"))));
+    givenReferencePrice(new BigDecimal("10.09"), TRADE_DATE);
+
+    FtConfirmationResult result = service(DAY_AFTER_TRADE).verify(confirmation()).orElseThrow();
+
+    assertThat(result.quantityStatus()).isEqualTo(OK);
+    assertThat(result.details()).containsEntry("orderUuid", ORDER_UUID.toString());
+  }
+
+  @Test
+  void normalConfirmation_multipleOrdersMatchQuantity_returnsAmbiguous() {
+    TransactionOrder first = order(10L, new BigDecimal("40434"));
+    TransactionOrder second = order(42L, new BigDecimal("40434"));
+    given(orderRepository.findByInstrumentIsin(ISIN)).willReturn(List.of(first, second));
+
+    FtConfirmationResult result = service(DAY_AFTER_TRADE).verify(confirmation()).orElseThrow();
+
+    assertThat(result.quantityStatus()).isEqualTo(AMBIGUOUS);
+    assertThat(result.priceStatus()).isEqualTo(AMBIGUOUS);
+    assertThat(result.details()).containsEntry("ambiguousOrderCount", "2");
+  }
+
   private FtConfirmation confirmation() {
     return confirmation(new BigDecimal("40434"), new BigDecimal("10.09"));
   }
 
   private FtConfirmation confirmation(BigDecimal quantity, BigDecimal grossPrice) {
     return new FtConfirmation(TUK75, ISIN, TRADE_DATE, quantity, grossPrice);
+  }
+
+  private FtConfirmation cancellationConfirmation() {
+    return new FtConfirmation(
+        TUK75,
+        ISIN,
+        TRADE_DATE,
+        new BigDecimal("40434"),
+        new BigDecimal("10.09"),
+        CANCELLATION,
+        "FT-ACC");
   }
 
   private TransactionOrder givenOrderAndExecution(
@@ -292,15 +371,19 @@ class FtConfirmationVerificationServiceTest {
   }
 
   private TransactionOrder order(BigDecimal orderQuantity) {
+    return order(42L, orderQuantity);
+  }
+
+  private TransactionOrder order(long id, BigDecimal orderQuantity) {
     return TransactionOrder.builder()
-        .id(42L)
+        .id(id)
         .fund(TUK75)
         .instrumentIsin(ISIN)
         .transactionType(BUY)
         .instrumentType(ETF)
         .orderQuantity(orderQuantity)
         .orderVenue(OrderVenue.FT)
-        .orderUuid(ORDER_UUID)
+        .orderUuid(id == 42L ? ORDER_UUID : new UUID(0, id))
         .orderStatus(EXECUTED)
         .orderTimestamp(Instant.parse("2026-06-08T09:30:00Z"))
         .build();

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/SebPendingTransactionExtractorTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/SebPendingTransactionExtractorTest.java
@@ -78,6 +78,62 @@ class SebPendingTransactionExtractorTest {
   }
 
   @Test
+  void extractWithDiagnostics_countsMalformedContentRowsAndReportsIncomplete() {
+    Map<String, Object> valid =
+        Map.of(
+            "ISIN", "IE000F60HVH9",
+            "Our ref", "DLA0799512",
+            "Buy/Sell", "Buy",
+            "Quantity", new BigDecimal("15007"),
+            "Client ref", "bd83f551-8c79-4193-b92b-18e1dfd0bd29",
+            "Trade date", "2026-05-11T10:26:04Z");
+    Map<String, Object> malformed = new java.util.HashMap<>();
+    malformed.put("ISIN", "IE000F60HVH9");
+    malformed.put("Client ref", "not-a-uuid");
+    malformed.put("Our ref", "DLA9999999");
+
+    InvestmentReport report =
+        InvestmentReport.builder()
+            .provider(SEB)
+            .reportType(PENDING_TRANSACTIONS)
+            .reportDate(LocalDate.of(2026, 5, 13))
+            .rawData(List.of(valid, malformed))
+            .build();
+
+    SebPendingTransactionExtractor.ExtractionResult result =
+        extractor.extractWithDiagnostics(report);
+
+    assertThat(result.rows()).hasSize(1);
+    assertThat(result.malformedCount()).isEqualTo(1);
+    assertThat(result.isComplete()).isFalse();
+  }
+
+  @Test
+  void extractWithDiagnostics_allRowsValid_reportsComplete() {
+    Map<String, Object> valid =
+        Map.of(
+            "ISIN", "IE000F60HVH9",
+            "Our ref", "DLA0799512",
+            "Buy/Sell", "Buy",
+            "Quantity", new BigDecimal("15007"),
+            "Client ref", "bd83f551-8c79-4193-b92b-18e1dfd0bd29",
+            "Trade date", "2026-05-11T10:26:04Z");
+    InvestmentReport report =
+        InvestmentReport.builder()
+            .provider(SEB)
+            .reportType(PENDING_TRANSACTIONS)
+            .reportDate(LocalDate.of(2026, 5, 13))
+            .rawData(List.of(valid))
+            .build();
+
+    SebPendingTransactionExtractor.ExtractionResult result =
+        extractor.extractWithDiagnostics(report);
+
+    assertThat(result.malformedCount()).isZero();
+    assertThat(result.isComplete()).isTrue();
+  }
+
+  @Test
   void extract_emptyRawData_returnsEmptyList() {
     InvestmentReport report =
         InvestmentReport.builder()

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/SebPendingTransactionReconciliationIT.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/SebPendingTransactionReconciliationIT.java
@@ -153,7 +153,7 @@ class SebPendingTransactionReconciliationIT {
   }
 
   @Test
-  void reconcile_matchedFundBuyWithDivergentAmount_persistsMismatchAuditAndStillExecutes() {
+  void reconcile_matchedFundBuyWithDivergentAmount_persistsMismatchAuditAndQuarantines() {
     order.setOrderAmount(new BigDecimal("50000.00"));
     orderRepository.save(order);
     entityManager.flush();
@@ -167,9 +167,10 @@ class SebPendingTransactionReconciliationIT {
     assertThat(mismatches).hasSize(1);
     assertThat(mismatches.get(0).getPayload().get("kind")).isEqualTo("FUND_BUY_AMOUNT");
 
-    assertThat(executionRepository.findByOrderId(order.getId())).isPresent();
+    // Quarantine: a divergent fill is flagged but not absorbed — no execution, order stays SENT.
+    assertThat(executionRepository.findByOrderId(order.getId())).isEmpty();
     TransactionOrder reloaded = orderRepository.findById(order.getId()).orElseThrow();
-    assertThat(reloaded.getOrderStatus()).isEqualTo(EXECUTED);
+    assertThat(reloaded.getOrderStatus()).isEqualTo(SENT);
   }
 
   @Test

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/SebPendingTransactionReconciliationServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/SebPendingTransactionReconciliationServiceTest.java
@@ -18,6 +18,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import ee.tuleva.onboarding.investment.report.InvestmentReport;
+import ee.tuleva.onboarding.investment.report.InvestmentReportService;
 import ee.tuleva.onboarding.investment.transaction.InstrumentType;
 import ee.tuleva.onboarding.investment.transaction.OrderVenue;
 import ee.tuleva.onboarding.investment.transaction.TransactionAuditEvent;
@@ -55,6 +56,7 @@ class SebPendingTransactionReconciliationServiceTest {
   @Mock private TransactionSettlementRepository settlementRepository;
   @Mock private ApplicationEventPublisher eventPublisher;
   @Mock private TransactionMatchingPolicy matchingPolicy;
+  @Mock private InvestmentReportService reportService;
 
   // Real collaborators so we exercise the actual extraction + mapping pipeline
   private final SebPendingTransactionExtractor extractor = new SebPendingTransactionExtractor();
@@ -81,7 +83,8 @@ class SebPendingTransactionReconciliationServiceTest {
         eventPublisher,
         new ReconciliationAuditRecorder(auditEventRepository, clock),
         settlementRepository,
-        new TransactionSettlementService(settlementRepository, orderRepository, clock));
+        new TransactionSettlementService(settlementRepository, orderRepository, clock),
+        reportService);
   }
 
   @Test
@@ -193,8 +196,8 @@ class SebPendingTransactionReconciliationServiceTest {
             .brokerTransactionId("DLA0799512")
             .executedQuantity(new BigDecimal("1"))
             .build();
-    given(executionRepository.findByBrokerTransactionId("DLA0799512"))
-        .willReturn(Optional.of(existing));
+    given(executionRepository.findAllByBrokerTransactionId("DLA0799512"))
+        .willReturn(List.of(existing));
     given(orderRepository.findById(123L)).willReturn(Optional.of(order));
     given(executionRepository.findByOrderId(123L)).willReturn(Optional.of(existing));
 
@@ -221,8 +224,8 @@ class SebPendingTransactionReconciliationServiceTest {
             .source("SEB_OOTEL")
             .brokerTransactionId("DLA0799512")
             .build();
-    given(executionRepository.findByBrokerTransactionId("DLA0799512"))
-        .willReturn(Optional.of(existing));
+    given(executionRepository.findAllByBrokerTransactionId("DLA0799512"))
+        .willReturn(List.of(existing));
     given(orderRepository.findById(123L)).willReturn(Optional.of(settledOrder));
     given(settlementRepository.findByOrderId(123L))
         .willReturn(Optional.of(settlement(123L, LocalDate.of(2026, 5, 10))));
@@ -276,12 +279,11 @@ class SebPendingTransactionReconciliationServiceTest {
   }
 
   @Test
-  void reconcile_uuidMatchWithDivergentEtfQuantity_publishesMismatchAndStillUpserts() {
+  void reconcile_uuidMatchWithDivergentEtfQuantity_quarantinesWithoutExecuting() {
     service = newService();
     UUID clientRef = UUID.fromString("bd83f551-8c79-4193-b92b-18e1dfd0bd29");
     TransactionOrder order = orderWith(clientRef, ETF, BUY, new BigDecimal("15000"), null);
     given(orderRepository.findByOrderUuid(clientRef)).willReturn(Optional.of(order));
-    given(executionRepository.findByOrderId(123L)).willReturn(Optional.empty());
 
     InvestmentReport report = reportWithSingleRow(clientRef);
     service.reconcile(report);
@@ -301,8 +303,9 @@ class SebPendingTransactionReconciliationServiceTest {
                 (TransactionAuditEvent event) ->
                     "QUANTITY_AMOUNT_MISMATCH".equals(event.getEventType())
                         && event.getOrderId().equals(123L)));
-    verify(executionRepository).save(any(TransactionExecution.class));
-    assertThat(order.getOrderStatus()).isEqualTo(EXECUTED);
+    // Quarantine: divergent fill is NOT absorbed as EXECUTED, no execution persisted.
+    verify(executionRepository, never()).save(any());
+    assertThat(order.getOrderStatus()).isEqualTo(SENT);
   }
 
   @Test
@@ -340,7 +343,6 @@ class SebPendingTransactionReconciliationServiceTest {
     TransactionOrder order =
         orderWith(clientRef, InstrumentType.FUND, BUY, null, new BigDecimal("60000.00"));
     given(orderRepository.findByOrderUuid(clientRef)).willReturn(Optional.of(order));
-    given(executionRepository.findByOrderId(123L)).willReturn(Optional.empty());
 
     service.reconcile(reportWithSingleRow(clientRef));
 
@@ -352,8 +354,8 @@ class SebPendingTransactionReconciliationServiceTest {
                         && qe.kind() == QuantityAmountMismatchEvent.MismatchKind.FUND_BUY_AMOUNT
                         && qe.expected().compareTo(new BigDecimal("60000.00")) == 0
                         && qe.actual().compareTo(new BigDecimal("70915.58")) == 0));
-    verify(executionRepository).save(any(TransactionExecution.class));
-    assertThat(order.getOrderStatus()).isEqualTo(EXECUTED);
+    verify(executionRepository, never()).save(any());
+    assertThat(order.getOrderStatus()).isEqualTo(SENT);
   }
 
   @Test
@@ -364,7 +366,6 @@ class SebPendingTransactionReconciliationServiceTest {
     TransactionOrder order =
         orderWith(clientRef, InstrumentType.FUND, BUY, null, new BigDecimal("69525.00"));
     given(orderRepository.findByOrderUuid(clientRef)).willReturn(Optional.of(order));
-    given(executionRepository.findByOrderId(123L)).willReturn(Optional.empty());
 
     service.reconcile(reportWithSingleRow(clientRef));
 
@@ -376,8 +377,8 @@ class SebPendingTransactionReconciliationServiceTest {
                         && qe.kind() == QuantityAmountMismatchEvent.MismatchKind.FUND_BUY_AMOUNT
                         && qe.expected().compareTo(new BigDecimal("69525.00")) == 0
                         && qe.actual().compareTo(new BigDecimal("70915.58")) == 0));
-    verify(executionRepository).save(any(TransactionExecution.class));
-    assertThat(order.getOrderStatus()).isEqualTo(EXECUTED);
+    verify(executionRepository, never()).save(any());
+    assertThat(order.getOrderStatus()).isEqualTo(SENT);
   }
 
   @Test
@@ -406,7 +407,6 @@ class SebPendingTransactionReconciliationServiceTest {
     TransactionOrder order =
         orderWith(clientRef, InstrumentType.FUND, SELL, new BigDecimal("15000"), null);
     given(orderRepository.findByOrderUuid(clientRef)).willReturn(Optional.of(order));
-    given(executionRepository.findByOrderId(123L)).willReturn(Optional.empty());
 
     Map<String, Object> sellRow = validRawRow(clientRef);
     sellRow.put("Buy/Sell", "Sell");
@@ -420,7 +420,8 @@ class SebPendingTransactionReconciliationServiceTest {
                         && qe.kind() == QuantityAmountMismatchEvent.MismatchKind.FUND_SELL_QUANTITY
                         && qe.expected().compareTo(new BigDecimal("15000")) == 0
                         && qe.actual().compareTo(new BigDecimal("15007")) == 0));
-    verify(executionRepository).save(any(TransactionExecution.class));
+    verify(executionRepository, never()).save(any());
+    assertThat(order.getOrderStatus()).isEqualTo(SENT);
   }
 
   @Test
@@ -481,8 +482,8 @@ class SebPendingTransactionReconciliationServiceTest {
     // Existing execution is linked to a DIFFERENT order (order 555)
     TransactionExecution existingOnOtherOrder =
         TransactionExecution.builder().id(99L).orderId(555L).source("SEB_OOTEL").build();
-    given(executionRepository.findByBrokerTransactionId("DLA0799512"))
-        .willReturn(Optional.of(existingOnOtherOrder));
+    given(executionRepository.findAllByBrokerTransactionId("DLA0799512"))
+        .willReturn(List.of(existingOnOtherOrder));
 
     service.reconcile(reportWithSingleRow(clientRef));
 
@@ -731,9 +732,9 @@ class SebPendingTransactionReconciliationServiceTest {
     UUID secondClientRef = UUID.fromString("00000000-0000-0000-0000-000000000099");
     given(orderRepository.findByOrderUuid(secondClientRef)).willReturn(Optional.empty());
     given(orderRepository.findByInstrumentIsin(any())).willReturn(List.of());
-    given(executionRepository.findByBrokerTransactionId("DLA0799512")).willReturn(Optional.empty());
-    given(executionRepository.findByBrokerTransactionId("DLA0888888"))
-        .willReturn(Optional.of(executionWithTradeInstant(456L, "2026-05-11T10:00:00Z")));
+    given(executionRepository.findAllByBrokerTransactionId("DLA0799512")).willReturn(List.of());
+    given(executionRepository.findAllByBrokerTransactionId("DLA0888888"))
+        .willReturn(List.of(executionWithTradeInstant(456L, "2026-05-11T10:00:00Z")));
 
     TransactionOrder presentByOurRef = executedOrder(456L);
     given(orderRepository.findByOrderStatusIn(anyCollection()))
@@ -753,6 +754,122 @@ class SebPendingTransactionReconciliationServiceTest {
 
     verify(settlementRepository, never()).save(any());
     assertThat(presentByOurRef.getOrderStatus()).isEqualTo(EXECUTED);
+  }
+
+  @Test
+  void reconcile_nonLatestReplayedReport_skipsSettlementByAbsence() {
+    service = newService();
+    UUID clientRef = UUID.fromString("bd83f551-8c79-4193-b92b-18e1dfd0bd29");
+    TransactionOrder matchedOrder = sampleOrder(clientRef);
+    given(orderRepository.findByOrderUuid(clientRef)).willReturn(Optional.of(matchedOrder));
+    given(executionRepository.findByOrderId(123L)).willReturn(Optional.empty());
+
+    // A newer pending report exists than the one being reconciled (lookback replay of an older one)
+    given(reportService.getLatestReport(SEB, PENDING_TRANSACTIONS))
+        .willReturn(
+            Optional.of(
+                InvestmentReport.builder()
+                    .provider(SEB)
+                    .reportType(PENDING_TRANSACTIONS)
+                    .reportDate(LocalDate.of(2026, 5, 14))
+                    .rawData(List.of())
+                    .build()));
+
+    service.reconcile(reportWithSingleRow(clientRef)); // reportDate 2026-05-13
+
+    verify(orderRepository, never()).findByOrderStatusIn(anyCollection());
+    verify(settlementRepository, never()).save(any());
+  }
+
+  @Test
+  void reconcile_reportWithMalformedRow_skipsSettlementByAbsence() {
+    service = newService();
+    UUID clientRef = UUID.fromString("bd83f551-8c79-4193-b92b-18e1dfd0bd29");
+    TransactionOrder matchedOrder = sampleOrder(clientRef);
+    given(orderRepository.findByOrderUuid(clientRef)).willReturn(Optional.of(matchedOrder));
+    given(executionRepository.findByOrderId(123L)).willReturn(Optional.empty());
+
+    Map<String, Object> malformed = new HashMap<>();
+    malformed.put("ISIN", "IE000F60HVH9");
+    malformed.put("Client ref", "not-a-uuid");
+    malformed.put("Buy/Sell", "Buy");
+    malformed.put("Our ref", "DLA9999999");
+
+    InvestmentReport report =
+        InvestmentReport.builder()
+            .provider(SEB)
+            .reportType(PENDING_TRANSACTIONS)
+            .reportDate(LocalDate.of(2026, 5, 13))
+            .rawData(List.of(validRawRow(clientRef), malformed))
+            .build();
+
+    service.reconcile(report);
+
+    verify(orderRepository, never()).findByOrderStatusIn(anyCollection());
+    verify(settlementRepository, never()).save(any());
+  }
+
+  @Test
+  void reconcile_existingExecutionFieldsChanged_recordsExecutionUpdatedAudit() {
+    service = newService();
+    UUID clientRef = UUID.fromString("bd83f551-8c79-4193-b92b-18e1dfd0bd29");
+    TransactionOrder order = sampleOrder(clientRef);
+    given(orderRepository.findByOrderUuid(clientRef)).willReturn(Optional.of(order));
+    TransactionExecution existing =
+        TransactionExecution.builder()
+            .id(99L)
+            .orderId(123L)
+            .source("SEB_OOTEL")
+            .brokerTransactionId("OLD")
+            .executedQuantity(new BigDecimal("1"))
+            .build();
+    given(executionRepository.findByOrderId(123L)).willReturn(Optional.of(existing));
+
+    service.reconcile(reportWithSingleRow(clientRef));
+
+    verify(auditEventRepository)
+        .save(
+            argThat(
+                (TransactionAuditEvent event) ->
+                    "EXECUTION_UPDATED".equals(event.getEventType())
+                        && event.getOrderId().equals(123L)
+                        && "DLA0799512".equals(event.getPayload().get("ourRef"))));
+  }
+
+  @Test
+  void reconcile_existingExecutionUnchanged_doesNotRecordExecutionUpdatedAudit() {
+    service = newService();
+    UUID clientRef = UUID.fromString("bd83f551-8c79-4193-b92b-18e1dfd0bd29");
+    TransactionOrder order = sampleOrder(clientRef);
+    given(orderRepository.findByOrderUuid(clientRef)).willReturn(Optional.of(order));
+    TransactionExecution existing =
+        mapper.toExecution(SebPendingTransactionRow.fromRawData(validRawRow(clientRef)), order);
+    existing.setId(99L);
+    given(executionRepository.findByOrderId(123L)).willReturn(Optional.of(existing));
+
+    service.reconcile(reportWithSingleRow(clientRef));
+
+    verify(auditEventRepository, never())
+        .save(argThat(event -> "EXECUTION_UPDATED".equals(event.getEventType())));
+  }
+
+  @Test
+  void reconcile_ambiguousBrokerRef_refusesMatchAndDoesNotPersist() {
+    service = newService();
+    UUID clientRef = UUID.fromString("00000000-0000-0000-0000-000000000099");
+    given(orderRepository.findByOrderUuid(clientRef)).willReturn(Optional.empty());
+    // ourRef DLA0799512 resolves to TWO executions → ambiguous → refuse the broker-ref tier
+    given(executionRepository.findAllByBrokerTransactionId("DLA0799512"))
+        .willReturn(
+            List.of(
+                TransactionExecution.builder().id(1L).orderId(11L).build(),
+                TransactionExecution.builder().id(2L).orderId(22L).build()));
+    given(orderRepository.findByInstrumentIsin(any())).willReturn(List.of());
+
+    service.reconcile(reportWithSingleRow(clientRef));
+
+    verify(orderRepository, never()).findById(any());
+    verify(executionRepository, never()).save(any());
   }
 
   private static TransactionOrder executedOrder(Long id) {

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/SettlementCheckJobScheduledTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/SettlementCheckJobScheduledTest.java
@@ -2,8 +2,8 @@ package ee.tuleva.onboarding.investment.transaction.ingest;
 
 import ee.tuleva.onboarding.config.ScheduledTest;
 import ee.tuleva.onboarding.deadline.PublicHolidays;
-import ee.tuleva.onboarding.investment.calendar.Target2Calendar;
 import ee.tuleva.onboarding.investment.report.InvestmentReportService;
+import ee.tuleva.onboarding.investment.transaction.SettlementDateCalculator;
 import ee.tuleva.onboarding.investment.transaction.TransactionExecutionRepository;
 import ee.tuleva.onboarding.investment.transaction.TransactionOrderRepository;
 import ee.tuleva.onboarding.notification.OperationsNotificationService;
@@ -18,7 +18,7 @@ class SettlementCheckJobScheduledTest {
 
   @MockitoBean Clock clock;
   @MockitoBean PublicHolidays publicHolidays;
-  @MockitoBean Target2Calendar target2Calendar;
+  @MockitoBean SettlementDateCalculator settlementDateCalculator;
   @MockitoBean TransactionOrderRepository orderRepository;
   @MockitoBean TransactionExecutionRepository executionRepository;
   @MockitoBean InvestmentReportService reportService;

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/SettlementCheckJobTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/SettlementCheckJobTest.java
@@ -21,12 +21,17 @@ import static org.mockito.Mockito.verifyNoInteractions;
 
 import ee.tuleva.onboarding.deadline.PublicHolidays;
 import ee.tuleva.onboarding.fund.TulevaFund;
+import ee.tuleva.onboarding.investment.calendar.DomicileCalendar;
 import ee.tuleva.onboarding.investment.calendar.Target2Calendar;
+import ee.tuleva.onboarding.investment.portfolio.ModelPortfolioAllocation;
+import ee.tuleva.onboarding.investment.portfolio.ModelPortfolioAllocationRepository;
+import ee.tuleva.onboarding.investment.portfolio.Provider;
 import ee.tuleva.onboarding.investment.report.InvestmentReport;
 import ee.tuleva.onboarding.investment.report.InvestmentReportService;
 import ee.tuleva.onboarding.investment.transaction.InstrumentType;
 import ee.tuleva.onboarding.investment.transaction.OrderStatus;
 import ee.tuleva.onboarding.investment.transaction.OrderVenue;
+import ee.tuleva.onboarding.investment.transaction.SettlementDateCalculator;
 import ee.tuleva.onboarding.investment.transaction.TransactionExecution;
 import ee.tuleva.onboarding.investment.transaction.TransactionExecutionRepository;
 import ee.tuleva.onboarding.investment.transaction.TransactionOrder;
@@ -66,8 +71,15 @@ class SettlementCheckJobTest {
   @Mock private UnmatchedPendingTransactionFinder unmatchedFinder;
   @Mock private SebClientNameToFundResolver fundResolver;
   @Mock private OperationsNotificationService notificationService;
+  @Mock private ModelPortfolioAllocationRepository allocationRepository;
 
   private final Clock clock = Clock.fixed(TODAY.atStartOfDay(TALLINN).toInstant(), TALLINN);
+
+  private SettlementDateCalculator settlementDateCalculator() {
+    Target2Calendar target2Calendar = new Target2Calendar();
+    return new SettlementDateCalculator(
+        target2Calendar, new DomicileCalendar(target2Calendar), allocationRepository);
+  }
 
   private SettlementCheckJob job() {
     return job(clock);
@@ -77,7 +89,7 @@ class SettlementCheckJobTest {
     return new SettlementCheckJob(
         clock,
         publicHolidays,
-        new Target2Calendar(),
+        settlementDateCalculator(),
         orderRepository,
         executionRepository,
         reportService,
@@ -85,6 +97,15 @@ class SettlementCheckJobTest {
         unmatchedFinder,
         fundResolver,
         notificationService);
+  }
+
+  private void givenProvider(String isin, Provider provider) {
+    given(
+            allocationRepository
+                .findFirstByIsinAndProviderIsNotNullAndEffectiveDateLessThanEqualOrderByEffectiveDateDesc(
+                    eq(isin), any()))
+        .willReturn(
+            Optional.of(ModelPortfolioAllocation.builder().isin(isin).provider(provider).build()));
   }
 
   @Test
@@ -276,6 +297,57 @@ class SettlementCheckJobTest {
     job(easterClock).run();
 
     verifyNoInteractions(notificationService);
+  }
+
+  @Test
+  void run_fundDeadlineUsesDomicileCalendar_irishHolidayDefersOverdue() {
+    // FUND order on Tue 2026-03-10, 5-business-day threshold. On TARGET2 the deadline is
+    // 2026-03-17, but the Irish domicile calendar skips St Patrick's Day (Mar 17), deferring the
+    // deadline to 2026-03-18. As of 2026-03-18 the order is therefore NOT yet overdue.
+    LocalDate stPatricksWeek = LocalDate.of(2026, 3, 18); // Wednesday
+    Clock irishClock = Clock.fixed(stPatricksWeek.atStartOfDay(TALLINN).toInstant(), TALLINN);
+    given(publicHolidays.previousWorkingDay(stPatricksWeek)).willReturn(LocalDate.of(2026, 3, 17));
+    InvestmentReport report = report(stPatricksWeek);
+    given(reportService.getLatestReport(SEB, PENDING_TRANSACTIONS)).willReturn(Optional.of(report));
+    given(extractor.extract(report)).willReturn(List.of());
+
+    givenProvider("IE00BFG1TM61", Provider.ISHARES);
+    TransactionOrder sentFund =
+        order(1L, FUND, SENT, dateOnly(2026, 3, 10), TUV100, "IE00BFG1TM61", SENT_UUID);
+    given(orderRepository.findByOrderStatusInAndOrderTimestampSince(any(), any()))
+        .willReturn(List.of(sentFund));
+    given(executionRepository.findByOrderIdIn(any())).willReturn(List.of());
+    given(unmatchedFinder.collectUnmatched(report)).willReturn(List.of());
+
+    job(irishClock).run();
+
+    verifyNoInteractions(notificationService);
+  }
+
+  @Test
+  void run_fundDeadlineOnTarget2WithoutProvider_isOverdueOnStPatricksDay() {
+    // Same FUND order as above, but with no resolvable provider the calculator falls back to
+    // TARGET2, whose deadline is 2026-03-17 (St Patrick's Day is a regular TARGET2 business day).
+    // As of 2026-03-18 the order is overdue, confirming the domicile calendar is what defers it.
+    LocalDate stPatricksWeek = LocalDate.of(2026, 3, 18); // Wednesday
+    Clock irishClock = Clock.fixed(stPatricksWeek.atStartOfDay(TALLINN).toInstant(), TALLINN);
+    given(publicHolidays.previousWorkingDay(stPatricksWeek)).willReturn(LocalDate.of(2026, 3, 17));
+    InvestmentReport report = report(stPatricksWeek);
+    given(reportService.getLatestReport(SEB, PENDING_TRANSACTIONS)).willReturn(Optional.of(report));
+    given(extractor.extract(report)).willReturn(List.of());
+
+    TransactionOrder sentFund =
+        order(1L, FUND, SENT, dateOnly(2026, 3, 10), TUV100, "EE3600109443", SENT_UUID);
+    given(orderRepository.findByOrderStatusInAndOrderTimestampSince(any(), any()))
+        .willReturn(List.of(sentFund));
+    given(executionRepository.findByOrderIdIn(any())).willReturn(List.of());
+    given(unmatchedFinder.collectUnmatched(report)).willReturn(List.of());
+
+    job(irishClock).run();
+
+    ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+    verify(notificationService).sendMessage(captor.capture(), eq(INVESTMENT));
+    assertThat(captor.getValue()).contains("[SAADETUD, täitmist pole] Order 1");
   }
 
   @Test

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/portfolio/CostBasisCalculatorSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/portfolio/CostBasisCalculatorSpec.groovy
@@ -108,7 +108,7 @@ class CostBasisCalculatorSpec extends Specification {
         result.deltaQuantity.compareTo(new BigDecimal("-1000")) == 0
     }
 
-    def "SELL: over-sell clamps to zero with warning"() {
+    def "SELL: over-sell fails the control instead of clamping"() {
         given:
         def prior = Optional.of(new PriorPosition(new BigDecimal("100"), new BigDecimal("10.00")))
         def execs = [
@@ -116,11 +116,10 @@ class CostBasisCalculatorSpec extends Specification {
         ]
 
         when:
-        def result = calculator.calculate(prior, execs, FUND_ISIN, INSTRUMENT_ISIN, DATE)
+        calculator.calculate(prior, execs, FUND_ISIN, INSTRUMENT_ISIN, DATE)
 
         then:
-        result.quantity.compareTo(BigDecimal.ZERO) == 0
-        result.totalCost.compareTo(BigDecimal.ZERO) == 0
+        thrown(IllegalStateException)
     }
 
     def "new ISIN: no prior, first BUY sets initial state"() {


### PR DESCRIPTION
Closes the post-#1696 work-list from the [Transaction Registry Gap Analysis & Remediation Plan](https://github.com/TulevaEE/tuleva/blob/main/work/investeerimistegevus/docs/Transaction%20Registry%20Gap%20Analysis%20%26%20Remediation%20Plan.md): the integrity defects found by the two adversarial Codex passes, the code-fixable regulatory findings, and the GAS-parity gaps. Every item was first re-verified as still-present against current `master`, then fixed **test-first**.

## Integrity defects (bugs in merged #1696 code)
- **D1** Settlement-by-absence now runs only on the latest pending report — a lookback/backfill replay can't flip an order SETTLED out of chronological order.
- **D2** A malformed SEB row disables absence-settlement for that report (a dropped row could make a still-pending order look absent → false settlement).
- **D3** In-place execution mutations are delta-audited (`EXECUTION_UPDATED`, before/after) — Art 16 no-silent-alteration.
- **D4** Quantity/amount mismatches are **quarantined**: the order is no longer auto-transitioned to EXECUTED; it's flagged and left `SENT` for manual handling.
- **D5** SELL distribution caps each position at its market value and water-fills the remainder; insufficient total liquidity fails loud (→ command FAILED) instead of emitting an impossible oversized sell.
- **D6** SELL_FAST redistributes a market-value-capped shortfall across positions with headroom.
- **D7** `netInvestable` includes receivables, matching `freeCash` (one consistent base). TKF100 reference golden master unchanged.
- **D8** Cost-basis oversell now fails the control (rolls back that fund's ledger) instead of silently clamping to zero.
- **D9** Ambiguous broker-ref lookups are refused rather than resolved to an arbitrary execution (index is non-unique / H2-portable).
- **D10** Unvalued R45 rows no longer flow into trade sizing as zero — the summary is marked incomplete (`epis_report_summary.complete`, V1_217), a Slack alert fires, and `getR45Net` blocks until the NAV is supplied.
- **N1** PEVA/RAVA flows are computed from the active `PevaRavaCycle`'s stored R17/R21 report ids, never cross-cycle "latest" summaries.
- **N2** The mismatch alert listener is `@TransactionalEventListener(AFTER_COMMIT)` and swallows send failures — can no longer roll back reconciliation.
- **N3** SEB fund **SELL (REDP)** export writes the Quantity column (was Transaction Sum → wrong order file to the custodian).
- **N4** Google Drive upload + event run after the batch commits, so a Drive failure can't roll back a committed batch.
- **N5** Fund settlement calendar resolves provider→domicile with `effectiveDate <= tradeDate` (future allocation no longer changes today's settlement date).
- **N6** Commands are marked FAILED (with errorMessage/processedAt) on unexpected error instead of stuck in PROCESSING.
- **N7** Injected `Clock` replaces direct `Instant.now()` (InvestmentReportService, FundLimit via ClockHolder).
- **N8** Overdue digest derives fund deadlines from the domicile calendar, consistent with real settlement dates.

## Regulatory & GAS-parity
- **R1/R2/GP2** Append-only batch cancellation: `POST /admin/transaction-batches/{id}/cancel` (never deletes, 409 if any order already EXECUTED/SETTLED, records reason + actor + `BATCH_CANCELLED` audit). Columns in V1_218.
- **R3** Operator attribution: optional `X-Admin-Actor` header → `confirmedBy`/`confirmedAt` on the batch.
- **R5** Codified retention guard (no delete operations on `investment_transaction_*` tables — Art 16 ≥5y).
- **R6** Codified fair-allocation invariant (calc engine is per-fund; no cross-fund pooling — 2010/43/EU art 28).
- **GP1** Inert-by-default custodian order email (recipients from config, disabled by default; attaches the order workbooks).
- **GP3** `v_settlement_delays` retrospective settlement-delay KPI view (V1_219).
- **GP5** Manual adjustments included in the `CALCULATION_COMPLETED` audit snapshot.
- **GP6** FT cancellation-confirmation handling + improved order selection (AMBIGUOUS instead of oldest-pick).
- **GP7** FT verification weekend-skip + per-row manual suppression (batched digest deferred — YAGNI).

## Migrations
`V1_217` (epis_report_summary.complete), `V1_218` (batch attribution + cancellation), `V1_219` (v_settlement_delays). All above master's current max — **re-check numbering before merge** per the repo's strict-ordering rule.

## Verification
- Full **H2** suite green; `spotlessCheck` clean.
- ⚠️ **PostgreSQL Testcontainers suite NOT run** (Docker unavailable in this environment). Please run `SPRING_PROFILES_ACTIVE=pg,test ./gradlew test` before merge — this PR adds 3 migrations and PG-only ITs exist.

## Out of scope (need product/compliance input or are operational)
**R4** (PEVA/RAVA calendar basis — needs Maria), **R16** AUM-ceiling (needs ceiling param + AUM source), **GP4** (prior-month fee-row zeroing — lives in the NAV/fees module), **FT PDF** automation, **G19** operational cutover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)