### PR TITLE
AML(#78): stop KYB DATA_CHANGED false-firing on newly added check types

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/aml/AmlKybCheckHistory.java
+++ b/src/main/java/ee/tuleva/onboarding/aml/AmlKybCheckHistory.java
@@ -26,6 +26,8 @@ public class AmlKybCheckHistory implements KybCheckHistory {
               AmlCheckType.KYB_SINGLE_BOARD_MEMBER_OWNERSHIP,
               KybCheckType.SINGLE_BOARD_MEMBER_OWNERSHIP),
           entry(AmlCheckType.KYB_COMPANY_ACTIVE, KybCheckType.COMPANY_ACTIVE),
+          entry(AmlCheckType.KYB_COMPANY_AGE, KybCheckType.COMPANY_AGE),
+          entry(AmlCheckType.KYB_COMPANY_LEGAL_FORM, KybCheckType.COMPANY_LEGAL_FORM),
           entry(AmlCheckType.KYB_RELATED_PERSONS_KYC, KybCheckType.RELATED_PERSONS_KYC),
           entry(AmlCheckType.KYB_COMPANY_SANCTION, KybCheckType.COMPANY_SANCTION),
           entry(AmlCheckType.KYB_COMPANY_PEP, KybCheckType.COMPANY_PEP),

--- a/src/main/java/ee/tuleva/onboarding/kyb/KybDataChangeDetector.java
+++ b/src/main/java/ee/tuleva/onboarding/kyb/KybDataChangeDetector.java
@@ -41,35 +41,34 @@ public class KybDataChangeDetector {
 
     for (var current : currentChecks) {
       var previous = previousByType.get(current.type());
-      // A newly introduced check TYPE (the screener gained a check, e.g. COMPANY_AGE) is not a
-      // change in the company's data — baseline it silently. Otherwise DATA_CHANGED false-fires for
-      // every company on the first screening after a screener expansion (AML #78). The new check's
-      // own risk is scored on its own aml_check row, independent of DATA_CHANGED. A genuine
-      // structural change (a conditional check swapping in, e.g. sole- -> dual-member) is still
-      // caught below, because the previously applicable check disappears (removed-check loop).
-      if (previous == null) {
-        continue;
-      }
-      if (changed(previous, current)) {
-        changes.add(
-            Map.of(
-                "check", current.type().name(),
-                "previousSuccess", previous.success(),
-                "currentSuccess", current.success()));
+      if (isExistingCheck(previous) && changed(previous, current)) {
+        changes.add(change(current.type(), previous.success(), current.success()));
       }
     }
 
     for (var previous : previousChecks) {
-      if (!currentByType.containsKey(previous.type())) {
-        changes.add(
-            Map.of(
-                "check", previous.type().name(),
-                "previousSuccess", previous.success(),
-                "currentSuccess", "N/A"));
+      if (isRemovedCheck(previous, currentByType)) {
+        changes.add(change(previous.type(), previous.success(), "N/A"));
       }
     }
 
     return new KybCheck(DATA_CHANGED, changes.isEmpty(), Map.of("changes", changes));
+  }
+
+  private boolean isExistingCheck(KybCheck previous) {
+    return previous != null;
+  }
+
+  private boolean isRemovedCheck(KybCheck previous, Map<KybCheckType, KybCheck> currentByType) {
+    return !currentByType.containsKey(previous.type());
+  }
+
+  private Map<String, Object> change(
+      KybCheckType type, Object previousSuccess, Object currentSuccess) {
+    return Map.of(
+        "check", type.name(),
+        "previousSuccess", previousSuccess,
+        "currentSuccess", currentSuccess);
   }
 
   private boolean changed(KybCheck previous, KybCheck current) {

--- a/src/main/java/ee/tuleva/onboarding/kyb/KybDataChangeDetector.java
+++ b/src/main/java/ee/tuleva/onboarding/kyb/KybDataChangeDetector.java
@@ -41,13 +41,16 @@ public class KybDataChangeDetector {
 
     for (var current : currentChecks) {
       var previous = previousByType.get(current.type());
+      // A newly introduced check TYPE (the screener gained a check, e.g. COMPANY_AGE) is not a
+      // change in the company's data — baseline it silently. Otherwise DATA_CHANGED false-fires for
+      // every company on the first screening after a screener expansion (AML #78). The new check's
+      // own risk is scored on its own aml_check row, independent of DATA_CHANGED. A genuine
+      // structural change (a conditional check swapping in, e.g. sole- -> dual-member) is still
+      // caught below, because the previously applicable check disappears (removed-check loop).
       if (previous == null) {
-        changes.add(
-            Map.of(
-                "check", current.type().name(),
-                "previousSuccess", "N/A",
-                "currentSuccess", current.success()));
-      } else if (changed(previous, current)) {
+        continue;
+      }
+      if (changed(previous, current)) {
         changes.add(
             Map.of(
                 "check", current.type().name(),

--- a/src/test/groovy/ee/tuleva/onboarding/aml/AmlKybCheckHistoryTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/aml/AmlKybCheckHistoryTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import ee.tuleva.onboarding.kyb.KybCheck;
+import ee.tuleva.onboarding.kyb.KybCheckType;
 import ee.tuleva.onboarding.kyb.PersonalCode;
 import java.time.Instant;
 import java.util.List;
@@ -75,5 +76,36 @@ class AmlKybCheckHistoryTest {
 
     assertThat(result).hasSize(1);
     assertThat(result.getFirst().type()).isEqualTo(COMPANY_ACTIVE);
+  }
+
+  @Test
+  void everyScreenerCheckTypeRoundTripsThroughHistory() {
+    // AML #78 guard: every screener check type (KybCheckType, except the DATA_CHANGED result type)
+    // must reverse-map, otherwise it is dropped from history, stays forever "new", and a real
+    // change to it is hidden once the detector baselines newly introduced types. COMPANY_AGE and
+    // COMPANY_LEGAL_FORM were the original gap.
+    for (KybCheckType kybType : KybCheckType.values()) {
+      if (kybType == DATA_CHANGED) {
+        continue;
+      }
+      var amlType = AmlCheckType.valueOf("KYB_" + kybType.name());
+      var check =
+          AmlCheck.builder()
+              .personalCode("38501010001")
+              .type(amlType)
+              .success(true)
+              .metadata(Map.of())
+              .build();
+      check.setCreatedTime(Instant.now());
+      when(repository.findAllByPersonalCodeAndCreatedTimeAfter(eq("38501010001"), any()))
+          .thenReturn(List.of(check));
+
+      var result = history.getLatestChecks(PERSONAL_CODE);
+
+      assertThat(result)
+          .as("screener check %s must reverse-map through AmlKybCheckHistory", kybType)
+          .hasSize(1);
+      assertThat(result.getFirst().type()).isEqualTo(kybType);
+    }
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/kyb/KybDataChangeDetectorTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyb/KybDataChangeDetectorTest.java
@@ -82,17 +82,64 @@ class KybDataChangeDetectorTest {
   }
 
   @Test
-  void newCheckTypeDetected() {
+  void newPassingCheckTypeDoesNotCountAsChange() {
+    // Screener gained a check (e.g. COMPANY_AGE). For an existing company this is a screener
+    // expansion, not a data change — it must not raise DATA_CHANGED (AML #78 false positive that
+    // flagged ~96% of companies after COMPANY_AGE / COMPANY_LEGAL_FORM were added).
     var previousChecks = List.of(new KybCheck(COMPANY_ACTIVE, true, Map.of("status", "R")));
     var currentChecks =
         List.of(
             new KybCheck(COMPANY_ACTIVE, true, Map.of("status", "R")),
+            new KybCheck(COMPANY_AGE, true, Map.of()));
+    when(checkHistory.getLatestChecks(PERSONAL_CODE)).thenReturn(previousChecks);
+
+    var result = detector.detect(PERSONAL_CODE, currentChecks);
+
+    assertThat(result.success()).isTrue();
+    assertThat((List<?>) result.metadata().get("changes")).isEmpty();
+  }
+
+  @Test
+  void newFailingCheckTypeDoesNotCountAsChange() {
+    // Even a newly introduced FAILING check is the new check's own risk (scored on its own
+    // aml_check row), not a change in existing data — DATA_CHANGED stays clear.
+    var previousChecks = List.of(new KybCheck(COMPANY_ACTIVE, true, Map.of("status", "R")));
+    var currentChecks =
+        List.of(
+            new KybCheck(COMPANY_ACTIVE, true, Map.of("status", "R")),
+            new KybCheck(COMPANY_AGE, false, Map.of()));
+    when(checkHistory.getLatestChecks(PERSONAL_CODE)).thenReturn(previousChecks);
+
+    var result = detector.detect(PERSONAL_CODE, currentChecks);
+
+    assertThat(result.success()).isTrue();
+    assertThat((List<?>) result.metadata().get("changes")).isEmpty();
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void structuralCheckSwapStillCountsAsChange() {
+    // A genuine structural change (sole- -> dual-member) swaps one conditional check for another.
+    // The disappearing check still raises DATA_CHANGED via the removed-check path, so real changes
+    // are NOT lost by baselining newly introduced check types.
+    var previousChecks =
+        List.of(
+            new KybCheck(COMPANY_ACTIVE, true, Map.of("status", "R")),
             new KybCheck(SOLE_MEMBER_OWNERSHIP, true, Map.of()));
+    var currentChecks =
+        List.of(
+            new KybCheck(COMPANY_ACTIVE, true, Map.of("status", "R")),
+            new KybCheck(DUAL_MEMBER_OWNERSHIP, true, Map.of()));
     when(checkHistory.getLatestChecks(PERSONAL_CODE)).thenReturn(previousChecks);
 
     var result = detector.detect(PERSONAL_CODE, currentChecks);
 
     assertThat(result.success()).isFalse();
+    var changes = (List<Map<String, Object>>) result.metadata().get("changes");
+    assertThat(changes).hasSize(1);
+    assertThat(changes.getFirst())
+        .containsEntry("check", "SOLE_MEMBER_OWNERSHIP")
+        .containsEntry("currentSuccess", "N/A");
   }
 
   @Test


### PR DESCRIPTION
## Problem
`KybDataChangeDetector.detect()` treated a check **type** that didn't exist at the previous screening (`previous == null`) as a change. So when the screener gains a check (recently `COMPANY_AGE`, `COMPANY_LEGAL_FORM`), **every existing company's next screening reports `KYB_DATA_CHANGED`** — even though nothing about the company changed.

Measured on `analytics.v_company_risk_metadata` (Read replica): **115 / 120 companies (96%)** carry `data_changed = true`. Since `KYB_DATA_CHANGED.success = false` feeds `tkr_related_changed = +10` in the matview, that phantom +10 inflates the company risk score — all 13 KESKMINE companies have it, and some are MADAL in reality.

## Fix
Baseline newly introduced check types silently (`if (previous == null) continue;`). `KYB_DATA_CHANGED` now fires only for:
- a check present at **both** screenings that flips or whose metadata genuinely changes, or
- a check that **disappears** (existing removed-check path, unchanged).

A genuine structural change (a conditional check swapping in, e.g. sole- → dual-member) is still detected, because the previously applicable check disappears. The new check's own risk is scored on its own `aml_check` row, independent of `DATA_CHANGED`.

Complements #1716 (volatile sanction metadata): that fixed metadata-noise, this fixes new-check-type noise.

## Tests
`KybDataChangeDetectorTest`: replaced `newCheckTypeDetected` (which asserted the false positive) with `newPassingCheckTypeDoesNotCountAsChange`, `newFailingCheckTypeDoesNotCountAsChange`, and `structuralCheckSwapStillCountsAsChange`. 10/10 green locally.

## Remediation
No data migration needed — existing false `KYB_DATA_CHANGED` rows self-clear on the next clean re-screening (the new checks are now baselined), at which point the matview drops the +10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)