### PR TITLE
Ingest FT confirmations in batch with idempotent orphan alerting

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/FtConfirmationBatchResult.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/FtConfirmationBatchResult.java
@@ -1,0 +1,18 @@
+package ee.tuleva.onboarding.investment.transaction;
+
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+@NullMarked
+public record FtConfirmationBatchResult(
+    int index, String isin, @Nullable FtConfirmationResult result, @Nullable String error) {
+
+  public static FtConfirmationBatchResult verified(
+      int index, String isin, FtConfirmationResult result) {
+    return new FtConfirmationBatchResult(index, isin, result, null);
+  }
+
+  public static FtConfirmationBatchResult failed(int index, String isin, String error) {
+    return new FtConfirmationBatchResult(index, isin, null, error);
+  }
+}

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/FtVerificationStatus.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/FtVerificationStatus.java
@@ -10,5 +10,6 @@ public enum FtVerificationStatus {
   PENDING_NAV,
   CANCELLED,
   AMBIGUOUS,
-  IGNORED
+  IGNORED,
+  ORPHAN
 }

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionRegistryController.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionRegistryController.java
@@ -3,7 +3,6 @@ package ee.tuleva.onboarding.investment.transaction;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.springframework.http.HttpStatus.ACCEPTED;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
-import static org.springframework.http.HttpStatus.NOT_FOUND;
 import static org.springframework.http.HttpStatus.SERVICE_UNAVAILABLE;
 import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 import static org.springframework.http.MediaType.MULTIPART_FORM_DATA_VALUE;
@@ -100,12 +99,22 @@ public class TransactionRegistryController {
         confirmation.fund(),
         confirmation.isin(),
         confirmation.tradeDate());
-    return ftConfirmationVerificationService
-        .verify(confirmation)
-        .orElseThrow(
-            () ->
-                new ResponseStatusException(
-                    NOT_FOUND, "No matching order found for FT confirmation"));
+    return ftConfirmationVerificationService.verify(confirmation);
+  }
+
+  @PostMapping("/transaction-registry/ft-confirmations")
+  public List<FtConfirmationBatchResult> verifyFtConfirmations(
+      @RequestHeader("X-Admin-Token") String token,
+      @RequestHeader(name = "X-Admin-Actor", required = false, defaultValue = "admin") String actor,
+      @RequestBody List<FtConfirmation> confirmations) {
+
+    validateToken(token);
+
+    log.info(
+        "Admin submitted FT confirmations batch for verification: count={}, actor={}",
+        confirmations.size(),
+        actor);
+    return ftConfirmationVerificationService.verifyAll(confirmations, actor);
   }
 
   @PostMapping(value = "/transaction-registry/import-history", consumes = TEXT_PLAIN_VALUE)

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationAuditRecorder.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationAuditRecorder.java
@@ -1,5 +1,7 @@
 package ee.tuleva.onboarding.investment.transaction.ingest;
 
+import static java.util.Comparator.comparing;
+
 import ee.tuleva.onboarding.investment.transaction.FtConfirmation;
 import ee.tuleva.onboarding.investment.transaction.FtConfirmationResult;
 import ee.tuleva.onboarding.investment.transaction.TransactionAuditEvent;
@@ -7,9 +9,12 @@ import ee.tuleva.onboarding.investment.transaction.TransactionAuditEventReposito
 import ee.tuleva.onboarding.investment.transaction.TransactionOrder;
 import java.time.Clock;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.springframework.stereotype.Component;
 
 @NullMarked
@@ -19,13 +24,63 @@ class FtConfirmationAuditRecorder {
 
   static final String FT_CONFIRMATION_VERIFIED = "FT_CONFIRMATION_VERIFIED";
 
-  private static final String ADMIN_ACTOR = "admin";
-
   private final TransactionAuditEventRepository auditEventRepository;
   private final Clock clock;
 
-  void recordVerified(
-      TransactionOrder order, FtConfirmation confirmation, FtConfirmationResult result) {
+  boolean recordOutcome(
+      @Nullable TransactionOrder order,
+      FtConfirmation confirmation,
+      FtConfirmationResult result,
+      String actor) {
+    if (statusUnchangedSinceLastRecord(confirmation, result)) {
+      return false;
+    }
+
+    auditEventRepository.save(
+        TransactionAuditEvent.builder()
+            .orderId(order == null ? null : order.getId())
+            .batch(order == null ? null : order.getBatch())
+            .eventType(FT_CONFIRMATION_VERIFIED)
+            .actor(actor)
+            .payload(payload(confirmation, result))
+            .createdAt(clock.instant())
+            .build());
+    return true;
+  }
+
+  private boolean statusUnchangedSinceLastRecord(
+      FtConfirmation confirmation, FtConfirmationResult result) {
+    return lastRecordedStatus(confirmation).filter(statusPair(result)::equals).isPresent();
+  }
+
+  private Optional<List<String>> lastRecordedStatus(FtConfirmation confirmation) {
+    return auditEventRepository.findByEventType(FT_CONFIRMATION_VERIFIED).stream()
+        .filter(event -> sameConfirmation(event.getPayload(), confirmation))
+        .max(comparing(TransactionAuditEvent::getCreatedAt))
+        .map(event -> statusPair(event.getPayload()));
+  }
+
+  private static boolean sameConfirmation(
+      Map<String, Object> payload, FtConfirmation confirmation) {
+    return confirmation.fund().name().equals(payload.get("fund"))
+        && confirmation.isin().equals(payload.get("isin"))
+        && confirmation.tradeDate().toString().equals(payload.get("tradeDate"))
+        && confirmation.quantity().toPlainString().equals(payload.get("quantity"))
+        && confirmation.grossPrice().toPlainString().equals(payload.get("grossPrice"))
+        && confirmation.type().name().equals(payload.get("type"));
+  }
+
+  private static List<String> statusPair(FtConfirmationResult result) {
+    return List.of(result.quantityStatus().name(), result.priceStatus().name());
+  }
+
+  private static List<String> statusPair(Map<String, Object> payload) {
+    return List.of(
+        String.valueOf(payload.get("quantityStatus")), String.valueOf(payload.get("priceStatus")));
+  }
+
+  private static Map<String, Object> payload(
+      FtConfirmation confirmation, FtConfirmationResult result) {
     Map<String, Object> payload = new LinkedHashMap<>();
     payload.put("fund", confirmation.fund().name());
     payload.put("isin", confirmation.isin());
@@ -39,15 +94,6 @@ class FtConfirmationAuditRecorder {
     payload.put("quantityStatus", result.quantityStatus().name());
     payload.put("priceStatus", result.priceStatus().name());
     payload.put("details", result.details());
-
-    auditEventRepository.save(
-        TransactionAuditEvent.builder()
-            .orderId(order.getId())
-            .batch(order.getBatch())
-            .eventType(FT_CONFIRMATION_VERIFIED)
-            .actor(ADMIN_ACTOR)
-            .payload(payload)
-            .createdAt(clock.instant())
-            .build());
+    return payload;
   }
 }

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationDigest.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationDigest.java
@@ -1,0 +1,82 @@
+package ee.tuleva.onboarding.investment.transaction.ingest;
+
+import static ee.tuleva.onboarding.investment.transaction.FtVerificationStatus.AMBIGUOUS;
+import static ee.tuleva.onboarding.investment.transaction.FtVerificationStatus.ERROR;
+import static ee.tuleva.onboarding.investment.transaction.FtVerificationStatus.ORPHAN;
+import static ee.tuleva.onboarding.notification.OperationsNotificationService.Channel.INVESTMENT;
+
+import ee.tuleva.onboarding.investment.transaction.FtConfirmation;
+import ee.tuleva.onboarding.investment.transaction.FtConfirmationResult;
+import ee.tuleva.onboarding.investment.transaction.FtVerificationStatus;
+import ee.tuleva.onboarding.notification.OperationsNotificationService;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NullMarked;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@NullMarked
+@Slf4j
+@Component
+class FtConfirmationDigest {
+
+  private final OperationsNotificationService notificationService;
+  private final boolean registryAuthoritative;
+
+  FtConfirmationDigest(
+      OperationsNotificationService notificationService,
+      @Value("${transaction-registry.ft-confirmation.registry-authoritative:false}")
+          boolean registryAuthoritative) {
+    this.notificationService = notificationService;
+    this.registryAuthoritative = registryAuthoritative;
+  }
+
+  void publish(List<FtConfirmationOutcome> changedOutcomes) {
+    List<FtConfirmationOutcome> actionable =
+        changedOutcomes.stream().filter(this::shouldAlert).toList();
+    if (actionable.isEmpty()) {
+      return;
+    }
+    String message = buildMessage(actionable);
+    try {
+      notificationService.sendMessage(message, INVESTMENT);
+    } catch (RuntimeException e) {
+      log.error("Failed to send FT confirmation digest to Slack: error={}", e.getMessage(), e);
+    }
+  }
+
+  private boolean shouldAlert(FtConfirmationOutcome outcome) {
+    FtConfirmationResult result = outcome.result();
+    if (result.quantityStatus() == ORPHAN) {
+      return registryAuthoritative;
+    }
+    return isActionable(result.quantityStatus()) || isActionable(result.priceStatus());
+  }
+
+  private static boolean isActionable(FtVerificationStatus status) {
+    return status == ERROR || status == AMBIGUOUS;
+  }
+
+  private static String buildMessage(List<FtConfirmationOutcome> actionable) {
+    StringBuilder message = new StringBuilder();
+    message
+        .append("FT confirmation check: ")
+        .append(actionable.size())
+        .append(" issue(s) need attention");
+    actionable.forEach(outcome -> message.append('\n').append(describe(outcome)));
+    return message.toString();
+  }
+
+  private static String describe(FtConfirmationOutcome outcome) {
+    FtConfirmation confirmation = outcome.confirmation();
+    FtConfirmationResult result = outcome.result();
+    return String.format(
+        "FT issue: fund=%s, isin=%s, tradeDate=%s, quantity=%s, quantityStatus=%s, priceStatus=%s",
+        confirmation.fund().name(),
+        confirmation.isin(),
+        confirmation.tradeDate(),
+        confirmation.quantity().toPlainString(),
+        result.quantityStatus(),
+        result.priceStatus());
+  }
+}

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationDigest.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationDigest.java
@@ -32,8 +32,11 @@ class FtConfirmationDigest {
   }
 
   void publish(List<FtConfirmationOutcome> changedOutcomes) {
+    if (!registryAuthoritative) {
+      return;
+    }
     List<FtConfirmationOutcome> actionable =
-        changedOutcomes.stream().filter(this::shouldAlert).toList();
+        changedOutcomes.stream().filter(FtConfirmationDigest::isActionable).toList();
     if (actionable.isEmpty()) {
       return;
     }
@@ -45,16 +48,13 @@ class FtConfirmationDigest {
     }
   }
 
-  private boolean shouldAlert(FtConfirmationOutcome outcome) {
+  private static boolean isActionable(FtConfirmationOutcome outcome) {
     FtConfirmationResult result = outcome.result();
-    if (result.quantityStatus() == ORPHAN) {
-      return registryAuthoritative;
-    }
     return isActionable(result.quantityStatus()) || isActionable(result.priceStatus());
   }
 
   private static boolean isActionable(FtVerificationStatus status) {
-    return status == ERROR || status == AMBIGUOUS;
+    return status == ERROR || status == AMBIGUOUS || status == ORPHAN;
   }
 
   private static String buildMessage(List<FtConfirmationOutcome> actionable) {

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationOutcome.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationOutcome.java
@@ -1,0 +1,8 @@
+package ee.tuleva.onboarding.investment.transaction.ingest;
+
+import ee.tuleva.onboarding.investment.transaction.FtConfirmation;
+import ee.tuleva.onboarding.investment.transaction.FtConfirmationResult;
+import org.jspecify.annotations.NullMarked;
+
+@NullMarked
+record FtConfirmationOutcome(FtConfirmation confirmation, FtConfirmationResult result) {}

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationVerificationService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationVerificationService.java
@@ -5,6 +5,7 @@ import static ee.tuleva.onboarding.investment.transaction.FtVerificationStatus.C
 import static ee.tuleva.onboarding.investment.transaction.FtVerificationStatus.ERROR;
 import static ee.tuleva.onboarding.investment.transaction.FtVerificationStatus.IGNORED;
 import static ee.tuleva.onboarding.investment.transaction.FtVerificationStatus.OK;
+import static ee.tuleva.onboarding.investment.transaction.FtVerificationStatus.ORPHAN;
 import static ee.tuleva.onboarding.investment.transaction.FtVerificationStatus.PENDING_EXECUTION;
 import static ee.tuleva.onboarding.investment.transaction.FtVerificationStatus.PENDING_NAV;
 import static java.util.Comparator.comparing;
@@ -15,6 +16,7 @@ import ee.tuleva.onboarding.comparisons.fundvalue.ResolvedPrice;
 import ee.tuleva.onboarding.comparisons.fundvalue.ValidationStatus;
 import ee.tuleva.onboarding.investment.calendar.Target2Calendar;
 import ee.tuleva.onboarding.investment.transaction.FtConfirmation;
+import ee.tuleva.onboarding.investment.transaction.FtConfirmationBatchResult;
 import ee.tuleva.onboarding.investment.transaction.FtConfirmationResult;
 import ee.tuleva.onboarding.investment.transaction.FtVerificationStatus;
 import ee.tuleva.onboarding.investment.transaction.TransactionExecution;
@@ -26,6 +28,7 @@ import java.time.Clock;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.ZoneId;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -34,6 +37,7 @@ import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
@@ -47,6 +51,7 @@ public class FtConfirmationVerificationService {
   private static final BigDecimal DEFAULT_PRICE_TOLERANCE = new BigDecimal("0.001");
   private static final ZoneId TALLINN = ZoneId.of("Europe/Tallinn");
   private static final int EXECUTION_PENDING_BUSINESS_DAYS = 1;
+  private static final String ADMIN_ACTOR = "admin";
 
   private final TransactionOrderRepository orderRepository;
   private final TransactionExecutionRepository executionRepository;
@@ -54,15 +59,72 @@ public class FtConfirmationVerificationService {
   private final PriceValidator priceValidator;
   private final Target2Calendar target2Calendar;
   private final FtConfirmationAuditRecorder auditRecorder;
+  private final FtConfirmationDigest digest;
   private final Clock clock;
 
   @Value("${investment.transaction.ft-confirmation.price-tolerance:0.001}")
   private BigDecimal priceTolerance = DEFAULT_PRICE_TOLERANCE;
 
-  public Optional<FtConfirmationResult> verify(FtConfirmation confirmation) {
-    Optional<FtConfirmationResult> ignored = ignoredResult(confirmation);
-    if (ignored.isPresent()) {
-      return ignored;
+  public FtConfirmationResult verify(FtConfirmation confirmation) {
+    Verification verification = verifyAndRecord(confirmation, ADMIN_ACTOR);
+    return verification.result();
+  }
+
+  public List<FtConfirmationBatchResult> verifyAll(
+      List<FtConfirmation> confirmations, String actor) {
+    List<FtConfirmationBatchResult> results = new ArrayList<>();
+    List<FtConfirmationOutcome> changedOutcomes = new ArrayList<>();
+    for (int index = 0; index < confirmations.size(); index++) {
+      FtConfirmation confirmation = confirmations.get(index);
+      try {
+        Verification verification = verifyAndRecord(confirmation, actor);
+        results.add(
+            FtConfirmationBatchResult.verified(index, confirmation.isin(), verification.result()));
+        if (verification.statusChanged()) {
+          changedOutcomes.add(new FtConfirmationOutcome(confirmation, verification.result()));
+        }
+      } catch (RuntimeException e) {
+        log.error(
+            "FT confirmation row failed: index={}, isin={}, error={}",
+            index,
+            confirmation.isin(),
+            e.getMessage(),
+            e);
+        results.add(FtConfirmationBatchResult.failed(index, confirmation.isin(), e.getMessage()));
+      }
+    }
+    digest.publish(changedOutcomes);
+    return results;
+  }
+
+  private Verification verifyAndRecord(FtConfirmation confirmation, String actor) {
+    Computed computed = compute(confirmation);
+    boolean statusChanged = record(confirmation, computed, actor);
+    return new Verification(computed.result(), statusChanged);
+  }
+
+  private boolean record(FtConfirmation confirmation, Computed computed, String actor) {
+    if (computed.result().quantityStatus() == IGNORED) {
+      return false;
+    }
+    boolean recorded =
+        auditRecorder.recordOutcome(computed.order(), confirmation, computed.result(), actor);
+    if (recorded) {
+      log.info(
+          "FT confirmation verified: isin={}, tradeDate={}, type={}, quantityStatus={}, priceStatus={}",
+          confirmation.isin(),
+          confirmation.tradeDate(),
+          confirmation.type(),
+          computed.result().quantityStatus(),
+          computed.result().priceStatus());
+    }
+    return recorded;
+  }
+
+  private Computed compute(FtConfirmation confirmation) {
+    FtConfirmationResult ignored = ignoredResult(confirmation);
+    if (ignored != null) {
+      return new Computed(ignored, null);
     }
 
     List<TransactionOrder> candidates = candidateOrders(confirmation);
@@ -72,7 +134,7 @@ public class FtConfirmationVerificationService {
           confirmation.fund(),
           confirmation.isin(),
           confirmation.tradeDate());
-      return Optional.empty();
+      return new Computed(orphan(), null);
     }
 
     OrderSelection selection = selectOrder(confirmation, candidates);
@@ -82,68 +144,59 @@ public class FtConfirmationVerificationService {
     details.put("orderUuid", order.getOrderUuid().toString());
 
     if (confirmation.isCancellation()) {
-      return cancel(confirmation, order, details);
+      details.put("cancellationSignature", confirmation.cancellationSignature());
+      return new Computed(result(CANCELLED, CANCELLED, details), order);
     }
 
     if (selection.ambiguous()) {
       details.put("ambiguousOrderCount", String.valueOf(selection.matchCount()));
-      return result(confirmation, order, AMBIGUOUS, AMBIGUOUS, details);
+      return new Computed(result(AMBIGUOUS, AMBIGUOUS, details), order);
     }
 
     FtVerificationStatus quantityStatus = checkQuantity(confirmation, order, details);
     FtVerificationStatus priceStatus = checkPrice(confirmation, details);
-    return result(confirmation, order, quantityStatus, priceStatus, details);
+    return new Computed(result(quantityStatus, priceStatus, details), order);
   }
 
-  private Optional<FtConfirmationResult> ignoredResult(FtConfirmation confirmation) {
+  private record Verification(FtConfirmationResult result, boolean statusChanged) {}
+
+  private record Computed(FtConfirmationResult result, @Nullable TransactionOrder order) {}
+
+  private static FtConfirmationResult result(
+      FtVerificationStatus quantityStatus,
+      FtVerificationStatus priceStatus,
+      Map<String, String> details) {
+    return new FtConfirmationResult(quantityStatus, priceStatus, Map.copyOf(details));
+  }
+
+  private static FtConfirmationResult orphan() {
+    return new FtConfirmationResult(
+        ORPHAN, ORPHAN, Map.of("orphanReason", "no matching order in registry"));
+  }
+
+  private @Nullable FtConfirmationResult ignoredResult(FtConfirmation confirmation) {
     if (confirmation.suppressed()) {
       return ignored(confirmation, "manually suppressed false positive");
     }
     if (isWeekend(confirmation.tradeDate())) {
       return ignored(confirmation, "weekend trade date: " + confirmation.tradeDate());
     }
-    return Optional.empty();
+    return null;
   }
 
-  private Optional<FtConfirmationResult> ignored(FtConfirmation confirmation, String reason) {
+  private FtConfirmationResult ignored(FtConfirmation confirmation, String reason) {
     log.info(
         "FT confirmation ignored: fund={}, isin={}, tradeDate={}, reason={}",
         confirmation.fund(),
         confirmation.isin(),
         confirmation.tradeDate(),
         reason);
-    return Optional.of(new FtConfirmationResult(IGNORED, IGNORED, Map.of("ignoreReason", reason)));
+    return new FtConfirmationResult(IGNORED, IGNORED, Map.of("ignoreReason", reason));
   }
 
   private static boolean isWeekend(LocalDate date) {
     DayOfWeek day = date.getDayOfWeek();
     return day == DayOfWeek.SATURDAY || day == DayOfWeek.SUNDAY;
-  }
-
-  private Optional<FtConfirmationResult> cancel(
-      FtConfirmation confirmation, TransactionOrder order, Map<String, String> details) {
-    details.put("cancellationSignature", confirmation.cancellationSignature());
-    return result(confirmation, order, CANCELLED, CANCELLED, details);
-  }
-
-  private Optional<FtConfirmationResult> result(
-      FtConfirmation confirmation,
-      TransactionOrder order,
-      FtVerificationStatus quantityStatus,
-      FtVerificationStatus priceStatus,
-      Map<String, String> details) {
-    FtConfirmationResult result =
-        new FtConfirmationResult(quantityStatus, priceStatus, Map.copyOf(details));
-    auditRecorder.recordVerified(order, confirmation, result);
-    log.info(
-        "FT confirmation verified: orderUuid={}, isin={}, tradeDate={}, type={}, quantityStatus={}, priceStatus={}",
-        order.getOrderUuid(),
-        confirmation.isin(),
-        confirmation.tradeDate(),
-        confirmation.type(),
-        quantityStatus,
-        priceStatus);
-    return Optional.of(result);
   }
 
   private List<TransactionOrder> candidateOrders(FtConfirmation confirmation) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -206,9 +206,11 @@ transaction-registry:
     # scan because orders never transition to SETTLED, so the EXECUTED backlog grows.
     scan-lookback-days: 60
   ft-confirmation:
-    # Whether onboarding-service is the authoritative order registry yet. While false
-    # (parallel run with GAS), orphan FT confirmations are recorded but not alerted,
-    # because the missing order may still live only in GAS. Flip to true at cutover.
+    # Whether onboarding-service is the authoritative FT-verification pipeline yet. While
+    # false (parallel run with GAS), the FT check runs in shadow mode: confirmations are
+    # verified and their outcomes recorded to the audit trail, but no alerts are sent —
+    # GAS remains the alerting authority. Flip to true at cutover (after retiring the GAS
+    # check) to start sending the Slack digest of ERROR/AMBIGUOUS/ORPHAN rows.
     registry-authoritative: ${TRANSACTION_REGISTRY_FT_CONFIRMATION_REGISTRY_AUTHORITATIVE:false}
 
 payment-provider:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -205,6 +205,11 @@ transaction-registry:
     # How far back the daily settlement check scans SENT/EXECUTED orders. Bounds the
     # scan because orders never transition to SETTLED, so the EXECUTED backlog grows.
     scan-lookback-days: 60
+  ft-confirmation:
+    # Whether onboarding-service is the authoritative order registry yet. While false
+    # (parallel run with GAS), orphan FT confirmations are recorded but not alerted,
+    # because the missing order may still live only in GAS. Flip to true at cutover.
+    registry-authoritative: ${TRANSACTION_REGISTRY_FT_CONFIRMATION_REGISTRY_AUTHORITATIVE:false}
 
 payment-provider:
   url: https://sandbox-stargate.montonio.com/api

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionRegistryControllerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionRegistryControllerTest.java
@@ -6,6 +6,7 @@ import static ee.tuleva.onboarding.investment.transaction.BatchStatus.AWAITING_C
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
@@ -40,7 +41,6 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
@@ -153,11 +153,10 @@ class TransactionRegistryControllerTest {
                     new BigDecimal("40434"),
                     new BigDecimal("10.09"))))
         .willReturn(
-            Optional.of(
-                new FtConfirmationResult(
-                    FtVerificationStatus.OK,
-                    FtVerificationStatus.PENDING_NAV,
-                    Map.of("orderQuantity", "40434"))));
+            new FtConfirmationResult(
+                FtVerificationStatus.OK,
+                FtVerificationStatus.PENDING_NAV,
+                Map.of("orderQuantity", "40434")));
 
     mockMvc
         .perform(
@@ -185,11 +184,10 @@ class TransactionRegistryControllerTest {
                     FtConfirmationType.CANCELLATION,
                     "FT-ACC")))
         .willReturn(
-            Optional.of(
-                new FtConfirmationResult(
-                    FtVerificationStatus.CANCELLED,
-                    FtVerificationStatus.CANCELLED,
-                    Map.of("cancellationSignature", "sig"))));
+            new FtConfirmationResult(
+                FtVerificationStatus.CANCELLED,
+                FtVerificationStatus.CANCELLED,
+                Map.of("cancellationSignature", "sig")));
 
     mockMvc
         .perform(
@@ -228,11 +226,10 @@ class TransactionRegistryControllerTest {
                     null,
                     true)))
         .willReturn(
-            Optional.of(
-                new FtConfirmationResult(
-                    FtVerificationStatus.IGNORED,
-                    FtVerificationStatus.IGNORED,
-                    Map.of("ignoreReason", "manually suppressed false positive"))));
+            new FtConfirmationResult(
+                FtVerificationStatus.IGNORED,
+                FtVerificationStatus.IGNORED,
+                Map.of("ignoreReason", "manually suppressed false positive")));
 
     mockMvc
         .perform(
@@ -257,8 +254,13 @@ class TransactionRegistryControllerTest {
   }
 
   @Test
-  void ftConfirmation_orderNotFound_returnsNotFound() throws Exception {
-    given(ftConfirmationVerificationService.verify(any())).willReturn(Optional.empty());
+  void ftConfirmation_orderNotFound_returnsOrphanResult() throws Exception {
+    given(ftConfirmationVerificationService.verify(any()))
+        .willReturn(
+            new FtConfirmationResult(
+                FtVerificationStatus.ORPHAN,
+                FtVerificationStatus.ORPHAN,
+                Map.of("orphanReason", "no matching order in registry")));
 
     mockMvc
         .perform(
@@ -267,7 +269,64 @@ class TransactionRegistryControllerTest {
                 .header("X-Admin-Token", "valid-token")
                 .contentType("application/json")
                 .content(FT_CONFIRMATION_JSON))
-        .andExpect(status().isNotFound());
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.quantityStatus").value("ORPHAN"))
+        .andExpect(jsonPath("$.priceStatus").value("ORPHAN"));
+  }
+
+  @Test
+  void ftConfirmations_batch_returnsResultPerRow() throws Exception {
+    given(ftConfirmationVerificationService.verifyAll(any(), eq("admin")))
+        .willReturn(
+            List.of(
+                FtConfirmationBatchResult.verified(
+                    0,
+                    "IE000F60HVH9",
+                    new FtConfirmationResult(
+                        FtVerificationStatus.OK, FtVerificationStatus.OK, Map.of())),
+                FtConfirmationBatchResult.failed(1, "BAD", "boom")));
+
+    mockMvc
+        .perform(
+            post("/admin/transaction-registry/ft-confirmations")
+                .with(csrf())
+                .header("X-Admin-Token", "valid-token")
+                .contentType("application/json")
+                .content("[" + FT_CONFIRMATION_JSON + "]"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0].index").value(0))
+        .andExpect(jsonPath("$[0].isin").value("IE000F60HVH9"))
+        .andExpect(jsonPath("$[0].result.quantityStatus").value("OK"))
+        .andExpect(jsonPath("$[1].error").value("boom"));
+  }
+
+  @Test
+  void ftConfirmations_passesAdminActorHeader() throws Exception {
+    given(ftConfirmationVerificationService.verifyAll(any(), eq("alice"))).willReturn(List.of());
+
+    mockMvc
+        .perform(
+            post("/admin/transaction-registry/ft-confirmations")
+                .with(csrf())
+                .header("X-Admin-Token", "valid-token")
+                .header("X-Admin-Actor", "alice")
+                .contentType("application/json")
+                .content("[]"))
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  void ftConfirmations_withInvalidToken_returnsUnauthorized() throws Exception {
+    mockMvc
+        .perform(
+            post("/admin/transaction-registry/ft-confirmations")
+                .with(csrf())
+                .header("X-Admin-Token", "wrong-token")
+                .contentType("application/json")
+                .content("[" + FT_CONFIRMATION_JSON + "]"))
+        .andExpect(status().isUnauthorized());
+
+    verifyNoInteractions(ftConfirmationVerificationService);
   }
 
   @Test

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationAuditRecorderTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationAuditRecorderTest.java
@@ -5,8 +5,13 @@ import static ee.tuleva.onboarding.investment.transaction.FtConfirmationType.CAN
 import static ee.tuleva.onboarding.investment.transaction.FtVerificationStatus.CANCELLED;
 import static ee.tuleva.onboarding.investment.transaction.FtVerificationStatus.ERROR;
 import static ee.tuleva.onboarding.investment.transaction.FtVerificationStatus.OK;
+import static ee.tuleva.onboarding.investment.transaction.FtVerificationStatus.ORPHAN;
 import static ee.tuleva.onboarding.investment.transaction.InstrumentType.ETF;
 import static ee.tuleva.onboarding.investment.transaction.TransactionType.BUY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import ee.tuleva.onboarding.investment.transaction.FtConfirmation;
@@ -20,6 +25,8 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
@@ -35,33 +42,21 @@ class FtConfirmationAuditRecorderTest {
 
   @Mock private TransactionAuditEventRepository auditEventRepository;
 
+  private FtConfirmationAuditRecorder recorder() {
+    return new FtConfirmationAuditRecorder(auditEventRepository, Clock.fixed(NOW, ZoneOffset.UTC));
+  }
+
   @Test
-  void recordVerified_savesOrderLevelEventWithInputsAndResult() {
-    TransactionOrder order =
-        TransactionOrder.builder()
-            .id(42L)
-            .fund(TUK75)
-            .instrumentIsin("IE000F60HVH9")
-            .transactionType(BUY)
-            .instrumentType(ETF)
-            .orderQuantity(new BigDecimal("40434"))
-            .orderVenue(OrderVenue.FT)
-            .orderUuid(ORDER_UUID)
-            .build();
-    FtConfirmation confirmation =
-        new FtConfirmation(
-            TUK75,
-            "IE000F60HVH9",
-            LocalDate.parse("2026-06-08"),
-            new BigDecimal("40434"),
-            new BigDecimal("10.09"));
+  void recordOutcome_noPriorEvent_savesOrderLevelEventAndReturnsTrue() {
+    TransactionOrder order = order();
+    FtConfirmation confirmation = confirmation();
     FtConfirmationResult result =
         new FtConfirmationResult(
             OK, ERROR, Map.of("orderQuantity", "40434", "priceDeltaPercent", "0.12"));
 
-    new FtConfirmationAuditRecorder(auditEventRepository, Clock.fixed(NOW, ZoneOffset.UTC))
-        .recordVerified(order, confirmation, result);
+    boolean recorded = recorder().recordOutcome(order, confirmation, result, "admin");
 
+    assertThat(recorded).isTrue();
     verify(auditEventRepository)
         .save(
             TransactionAuditEvent.builder()
@@ -84,18 +79,8 @@ class FtConfirmationAuditRecorderTest {
   }
 
   @Test
-  void recordVerified_cancellation_recordsTypeAndAccount() {
-    TransactionOrder order =
-        TransactionOrder.builder()
-            .id(42L)
-            .fund(TUK75)
-            .instrumentIsin("IE000F60HVH9")
-            .transactionType(BUY)
-            .instrumentType(ETF)
-            .orderQuantity(new BigDecimal("40434"))
-            .orderVenue(OrderVenue.FT)
-            .orderUuid(ORDER_UUID)
-            .build();
+  void recordOutcome_cancellation_recordsTypeAndAccount() {
+    TransactionOrder order = order();
     FtConfirmation confirmation =
         new FtConfirmation(
             TUK75,
@@ -108,8 +93,7 @@ class FtConfirmationAuditRecorderTest {
     FtConfirmationResult result =
         new FtConfirmationResult(CANCELLED, CANCELLED, Map.of("cancellationSignature", "sig"));
 
-    new FtConfirmationAuditRecorder(auditEventRepository, Clock.fixed(NOW, ZoneOffset.UTC))
-        .recordVerified(order, confirmation, result);
+    recorder().recordOutcome(order, confirmation, result, "admin");
 
     verify(auditEventRepository)
         .save(
@@ -131,5 +115,101 @@ class FtConfirmationAuditRecorderTest {
                         "details", Map.of("cancellationSignature", "sig")))
                 .createdAt(NOW)
                 .build());
+  }
+
+  @Test
+  void recordOutcome_sameStatusAlreadyRecorded_skipsSaveAndReturnsFalse() {
+    given(auditEventRepository.findByEventType("FT_CONFIRMATION_VERIFIED"))
+        .willReturn(List.of(priorEvent("ERROR", "OK")));
+
+    boolean recorded =
+        recorder()
+            .recordOutcome(
+                order(), confirmation(), new FtConfirmationResult(ERROR, OK, Map.of()), "admin");
+
+    assertThat(recorded).isFalse();
+    verify(auditEventRepository, never()).save(any());
+  }
+
+  @Test
+  void recordOutcome_statusChangedSinceLastRecord_savesAndReturnsTrue() {
+    given(auditEventRepository.findByEventType("FT_CONFIRMATION_VERIFIED"))
+        .willReturn(List.of(priorEvent("PENDING_EXECUTION", "PENDING_NAV")));
+
+    boolean recorded =
+        recorder()
+            .recordOutcome(
+                order(), confirmation(), new FtConfirmationResult(ERROR, OK, Map.of()), "admin");
+
+    assertThat(recorded).isTrue();
+    verify(auditEventRepository).save(any());
+  }
+
+  @Test
+  void recordOutcome_orphanHasNoOrder_savesWithNullOrderIdAndGivenActor() {
+    FtConfirmation confirmation = confirmation();
+    FtConfirmationResult result =
+        new FtConfirmationResult(ORPHAN, ORPHAN, Map.of("orphanReason", "no matching order"));
+
+    boolean recorded = recorder().recordOutcome(null, confirmation, result, "ops-person");
+
+    assertThat(recorded).isTrue();
+    verify(auditEventRepository)
+        .save(
+            TransactionAuditEvent.builder()
+                .eventType("FT_CONFIRMATION_VERIFIED")
+                .actor("ops-person")
+                .payload(
+                    Map.of(
+                        "fund", "TUK75",
+                        "isin", "IE000F60HVH9",
+                        "tradeDate", "2026-06-08",
+                        "quantity", "40434",
+                        "grossPrice", "10.09",
+                        "type", "NORMAL",
+                        "quantityStatus", "ORPHAN",
+                        "priceStatus", "ORPHAN",
+                        "details", Map.of("orphanReason", "no matching order")))
+                .createdAt(NOW)
+                .build());
+  }
+
+  private static TransactionOrder order() {
+    return TransactionOrder.builder()
+        .id(42L)
+        .fund(TUK75)
+        .instrumentIsin("IE000F60HVH9")
+        .transactionType(BUY)
+        .instrumentType(ETF)
+        .orderQuantity(new BigDecimal("40434"))
+        .orderVenue(OrderVenue.FT)
+        .orderUuid(ORDER_UUID)
+        .build();
+  }
+
+  private static FtConfirmation confirmation() {
+    return new FtConfirmation(
+        TUK75,
+        "IE000F60HVH9",
+        LocalDate.parse("2026-06-08"),
+        new BigDecimal("40434"),
+        new BigDecimal("10.09"));
+  }
+
+  private static TransactionAuditEvent priorEvent(String quantityStatus, String priceStatus) {
+    Map<String, Object> payload = new LinkedHashMap<>();
+    payload.put("fund", "TUK75");
+    payload.put("isin", "IE000F60HVH9");
+    payload.put("tradeDate", "2026-06-08");
+    payload.put("quantity", "40434");
+    payload.put("grossPrice", "10.09");
+    payload.put("type", "NORMAL");
+    payload.put("quantityStatus", quantityStatus);
+    payload.put("priceStatus", priceStatus);
+    return TransactionAuditEvent.builder()
+        .eventType("FT_CONFIRMATION_VERIFIED")
+        .payload(payload)
+        .createdAt(NOW.minusSeconds(60))
+        .build();
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationDigestTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationDigestTest.java
@@ -40,8 +40,8 @@ class FtConfirmationDigestTest {
   }
 
   @Test
-  void errorRow_isSentAsOneInvestmentDigest() {
-    digest(false).publish(List.of(outcome(ERROR, OK)));
+  void errorRow_whenRegistryAuthoritative_isSentAsOneInvestmentDigest() {
+    digest(true).publish(List.of(outcome(ERROR, OK)));
 
     verify(notificationService)
         .sendMessage(
@@ -52,8 +52,8 @@ class FtConfirmationDigestTest {
   }
 
   @Test
-  void ambiguousRow_isSent() {
-    digest(false).publish(List.of(outcome(AMBIGUOUS, AMBIGUOUS)));
+  void ambiguousRow_whenRegistryAuthoritative_isSent() {
+    digest(true).publish(List.of(outcome(AMBIGUOUS, AMBIGUOUS)));
 
     verify(notificationService)
         .sendMessage(
@@ -64,8 +64,10 @@ class FtConfirmationDigestTest {
   }
 
   @Test
-  void orphanRow_whileRegistryNotAuthoritative_isNotSent() {
-    digest(false).publish(List.of(outcome(ORPHAN, ORPHAN)));
+  void whileRegistryNotAuthoritative_nothingIsSent_evenForActionableRows() {
+    digest(false)
+        .publish(
+            List.of(outcome(ERROR, OK), outcome(AMBIGUOUS, AMBIGUOUS), outcome(ORPHAN, ORPHAN)));
 
     verifyNoInteractions(notificationService);
   }

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationDigestTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationDigestTest.java
@@ -1,0 +1,117 @@
+package ee.tuleva.onboarding.investment.transaction.ingest;
+
+import static ee.tuleva.onboarding.fund.TulevaFund.TUK75;
+import static ee.tuleva.onboarding.investment.transaction.FtVerificationStatus.AMBIGUOUS;
+import static ee.tuleva.onboarding.investment.transaction.FtVerificationStatus.ERROR;
+import static ee.tuleva.onboarding.investment.transaction.FtVerificationStatus.OK;
+import static ee.tuleva.onboarding.investment.transaction.FtVerificationStatus.ORPHAN;
+import static ee.tuleva.onboarding.investment.transaction.FtVerificationStatus.PENDING_NAV;
+import static ee.tuleva.onboarding.notification.OperationsNotificationService.Channel.INVESTMENT;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import ee.tuleva.onboarding.investment.transaction.FtConfirmation;
+import ee.tuleva.onboarding.investment.transaction.FtConfirmationResult;
+import ee.tuleva.onboarding.investment.transaction.FtVerificationStatus;
+import ee.tuleva.onboarding.notification.OperationsNotificationService;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class FtConfirmationDigestTest {
+
+  private static final String ISIN = "IE000F60HVH9";
+  private static final LocalDate TRADE_DATE = LocalDate.of(2026, 6, 8);
+
+  @Mock private OperationsNotificationService notificationService;
+
+  private FtConfirmationDigest digest(boolean registryAuthoritative) {
+    return new FtConfirmationDigest(notificationService, registryAuthoritative);
+  }
+
+  @Test
+  void errorRow_isSentAsOneInvestmentDigest() {
+    digest(false).publish(List.of(outcome(ERROR, OK)));
+
+    verify(notificationService)
+        .sendMessage(
+            "FT confirmation check: 1 issue(s) need attention\n"
+                + "FT issue: fund=TUK75, isin=IE000F60HVH9, tradeDate=2026-06-08, quantity=40434,"
+                + " quantityStatus=ERROR, priceStatus=OK",
+            INVESTMENT);
+  }
+
+  @Test
+  void ambiguousRow_isSent() {
+    digest(false).publish(List.of(outcome(AMBIGUOUS, AMBIGUOUS)));
+
+    verify(notificationService)
+        .sendMessage(
+            "FT confirmation check: 1 issue(s) need attention\n"
+                + "FT issue: fund=TUK75, isin=IE000F60HVH9, tradeDate=2026-06-08, quantity=40434,"
+                + " quantityStatus=AMBIGUOUS, priceStatus=AMBIGUOUS",
+            INVESTMENT);
+  }
+
+  @Test
+  void orphanRow_whileRegistryNotAuthoritative_isNotSent() {
+    digest(false).publish(List.of(outcome(ORPHAN, ORPHAN)));
+
+    verifyNoInteractions(notificationService);
+  }
+
+  @Test
+  void orphanRow_whenRegistryAuthoritative_isSent() {
+    digest(true).publish(List.of(outcome(ORPHAN, ORPHAN)));
+
+    verify(notificationService)
+        .sendMessage(
+            "FT confirmation check: 1 issue(s) need attention\n"
+                + "FT issue: fund=TUK75, isin=IE000F60HVH9, tradeDate=2026-06-08, quantity=40434,"
+                + " quantityStatus=ORPHAN, priceStatus=ORPHAN",
+            INVESTMENT);
+  }
+
+  @Test
+  void cleanAndPendingRows_areNotSent() {
+    digest(true).publish(List.of(outcome(OK, OK), outcome(OK, PENDING_NAV)));
+
+    verifyNoInteractions(notificationService);
+  }
+
+  @Test
+  void emptyOutcomes_areNotSent() {
+    digest(true).publish(List.of());
+
+    verifyNoInteractions(notificationService);
+  }
+
+  @Test
+  void slackFailure_doesNotPropagate() {
+    willThrow(new RuntimeException("slack down"))
+        .given(notificationService)
+        .sendMessage(anyString(), eq(INVESTMENT));
+
+    assertThatCode(() -> digest(true).publish(List.of(outcome(ERROR, OK))))
+        .doesNotThrowAnyException();
+  }
+
+  private static FtConfirmationOutcome outcome(
+      FtVerificationStatus quantityStatus, FtVerificationStatus priceStatus) {
+    FtConfirmation confirmation =
+        new FtConfirmation(
+            TUK75, ISIN, TRADE_DATE, new BigDecimal("40434"), new BigDecimal("10.09"));
+    return new FtConfirmationOutcome(
+        confirmation, new FtConfirmationResult(quantityStatus, priceStatus, Map.of()));
+  }
+}

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationVerificationServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationVerificationServiceTest.java
@@ -8,12 +8,15 @@ import static ee.tuleva.onboarding.investment.transaction.FtVerificationStatus.C
 import static ee.tuleva.onboarding.investment.transaction.FtVerificationStatus.ERROR;
 import static ee.tuleva.onboarding.investment.transaction.FtVerificationStatus.IGNORED;
 import static ee.tuleva.onboarding.investment.transaction.FtVerificationStatus.OK;
+import static ee.tuleva.onboarding.investment.transaction.FtVerificationStatus.ORPHAN;
 import static ee.tuleva.onboarding.investment.transaction.FtVerificationStatus.PENDING_EXECUTION;
 import static ee.tuleva.onboarding.investment.transaction.FtVerificationStatus.PENDING_NAV;
 import static ee.tuleva.onboarding.investment.transaction.InstrumentType.ETF;
 import static ee.tuleva.onboarding.investment.transaction.OrderStatus.EXECUTED;
 import static ee.tuleva.onboarding.investment.transaction.TransactionType.BUY;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -24,6 +27,7 @@ import ee.tuleva.onboarding.comparisons.fundvalue.ResolvedPrice;
 import ee.tuleva.onboarding.comparisons.fundvalue.ValidationStatus;
 import ee.tuleva.onboarding.investment.calendar.Target2Calendar;
 import ee.tuleva.onboarding.investment.transaction.FtConfirmation;
+import ee.tuleva.onboarding.investment.transaction.FtConfirmationBatchResult;
 import ee.tuleva.onboarding.investment.transaction.FtConfirmationResult;
 import ee.tuleva.onboarding.investment.transaction.OrderVenue;
 import ee.tuleva.onboarding.investment.transaction.TransactionExecution;
@@ -56,6 +60,7 @@ class FtConfirmationVerificationServiceTest {
   @Mock private TransactionExecutionRepository executionRepository;
   @Mock private PositionPriceResolver positionPriceResolver;
   @Mock private FtConfirmationAuditRecorder auditRecorder;
+  @Mock private FtConfirmationDigest digest;
 
   private FtConfirmationVerificationService service(Instant now) {
     return new FtConfirmationVerificationService(
@@ -65,39 +70,42 @@ class FtConfirmationVerificationServiceTest {
         new PriceValidator(),
         new Target2Calendar(),
         auditRecorder,
+        digest,
         Clock.fixed(now, ZoneOffset.UTC));
   }
 
   @Test
-  void orderNotFound_returnsEmpty() {
+  void orderNotFound_returnsOrphan() {
     given(orderRepository.findByInstrumentIsin(ISIN)).willReturn(List.of());
+    FtConfirmation confirmation = confirmation();
 
-    Optional<FtConfirmationResult> result = service(DAY_AFTER_TRADE).verify(confirmation());
+    FtConfirmationResult result = service(DAY_AFTER_TRADE).verify(confirmation);
 
-    assertThat(result).isEmpty();
-    verifyNoInteractions(auditRecorder);
+    assertThat(result.quantityStatus()).isEqualTo(ORPHAN);
+    assertThat(result.priceStatus()).isEqualTo(ORPHAN);
+    verify(auditRecorder).recordOutcome(null, confirmation, result, "admin");
   }
 
   @Test
-  void orderForDifferentFund_returnsEmpty() {
+  void orderForDifferentFund_returnsOrphan() {
     TransactionOrder order = order(new BigDecimal("40434"));
     order.setFund(TUK00);
     given(orderRepository.findByInstrumentIsin(ISIN)).willReturn(List.of(order));
 
-    Optional<FtConfirmationResult> result = service(DAY_AFTER_TRADE).verify(confirmation());
+    FtConfirmationResult result = service(DAY_AFTER_TRADE).verify(confirmation());
 
-    assertThat(result).isEmpty();
+    assertThat(result.quantityStatus()).isEqualTo(ORPHAN);
   }
 
   @Test
-  void orderForDifferentTradeDate_returnsEmpty() {
+  void orderForDifferentTradeDate_returnsOrphan() {
     TransactionOrder order = order(new BigDecimal("40434"));
     order.setOrderTimestamp(Instant.parse("2026-06-05T09:30:00Z"));
     given(orderRepository.findByInstrumentIsin(ISIN)).willReturn(List.of(order));
 
-    Optional<FtConfirmationResult> result = service(DAY_AFTER_TRADE).verify(confirmation());
+    FtConfirmationResult result = service(DAY_AFTER_TRADE).verify(confirmation());
 
-    assertThat(result).isEmpty();
+    assertThat(result.quantityStatus()).isEqualTo(ORPHAN);
   }
 
   @Test
@@ -105,7 +113,7 @@ class FtConfirmationVerificationServiceTest {
     givenOrderAndExecution(new BigDecimal("40434"), new BigDecimal("40434"));
     givenReferencePrice(new BigDecimal("10.09"), TRADE_DATE);
 
-    FtConfirmationResult result = service(DAY_AFTER_TRADE).verify(confirmation()).orElseThrow();
+    FtConfirmationResult result = service(DAY_AFTER_TRADE).verify(confirmation());
 
     assertThat(result.quantityStatus()).isEqualTo(OK);
     assertThat(result.priceStatus()).isEqualTo(OK);
@@ -121,7 +129,7 @@ class FtConfirmationVerificationServiceTest {
     givenOrderAndExecution(new BigDecimal("40433"), new BigDecimal("40435"));
     givenReferencePrice(new BigDecimal("10.09"), TRADE_DATE);
 
-    FtConfirmationResult result = service(DAY_AFTER_TRADE).verify(confirmation()).orElseThrow();
+    FtConfirmationResult result = service(DAY_AFTER_TRADE).verify(confirmation());
 
     assertThat(result.quantityStatus()).isEqualTo(OK);
   }
@@ -139,7 +147,7 @@ class FtConfirmationVerificationServiceTest {
                 executionPiece(8L, new BigDecimal("20217"))));
     givenReferencePrice(new BigDecimal("10.09"), TRADE_DATE);
 
-    FtConfirmationResult result = service(DAY_AFTER_TRADE).verify(confirmation()).orElseThrow();
+    FtConfirmationResult result = service(DAY_AFTER_TRADE).verify(confirmation());
 
     assertThat(result.quantityStatus()).isEqualTo(OK);
     assertThat(result.details()).containsEntry("executedQuantity", "40434");
@@ -150,7 +158,7 @@ class FtConfirmationVerificationServiceTest {
     givenOrderAndExecution(new BigDecimal("40432"), new BigDecimal("40434"));
     givenReferencePrice(new BigDecimal("10.09"), TRADE_DATE);
 
-    FtConfirmationResult result = service(DAY_AFTER_TRADE).verify(confirmation()).orElseThrow();
+    FtConfirmationResult result = service(DAY_AFTER_TRADE).verify(confirmation());
 
     assertThat(result.quantityStatus()).isEqualTo(ERROR);
   }
@@ -160,7 +168,7 @@ class FtConfirmationVerificationServiceTest {
     givenOrderAndExecution(new BigDecimal("40434"), new BigDecimal("40436"));
     givenReferencePrice(new BigDecimal("10.09"), TRADE_DATE);
 
-    FtConfirmationResult result = service(DAY_AFTER_TRADE).verify(confirmation()).orElseThrow();
+    FtConfirmationResult result = service(DAY_AFTER_TRADE).verify(confirmation());
 
     assertThat(result.quantityStatus()).isEqualTo(ERROR);
   }
@@ -170,7 +178,7 @@ class FtConfirmationVerificationServiceTest {
     givenOrderAndExecution(null, new BigDecimal("40434"));
     givenReferencePrice(new BigDecimal("10.09"), TRADE_DATE);
 
-    FtConfirmationResult result = service(DAY_AFTER_TRADE).verify(confirmation()).orElseThrow();
+    FtConfirmationResult result = service(DAY_AFTER_TRADE).verify(confirmation());
 
     assertThat(result.quantityStatus()).isEqualTo(ERROR);
   }
@@ -182,7 +190,7 @@ class FtConfirmationVerificationServiceTest {
     given(executionRepository.findAllByOrderId(order.getId())).willReturn(List.of());
     givenReferencePrice(new BigDecimal("10.09"), TRADE_DATE);
 
-    FtConfirmationResult result = service(DAY_AFTER_TRADE).verify(confirmation()).orElseThrow();
+    FtConfirmationResult result = service(DAY_AFTER_TRADE).verify(confirmation());
 
     assertThat(result.quantityStatus()).isEqualTo(PENDING_EXECUTION);
     assertThat(result.details()).containsEntry("executionPendingUntil", "2026-06-09");
@@ -195,8 +203,7 @@ class FtConfirmationVerificationServiceTest {
     given(executionRepository.findAllByOrderId(order.getId())).willReturn(List.of());
     givenReferencePrice(new BigDecimal("10.09"), TRADE_DATE);
 
-    FtConfirmationResult result =
-        service(TWO_DAYS_AFTER_TRADE).verify(confirmation()).orElseThrow();
+    FtConfirmationResult result = service(TWO_DAYS_AFTER_TRADE).verify(confirmation());
 
     assertThat(result.quantityStatus()).isEqualTo(ERROR);
   }
@@ -208,7 +215,7 @@ class FtConfirmationVerificationServiceTest {
     given(executionRepository.findAllByOrderId(order.getId())).willReturn(List.of());
     givenReferencePrice(new BigDecimal("10.09"), TRADE_DATE);
 
-    FtConfirmationResult result = service(DAY_AFTER_TRADE).verify(confirmation()).orElseThrow();
+    FtConfirmationResult result = service(DAY_AFTER_TRADE).verify(confirmation());
 
     assertThat(result.quantityStatus()).isEqualTo(ERROR);
   }
@@ -218,7 +225,7 @@ class FtConfirmationVerificationServiceTest {
     givenOrderAndExecution(new BigDecimal("40434"), new BigDecimal("40434"));
     given(positionPriceResolver.resolve(ISIN, TRADE_DATE)).willReturn(Optional.empty());
 
-    FtConfirmationResult result = service(DAY_AFTER_TRADE).verify(confirmation()).orElseThrow();
+    FtConfirmationResult result = service(DAY_AFTER_TRADE).verify(confirmation());
 
     assertThat(result.priceStatus()).isEqualTo(PENDING_NAV);
   }
@@ -231,7 +238,7 @@ class FtConfirmationVerificationServiceTest {
             Optional.of(
                 ResolvedPrice.builder().validationStatus(ValidationStatus.NO_PRICE_DATA).build()));
 
-    FtConfirmationResult result = service(DAY_AFTER_TRADE).verify(confirmation()).orElseThrow();
+    FtConfirmationResult result = service(DAY_AFTER_TRADE).verify(confirmation());
 
     assertThat(result.priceStatus()).isEqualTo(PENDING_NAV);
   }
@@ -241,7 +248,7 @@ class FtConfirmationVerificationServiceTest {
     givenOrderAndExecution(new BigDecimal("40434"), new BigDecimal("40434"));
     givenReferencePrice(new BigDecimal("10.09"), TRADE_DATE.minusDays(1));
 
-    FtConfirmationResult result = service(DAY_AFTER_TRADE).verify(confirmation()).orElseThrow();
+    FtConfirmationResult result = service(DAY_AFTER_TRADE).verify(confirmation());
 
     assertThat(result.priceStatus()).isEqualTo(PENDING_NAV);
   }
@@ -253,8 +260,7 @@ class FtConfirmationVerificationServiceTest {
 
     FtConfirmationResult result =
         service(DAY_AFTER_TRADE)
-            .verify(confirmation(new BigDecimal("40434"), new BigDecimal("10.102")))
-            .orElseThrow();
+            .verify(confirmation(new BigDecimal("40434"), new BigDecimal("10.102")));
 
     assertThat(result.priceStatus()).isEqualTo(ERROR);
     assertThat(result.details()).containsKey("priceDeltaPercent");
@@ -267,8 +273,7 @@ class FtConfirmationVerificationServiceTest {
 
     FtConfirmationResult result =
         service(DAY_AFTER_TRADE)
-            .verify(confirmation(new BigDecimal("40434"), new BigDecimal("10.10009")))
-            .orElseThrow();
+            .verify(confirmation(new BigDecimal("40434"), new BigDecimal("10.10009")));
 
     assertThat(result.priceStatus()).isEqualTo(OK);
   }
@@ -280,9 +285,9 @@ class FtConfirmationVerificationServiceTest {
     givenReferencePrice(new BigDecimal("10.09"), TRADE_DATE);
     FtConfirmation confirmation = confirmation();
 
-    FtConfirmationResult result = service(DAY_AFTER_TRADE).verify(confirmation).orElseThrow();
+    FtConfirmationResult result = service(DAY_AFTER_TRADE).verify(confirmation);
 
-    verify(auditRecorder).recordVerified(order, confirmation, result);
+    verify(auditRecorder).recordOutcome(order, confirmation, result, "admin");
   }
 
   @Test
@@ -290,8 +295,7 @@ class FtConfirmationVerificationServiceTest {
     TransactionOrder order = order(new BigDecimal("40434"));
     given(orderRepository.findByInstrumentIsin(ISIN)).willReturn(List.of(order));
 
-    FtConfirmationResult result =
-        service(DAY_AFTER_TRADE).verify(cancellationConfirmation()).orElseThrow();
+    FtConfirmationResult result = service(DAY_AFTER_TRADE).verify(cancellationConfirmation());
 
     assertThat(result.quantityStatus()).isEqualTo(CANCELLED);
     assertThat(result.priceStatus()).isEqualTo(CANCELLED);
@@ -306,20 +310,19 @@ class FtConfirmationVerificationServiceTest {
     given(orderRepository.findByInstrumentIsin(ISIN)).willReturn(List.of(order));
     FtConfirmation confirmation = cancellationConfirmation();
 
-    FtConfirmationResult result = service(DAY_AFTER_TRADE).verify(confirmation).orElseThrow();
+    FtConfirmationResult result = service(DAY_AFTER_TRADE).verify(confirmation);
 
-    verify(auditRecorder).recordVerified(order, confirmation, result);
+    verify(auditRecorder).recordOutcome(order, confirmation, result, "admin");
   }
 
   @Test
-  void cancellationConfirmation_orderNotFound_returnsEmpty() {
+  void cancellationConfirmation_orderNotFound_returnsOrphan() {
     given(orderRepository.findByInstrumentIsin(ISIN)).willReturn(List.of());
 
-    Optional<FtConfirmationResult> result =
-        service(DAY_AFTER_TRADE).verify(cancellationConfirmation());
+    FtConfirmationResult result = service(DAY_AFTER_TRADE).verify(cancellationConfirmation());
 
-    assertThat(result).isEmpty();
-    verifyNoInteractions(auditRecorder);
+    assertThat(result.quantityStatus()).isEqualTo(ORPHAN);
+    assertThat(result.priceStatus()).isEqualTo(ORPHAN);
   }
 
   @Test
@@ -331,7 +334,7 @@ class FtConfirmationVerificationServiceTest {
         .willReturn(List.of(execution(new BigDecimal("40434"))));
     givenReferencePrice(new BigDecimal("10.09"), TRADE_DATE);
 
-    FtConfirmationResult result = service(DAY_AFTER_TRADE).verify(confirmation()).orElseThrow();
+    FtConfirmationResult result = service(DAY_AFTER_TRADE).verify(confirmation());
 
     assertThat(result.quantityStatus()).isEqualTo(OK);
     assertThat(result.details()).containsEntry("orderUuid", ORDER_UUID.toString());
@@ -343,7 +346,7 @@ class FtConfirmationVerificationServiceTest {
     TransactionOrder second = order(42L, new BigDecimal("40434"));
     given(orderRepository.findByInstrumentIsin(ISIN)).willReturn(List.of(first, second));
 
-    FtConfirmationResult result = service(DAY_AFTER_TRADE).verify(confirmation()).orElseThrow();
+    FtConfirmationResult result = service(DAY_AFTER_TRADE).verify(confirmation());
 
     assertThat(result.quantityStatus()).isEqualTo(AMBIGUOUS);
     assertThat(result.priceStatus()).isEqualTo(AMBIGUOUS);
@@ -356,8 +359,7 @@ class FtConfirmationVerificationServiceTest {
     FtConfirmation weekendConfirmation =
         new FtConfirmation(TUK75, ISIN, saturday, new BigDecimal("40434"), new BigDecimal("10.09"));
 
-    FtConfirmationResult result =
-        service(DAY_AFTER_TRADE).verify(weekendConfirmation).orElseThrow();
+    FtConfirmationResult result = service(DAY_AFTER_TRADE).verify(weekendConfirmation);
 
     assertThat(result.quantityStatus()).isEqualTo(IGNORED);
     assertThat(result.priceStatus()).isEqualTo(IGNORED);
@@ -379,7 +381,7 @@ class FtConfirmationVerificationServiceTest {
             null,
             true);
 
-    FtConfirmationResult result = service(DAY_AFTER_TRADE).verify(suppressed).orElseThrow();
+    FtConfirmationResult result = service(DAY_AFTER_TRADE).verify(suppressed);
 
     assertThat(result.quantityStatus()).isEqualTo(IGNORED);
     assertThat(result.priceStatus()).isEqualTo(IGNORED);
@@ -387,6 +389,77 @@ class FtConfirmationVerificationServiceTest {
         .containsEntry("ignoreReason", "manually suppressed false positive");
     verifyNoInteractions(orderRepository, executionRepository, positionPriceResolver);
     verifyNoInteractions(auditRecorder);
+  }
+
+  @Test
+  void verifyAll_returnsResultPerRowWithIndexAndIsin() {
+    givenOrderAndExecution(new BigDecimal("40434"), new BigDecimal("40434"));
+    givenReferencePrice(new BigDecimal("10.09"), TRADE_DATE);
+
+    List<FtConfirmationBatchResult> results =
+        service(DAY_AFTER_TRADE).verifyAll(List.of(confirmation()), "ops");
+
+    assertThat(results).hasSize(1);
+    FtConfirmationBatchResult row = results.get(0);
+    assertThat(row.index()).isZero();
+    assertThat(row.isin()).isEqualTo(ISIN);
+    assertThat(row.error()).isNull();
+    assertThat(row.result().quantityStatus()).isEqualTo(OK);
+  }
+
+  @Test
+  void verifyAll_passesActorToAuditRecorder() {
+    TransactionOrder order =
+        givenOrderAndExecution(new BigDecimal("40434"), new BigDecimal("40434"));
+    givenReferencePrice(new BigDecimal("10.09"), TRADE_DATE);
+    FtConfirmation confirmation = confirmation();
+
+    service(DAY_AFTER_TRADE).verifyAll(List.of(confirmation), "alice");
+
+    verify(auditRecorder).recordOutcome(eq(order), eq(confirmation), any(), eq("alice"));
+  }
+
+  @Test
+  void verifyAll_rowThatThrows_isIsolatedAsError() {
+    given(orderRepository.findByInstrumentIsin("BAD")).willThrow(new RuntimeException("boom"));
+    FtConfirmation bad =
+        new FtConfirmation(TUK75, "BAD", TRADE_DATE, new BigDecimal("1"), new BigDecimal("1"));
+
+    List<FtConfirmationBatchResult> results =
+        service(DAY_AFTER_TRADE).verifyAll(List.of(bad), "ops");
+
+    assertThat(results).hasSize(1);
+    assertThat(results.get(0).isin()).isEqualTo("BAD");
+    assertThat(results.get(0).result()).isNull();
+    assertThat(results.get(0).error()).isEqualTo("boom");
+  }
+
+  @Test
+  void verifyAll_changedActionableRows_arePublishedToDigest() {
+    TransactionOrder order = order(new BigDecimal("40432"));
+    given(orderRepository.findByInstrumentIsin(ISIN)).willReturn(List.of(order));
+    given(executionRepository.findAllByOrderId(order.getId()))
+        .willReturn(List.of(execution(new BigDecimal("40432"))));
+    givenReferencePrice(new BigDecimal("10.09"), TRADE_DATE);
+    given(auditRecorder.recordOutcome(any(), any(), any(), any())).willReturn(true);
+    FtConfirmation confirmation = confirmation();
+
+    List<FtConfirmationBatchResult> results =
+        service(DAY_AFTER_TRADE).verifyAll(List.of(confirmation), "ops");
+
+    FtConfirmationResult result = results.get(0).result();
+    assertThat(result.quantityStatus()).isEqualTo(ERROR);
+    verify(digest).publish(List.of(new FtConfirmationOutcome(confirmation, result)));
+  }
+
+  @Test
+  void verifyAll_unchangedRows_areNotPublishedToDigest() {
+    givenOrderAndExecution(new BigDecimal("40434"), new BigDecimal("40434"));
+    givenReferencePrice(new BigDecimal("10.09"), TRADE_DATE);
+
+    service(DAY_AFTER_TRADE).verifyAll(List.of(confirmation()), "ops");
+
+    verify(digest).publish(List.of());
   }
 
   private FtConfirmation confirmation() {


### PR DESCRIPTION
Closes the §4.1 cutover blocker in the Transaction Registry plan: gets Flow Traders trade-confirmation data into onboarding-service so the FT verification check survives GAS cutover. Built on top of #1741 (split/partial settlement), per the scope doc's sequencing.

## What this does
- **`verify()` returns a first-class `ORPHAN` result** instead of `Optional.empty()` on no match, mirroring the SEB `UNMATCHED_SEB_TRANSACTION` path. An FT confirmation for an order we never placed is one of the highest-value things this check exists to catch — it must not be silently swallowed.
- **New `POST /admin/transaction-registry/ft-confirmations`** taking `List<FtConfirmation>`, returning `List<FtConfirmationBatchResult>{index, isin, result, error}`. Loops the existing `verify()` with **per-row error isolation** (a bad row → `{error}`, never a failed batch — required so GAS's intraday push is robust), then emits **one** Slack `INVESTMENT` digest of the actionable rows (`ERROR`/`AMBIGUOUS`/`ORPHAN`) after the writes commit. Optional `X-Admin-Actor` header (ties to R3).
- **Idempotent alerting**: the audit recorder persists an FT outcome only when the confirmation's status is *new or changed*, so the 1–2h push cadence doesn't re-alert an unchanged `ERROR`. Resolution to `OK`/`CANCELLED` is recorded too, so a later recurrence re-alerts.
- **`registry-authoritative` flag** (`transaction-registry.ft-confirmation.registry-authoritative`, default `false`): during parallel run the missing order may still live only in GAS, so orphans are *recorded but not alerted* until cutover flips the flag. The gate lives in the digest layer; `verify()` is unchanged by it. Never inferred from an empty registry.

## Pairs with
- GAS push side: TulevaEE/tuleva#111 (`pushFtConfirmationsToRegistry()`), which maps `FT_tehingukinnitused` rows and POSTs them here. Contract honored: `X-Admin-Token`, path `/ft-confirmations`, `index`-keyed results, `TulevaFund` enum-name `fund`, per-row `{error}` instead of 400.

## Not in scope (deferred)
- A `v_ft_orphan_confirmations` Metabase view (parity with `v_unmatched_seb_entries`) — left out to avoid H2/PG JSON-in-view differences; orphans remain queryable via `investment_transaction_audit_event`.
- The end-state PDFBox port (FT email → S3 like SEB reports). This is the interim bridge; GAS stays the format spec.

## Tests
- `FtConfirmationVerificationServiceTest` — orphan results, batch per-row results, actor threading, per-row error isolation, changed-vs-unchanged digest publishing.
- `FtConfirmationAuditRecorderTest` — idempotency (skip same status, save on change), nullable-order orphan event, actor.
- `FtConfirmationDigestTest` — the authoritative gate + message format + Slack-failure isolation.
- `TransactionRegistryControllerTest` — single endpoint now 200+ORPHAN (was 404), plural endpoint happy/actor/unauthorized paths.

Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)