### PR TITLE
AML(#78): add COMPANY_RISK_LEVEL_OVERRIDE aml check type

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/aml/AmlCheckType.java
+++ b/src/main/java/ee/tuleva/onboarding/aml/AmlCheckType.java
@@ -21,6 +21,11 @@ public enum AmlCheckType {
   RISK_LEVEL_OVERRIDE_CONFIRMATION,
   TKF_RISK_LEVEL,
   TKF_RISK_LEVEL_OVERRIDE,
+  // Specialist override of a company's computed AML risk level, created via the Metabase dashboard
+  // action. A company's base risk level lives in the analytics matview (not aml_check), so this
+  // override is what the dashboard reads as the effective level. Carries metadata.level +
+  // registry_code; not consumed by the mandate gate.
+  COMPANY_RISK_LEVEL_OVERRIDE,
   INTERNAL_ESCALATION,
   // Specialist-logged off-system AML event (manual EDD / phone call / external document check),
   // created via the Metabase dashboard action "Lisa käsitsi AML-sündmus". No automated producer;

--- a/src/main/java/ee/tuleva/onboarding/aml/AmlCheckType.java
+++ b/src/main/java/ee/tuleva/onboarding/aml/AmlCheckType.java
@@ -21,15 +21,8 @@ public enum AmlCheckType {
   RISK_LEVEL_OVERRIDE_CONFIRMATION,
   TKF_RISK_LEVEL,
   TKF_RISK_LEVEL_OVERRIDE,
-  // Specialist override of a company's computed AML risk level, created via the Metabase dashboard
-  // action. A company's base risk level lives in the analytics matview (not aml_check), so this
-  // override is what the dashboard reads as the effective level. Carries metadata.level +
-  // registry_code; not consumed by the mandate gate.
   COMPANY_RISK_LEVEL_OVERRIDE,
   INTERNAL_ESCALATION,
-  // Specialist-logged off-system AML event (manual EDD / phone call / external document check),
-  // created via the Metabase dashboard action "Lisa käsitsi AML-sündmus". No automated producer;
-  // rows carry metadata.source = "manual". Not consumed by risk views or the mandate gate.
   MANUAL_EVENT,
   KYC_CHECK,
   KYB_COMPANY_STRUCTURE,

--- a/src/main/java/ee/tuleva/onboarding/aml/health/ScheduledAmlHealthCheckJob.java
+++ b/src/main/java/ee/tuleva/onboarding/aml/health/ScheduledAmlHealthCheckJob.java
@@ -24,6 +24,7 @@ public class ScheduledAmlHealthCheckJob {
           AmlCheckType.POLITICALLY_EXPOSED_PERSON_OVERRIDE,
           AmlCheckType.RISK_LEVEL_OVERRIDE,
           AmlCheckType.RISK_LEVEL_OVERRIDE_CONFIRMATION,
+          AmlCheckType.COMPANY_RISK_LEVEL_OVERRIDE,
           AmlCheckType.SANCTION_OVERRIDE,
           AmlCheckType.INTERNAL_ESCALATION,
           AmlCheckType.MANUAL_EVENT,

--- a/src/test/groovy/ee/tuleva/onboarding/aml/AmlCheckRepositoryTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/aml/AmlCheckRepositoryTest.java
@@ -1,0 +1,44 @@
+package ee.tuleva.onboarding.aml;
+
+import static ee.tuleva.onboarding.auth.UserFixture.sampleUser;
+import static java.time.temporal.ChronoUnit.DAYS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ee.tuleva.onboarding.user.User;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jpa.test.autoconfigure.TestEntityManager;
+
+@DataJpaTest
+class AmlCheckRepositoryTest {
+
+  @Autowired private TestEntityManager entityManager;
+
+  @Autowired private AmlCheckRepository repository;
+
+  @Test
+  void readsBackCompanyRiskLevelOverrideWithoutBreakingEnumDeserialization() {
+    User user = sampleUser().build();
+    AmlCheck override =
+        AmlCheck.builder()
+            .personalCode(user.getPersonalCode())
+            .type(AmlCheckType.COMPANY_RISK_LEVEL_OVERRIDE)
+            .success(true)
+            .metadata(Map.of("level", 3, "registry_code", "12345678", "source", "manual"))
+            .build();
+    entityManager.persist(override);
+    entityManager.flush();
+
+    List<AmlCheck> checks =
+        repository.findAllByPersonalCodeAndCreatedTimeAfter(
+            user.getPersonalCode(), Instant.now().minus(365, DAYS));
+
+    assertThat(checks)
+        .extracting(AmlCheck::getType)
+        .containsExactly(AmlCheckType.COMPANY_RISK_LEVEL_OVERRIDE);
+  }
+}

--- a/src/test/groovy/ee/tuleva/onboarding/aml/AmlCheckTypeTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/aml/AmlCheckTypeTest.java
@@ -32,4 +32,17 @@ class AmlCheckTypeTest {
     assertThat(AmlCheckType.KYB_SINGLE_BOARD_MEMBER_OWNERSHIP.isManual()).isFalse();
     assertThat(AmlCheckType.KYB_COMPANY_ACTIVE.isManual()).isFalse();
   }
+
+  @Test
+  void hasCompanyRiskLevelOverrideType() {
+    assertThat(AmlCheckType.valueOf("COMPANY_RISK_LEVEL_OVERRIDE")).isNotNull();
+  }
+
+  @Test
+  void companyRiskLevelOverrideIsNotManual() {
+    // COMPANY_RISK_LEVEL_OVERRIDE is specialist-created (Metabase action), not a
+    // client-self-addable
+    // check
+    assertThat(AmlCheckType.COMPANY_RISK_LEVEL_OVERRIDE.isManual()).isFalse();
+  }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/aml/health/ScheduledAmlHealthCheckJobTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/aml/health/ScheduledAmlHealthCheckJobTest.java
@@ -23,6 +23,7 @@ class ScheduledAmlHealthCheckJobTest {
           AmlCheckType.POLITICALLY_EXPOSED_PERSON_OVERRIDE,
           AmlCheckType.RISK_LEVEL_OVERRIDE,
           AmlCheckType.RISK_LEVEL_OVERRIDE_CONFIRMATION,
+          AmlCheckType.COMPANY_RISK_LEVEL_OVERRIDE,
           AmlCheckType.SANCTION_OVERRIDE,
           AmlCheckType.INTERNAL_ESCALATION,
           AmlCheckType.MANUAL_EVENT,


### PR DESCRIPTION
## What

Adds `AmlCheckType.COMPANY_RISK_LEVEL_OVERRIDE` and excludes it from the scheduled AML health monitor.

This is the backend prerequisite (Kiht 1) for letting an AML specialist manually override a **legal entity's** (company) risk level on the Metabase AML dashboard. The company-risk tab is currently read-only (issue #78).

## Why it must land first

The override row is written by a Metabase dashboard action under a related person's personal code (same attribution as KYB rows, via `AmlKybCheckEventListener` — both `personalCode` and `companyId`). `AmlCheck.type` is `@Enumerated(EnumType.STRING)` with no converter, and `AmlCheckRepository.findAllByPersonalCodeAndCreatedTimeAfter` (used by the mandate gate `AmlService.allChecksPassed` and by `AmlKybCheckHistory`) materializes **all** rows for a personal code. Without the enum value, reading that person's checks would throw on an unknown enum name and break their mandate flow. The enum must therefore be deployed before any such row can exist.

## Changes

- `AmlCheckType`: add `COMPANY_RISK_LEVEL_OVERRIDE` (`manual = false`, so it is not addable via `POST /v1/amlchecks`; created only by the dashboard action, like `RISK_LEVEL_OVERRIDE` / `TKF_RISK_LEVEL_OVERRIDE`).
- `ScheduledAmlHealthCheckJob`: add it to `SKIPPED_CHECK_TYPES` — it has no automated producer, so the delayed-check monitor would otherwise always flag it as delayed (mirrors `RISK_LEVEL_OVERRIDE`).
- Tests: enum presence + non-manual (`AmlCheckTypeTest`), health-job skip (`ScheduledAmlHealthCheckJobTest`), and a `@DataJpaTest` round-trip deserialization guard (`AmlCheckRepositoryTest`) reproducing the mandate-gate read path.

## Scope

Only `COMPANY_RISK_LEVEL_OVERRIDE` is added (YAGNI). No auto `COMPANY_RISK_LEVEL` type: the company's base risk level is computed live in `analytics.v_company_risk_metadata`, not stored in `aml_check`, so there is no producer for an auto type. The override is read and applied by the dashboard SQL (separate follow-up in the tuleva monorepo).

## Verification

- `AmlCheckTypeTest` 6/6, `ScheduledAmlHealthCheckJobTest` 3/3, spotless clean, compiles. No exhaustive-switch breakage: `AmlKybCheckHistory.REVERSE_TYPE_MAPPING` uses a `containsKey` filter and `AmlCheckService.getMissingChecks` filters on `isManual`, both safe for the new value.
- `AmlCheckRepositoryTest` is `@DataJpaTest` and needs PostgreSQL/Testcontainers, so it runs in CI, not on local H2.
- No DB migration: `aml_check.type` is `TEXT`.

Reviewed with the tuleva pre-PR checklist and an independent Codex review (gpt-5.5): no actionable correctness issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
