### PR TITLE
AML(#78): stop KYB change-detector false-firing on volatile sanction metadata

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/kyb/KybDataChangeDetector.java
+++ b/src/main/java/ee/tuleva/onboarding/kyb/KybDataChangeDetector.java
@@ -1,10 +1,13 @@
 package ee.tuleva.onboarding.kyb;
 
+import static ee.tuleva.onboarding.kyb.KybCheckType.COMPANY_PEP;
+import static ee.tuleva.onboarding.kyb.KybCheckType.COMPANY_SANCTION;
 import static ee.tuleva.onboarding.kyb.KybCheckType.DATA_CHANGED;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -13,6 +16,9 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 public class KybDataChangeDetector {
+
+  private static final Set<KybCheckType> AUDIT_ONLY_METADATA =
+      Set.of(COMPANY_SANCTION, COMPANY_PEP);
 
   private final KybCheckHistory checkHistory;
 
@@ -41,8 +47,7 @@ public class KybDataChangeDetector {
                 "check", current.type().name(),
                 "previousSuccess", "N/A",
                 "currentSuccess", current.success()));
-      } else if (previous.success() != current.success()
-          || !previous.metadata().equals(current.metadata())) {
+      } else if (changed(previous, current)) {
         changes.add(
             Map.of(
                 "check", current.type().name(),
@@ -62,5 +67,13 @@ public class KybDataChangeDetector {
     }
 
     return new KybCheck(DATA_CHANGED, changes.isEmpty(), Map.of("changes", changes));
+  }
+
+  private boolean changed(KybCheck previous, KybCheck current) {
+    if (previous.success() != current.success()) {
+      return true;
+    }
+    return !AUDIT_ONLY_METADATA.contains(current.type())
+        && !previous.metadata().equals(current.metadata());
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/kyb/KybDataChangeDetectorTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyb/KybDataChangeDetectorTest.java
@@ -114,4 +114,30 @@ class KybDataChangeDetectorTest {
     var changes = (List<Map<String, Object>>) result.metadata().get("changes");
     assertThat(changes).hasSize(2);
   }
+
+  @Test
+  void volatileSanctionMetadataAloneDoesNotCountAsChange() {
+    var previousChecks =
+        List.of(new KybCheck(COMPANY_SANCTION, true, Map.of("results", "[{id=Q1, score=0.31}]")));
+    var currentChecks =
+        List.of(new KybCheck(COMPANY_SANCTION, true, Map.of("results", "[{id=Q2, score=0.62}]")));
+    when(checkHistory.getLatestChecks(PERSONAL_CODE)).thenReturn(previousChecks);
+
+    var result = detector.detect(PERSONAL_CODE, currentChecks);
+
+    assertThat(result.success()).isTrue();
+    assertThat((List<?>) result.metadata().get("changes")).isEmpty();
+  }
+
+  @Test
+  void sanctionSuccessFlipStillCountsAsChange() {
+    var previousChecks = List.of(new KybCheck(COMPANY_SANCTION, true, Map.of("results", "[]")));
+    var currentChecks =
+        List.of(new KybCheck(COMPANY_SANCTION, false, Map.of("results", "[{match=true}]")));
+    when(checkHistory.getLatestChecks(PERSONAL_CODE)).thenReturn(previousChecks);
+
+    var result = detector.detect(PERSONAL_CODE, currentChecks);
+
+    assertThat(result.success()).isFalse();
+  }
 }


### PR DESCRIPTION
## What & why

Surfaced while validating the **M6** company risk scoring query against real data: **every company scored KÕRGE**, because `KYB_DATA_CHANGED` was failing for **100% of companies on every monitoring re-screen** (→ `kkr_related_changed=100`). That also makes the daily KYB monitor useless — it flags everything, every day.

## Root cause

`KybDataChangeDetector` (Tõnu's daily KYB change detection, "item 35") compares each check's `metadata` between screenings. The `COMPANY_SANCTION`/`COMPANY_PEP` checks store the **raw OpenSanctions response** in metadata (`results.toString()` + `query` — the fuzzy-match candidate list with scores/ordering), which is **non-deterministic across runs even when the company hasn't changed**. So the metadata diff tripped every re-screen.

## Fix (in the detector, not the screener)

Treat `COMPANY_SANCTION`/`COMPANY_PEP` metadata as **audit-only**: compare just the match outcome (`success`) for those checks, while still diffing metadata for every other check (so e.g. ownership-percent changes are still caught).

- **Erko's audit trail is preserved** — the full sanction metadata (scores, near-misses, threshold context, e.g. "0.75 vs 0.8") still gets stored exactly as today. Only its run-to-run churn no longer counts as "data changed." (My first attempt summarised the metadata in the screener and lost that audit detail — reverted.)
- A company **genuinely** becoming sanctioned / non-EU PEP flips `success` → still detected.
- The detector's intended metadata sensitivity for the other checks is unchanged.

## Tests
- `KybDataChangeDetectorTest.volatileSanctionMetadataAloneDoesNotCountAsChange` (RED→GREEN).
- `KybDataChangeDetectorTest.sanctionSuccessFlipStillCountsAsChange`.
- Existing detector + `CompanySanctionScreener` tests unchanged and green.

## Notes for reviewers
- Touches **Tõnu's** detector (item 35) in service of **Erko's** "keep the why" audit principle — it protects that audit, doesn't remove it.
- Complementary to master's *"Stop Jackson 3 nodes from corrupting AML check metadata"* (different fix, same area).
- Historical `DATA_CHANGED` rows self-clear after two re-screen cycles post-deploy.

Refs TulevaEE/tuleva#78
