### PR TITLE
Don't fail health check when runoff instrument is fully liquidated

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/investment/check/health/IsinMatchChecker.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/check/health/IsinMatchChecker.java
@@ -56,14 +56,23 @@ class IsinMatchChecker {
         }
       }
       if (position.getQuantity() == null || position.getQuantity().compareTo(ZERO) == 0) {
-        boolean previouslyHeld = isin != null && previousIsins.contains(isin);
-        if (previouslyHeld) {
+        boolean inCurrent = isin != null && currentIsins.contains(isin);
+        boolean inPrevious = isin != null && previousIsins.contains(isin);
+        if (inCurrent && inPrevious) {
           findings.add(
               new HealthCheckFinding(
                   fund,
                   ISIN_MATCH,
                   FAIL,
-                  "%s: quantity is %s for ISIN %s (previously held — position emptied?)"
+                  "%s: quantity is %s for ISIN %s (held in model but position emptied?)"
+                      .formatted(fund, position.getQuantity(), isin)));
+        } else if (inPrevious) {
+          findings.add(
+              new HealthCheckFinding(
+                  fund,
+                  ISIN_MATCH,
+                  WARNING,
+                  "%s: quantity is %s for ISIN %s (in-runoff — fully liquidated)"
                       .formatted(fund, position.getQuantity(), isin)));
         } else {
           findings.add(

--- a/src/main/java/ee/tuleva/onboarding/investment/check/health/IsinMatchChecker.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/check/health/IsinMatchChecker.java
@@ -56,8 +56,8 @@ class IsinMatchChecker {
         }
       }
       if (position.getQuantity() == null || position.getQuantity().compareTo(ZERO) == 0) {
-        boolean inCurrent = isin != null && currentIsins.contains(isin);
-        boolean inPrevious = isin != null && previousIsins.contains(isin);
+        boolean inCurrent = currentIsins.contains(isin);
+        boolean inPrevious = previousIsins.contains(isin);
         if (inCurrent && inPrevious) {
           findings.add(
               new HealthCheckFinding(

--- a/src/test/groovy/ee/tuleva/onboarding/investment/check/health/IsinMatchCheckerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/check/health/IsinMatchCheckerTest.java
@@ -90,7 +90,7 @@ class IsinMatchCheckerTest {
   }
 
   @Test
-  void failsWhenPreviouslyHeldPositionDropsToZero() {
+  void failsWhenModelHoldingDropsToZero() {
     var positions = List.of(securityPosition("IE00BFG1TM61", BigDecimal.ZERO));
     var allocations = List.of(allocation("IE00BFG1TM61"));
     var previousAllocations = List.of(allocation("IE00BFG1TM61"));
@@ -98,6 +98,17 @@ class IsinMatchCheckerTest {
     var findings = checker.check(TUK75, positions, allocations, previousAllocations);
 
     assertThat(findings).singleElement().satisfies(f -> assertThat(f.severity()).isEqualTo(FAIL));
+  }
+
+  @Test
+  void warnsWhenRunoffInstrumentFullyLiquidated() {
+    var positions = List.of(securityPosition("IE00OLDONE", BigDecimal.ZERO));
+    var allocations = List.of(allocation("IE00BFG1TM61"));
+    var previousAllocations = List.of(allocation("IE00OLDONE"));
+
+    var findings = checker.check(TUK75, positions, allocations, previousAllocations);
+
+    assertThat(findings).isNotEmpty().allSatisfy(f -> assertThat(f.severity()).isEqualTo(WARNING));
   }
 
   @Test


### PR DESCRIPTION
## Problem

The SEB 2026-06-22 position import was **blocked** by the ISIN match health check after the TUK75/TUV100 model-portfolio switch (2026-06-17):

```
[FAIL] ISIN_MATCH TUV100: quantity is 0.0 for ISIN IE00BFNM3G45 (previously held — position emptied?)
... (same for IE00BFNM3L97, IE00BFNM3D14, on TUK75 and TUV100)
:x: Health Check FAILED — Import blocked: provider=SEB, date=2026-06-22
```

The source files were correct: those three ISINs are the **old model-portfolio instruments**, sold down to zero as the planned runoff completed. Reaching quantity 0 is the *expected* end state — but `IsinMatchChecker` raised a FAIL on it, and any FAIL blocks the entire provider/date import (`FundPositionImportJob`), skipping Execution Matching too.

## Root cause

The zero-quantity branch decided FAIL vs WARNING purely on whether the ISIN was in the *previous* model (`previouslyHeld`). It never checked the *current* model, so it couldn't tell a steady holding that unexpectedly emptied apart from a runoff instrument that successfully liquidated.

## Fix

Discriminate by model membership:

| In current | In previous | qty 0 verdict |
|---|---|---|
| ✅ | ✅ | **FAIL** — held in model but position emptied? |
| ❌ | ✅ | **WARNING** — in-runoff, fully liquidated (expected) |
| ✅ | ❌ | **WARNING** — newly added, not yet bought |

FAIL now fires only when an instrument present in **both** the current and previous model goes to zero — a genuine regression.

## Tests

- Renamed `failsWhenPreviouslyHeldPositionDropsToZero` → `failsWhenModelHoldingDropsToZero` (the real discriminator; setup has the ISIN in both current and previous).
- Added `warnsWhenRunoffInstrumentFullyLiquidated` covering the previously-untested in-runoff-to-zero case that caused the block.

All `check.health.*` tests pass.

> Note: this is a redeploy — it does not retroactively unblock 2026-06-22 until shipped. The blocked import re-runs on the next pipeline pass once deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)