### PR TITLE
AML(#78): make KYB ownership/age check metadata deterministic (stop DATA_CHANGED false-fire)

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/kyb/screener/DualMemberOwnershipScreener.java
+++ b/src/main/java/ee/tuleva/onboarding/kyb/screener/DualMemberOwnershipScreener.java
@@ -45,6 +45,9 @@ public class DualMemberOwnershipScreener implements KybScreener {
             && totalOwnership.compareTo(BigDecimal.valueOf(100)) == 0;
 
     return List.of(
-        new KybCheck(DUAL_MEMBER_OWNERSHIP, success, Map.of("totalOwnership", totalOwnership)));
+        new KybCheck(
+            DUAL_MEMBER_OWNERSHIP,
+            success,
+            Map.of("totalOwnership", totalOwnership.toPlainString())));
   }
 }

--- a/src/main/java/ee/tuleva/onboarding/kyb/screener/SoleMemberOwnershipScreener.java
+++ b/src/main/java/ee/tuleva/onboarding/kyb/screener/SoleMemberOwnershipScreener.java
@@ -37,7 +37,7 @@ public class SoleMemberOwnershipScreener implements KybScreener {
     if (personalCode != null) {
       metadata.put("personalCode", personalCode.toString());
     }
-    metadata.put("ownershipPercent", person.ownershipPercent());
+    metadata.put("ownershipPercent", person.ownershipPercent().toPlainString());
     return Map.copyOf(metadata);
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/kyb/KybScreeningIntegrationTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyb/KybScreeningIntegrationTest.java
@@ -15,6 +15,7 @@ import ee.tuleva.onboarding.aml.AmlCheck;
 import ee.tuleva.onboarding.aml.AmlCheckRepository;
 import ee.tuleva.onboarding.aml.sanctions.MatchResponse;
 import ee.tuleva.onboarding.aml.sanctions.PepAndSanctionCheckService;
+import jakarta.persistence.EntityManager;
 import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.LocalDate;
@@ -38,6 +39,7 @@ class KybScreeningIntegrationTest {
   @Autowired private AmlCheckRepository amlCheckRepository;
   @Autowired private JsonMapper objectMapper;
   @Autowired private Clock clock;
+  @Autowired private EntityManager entityManager;
   @MockitoBean private PepAndSanctionCheckService sanctionCheckService;
 
   @BeforeEach
@@ -178,6 +180,97 @@ class KybScreeningIntegrationTest {
         amlChecks.stream().filter(c -> c.getType() == KYB_COMPANY_STRUCTURE).findFirst();
     assertThat(structureAmlCheck).isPresent();
     assertThat(structureAmlCheck.get().isSuccess()).isFalse();
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void rescreeningAnUnchangedSoleOwnerCompanyDoesNotFlagDataChanged() {
+    // Same company, screened twice with byte-identical input. The ownership and age metadata must
+    // survive the AmlCheck jsonb round-trip so KybDataChangeDetector sees no change. AML #78: a
+    // BigDecimal ownershipPercent was reloaded as a Double, so DATA_CHANGED fired for ~95% of
+    // companies on every screening.
+    var person = boardMemberOwner(PERSONAL_CODE, 100.0).build();
+    var data =
+        new KybCompanyData(
+            new CompanyDto(new RegistryCode("12345678"), "Test OÜ", "62011", LegalForm.OÜ),
+            PERSONAL_CODE,
+            R,
+            List.of(person),
+            new SelfCertification(true, true, true),
+            "EE",
+            "Harju maakond, Tallinn, Pärnu mnt 1",
+            LocalDate.now(clock).minusYears(3),
+            List.of());
+
+    kybScreeningService.screen(data);
+    // Force a fresh read so the second screening deserializes metadata from JSON, exactly as a
+    // separate production screening transaction does — not the in-transaction L1 cache.
+    entityManager.flush();
+    entityManager.clear();
+    var secondResults = kybScreeningService.screen(data);
+
+    var dataChanged =
+        secondResults.stream()
+            .filter(c -> c.type() == KybCheckType.DATA_CHANGED)
+            .findFirst()
+            .orElseThrow();
+    assertThat(dataChanged.success()).isTrue();
+    assertThat((List<Map<String, Object>>) dataChanged.metadata().get("changes")).isEmpty();
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void rescreeningAnUnchangedDualOwnerCompanyDoesNotFlagDataChanged() {
+    var person1 = boardMemberOwner(PERSONAL_CODE, 50.0).build();
+    var person2 = boardMemberOwner("49001010001", 50.0).build();
+    var data =
+        new KybCompanyData(
+            new CompanyDto(new RegistryCode("12345678"), "Test OÜ", "62011", LegalForm.OÜ),
+            PERSONAL_CODE,
+            R,
+            List.of(person1, person2),
+            new SelfCertification(true, true, true),
+            "EE",
+            "Harju maakond, Tallinn, Pärnu mnt 1",
+            LocalDate.now(clock).minusYears(3),
+            List.of());
+
+    kybScreeningService.screen(data);
+    // Force a fresh read so the second screening deserializes metadata from JSON, exactly as a
+    // separate production screening transaction does — not the in-transaction L1 cache.
+    entityManager.flush();
+    entityManager.clear();
+    var secondResults = kybScreeningService.screen(data);
+
+    var dataChanged =
+        secondResults.stream()
+            .filter(c -> c.type() == KybCheckType.DATA_CHANGED)
+            .findFirst()
+            .orElseThrow();
+    assertThat(dataChanged.success()).isTrue();
+    assertThat((List<Map<String, Object>>) dataChanged.metadata().get("changes")).isEmpty();
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void rescreeningAfterAGenuineOwnerChangeStillFlagsDataChanged() {
+    var firstOwner = boardMemberOwner(PERSONAL_CODE, 100.0).build();
+    kybScreeningService.screen(companyWith(firstOwner));
+    entityManager.flush();
+    entityManager.clear();
+
+    // Genuine change: a different natural person now solely owns the company.
+    var newOwner = boardMemberOwner("49001010001", 100.0).build();
+    var secondResults = kybScreeningService.screen(companyWith(newOwner));
+
+    var dataChanged =
+        secondResults.stream()
+            .filter(c -> c.type() == KybCheckType.DATA_CHANGED)
+            .findFirst()
+            .orElseThrow();
+    assertThat(dataChanged.success()).isFalse();
+    var changes = (List<Map<String, Object>>) dataChanged.metadata().get("changes");
+    assertThat(changes).anyMatch(c -> "SOLE_MEMBER_OWNERSHIP".equals(c.get("check")));
   }
 
   @Test

--- a/src/test/groovy/ee/tuleva/onboarding/kyb/screener/DualMemberOwnershipScreenerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyb/screener/DualMemberOwnershipScreenerTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.tuple;
 
 import ee.tuleva.onboarding.kyb.KybCheck;
 import java.math.BigDecimal;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 class DualMemberOwnershipScreenerTest {
@@ -119,6 +120,20 @@ class DualMemberOwnershipScreenerTest {
     assertThat(result)
         .extracting(KybCheck::type, KybCheck::success)
         .containsExactly(tuple(DUAL_MEMBER_OWNERSHIP, false));
+  }
+
+  @Test
+  void totalOwnershipIsStoredAsCanonicalStringForStableJsonRoundTrip() {
+    // totalOwnership must be a String, not a BigDecimal. The AmlCheck.metadata jsonb column
+    // deserializes JSON numbers as Double/Integer, so a BigDecimal value never equals its reloaded
+    // form and KybDataChangeDetector raises a spurious DATA_CHANGED every screening (AML #78).
+    var person1 = boardMemberOwner("38501010001", 50.0).build();
+    var person2 = boardMemberOwner("38501010002", 50.0).build();
+    var data = companyWith(person1, person2);
+
+    var result = screener.screen(data);
+
+    assertThat(result.getFirst().metadata()).isEqualTo(Map.of("totalOwnership", "100.0"));
   }
 
   @Test

--- a/src/test/groovy/ee/tuleva/onboarding/kyb/screener/SoleMemberOwnershipScreenerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyb/screener/SoleMemberOwnershipScreenerTest.java
@@ -10,6 +10,7 @@ import static org.assertj.core.api.Assertions.tuple;
 import ee.tuleva.onboarding.kyb.KybCheck;
 import ee.tuleva.onboarding.kyb.PersonalCode;
 import java.math.BigDecimal;
+import java.util.Map;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -60,6 +61,20 @@ class SoleMemberOwnershipScreenerTest {
         .extracting(KybCheck::type, KybCheck::success)
         .containsExactly(tuple(SOLE_MEMBER_OWNERSHIP, true));
     assertThat(result.getFirst().metadata()).doesNotContainKey("personalCode");
+  }
+
+  @Test
+  void ownershipPercentIsStoredAsCanonicalStringForStableJsonRoundTrip() {
+    // ownershipPercent must be a String, not a BigDecimal. The AmlCheck.metadata jsonb column
+    // deserializes JSON numbers as Double/Integer, so a BigDecimal value never equals its reloaded
+    // form and KybDataChangeDetector raises a spurious DATA_CHANGED every screening (AML #78).
+    var person = boardMemberOwner("38501010001", 100.0).build();
+    var data = companyWith(person);
+
+    var result = screener.screen(data);
+
+    assertThat(result.getFirst().metadata())
+        .isEqualTo(Map.of("personalCode", "38501010001", "ownershipPercent", "100.0"));
   }
 
   @Test


### PR DESCRIPTION
## The bug

`KYB_DATA_CHANGED.success=false` was firing for **~95% of companies on every screening** even when nothing about the company changed. That AML check feeds `tkr_related_changed = +10` in `analytics.v_company_risk_metadata`, so it inflated company risk scores (false KESKMINE).

**Evidence (prod, Metabase read replica, 2026-06-25):**
- 121/128 companies in `analytics.v_company_risk_metadata` showed `data_changed = true`.
- Every sampled `KYB_DATA_CHANGED.metadata.changes` entry was **metadata-only** (`previousSuccess == currentSuccess`, status unchanged) on the ownership checks — `SOLE_MEMBER_OWNERSHIP` (most), then `DUAL_MEMBER_OWNERSHIP`.

## Root cause (confirmed, not the initial hypothesis)

The original hunch was "unordered owner list / drifting COMPANY_AGE value". Investigation ruled both out:
- `KybDataChangeDetector.changed()` compares with `Map.equals()`, which is **order-independent**, and the ownership/age metadata values are all single-person or aggregate — list ordering can't change them.

The real cause is **JSON type coercion on the `AmlCheck.metadata` jsonb round-trip**:
- `AmlCheck.metadata` is `@JdbcTypeCode(JSON)`, serialized/deserialized by `RuntimeTypeJacksonJsonFormatMapper`. Its `ObjectMapper` enables `WRITE_BIGDECIMAL_AS_PLAIN` but does **not** enable `USE_BIG_DECIMAL_FOR_FLOATS`.
- So a `BigDecimal` written as a plain JSON number reloads as a `Double`/`Integer`. `KybDataChangeDetector` then compares the reloaded previous check (`Double 100.0`) against the freshly built current check (`BigDecimal 100.0`) → `Map.equals` is `false` **every screening** → spurious `DATA_CHANGED`.
- The **only two** screeners that put a `BigDecimal` in metadata are `SoleMemberOwnershipScreener` (`ownershipPercent`) and `DualMemberOwnershipScreener` (`totalOwnership`) — exactly the prod evidence ranking.

This bug never showed in tests because the existing `@Transactional` integration test re-screens within one transaction, so the second screening reads L1-cached managed entities (metadata still the original in-memory `BigDecimal`) and never round-trips through JSON. Production runs each screening in a separate transaction.

## The fix

Store those two values as canonical Strings (`toPlainString()`) — the same round-trip-stable idiom already used for `COMPANY_AGE` `foundingDate` and `SINGLE_BOARD_MEMBER_OWNERSHIP` `boardMemberPersonalCode`. A genuine ownership change still flips the String and raises `DATA_CHANGED`.

```java
// SoleMemberOwnershipScreener
metadata.put("ownershipPercent", person.ownershipPercent().toPlainString());
// DualMemberOwnershipScreener
Map.of("totalOwnership", totalOwnership.toPlainString())
```

### Investigated, no change needed (radical candor)

The task asked to also touch `COMPANY_AGE`, `SINGLE_BOARD_MEMBER_OWNERSHIP`, `COMPANY_STRUCTURE` and to "sort owners". All were checked and confirmed already deterministic:
- `COMPANY_AGE` → `{"foundingDate": String}` (already a stable input, not a drifting age value — the task's requirement #3 is already met).
- `SINGLE_BOARD_MEMBER_OWNERSHIP` → `{"boardMemberPersonalCode": String}`.
- `COMPANY_STRUCTURE` → Integer + Booleans (round-trip cleanly).

Their prod `DATA_CHANGED` hits are transitional (recently-added checks) and clear on re-screen. Sorting `relatedPersons` would not fix this bug (the metadata doesn't depend on list order). A separate, out-of-scope list-order risk exists for `RELATED_PERSONS_KYC.incompletePersons` (a JSON list, order-sensitive, but empty for compliant companies) — flagging as a follow-up, not fixing here.

## Tests (TDD: RED → GREEN)

- `SoleMemberOwnershipScreenerTest` / `DualMemberOwnershipScreenerTest`: pin the metadata value to a canonical String (failed before the fix, pass after).
- `KybScreeningIntegrationTest`: re-screen an unchanged sole-owner and dual-owner company through the **real** Hibernate jsonb round-trip — `entityManager.flush()/clear()` forces a fresh deserialization, exactly as a separate production screening transaction does — and assert no spurious `DATA_CHANGED` (incl. `COMPANY_AGE` for the sole-owner case). A third test asserts a **genuine owner change still flags** `DATA_CHANGED`. Verified: the two unchanged-company tests are RED without the production fix and GREEN with it.

`./gradlew test --tests "ee.tuleva.onboarding.kyb.*" --tests "ee.tuleva.onboarding.aml.AmlKybCheckHistoryTest"` — all green. Spotless clean.

## Rollout / cleanup (no data migration)

Existing false `KYB_DATA_CHANGED` rows clear once each company is re-screened with this deployed and the matview refreshes (09/13/16 daily). No backfill.

One known transitional detail (raised by the Codex review below, and matching the task's note): the **first** post-deploy re-screen of an affected company still flags once — old stored metadata is a number, new metadata is a String. The company was already false-firing on *every* screen before this change, so this is the *last* false fire; the next screen reads String-vs-String and is permanently clean. Avoiding even that one fire would require rewriting existing jsonb (a migration we're explicitly not doing).

## Codex review

Ran `codex review --base master` — **gate PASS** (one P2, no P1). The P2 is the transitional first-rescreen behavior described above (expected, self-clearing, no migration by design).

Context issue: TulevaEE/tuleva #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)
