### PR TITLE
Make KYC flow role-aware for represented children (TKF PR0)

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/kyc/KycCheckService.java
+++ b/src/main/java/ee/tuleva/onboarding/kyc/KycCheckService.java
@@ -1,7 +1,7 @@
 package ee.tuleva.onboarding.kyc;
 
-import ee.tuleva.onboarding.auth.principal.AuthenticatedPerson;
 import ee.tuleva.onboarding.country.Country;
+import ee.tuleva.onboarding.user.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
@@ -13,10 +13,10 @@ public class KycCheckService {
   private final ApplicationEventPublisher eventPublisher;
   private final KycChecker kycChecker;
 
-  public void check(AuthenticatedPerson person, Country country, KycSurveyPurpose purpose) {
-    eventPublisher.publishEvent(new BeforeKycCheckedEvent(person, country));
-    var kycCheck = kycChecker.check(person.getUserId());
+  public void check(User subject, Country country, KycSurveyPurpose purpose) {
+    eventPublisher.publishEvent(new BeforeKycCheckedEvent(subject, country));
+    var kycCheck = kycChecker.check(subject.getId());
     eventPublisher.publishEvent(
-        new KycCheckPerformedEvent(this, person.getPersonalCode(), kycCheck, purpose));
+        new KycCheckPerformedEvent(this, subject.getPersonalCode(), kycCheck, purpose));
   }
 }

--- a/src/main/java/ee/tuleva/onboarding/kyc/survey/KycIdentityController.java
+++ b/src/main/java/ee/tuleva/onboarding/kyc/survey/KycIdentityController.java
@@ -19,6 +19,6 @@ class KycIdentityController {
   @Operation(summary = "Get the latest KYC identity of the authenticated person")
   public KycIdentityResponse getIdentity(
       @AuthenticationPrincipal AuthenticatedPerson authenticatedPerson) {
-    return kycSurveyService.getIdentity(authenticatedPerson.getUserId());
+    return kycSurveyService.getIdentity(authenticatedPerson);
   }
 }

--- a/src/main/java/ee/tuleva/onboarding/kyc/survey/KycSurveyService.java
+++ b/src/main/java/ee/tuleva/onboarding/kyc/survey/KycSurveyService.java
@@ -3,6 +3,7 @@ package ee.tuleva.onboarding.kyc.survey;
 import ee.tuleva.onboarding.auth.principal.AuthenticatedPerson;
 import ee.tuleva.onboarding.country.Country;
 import ee.tuleva.onboarding.kyc.KycCheckService;
+import ee.tuleva.onboarding.user.User;
 import ee.tuleva.onboarding.user.UserService;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -19,17 +20,21 @@ public class KycSurveyService {
 
   @Transactional
   public KycSurvey submit(AuthenticatedPerson person, KycSurveyResponse surveyResponse) {
-    KycSurvey survey =
-        KycSurvey.builder().userId(person.getUserId()).survey(surveyResponse).build();
+    User subject = resolveSubject(person);
+    KycSurvey survey = KycSurvey.builder().userId(subject.getId()).survey(surveyResponse).build();
     // The risk assessment reads kyc_survey with plain JDBC inside this same
     // transaction, which does not trigger Hibernate's auto-flush — without an
     // explicit flush a first-time submitter's survey is invisible to it.
     KycSurvey saved = kycSurveyRepository.saveAndFlush(survey);
 
     var country = extractCountry(surveyResponse);
-    kycCheckService.check(person, country, surveyResponse.purpose());
+    kycCheckService.check(subject, country, surveyResponse.purpose());
 
     return saved;
+  }
+
+  public KycIdentityResponse getIdentity(AuthenticatedPerson person) {
+    return getIdentity(resolveSubject(person).getId());
   }
 
   public KycIdentityResponse getIdentity(Long userId) {
@@ -45,6 +50,15 @@ public class KycSurveyService {
         .findFirstByUserIdOrderByCreatedTimeDesc(userId)
         .flatMap(survey -> survey.getSurvey().address())
         .map(address -> new Country(address.countryCode()));
+  }
+
+  private User resolveSubject(AuthenticatedPerson person) {
+    return userService
+        .findByPersonalCode(person.getRoleCode())
+        .orElseThrow(
+            () ->
+                new IllegalStateException(
+                    "KYC subject user not found: roleCode=" + person.getRoleCode()));
   }
 
   private Country extractCountry(KycSurveyResponse surveyResponse) {

--- a/src/main/java/ee/tuleva/onboarding/kyc/survey/KycSurveyService.java
+++ b/src/main/java/ee/tuleva/onboarding/kyc/survey/KycSurveyService.java
@@ -34,15 +34,13 @@ public class KycSurveyService {
   }
 
   public KycIdentityResponse getIdentity(AuthenticatedPerson person) {
-    return getIdentity(resolveSubject(person).getId());
-  }
-
-  public KycIdentityResponse getIdentity(Long userId) {
-    var user = userService.getByIdOrThrow(userId);
+    User subject = resolveSubject(person);
     return kycSurveyRepository
-        .findFirstByUserIdOrderByCreatedTimeDesc(userId)
-        .map(survey -> KycIdentityResponse.from(survey.getSurvey(), survey.getCreatedTime(), user))
-        .orElseGet(() -> KycIdentityResponse.empty(user));
+        .findFirstByUserIdOrderByCreatedTimeDesc(subject.getId())
+        .map(
+            survey ->
+                KycIdentityResponse.from(survey.getSurvey(), survey.getCreatedTime(), subject))
+        .orElseGet(() -> KycIdentityResponse.empty(subject));
   }
 
   public Optional<Country> getCountry(Long userId) {

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/redemption/RedemptionVerificationService.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/redemption/RedemptionVerificationService.java
@@ -56,7 +56,13 @@ public class RedemptionVerificationService {
   }
 
   private boolean runPersonChecks(RedemptionRequest request) {
-    User user = userService.getByIdOrThrow(request.getUserId());
+    User user =
+        userService
+            .findByPersonalCode(request.getPartyId().code())
+            .orElseThrow(
+                () ->
+                    new IllegalStateException(
+                        "Redemption party user not found: party=" + request.getPartyId()));
     Country country =
         kycSurveyService
             .getCountry(user.getId())

--- a/src/test/groovy/ee/tuleva/onboarding/kyc/survey/ChildRoleAwareKycIntegrationTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyc/survey/ChildRoleAwareKycIntegrationTest.java
@@ -1,0 +1,198 @@
+package ee.tuleva.onboarding.kyc.survey;
+
+import static ee.tuleva.onboarding.aml.AmlCheckType.KYC_CHECK;
+import static ee.tuleva.onboarding.auth.AuthenticatedPersonFixture.authenticatedPersonFromUser;
+import static ee.tuleva.onboarding.auth.UserFixture.sampleUserNonMember;
+import static ee.tuleva.onboarding.auth.authority.Authority.USER;
+import static ee.tuleva.onboarding.party.PartyId.Type.PERSON;
+import static ee.tuleva.onboarding.savings.fund.SavingsFundOnboardingStatus.COMPLETED;
+import static ee.tuleva.onboarding.time.ClockHolder.aYearAgo;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import ee.tuleva.onboarding.aml.AmlCheck;
+import ee.tuleva.onboarding.aml.AmlCheckRepository;
+import ee.tuleva.onboarding.auth.role.Role;
+import ee.tuleva.onboarding.auth.role.RoleType;
+import ee.tuleva.onboarding.kyc.BeforeKycCheckedEvent;
+import ee.tuleva.onboarding.kyc.KycCheckPerformedEvent;
+import ee.tuleva.onboarding.kyc.TestKycChecker;
+import ee.tuleva.onboarding.kyc.TestKycCheckerConfiguration;
+import ee.tuleva.onboarding.savings.fund.SavingsFundOnboardingRepository;
+import ee.tuleva.onboarding.user.User;
+import ee.tuleva.onboarding.user.UserRepository;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.event.ApplicationEvents;
+import org.springframework.test.context.event.RecordApplicationEvents;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@RecordApplicationEvents
+@Import(TestKycCheckerConfiguration.class)
+class ChildRoleAwareKycIntegrationTest {
+
+  private static final String PARENT_CODE = "47508120049";
+  private static final String CHILD_CODE = "61603140009";
+
+  private static final String ONBOARDING_SURVEY =
+      """
+      {
+        "answers": [
+          { "type": "CITIZENSHIP", "value": { "type": "COUNTRIES", "value": ["EE", "FI"] } },
+          {
+            "type": "ADDRESS",
+            "value": {
+              "type": "ADDRESS",
+              "value": {
+                "street": "123 Main St",
+                "city": "Tallinn",
+                "postalCode": "10115",
+                "countryCode": "EE"
+              }
+            }
+          },
+          { "type": "EMAIL", "value": { "type": "TEXT", "value": "survey@example.com" } },
+          { "type": "PEP_SELF_DECLARATION", "value": { "type": "OPTION", "value": "IS_NOT_PEP" } },
+          { "type": "INVESTMENT_GOALS", "value": { "type": "OPTION", "value": "LONG_TERM" } },
+          { "type": "INVESTABLE_ASSETS", "value": { "type": "OPTION", "value": "LESS_THAN_20K" } },
+          { "type": "SOURCE_OF_INCOME", "value": [ { "type": "OPTION", "value": "SALARY" } ] },
+          { "type": "TERMS", "value": { "type": "OPTION", "value": "ACCEPTED" } }
+        ]
+      }
+      """;
+
+  @Autowired private MockMvc mockMvc;
+  @Autowired private UserRepository userRepository;
+  @Autowired private KycSurveyRepository kycSurveyRepository;
+  @Autowired private SavingsFundOnboardingRepository savingsFundOnboardingRepository;
+  @Autowired private AmlCheckRepository amlCheckRepository;
+  @Autowired private ApplicationEvents applicationEvents;
+  @Autowired private TestKycChecker testKycChecker;
+
+  private User parent;
+  private User child;
+  private Authentication parentActingAsChild;
+
+  @BeforeEach
+  void setUp() {
+    testKycChecker.reset();
+    parent =
+        userRepository.save(
+            sampleUserNonMember()
+                .id(null)
+                .personalCode(PARENT_CODE)
+                .firstName("Parent")
+                .lastName("Person")
+                .email("parent@example.com")
+                .build());
+    child =
+        userRepository.save(
+            sampleUserNonMember()
+                .id(null)
+                .personalCode(CHILD_CODE)
+                .firstName("Child")
+                .lastName("Person")
+                .email("child@example.com")
+                .phoneNumber("+37255500000")
+                .build());
+
+    parentActingAsChild =
+        authenticatedAs(parent, new Role(RoleType.PERSON, CHILD_CODE, "Child Person"));
+  }
+
+  @Test
+  void parentActingAsChild_writesKycToChildAndCompletesChildOnboarding() throws Exception {
+    submitOnboardingSurvey(parentActingAsChild);
+
+    assertThat(kycSurveyRepository.findFirstByUserIdOrderByCreatedTimeDesc(child.getId()))
+        .as("survey is stored under the child")
+        .isPresent();
+    assertThat(kycSurveyRepository.findFirstByUserIdOrderByCreatedTimeDesc(parent.getId()))
+        .as("survey is NOT stored under the parent")
+        .isEmpty();
+
+    assertThat(savingsFundOnboardingRepository.findStatus(child.getPersonalCode(), PERSON))
+        .as("child onboarding completes")
+        .contains(COMPLETED);
+    assertThat(savingsFundOnboardingRepository.findStatus(parent.getPersonalCode(), PERSON))
+        .as("parent onboarding is untouched")
+        .isEmpty();
+  }
+
+  @Test
+  void parentActingAsChild_screensTheChildNotTheParent() throws Exception {
+    submitOnboardingSurvey(parentActingAsChild);
+
+    var beforeKycEvents = applicationEvents.stream(BeforeKycCheckedEvent.class).toList();
+    assertThat(beforeKycEvents).hasSize(1);
+    assertThat(beforeKycEvents.getFirst().person().getPersonalCode())
+        .as("sanction/PEP screening is aimed at the child")
+        .isEqualTo(CHILD_CODE);
+
+    var kycCheckEvents = applicationEvents.stream(KycCheckPerformedEvent.class).toList();
+    assertThat(kycCheckEvents).hasSize(1);
+    assertThat(kycCheckEvents.getFirst().getPersonalCode()).isEqualTo(CHILD_CODE);
+
+    assertThat(amlCheckRepository.findAllByPersonalCodeAndCreatedTimeAfter(CHILD_CODE, aYearAgo()))
+        .extracting(AmlCheck::getType)
+        .contains(KYC_CHECK);
+    assertThat(amlCheckRepository.findAllByPersonalCodeAndCreatedTimeAfter(PARENT_CODE, aYearAgo()))
+        .as("no AML checks are written against the parent")
+        .isEmpty();
+  }
+
+  @Test
+  void identityRead_returnsChildIdentityWhenActingAsChild() throws Exception {
+    submitOnboardingSurvey(parentActingAsChild);
+
+    mockMvc
+        .perform(get("/v1/kyc/identity").with(authentication(parentActingAsChild)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.citizenship[0]").value("EE"))
+        .andExpect(jsonPath("$.citizenship[1]").value("FI"))
+        .andExpect(jsonPath("$.email").value(child.getEmail()))
+        .andExpect(jsonPath("$.complete").value(true));
+
+    var parentSelf =
+        authenticatedAs(parent, new Role(RoleType.PERSON, PARENT_CODE, "Parent Person"));
+    mockMvc
+        .perform(get("/v1/kyc/identity").with(authentication(parentSelf)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.complete").value(false));
+  }
+
+  private void submitOnboardingSurvey(Authentication as) throws Exception {
+    mockMvc
+        .perform(
+            post("/v1/kyc/surveys")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(ONBOARDING_SURVEY)
+                .with(csrf())
+                .with(authentication(as)))
+        .andExpect(status().isOk());
+  }
+
+  private static Authentication authenticatedAs(User user, Role role) {
+    var principal = authenticatedPersonFromUser(user).role(role).build();
+    return new UsernamePasswordAuthenticationToken(
+        principal, null, List.of(new SimpleGrantedAuthority(USER)));
+  }
+}

--- a/src/test/groovy/ee/tuleva/onboarding/kyc/survey/KycIdentityControllerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyc/survey/KycIdentityControllerTest.java
@@ -52,7 +52,7 @@ class KycIdentityControllerTest {
 
   @Test
   void getIdentity_returnsCompleteIdentity() throws Exception {
-    given(kycSurveyService.getIdentity(authPerson.getUserId()))
+    given(kycSurveyService.getIdentity(authPerson))
         .willReturn(
             new KycIdentityResponse(
                 List.of("EE", "FI"),
@@ -79,7 +79,7 @@ class KycIdentityControllerTest {
 
   @Test
   void getIdentity_returnsEmptyIncompleteIdentityForFreshUser() throws Exception {
-    given(kycSurveyService.getIdentity(authPerson.getUserId()))
+    given(kycSurveyService.getIdentity(authPerson))
         .willReturn(new KycIdentityResponse(null, null, null, null, null, null));
 
     mvc.perform(get("/v1/kyc/identity").with(authentication(authentication)))

--- a/src/test/groovy/ee/tuleva/onboarding/kyc/survey/KycSurveyServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyc/survey/KycSurveyServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
+import ee.tuleva.onboarding.auth.principal.AuthenticatedPerson;
 import ee.tuleva.onboarding.auth.role.Role;
 import ee.tuleva.onboarding.auth.role.RoleType;
 import ee.tuleva.onboarding.country.Country;
@@ -33,6 +34,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class KycSurveyServiceTest {
 
   private static final Instant NOW = Instant.parse("2026-06-11T12:00:00Z");
+  private static final Long USER_ID = 1L;
 
   @Mock private KycSurveyRepository kycSurveyRepository;
   @Mock private KycCheckService kycCheckService;
@@ -41,7 +43,7 @@ class KycSurveyServiceTest {
   @InjectMocks private KycSurveyService kycSurveyService;
 
   private final User user =
-      User.builder().email("test@example.com").phoneNumber("+37255555555").build();
+      User.builder().id(USER_ID).email("test@example.com").phoneNumber("+37255555555").build();
 
   @BeforeEach
   void setUp() {
@@ -142,12 +144,11 @@ class KycSurveyServiceTest {
 
   @Test
   void getIdentity_returnsUserContactDetailsAndIncompleteWhenNoSurveyExists() {
-    Long userId = 1L;
-    given(userService.getByIdOrThrow(userId)).willReturn(user);
-    given(kycSurveyRepository.findFirstByUserIdOrderByCreatedTimeDesc(userId))
+    var person = personResolvingTo(user);
+    given(kycSurveyRepository.findFirstByUserIdOrderByCreatedTimeDesc(USER_ID))
         .willReturn(Optional.empty());
 
-    var identity = kycSurveyService.getIdentity(userId);
+    var identity = kycSurveyService.getIdentity(person);
 
     assertThat(identity)
         .isEqualTo(
@@ -157,7 +158,6 @@ class KycSurveyServiceTest {
 
   @Test
   void getIdentity_combinesLatestSurveyWithUserContactDetails() {
-    Long userId = 1L;
     var createdTime = Instant.parse("2026-06-01T10:00:00Z");
     var survey =
         identitySurvey(
@@ -166,11 +166,11 @@ class KycSurveyServiceTest {
                 new AddressValue(
                     "ADDRESS", new AddressDetails("Street 1", "Tallinn", "12345", "EE"))),
             new PepSelfDeclaration(new OptionValue<>("OPTION", PepStatus.IS_NOT_PEP)));
-    given(userService.getByIdOrThrow(userId)).willReturn(user);
-    given(kycSurveyRepository.findFirstByUserIdOrderByCreatedTimeDesc(userId))
-        .willReturn(Optional.of(kycSurvey(userId, survey, createdTime)));
+    var person = personResolvingTo(user);
+    given(kycSurveyRepository.findFirstByUserIdOrderByCreatedTimeDesc(USER_ID))
+        .willReturn(Optional.of(kycSurvey(USER_ID, survey, createdTime)));
 
-    var identity = kycSurveyService.getIdentity(userId);
+    var identity = kycSurveyService.getIdentity(person);
 
     assertThat(identity)
         .isEqualTo(
@@ -186,7 +186,6 @@ class KycSurveyServiceTest {
 
   @Test
   void getIdentity_withoutPepDeclaration_isIncomplete() {
-    Long userId = 1L;
     var createdTime = Instant.parse("2026-06-01T10:00:00Z");
     var survey =
         identitySurvey(
@@ -194,11 +193,11 @@ class KycSurveyServiceTest {
             new Address(
                 new AddressValue(
                     "ADDRESS", new AddressDetails("Street 1", "Tallinn", "12345", "EE"))));
-    given(userService.getByIdOrThrow(userId)).willReturn(user);
-    given(kycSurveyRepository.findFirstByUserIdOrderByCreatedTimeDesc(userId))
-        .willReturn(Optional.of(kycSurvey(userId, survey, createdTime)));
+    var person = personResolvingTo(user);
+    given(kycSurveyRepository.findFirstByUserIdOrderByCreatedTimeDesc(USER_ID))
+        .willReturn(Optional.of(kycSurvey(USER_ID, survey, createdTime)));
 
-    var identity = kycSurveyService.getIdentity(userId);
+    var identity = kycSurveyService.getIdentity(person);
 
     assertThat(identity)
         .isEqualTo(
@@ -214,7 +213,6 @@ class KycSurveyServiceTest {
 
   @Test
   void getIdentity_withoutUserEmail_isIncomplete() {
-    Long userId = 1L;
     var createdTime = Instant.parse("2026-06-01T10:00:00Z");
     var survey =
         identitySurvey(
@@ -223,11 +221,11 @@ class KycSurveyServiceTest {
                 new AddressValue(
                     "ADDRESS", new AddressDetails("Street 1", "Tallinn", "12345", "EE"))),
             new PepSelfDeclaration(new OptionValue<>("OPTION", PepStatus.IS_NOT_PEP)));
-    given(userService.getByIdOrThrow(userId)).willReturn(User.builder().build());
-    given(kycSurveyRepository.findFirstByUserIdOrderByCreatedTimeDesc(userId))
-        .willReturn(Optional.of(kycSurvey(userId, survey, createdTime)));
+    var person = personResolvingTo(User.builder().id(USER_ID).build());
+    given(kycSurveyRepository.findFirstByUserIdOrderByCreatedTimeDesc(USER_ID))
+        .willReturn(Optional.of(kycSurvey(USER_ID, survey, createdTime)));
 
-    var identity = kycSurveyService.getIdentity(userId);
+    var identity = kycSurveyService.getIdentity(person);
 
     assertThat(identity)
         .isEqualTo(
@@ -243,7 +241,6 @@ class KycSurveyServiceTest {
 
   @Test
   void getIdentity_returnsSurveyOlderThanAYearForPrefillButIncomplete() {
-    Long userId = 1L;
     var createdTime = NOW.minus(Duration.ofDays(366));
     var survey =
         identitySurvey(
@@ -252,11 +249,11 @@ class KycSurveyServiceTest {
                 new AddressValue(
                     "ADDRESS", new AddressDetails("Street 1", "Tallinn", "12345", "EE"))),
             new PepSelfDeclaration(new OptionValue<>("OPTION", PepStatus.IS_NOT_PEP)));
-    given(userService.getByIdOrThrow(userId)).willReturn(user);
-    given(kycSurveyRepository.findFirstByUserIdOrderByCreatedTimeDesc(userId))
-        .willReturn(Optional.of(kycSurvey(userId, survey, createdTime)));
+    var person = personResolvingTo(user);
+    given(kycSurveyRepository.findFirstByUserIdOrderByCreatedTimeDesc(USER_ID))
+        .willReturn(Optional.of(kycSurvey(USER_ID, survey, createdTime)));
 
-    var identity = kycSurveyService.getIdentity(userId);
+    var identity = kycSurveyService.getIdentity(person);
 
     assertThat(identity)
         .isEqualTo(
@@ -268,6 +265,12 @@ class KycSurveyServiceTest {
                 PepStatus.IS_NOT_PEP,
                 createdTime));
     assertThat(identity.isComplete()).isFalse();
+  }
+
+  private AuthenticatedPerson personResolvingTo(User subject) {
+    var person = sampleAuthenticatedPersonNonMember().build();
+    given(userService.findByPersonalCode(person.getRoleCode())).willReturn(Optional.of(subject));
+    return person;
   }
 
   private KycSurveyResponse identitySurvey(KycSurveyResponseItem... answers) {

--- a/src/test/groovy/ee/tuleva/onboarding/kyc/survey/KycSurveyServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyc/survey/KycSurveyServiceTest.java
@@ -3,10 +3,13 @@ package ee.tuleva.onboarding.kyc.survey;
 import static ee.tuleva.onboarding.auth.AuthenticatedPersonFixture.sampleAuthenticatedPersonNonMember;
 import static ee.tuleva.onboarding.kyc.survey.KycSurveyResponseItem.*;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
+import ee.tuleva.onboarding.auth.role.Role;
+import ee.tuleva.onboarding.auth.role.RoleType;
 import ee.tuleva.onboarding.country.Country;
 import ee.tuleva.onboarding.kyc.KycCheckService;
 import ee.tuleva.onboarding.time.ClockHolder;
@@ -51,20 +54,45 @@ class KycSurveyServiceTest {
   }
 
   @Test
-  void submit_flushesTheSurveySoTheSameTransactionRiskQueryCanSeeIt() {
-    var person = sampleAuthenticatedPersonNonMember().build();
+  void submit_storesSurveyUnderActiveRoleSubjectAndRunsCheckOnSubject() {
+    var childCode = "61506150006";
+    var person =
+        sampleAuthenticatedPersonNonMember()
+            .role(new Role(RoleType.PERSON, childCode, "Child Person"))
+            .build();
+    var subject = User.builder().id(7L).personalCode(childCode).build();
     var survey =
         identitySurvey(
             new Address(
                 new AddressValue(
                     "ADDRESS", new AddressDetails("Street 1", "Tallinn", "12345", "EE"))));
+    given(userService.findByPersonalCode(childCode)).willReturn(Optional.of(subject));
     given(kycSurveyRepository.saveAndFlush(any(KycSurvey.class)))
         .willAnswer(invocation -> invocation.getArgument(0));
 
     var saved = kycSurveyService.submit(person, survey);
 
     assertThat(saved.getSurvey()).isEqualTo(survey);
-    verify(kycCheckService).check(person, new Country("EE"), survey.purpose());
+    assertThat(saved.getUserId()).isEqualTo(subject.getId());
+    verify(kycCheckService).check(subject, new Country("EE"), survey.purpose());
+  }
+
+  @Test
+  void submit_throwsWhenActiveRoleSubjectNotFound() {
+    var childCode = "61506150006";
+    var person =
+        sampleAuthenticatedPersonNonMember()
+            .role(new Role(RoleType.PERSON, childCode, "Child Person"))
+            .build();
+    var survey =
+        identitySurvey(
+            new Address(
+                new AddressValue(
+                    "ADDRESS", new AddressDetails("Street 1", "Tallinn", "12345", "EE"))));
+    given(userService.findByPersonalCode(childCode)).willReturn(Optional.empty());
+
+    assertThatThrownBy(() -> kycSurveyService.submit(person, survey))
+        .isInstanceOf(IllegalStateException.class);
   }
 
   @Test

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/redemption/RedemptionVerificationServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/redemption/RedemptionVerificationServiceTest.java
@@ -62,7 +62,7 @@ class RedemptionVerificationServiceTest {
             .success(true)
             .build();
 
-    given(userService.getByIdOrThrow(userId)).willReturn(user);
+    given(userService.findByPersonalCode("38812121215")).willReturn(Optional.of(user));
     given(kycSurveyService.getCountry(userId)).willReturn(Optional.of(country));
     given(amlService.addSanctionAndPepCheckIfMissing(user, country)).willReturn(List.of(passing));
 
@@ -85,7 +85,7 @@ class RedemptionVerificationServiceTest {
     var user = sampleUser().id(userId).build();
     var country = new Country("EE");
 
-    given(userService.getByIdOrThrow(userId)).willReturn(user);
+    given(userService.findByPersonalCode("38812121215")).willReturn(Optional.of(user));
     given(kycSurveyService.getCountry(userId)).willReturn(Optional.of(country));
     given(amlService.addSanctionAndPepCheckIfMissing(user, country)).willReturn(List.of());
 
@@ -113,7 +113,7 @@ class RedemptionVerificationServiceTest {
             .success(false)
             .build();
 
-    given(userService.getByIdOrThrow(userId)).willReturn(user);
+    given(userService.findByPersonalCode("38812121215")).willReturn(Optional.of(user));
     given(kycSurveyService.getCountry(userId)).willReturn(Optional.of(country));
     given(amlService.addSanctionAndPepCheckIfMissing(user, country)).willReturn(List.of(failing));
 
@@ -121,6 +121,35 @@ class RedemptionVerificationServiceTest {
 
     verify(redemptionStatusService).changeStatus(requestId, IN_REVIEW);
     verify(redemptionStatusService, never()).changeStatus(requestId, VERIFIED);
+  }
+
+  @Test
+  void process_personRequest_screensThePartyNotTheActor() {
+    var actorUserId = 1L;
+    var childCode = "61506150006";
+    var requestId = UUID.randomUUID();
+    var request =
+        redemptionRequestFixture()
+            .id(requestId)
+            .userId(actorUserId)
+            .partyId(new PartyId(PERSON, childCode))
+            .build();
+    var child = sampleUser().id(2L).personalCode(childCode).build();
+    var country = new Country("EE");
+    var passing =
+        AmlCheck.builder()
+            .personalCode(childCode)
+            .type(AmlCheckType.SANCTION)
+            .success(true)
+            .build();
+
+    given(userService.findByPersonalCode(childCode)).willReturn(Optional.of(child));
+    given(kycSurveyService.getCountry(child.getId())).willReturn(Optional.of(country));
+    given(amlService.addSanctionAndPepCheckIfMissing(child, country)).willReturn(List.of(passing));
+
+    service.process(request);
+
+    verify(redemptionStatusService).changeStatus(requestId, VERIFIED);
   }
 
   @Test
@@ -133,8 +162,18 @@ class RedemptionVerificationServiceTest {
             .build();
     var user = sampleUser().id(userId).build();
 
-    given(userService.getByIdOrThrow(userId)).willReturn(user);
+    given(userService.findByPersonalCode("38812121215")).willReturn(Optional.of(user));
     given(kycSurveyService.getCountry(userId)).willReturn(Optional.empty());
+
+    assertThatThrownBy(() -> service.process(request)).isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  void process_personRequest_throwsWhenPartyUserNotFound() {
+    var request =
+        redemptionRequestFixture().userId(1L).partyId(new PartyId(PERSON, "61506150006")).build();
+
+    given(userService.findByPersonalCode("61506150006")).willReturn(Optional.empty());
 
     assertThatThrownBy(() -> service.process(request)).isInstanceOf(IllegalStateException.class);
   }


### PR DESCRIPTION
PR0 of the TKF child-onboarding feature — makes the KYC/AML flow **role-aware**.

## Problem
KYC keyed off the authenticated person's `userId`/`personalCode` (the parent). When a parent acted as a represented child, the survey, AML screening and `savings_fund_onboarding` all landed on the **parent**, so the child's onboarding never completed and sanctions screening screened the parent. `RedemptionRequest` had the same parent-not-child bug.

## Change — target the active role's party (the child)
- `KycSurveyService.submit` / `getIdentity` resolve the subject from the active role code → write/read under the child
- `KycCheckService` runs the risk check + `BeforeKycCheckedEvent` + `KycCheckPerformedEvent` against the child
- `KycIdentityController` returns the child's identity
- `RedemptionVerificationService` screens the redemption **party** (child), not the actor (kept `userId` = actor for audit)

PEP stays derived from the parent's own KYC (unchanged).

## Gate test
`ChildRoleAwareKycIntegrationTest`: parent switches into the child role → submits KYC → the **child's** `savings_fund_onboarding` flips to `COMPLETED`, and the AML screening + identity read target the child, not the parent. Risk is driven via `TestKycChecker`, so role-targeting is proven independently of the DB risk rule.

> End-to-end child `COMPLETED` against the live DB also needs the `database-administration` change removing "minor without 3rd pillar = medium" from `kyc_ob_assess_user_risk` (plan decision 20).

Plan: `TulevaEE/TKF-VPII2026` → `plaanid/lapse-tkf-klient-rahvastikuregister-plaan.md` §0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
