### PR TITLE
Cover legal entities in TKF volume AML alerts

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/aml/alert/AlertPartyType.java
+++ b/src/main/java/ee/tuleva/onboarding/aml/alert/AlertPartyType.java
@@ -1,0 +1,6 @@
+package ee.tuleva.onboarding.aml.alert;
+
+enum AlertPartyType {
+  PERSON,
+  LEGAL_ENTITY
+}

--- a/src/main/java/ee/tuleva/onboarding/aml/alert/AmlAlertNotifier.java
+++ b/src/main/java/ee/tuleva/onboarding/aml/alert/AmlAlertNotifier.java
@@ -1,14 +1,17 @@
 package ee.tuleva.onboarding.aml.alert;
 
+import static ee.tuleva.onboarding.aml.alert.AlertPartyType.LEGAL_ENTITY;
 import static ee.tuleva.onboarding.notification.OperationsNotificationService.Channel.AML;
 
 import ee.tuleva.onboarding.notification.OperationsNotificationService;
 import ee.tuleva.onboarding.user.User;
 import ee.tuleva.onboarding.user.UserService;
 import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.NullMarked;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
+@NullMarked
 @Component
 @RequiredArgsConstructor
 public class AmlAlertNotifier {
@@ -18,11 +21,24 @@ public class AmlAlertNotifier {
 
   @EventListener
   public void onAmlThresholdAlert(AmlThresholdAlertEvent event) {
-    Long userId =
-        userService.findByPersonalCode(event.getPersonalId()).map(User::getId).orElse(null);
     notificationService.sendMessage(
-        "AML alert: %s, userId=%s, amount=%s, ref=%s"
-            .formatted(event.getType(), userId, event.getAmount(), event.getReference()),
+        "AML alert: %s, %s, amount=%s, ref=%s"
+            .formatted(
+                event.getType(),
+                partyReference(event),
+                event.getAmount().toPlainString(),
+                event.getReference()),
         AML);
+  }
+
+  private String partyReference(AmlThresholdAlertEvent event) {
+    if (event.getPartyType() == LEGAL_ENTITY) {
+      return "code=" + event.getPersonalId();
+    }
+    return userService
+        .findByPersonalCode(event.getPersonalId())
+        .map(User::getId)
+        .map(userId -> "userId=" + userId)
+        .orElse("userId=null");
   }
 }

--- a/src/main/java/ee/tuleva/onboarding/aml/alert/AmlThresholdAlertEvent.java
+++ b/src/main/java/ee/tuleva/onboarding/aml/alert/AmlThresholdAlertEvent.java
@@ -11,13 +11,20 @@ public class AmlThresholdAlertEvent extends ApplicationEvent {
   private final String personalId;
   private final BigDecimal amount;
   private final String reference;
+  private final AlertPartyType partyType;
 
   public AmlThresholdAlertEvent(
-      Object source, AmlAlertType type, String personalId, BigDecimal amount, String reference) {
+      Object source,
+      AmlAlertType type,
+      String personalId,
+      BigDecimal amount,
+      String reference,
+      AlertPartyType partyType) {
     super(source);
     this.type = type;
     this.personalId = personalId;
     this.amount = amount;
     this.reference = reference;
+    this.partyType = partyType;
   }
 }

--- a/src/main/java/ee/tuleva/onboarding/aml/alert/ThirdPillarAlertService.java
+++ b/src/main/java/ee/tuleva/onboarding/aml/alert/ThirdPillarAlertService.java
@@ -1,5 +1,7 @@
 package ee.tuleva.onboarding.aml.alert;
 
+import static ee.tuleva.onboarding.aml.alert.AlertPartyType.PERSON;
+
 import ee.tuleva.onboarding.analytics.transaction.thirdpillar.AnalyticsThirdPillarTransaction;
 import ee.tuleva.onboarding.analytics.transaction.thirdpillar.AnalyticsThirdPillarTransactionRepository;
 import java.time.Clock;
@@ -44,7 +46,8 @@ public class ThirdPillarAlertService {
               alertType,
               transaction.getPersonalId(),
               transaction.getTransactionValue(),
-              String.valueOf(transaction.getId())));
+              String.valueOf(transaction.getId()),
+              PERSON));
       alertRepository.save(
           AmlThirdPillarAlert.builder()
               .transactionFingerprint(fingerprint)

--- a/src/main/java/ee/tuleva/onboarding/aml/alert/TkfVolumeAggregate.java
+++ b/src/main/java/ee/tuleva/onboarding/aml/alert/TkfVolumeAggregate.java
@@ -4,10 +4,12 @@ import java.math.BigDecimal;
 import java.time.Instant;
 
 /**
- * One TKF volume window for one person. A monthly window carries month sums (year fields
- * zero/blank) and feeds the 15k/30k rules; a yearly window carries the year deposit sum (month
- * fields zero/blank) and feeds the 49k rule. Separate last-deposit and last-redemption timestamps
- * let the manual-override suppression compare against the matching direction.
+ * One TKF volume window for one party (person or legal entity). A monthly window carries month sums
+ * (year fields zero/blank) and feeds the 15k/30k rules; a yearly window carries the year deposit
+ * sum (month fields zero/blank) and feeds the 49k rule. Separate last-deposit and last-redemption
+ * timestamps let the manual-override suppression compare against the matching direction. Legal
+ * entities are classified as present, new clients ({@code presentInCrm=true}, {@code
+ * existingClient=false}); {@code partyType} drives how the alert message identifies the party.
  */
 public record TkfVolumeAggregate(
     String personalId,
@@ -21,4 +23,5 @@ public record TkfVolumeAggregate(
     String yearKey,
     boolean presentInCrm,
     boolean existingClient,
-    Instant lastManualReview) {}
+    Instant lastManualReview,
+    AlertPartyType partyType) {}

--- a/src/main/java/ee/tuleva/onboarding/aml/alert/TkfVolumeAlertService.java
+++ b/src/main/java/ee/tuleva/onboarding/aml/alert/TkfVolumeAlertService.java
@@ -20,12 +20,13 @@ public class TkfVolumeAlertService {
   public void checkAndAlert() {
     for (TkfVolumeAggregate aggregate : reader.readVolumeAggregates()) {
       for (TkfVolumeAlert alert : evaluator.evaluate(aggregate)) {
-        alertOnce(aggregate.personalId(), alert);
+        alertOnce(aggregate, alert);
       }
     }
   }
 
-  private void alertOnce(String personalId, TkfVolumeAlert alert) {
+  private void alertOnce(TkfVolumeAggregate aggregate, TkfVolumeAlert alert) {
+    String personalId = aggregate.personalId();
     if (alertRepository.existsByPersonalIdAndAlertTypeAndDirectionAndWindowKey(
         personalId, alert.type(), alert.direction(), alert.windowKey())) {
       return;
@@ -33,7 +34,8 @@ public class TkfVolumeAlertService {
     try {
       String reference = alert.direction() + "/" + alert.windowKey();
       eventPublisher.publishEvent(
-          new AmlThresholdAlertEvent(this, alert.type(), personalId, alert.amount(), reference));
+          new AmlThresholdAlertEvent(
+              this, alert.type(), personalId, alert.amount(), reference, aggregate.partyType()));
       alertRepository.save(
           AmlTkfVolumeAlert.builder()
               .personalId(personalId)

--- a/src/main/java/ee/tuleva/onboarding/aml/alert/TkfVolumeReader.java
+++ b/src/main/java/ee/tuleva/onboarding/aml/alert/TkfVolumeReader.java
@@ -1,5 +1,7 @@
 package ee.tuleva.onboarding.aml.alert;
 
+import static ee.tuleva.onboarding.aml.alert.AlertPartyType.LEGAL_ENTITY;
+
 import java.math.BigDecimal;
 import java.sql.Timestamp;
 import java.time.Clock;
@@ -14,13 +16,15 @@ import org.springframework.jdbc.core.simple.JdbcClient;
 import org.springframework.stereotype.Service;
 
 /**
- * Reads per-person TKF volume aggregates, mirroring the volume CTEs of T1_ulevaatamist_vajavad.sql:
- * deposits from saving_fund_payment (PERSON, EUR, effected statuses) and redemptions from ledger
- * REDEMPTIONS entries whose transaction touches a TKF100 system account. Emits one aggregate per
- * (person, calendar month) for the current AND previous month (15k/30k) and one per (person,
- * calendar year) for the current AND previous year (49k), so a breach that ages across a boundary
- * is still caught up after a scheduler outage. Window boundaries come from the injected Clock zone,
- * not the database clock. The TkfVolumeEvaluator applies the thresholds and the override.
+ * Reads per-party TKF volume aggregates (persons and legal entities), mirroring the volume CTEs of
+ * T1_ulevaatamist_vajavad.sql: deposits from saving_fund_payment (EUR, effected statuses) and
+ * redemptions from ledger REDEMPTIONS entries whose transaction touches a TKF100 system account.
+ * Emits one aggregate per (party, calendar month) for the current AND previous month (15k/30k) and
+ * one per (party, calendar year) for the current AND previous year (49k), so a breach that ages
+ * across a boundary is still caught up after a scheduler outage. Legal entities are classified as
+ * present, new clients (so the 15k/49k rules apply; the 30k existing-client rule never does), as
+ * the person-keyed mv_crm has no rows for them. Window boundaries come from the injected Clock
+ * zone, not the database clock. The TkfVolumeEvaluator applies the thresholds and the override.
  */
 @Service
 @RequiredArgsConstructor
@@ -32,6 +36,7 @@ public class TkfVolumeReader {
       """
       SELECT
         f.party_code AS personal_id,
+        f.party_type AS party_type,
         f.period AS period,
         SUM(CASE WHEN f.direction = 'IN' THEN f.amount ELSE 0 END) AS deposits_month,
         SUM(CASE WHEN f.direction = 'OUT' THEN f.amount ELSE 0 END) AS redemptions_month,
@@ -43,21 +48,21 @@ public class TkfVolumeReader {
           OR COALESCE(crm.balance_in_tuk00, false)) AS existing_client,
         ov.manual_date AS last_manual_review
       FROM (
-        SELECT party_code, amount, created_at, 'IN' AS direction,
-               date_trunc('month', created_at) AS period
+        SELECT party_code, CAST(party_type AS varchar) AS party_type, amount, created_at,
+               'IN' AS direction, date_trunc('month', created_at) AS period
         FROM saving_fund_payment
-        WHERE party_type = 'PERSON'
+        WHERE party_type IN ('PERSON', 'LEGAL_ENTITY')
           AND currency = 'EUR'
           AND status IN ('RECEIVED', 'VERIFIED', 'RESERVED', 'ISSUED', 'PROCESSED')
           AND created_at >= :monthFloor
         UNION ALL
-        SELECT p.owner_id AS party_code, ABS(e.amount) AS amount, e.created_at, 'OUT' AS direction,
+        SELECT p.owner_id AS party_code, CAST(p.party_type AS varchar) AS party_type,
+               ABS(e.amount) AS amount, e.created_at, 'OUT' AS direction,
                date_trunc('month', e.created_at) AS period
         FROM ledger.entry e
         JOIN ledger.account a ON a.id = e.account_id
         JOIN ledger.party p ON p.id = a.owner_party_id
-        WHERE p.party_type = 'PERSON'
-          AND a.purpose = 'USER_ACCOUNT'
+        WHERE a.purpose = 'USER_ACCOUNT'
           AND a.name = 'REDEMPTIONS'
           AND a.account_type = 'EXPENSE'
           AND a.asset_type = 'EUR'
@@ -74,7 +79,7 @@ public class TkfVolumeReader {
         SELECT personal_code, MAX(created_time) AS manual_date
         FROM aml_check WHERE type = 'TKF_RISK_LEVEL_OVERRIDE' GROUP BY personal_code
       ) ov ON ov.personal_code = f.party_code
-      GROUP BY f.party_code, f.period, crm.personal_id, crm.balance_in_third_pillar,
+      GROUP BY f.party_code, f.party_type, f.period, crm.personal_id, crm.balance_in_third_pillar,
                crm.balance_in_tuk75, crm.balance_in_tuk00, ov.manual_date
       """;
 
@@ -82,6 +87,7 @@ public class TkfVolumeReader {
       """
       SELECT
         f.party_code AS personal_id,
+        f.party_type AS party_type,
         f.period AS period,
         SUM(f.amount) AS deposits_year,
         MAX(f.created_at) AS last_deposit_year,
@@ -91,9 +97,9 @@ public class TkfVolumeReader {
           OR COALESCE(crm.balance_in_tuk00, false)) AS existing_client,
         ov.manual_date AS last_manual_review
       FROM (
-        SELECT party_code, amount, created_at, date_trunc('year', created_at) AS period
+        SELECT party_code, party_type, amount, created_at, date_trunc('year', created_at) AS period
         FROM saving_fund_payment
-        WHERE party_type = 'PERSON'
+        WHERE party_type IN ('PERSON', 'LEGAL_ENTITY')
           AND currency = 'EUR'
           AND status IN ('RECEIVED', 'VERIFIED', 'RESERVED', 'ISSUED', 'PROCESSED')
           AND created_at >= :yearFloor
@@ -103,7 +109,7 @@ public class TkfVolumeReader {
         SELECT personal_code, MAX(created_time) AS manual_date
         FROM aml_check WHERE type = 'TKF_RISK_LEVEL_OVERRIDE' GROUP BY personal_code
       ) ov ON ov.personal_code = f.party_code
-      GROUP BY f.party_code, f.period, crm.personal_id, crm.balance_in_third_pillar,
+      GROUP BY f.party_code, f.party_type, f.period, crm.personal_id, crm.balance_in_third_pillar,
                crm.balance_in_tuk75, crm.balance_in_tuk00, ov.manual_date
       """;
 
@@ -135,6 +141,7 @@ public class TkfVolumeReader {
   private TkfVolumeAggregate monthlyAggregate(java.sql.ResultSet rs, ZoneId zone)
       throws java.sql.SQLException {
     Instant period = rs.getTimestamp("period").toInstant();
+    AlertPartyType partyType = partyType(rs);
     return new TkfVolumeAggregate(
         rs.getString("personal_id"),
         rs.getBigDecimal("deposits_month"),
@@ -145,14 +152,16 @@ public class TkfVolumeReader {
         BigDecimal.ZERO,
         null,
         "",
-        rs.getBoolean("present_in_crm"),
-        rs.getBoolean("existing_client"),
-        toInstant(rs.getTimestamp("last_manual_review")));
+        presentInCrm(rs, partyType),
+        existingClient(rs, partyType),
+        toInstant(rs.getTimestamp("last_manual_review")),
+        partyType);
   }
 
   private TkfVolumeAggregate yearlyAggregate(java.sql.ResultSet rs, ZoneId zone)
       throws java.sql.SQLException {
     Instant period = rs.getTimestamp("period").toInstant();
+    AlertPartyType partyType = partyType(rs);
     return new TkfVolumeAggregate(
         rs.getString("personal_id"),
         BigDecimal.ZERO,
@@ -163,9 +172,24 @@ public class TkfVolumeReader {
         rs.getBigDecimal("deposits_year"),
         toInstant(rs.getTimestamp("last_deposit_year")),
         String.valueOf(LocalDate.ofInstant(period, zone).getYear()),
-        rs.getBoolean("present_in_crm"),
-        rs.getBoolean("existing_client"),
-        toInstant(rs.getTimestamp("last_manual_review")));
+        presentInCrm(rs, partyType),
+        existingClient(rs, partyType),
+        toInstant(rs.getTimestamp("last_manual_review")),
+        partyType);
+  }
+
+  private static AlertPartyType partyType(java.sql.ResultSet rs) throws java.sql.SQLException {
+    return AlertPartyType.valueOf(rs.getString("party_type"));
+  }
+
+  private static boolean presentInCrm(java.sql.ResultSet rs, AlertPartyType partyType)
+      throws java.sql.SQLException {
+    return partyType == LEGAL_ENTITY || rs.getBoolean("present_in_crm");
+  }
+
+  private static boolean existingClient(java.sql.ResultSet rs, AlertPartyType partyType)
+      throws java.sql.SQLException {
+    return partyType != LEGAL_ENTITY && rs.getBoolean("existing_client");
   }
 
   private static Instant toInstant(Timestamp timestamp) {

--- a/src/test/groovy/ee/tuleva/onboarding/aml/alert/AmlAlertNotifierTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/aml/alert/AmlAlertNotifierTest.java
@@ -1,12 +1,16 @@
 package ee.tuleva.onboarding.aml.alert;
 
+import static ee.tuleva.onboarding.aml.alert.AlertPartyType.LEGAL_ENTITY;
+import static ee.tuleva.onboarding.aml.alert.AlertPartyType.PERSON;
 import static ee.tuleva.onboarding.aml.alert.AmlAlertType.III_PILLAR_DEPOSIT_PERSON;
+import static ee.tuleva.onboarding.aml.alert.AmlAlertType.TKF_VOLUME_49K_YEARLY;
 import static ee.tuleva.onboarding.auth.UserFixture.sampleUser;
 import static ee.tuleva.onboarding.notification.OperationsNotificationService.Channel.AML;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import ee.tuleva.onboarding.notification.OperationsNotificationService;
@@ -40,7 +44,12 @@ class AmlAlertNotifierTest {
 
     notifier.onAmlThresholdAlert(
         new AmlThresholdAlertEvent(
-            this, III_PILLAR_DEPOSIT_PERSON, "38001010000", new BigDecimal("6001.00"), "7"));
+            this,
+            III_PILLAR_DEPOSIT_PERSON,
+            "38001010000",
+            new BigDecimal("6001.00"),
+            "7",
+            PERSON));
 
     verify(notificationService)
         .sendMessage(
@@ -56,11 +65,34 @@ class AmlAlertNotifierTest {
 
     notifier.onAmlThresholdAlert(
         new AmlThresholdAlertEvent(
-            this, III_PILLAR_DEPOSIT_PERSON, "38001010000", new BigDecimal("6001.00"), "7"));
+            this,
+            III_PILLAR_DEPOSIT_PERSON,
+            "38001010000",
+            new BigDecimal("6001.00"),
+            "7",
+            PERSON));
 
     verify(notificationService)
         .sendMessage(
             "AML alert: III_PILLAR_DEPOSIT_PERSON, userId=null, amount=6001.00, ref=7", AML);
+  }
+
+  @Test
+  void onAmlThresholdAlert_legalEntity_showsRegistryCode() {
+    notifier.onAmlThresholdAlert(
+        new AmlThresholdAlertEvent(
+            this,
+            TKF_VOLUME_49K_YEARLY,
+            "12345678",
+            new BigDecimal("100000.00"),
+            "COMBINED/2026",
+            LEGAL_ENTITY));
+
+    verify(notificationService)
+        .sendMessage(
+            "AML alert: TKF_VOLUME_49K_YEARLY, code=12345678, amount=100000.00, ref=COMBINED/2026",
+            AML);
+    verifyNoInteractions(userService);
   }
 
   @Test
@@ -79,7 +111,8 @@ class AmlAlertNotifierTest {
                         III_PILLAR_DEPOSIT_PERSON,
                         "38001010000",
                         new BigDecimal("6001.00"),
-                        "7")))
+                        "7",
+                        PERSON)))
         .isInstanceOf(IllegalStateException.class);
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/aml/alert/TkfVolumeAlertIntegrationTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/aml/alert/TkfVolumeAlertIntegrationTest.java
@@ -1,6 +1,8 @@
 package ee.tuleva.onboarding.aml.alert;
 
 import static ee.tuleva.onboarding.aml.alert.AmlAlertType.TKF_VOLUME_15K_NEW_CLIENT;
+import static ee.tuleva.onboarding.aml.alert.AmlAlertType.TKF_VOLUME_49K_YEARLY;
+import static ee.tuleva.onboarding.aml.alert.TkfFlowDirection.COMBINED;
 import static ee.tuleva.onboarding.aml.alert.TkfFlowDirection.IN;
 import static ee.tuleva.onboarding.notification.OperationsNotificationService.Channel.AML;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -8,6 +10,7 @@ import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 import ee.tuleva.onboarding.notification.OperationsNotificationService;
 import java.math.BigDecimal;
@@ -83,5 +86,67 @@ class TkfVolumeAlertIntegrationTest {
 
     verify(notificationService, times(1))
         .sendMessage(argThat(message -> message.contains("amount=15123.45")), eq(AML));
+  }
+
+  @Test
+  void legalEntityLargeDeposit_alertsByRegistryCodeAsNewClient_isIdempotent() {
+    String registryCode = "12345678";
+    BigDecimal amount = new BigDecimal("100000.99");
+    String monthKey = LocalDate.now(clock).format(DateTimeFormatter.ofPattern("yyyy-MM"));
+    String yearKey = String.valueOf(LocalDate.now(clock).getYear());
+
+    jdbcClient
+        .sql(
+            "INSERT INTO saving_fund_payment"
+                + " (id, external_id, amount, currency, status, party_type, party_code, created_at)"
+                + " VALUES (?, ?, ?, 'EUR', 'PROCESSED', 'LEGAL_ENTITY', ?, ?)")
+        .params(
+            UUID.randomUUID(),
+            "ext-" + UUID.randomUUID(),
+            amount,
+            registryCode,
+            Timestamp.from(clock.instant()))
+        .update();
+
+    tkfVolumeAlertService.checkAndAlert();
+    tkfVolumeAlertService.checkAndAlert();
+
+    verify(notificationService, times(1))
+        .sendMessage(
+            "AML alert: TKF_VOLUME_49K_YEARLY, code=12345678, amount=100000.99, ref=COMBINED/"
+                + yearKey,
+            AML);
+    verify(notificationService, times(1))
+        .sendMessage(
+            "AML alert: TKF_VOLUME_15K_NEW_CLIENT, code=12345678, amount=100000.99, ref=IN/"
+                + monthKey,
+            AML);
+    assertThat(
+            alertRepository.existsByPersonalIdAndAlertTypeAndDirectionAndWindowKey(
+                registryCode, TKF_VOLUME_49K_YEARLY, COMBINED, yearKey))
+        .isTrue();
+    assertThat(
+            alertRepository.existsByPersonalIdAndAlertTypeAndDirectionAndWindowKey(
+                registryCode, TKF_VOLUME_15K_NEW_CLIENT, IN, monthKey))
+        .isTrue();
+  }
+
+  @Test
+  void unattributedReceivedPayment_isIgnored_andDoesNotCrashTheRun() {
+    jdbcClient
+        .sql(
+            "INSERT INTO saving_fund_payment"
+                + " (id, external_id, amount, currency, status, party_type, party_code, created_at)"
+                + " VALUES (?, ?, ?, 'EUR', 'RECEIVED', NULL, NULL, ?)")
+        .params(
+            UUID.randomUUID(),
+            "ext-" + UUID.randomUUID(),
+            new BigDecimal("100000.99"),
+            Timestamp.from(clock.instant()))
+        .update();
+
+    tkfVolumeAlertService.checkAndAlert();
+
+    verifyNoInteractions(notificationService);
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/aml/alert/TkfVolumeAlertServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/aml/alert/TkfVolumeAlertServiceTest.java
@@ -1,5 +1,7 @@
 package ee.tuleva.onboarding.aml.alert;
 
+import static ee.tuleva.onboarding.aml.alert.AlertPartyType.LEGAL_ENTITY;
+import static ee.tuleva.onboarding.aml.alert.AlertPartyType.PERSON;
 import static ee.tuleva.onboarding.aml.alert.AmlAlertType.TKF_VOLUME_15K_NEW_CLIENT;
 import static ee.tuleva.onboarding.aml.alert.TkfFlowDirection.IN;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -54,7 +56,25 @@ class TkfVolumeAlertServiceTest {
         "2026",
         true,
         false,
-        null);
+        null,
+        PERSON);
+  }
+
+  private TkfVolumeAggregate legalEntityAggregate() {
+    return new TkfVolumeAggregate(
+        "12345678",
+        new BigDecimal("100000.00"),
+        BigDecimal.ZERO,
+        Instant.parse("2026-06-10T00:00:00Z"),
+        null,
+        "2026-06",
+        new BigDecimal("100000.00"),
+        Instant.parse("2026-06-10T00:00:00Z"),
+        "2026",
+        true,
+        false,
+        null,
+        LEGAL_ENTITY);
   }
 
   private final TkfVolumeAlert alert =
@@ -90,6 +110,25 @@ class TkfVolumeAlertServiceTest {
     assertThat(saved.getDirection()).isEqualTo(IN);
     assertThat(saved.getWindowKey()).isEqualTo("2026-06");
     assertThat(saved.getAlertedAt()).isEqualTo(clock.instant());
+  }
+
+  @Test
+  void checkAndAlert_legalEntity_publishesLegalEntityEvent() {
+    var aggregate = legalEntityAggregate();
+    when(reader.readVolumeAggregates()).thenReturn(List.of(aggregate));
+    when(evaluator.evaluate(aggregate)).thenReturn(List.of(alert));
+    when(alertRepository.existsByPersonalIdAndAlertTypeAndDirectionAndWindowKey(
+            any(), any(), any(), any()))
+        .thenReturn(false);
+
+    service.checkAndAlert();
+
+    ArgumentCaptor<AmlThresholdAlertEvent> eventCaptor =
+        ArgumentCaptor.forClass(AmlThresholdAlertEvent.class);
+    verify(eventPublisher).publishEvent(eventCaptor.capture());
+    AmlThresholdAlertEvent event = eventCaptor.getValue();
+    assertThat(event.getPartyType()).isEqualTo(LEGAL_ENTITY);
+    assertThat(event.getPersonalId()).isEqualTo("12345678");
   }
 
   @Test

--- a/src/test/groovy/ee/tuleva/onboarding/aml/alert/TkfVolumeEvaluatorSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/aml/alert/TkfVolumeEvaluatorSpec.groovy
@@ -5,6 +5,7 @@ import spock.lang.Unroll
 
 import java.time.Instant
 
+import static ee.tuleva.onboarding.aml.alert.AlertPartyType.*
 import static ee.tuleva.onboarding.aml.alert.AmlAlertType.*
 import static ee.tuleva.onboarding.aml.alert.TkfFlowDirection.*
 
@@ -28,7 +29,8 @@ class TkfVolumeEvaluatorSpec extends Specification {
         "2026",
         args.containsKey('inCrm') ? args.inCrm as boolean : true,
         args.existing as boolean,
-        args.review as Instant)
+        args.review as Instant,
+        PERSON)
   }
 
   @Unroll
@@ -126,7 +128,7 @@ class TkfVolumeEvaluatorSpec extends Specification {
   def "alerts a 49k yearly breach with no current-month flow when not reviewed"() {
     given:
     def agg = new TkfVolumeAggregate(
-        "38001010000", 0.00, 0.00, null, null, "2026-06", 50000.00, YEAR_FLOW, "2026", true, true, null)
+        "38001010000", 0.00, 0.00, null, null, "2026-06", 50000.00, YEAR_FLOW, "2026", true, true, null, PERSON)
 
     expect:
     evaluator.evaluate(agg).collect { it.type() } == [TKF_VOLUME_49K_YEARLY]
@@ -136,7 +138,7 @@ class TkfVolumeEvaluatorSpec extends Specification {
     given:
     def agg = new TkfVolumeAggregate(
         "38001010000", 0.00, 0.00, null, null, "2026-06", 50000.00, YEAR_FLOW, "2026", true, true,
-        Instant.parse("2026-12-01T00:00:00Z"))
+        Instant.parse("2026-12-01T00:00:00Z"), PERSON)
 
     expect:
     evaluator.evaluate(agg).isEmpty()


### PR DESCRIPTION
## Problem

Automatic AML alerts (AML-teated) fire for large TKF (savings-fund) transactions, but a large payment by a **legal entity** never produced one. Root cause: `TkfVolumeReader` built its aggregates with a hard `WHERE party_type = 'PERSON'` filter, so legal-entity payments were excluded before any threshold was evaluated. The whole TKF risk/volume machinery (`analytics.mv_crm`, `v_tkf_risk_metadata`) is person-keyed; companies aren't represented in it. (Not a weekend/timing issue — the alert jobs run daily, including weekends.)

## Change

Treat legal entities like persons, **classified as present + new clients** (so the 15k-monthly and 49k-yearly rules apply; the 30k *existing-client* rule never does — consistent with how a brand-new person is treated). The alert message identifies the company by registry code; persons keep `userId=` and their isikukood stays out of Slack.

- New `AlertPartyType` (PERSON / LEGAL_ENTITY) threaded through `AmlThresholdAlertEvent` → `TkfVolumeAggregate` → `AmlAlertNotifier`.
- `TkfVolumeReader`: drop the `party_type = 'PERSON'` filter; force legal entities to `present_in_crm = true` / `existing_client = false`.
- Amounts rendered with `BigDecimal.toPlainString()` (no scientific notation).

No schema change, no new `AmlAlertType`, no `mv_crm` / cross-repo change.

### Reviewer-found fixes (Codex)
An independent Codex review caught two production bugs that passed local H2 tests (H2-vs-Postgres divergence):
- **Postgres UNION type mismatch** — the monthly query unions `saving_fund_payment.party_type` (`text`) with `ledger.party.party_type` (a Postgres `enum`); Postgres rejects that without a cast, which would break the *entire* reader (all alerts, persons included). Fixed with `CAST(... AS varchar)` on both branches.
- **NULL `party_type` NPE** — removing the `='PERSON'` predicate also stopped excluding NULLs; a freshly-imported `RECEIVED` payment is NULL until verification attaches a party. Fixed by restricting deposit subqueries to attributed `PERSON`/`LEGAL_ENTITY` rows + a regression test.

## Consequence (intentional)
Because companies are treated as new clients, the only outgoing-money rule (30k existing-client) never applies to them, so **company redemptions/outflows won't alert** — same as new-client persons. Easy follow-up if outflow coverage is wanted.

## Testing
- `TkfVolumeAlertIntegrationTest`: legal-entity large deposit → `TKF_VOLUME_15K_NEW_CLIENT` + `TKF_VOLUME_49K_YEARLY` to the AML channel by registry code, idempotent; plus an unattributed-NULL regression case.
- Unit tests for the notifier (incl. isikukood-privacy + legal-entity branches) and party-type propagation.
- `spotlessCheck` clean; Codex review clean on final pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
