### PR TITLE
AML(#78): refresh company risk metadata view on schedule

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/aml/risklevel/CompanyRiskReader.java
+++ b/src/main/java/ee/tuleva/onboarding/aml/risklevel/CompanyRiskReader.java
@@ -1,0 +1,22 @@
+package ee.tuleva.onboarding.aml.risklevel;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.jdbc.core.simple.JdbcClient;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+class CompanyRiskReader {
+
+  private final JdbcClient jdbcClient;
+
+  public void refreshMaterializedView() {
+    log.info("Start materialized view refresh: analytics.v_company_risk_metadata");
+    jdbcClient
+        .sql("REFRESH MATERIALIZED VIEW CONCURRENTLY analytics.v_company_risk_metadata")
+        .update();
+    log.info("Materialized view refreshed: analytics.v_company_risk_metadata");
+  }
+}

--- a/src/main/java/ee/tuleva/onboarding/aml/risklevel/ScheduledAmlRiskMetadataRefreshJob.java
+++ b/src/main/java/ee/tuleva/onboarding/aml/risklevel/ScheduledAmlRiskMetadataRefreshJob.java
@@ -15,6 +15,7 @@ public class ScheduledAmlRiskMetadataRefreshJob {
 
   private final AmlRiskReader amlRiskReader;
   private final TkfRiskReader tkfRiskReader;
+  private final CompanyRiskReader companyRiskReader;
 
   @Scheduled(cron = "0 0 9,13,16 * * ?", zone = "Europe/Tallinn")
   @SchedulerLock(
@@ -32,6 +33,11 @@ public class ScheduledAmlRiskMetadataRefreshJob {
       tkfRiskReader.refreshMaterializedView();
     } catch (Exception e) {
       log.error("TKF risk metadata view refresh failed", e);
+    }
+    try {
+      companyRiskReader.refreshMaterializedView();
+    } catch (Exception e) {
+      log.error("Company risk metadata view refresh failed", e);
     }
     log.info("Finished scheduled risk metadata view refresh");
   }

--- a/src/test/groovy/ee/tuleva/onboarding/aml/risklevel/CompanyRiskReaderTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/aml/risklevel/CompanyRiskReaderTest.java
@@ -1,0 +1,34 @@
+package ee.tuleva.onboarding.aml.risklevel;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.simple.JdbcClient;
+
+class CompanyRiskReaderTest {
+
+  private JdbcClient jdbcClient;
+  private JdbcClient.StatementSpec statementSpec;
+  private CompanyRiskReader reader;
+
+  @BeforeEach
+  void setUp() {
+    jdbcClient = mock(JdbcClient.class);
+    statementSpec = mock(JdbcClient.StatementSpec.class);
+    when(jdbcClient.sql(anyString())).thenReturn(statementSpec);
+    when(statementSpec.update()).thenReturn(0);
+    reader = new CompanyRiskReader(jdbcClient);
+  }
+
+  @Test
+  void refreshMaterializedView_refreshesCompanyRiskView() {
+    reader.refreshMaterializedView();
+
+    verify(jdbcClient)
+        .sql("REFRESH MATERIALIZED VIEW CONCURRENTLY analytics.v_company_risk_metadata");
+  }
+}

--- a/src/test/groovy/ee/tuleva/onboarding/aml/risklevel/ScheduledAmlRiskMetadataRefreshJobTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/aml/risklevel/ScheduledAmlRiskMetadataRefreshJobTest.java
@@ -16,18 +16,21 @@ class ScheduledAmlRiskMetadataRefreshJobTest {
 
   @Mock private TkfRiskReader tkfRiskReader;
 
+  @Mock private CompanyRiskReader companyRiskReader;
+
   @InjectMocks private ScheduledAmlRiskMetadataRefreshJob scheduledAmlRiskMetadataRefreshJob;
 
   @Test
-  void refreshesAmlAndTkfViews() {
+  void refreshesAmlTkfAndCompanyViews() {
     scheduledAmlRiskMetadataRefreshJob.refreshAmlRiskMetadata();
 
     verify(amlRiskReader).refreshAmlRiskMetadataView();
     verify(tkfRiskReader).refreshMaterializedView();
+    verify(companyRiskReader).refreshMaterializedView();
   }
 
   @Test
-  void tkfRefreshStillRunsWhenAmlRefreshFails() {
+  void tkfAndCompanyRefreshStillRunWhenAmlRefreshFails() {
     willThrow(new RuntimeException("AML refresh failure"))
         .given(amlRiskReader)
         .refreshAmlRiskMetadataView();
@@ -35,10 +38,11 @@ class ScheduledAmlRiskMetadataRefreshJobTest {
     scheduledAmlRiskMetadataRefreshJob.refreshAmlRiskMetadata();
 
     verify(tkfRiskReader).refreshMaterializedView();
+    verify(companyRiskReader).refreshMaterializedView();
   }
 
   @Test
-  void amlRefreshStillRunsWhenTkfRefreshFails() {
+  void amlAndCompanyRefreshStillRunWhenTkfRefreshFails() {
     willThrow(new RuntimeException("TKF refresh failure"))
         .given(tkfRiskReader)
         .refreshMaterializedView();
@@ -46,5 +50,18 @@ class ScheduledAmlRiskMetadataRefreshJobTest {
     scheduledAmlRiskMetadataRefreshJob.refreshAmlRiskMetadata();
 
     verify(amlRiskReader).refreshAmlRiskMetadataView();
+    verify(companyRiskReader).refreshMaterializedView();
+  }
+
+  @Test
+  void amlAndTkfRefreshStillRunWhenCompanyRefreshFails() {
+    willThrow(new RuntimeException("Company refresh failure"))
+        .given(companyRiskReader)
+        .refreshMaterializedView();
+
+    scheduledAmlRiskMetadataRefreshJob.refreshAmlRiskMetadata();
+
+    verify(amlRiskReader).refreshAmlRiskMetadataView();
+    verify(tkfRiskReader).refreshMaterializedView();
   }
 }


### PR DESCRIPTION
## What
Wires `analytics.v_company_risk_metadata` (created in database-administration PR #3 / migration V19) into the existing **`ScheduledAmlRiskMetadataRefreshJob`** (09:00 / 13:00 / 16:00 Europe/Tallinn), next to the III-pillar and TKF view refreshes.

- New `CompanyRiskReader` mirrors `TkfRiskReader` — `REFRESH MATERIALIZED VIEW CONCURRENTLY analytics.v_company_risk_metadata` (the view has a UNIQUE index on `registry_code`, required for concurrent refresh).
- Each of the three view refreshes is independently `try/catch`'d, so one failure doesn't block the others.

## Why
Without this, the company matview is populated **once** at migration time and never updates — the company risk tab would show a frozen snapshot. 09:00 runs after the **02:00** nightly KYB re-screen (`ScheduledKybCheckJob`), so the view always scores fresh KYB data.

## Tests
- `CompanyRiskReaderTest` — verifies the concurrent-refresh SQL.
- `ScheduledAmlRiskMetadataRefreshJobTest` — all three views refresh; each still runs when another throws.

## Depends on
`database-administration` PR #3 (the `v_company_risk_metadata` view must exist in the analytics DB before this runs). Refs TulevaEE/tuleva#78.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
