### PR TITLE
Add Amundi MSCI World Screened to TUK75/TUV100 model portfolio order

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/fund/TulevaFund.java
+++ b/src/main/java/ee/tuleva/onboarding/fund/TulevaFund.java
@@ -26,6 +26,7 @@ public enum TulevaFund {
       List.of(
           "IE00BFG1TM61",
           "IE0009FT4LX4",
+          "IE000QWCYQT0",
           "IE00BFNM3G45",
           "IE00BFNM3D14",
           "IE00BFNM3L97",
@@ -57,6 +58,7 @@ public enum TulevaFund {
       List.of(
           "IE00BFG1TM61",
           "IE0009FT4LX4",
+          "IE000QWCYQT0",
           "IE00BFNM3G45",
           "IE00BFNM3D14",
           "IE00BFNM3L97",


### PR DESCRIPTION
Inserts `IE000QWCYQT0` (Amundi MSCI World Screened UCITS ETF) into the `modelPortfolioOrder` for **TUK75** and **TUV100**, positioned right after the exiting CCF Developed World Screened index fund it replaces.

- Display ordering only — sole consumer is `NavReportMapper.sortedSecurities()`. No-op until the position is actually held.
- `FundTicker.AMUNDI_WORLD_SCREENED` (`WLSC.PA` / `IE000QWCYQT0`) was already added 2026-06-17, so prices already flow into `index_values`.
- Mirrors the XWSC precedent (PR #1714). CCF (`IE0009FT4LX4`) is intentionally kept for the transition window and removed later once sold to 0.

Part of the CCF → Amundi World model-portfolio switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)