### PR TITLE
Clarify TD notification wording + add model-portfolio TD to NAV report

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/investment/check/tracking/TrackingDifferenceNotifier.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/check/tracking/TrackingDifferenceNotifier.java
@@ -103,13 +103,18 @@ class TrackingDifferenceNotifier {
     }
   }
 
+  private String returnLabel(TrackingDifferenceResult result) {
+    return result.checkType() == BENCHMARK_MODEL ? "holdings" : "fund";
+  }
+
   private String formatWithinLimits(TrackingDifferenceResult result) {
     var sb = new StringBuilder();
     sb.append(
-        "\n  %s TD=%s%% (fund=%s%%, benchmark=%s%%)"
+        "\n  %s TD=%s%% (%s=%s%%, benchmark=%s%%)"
             .formatted(
                 result.checkType(),
                 formatPercent(result.trackingDifference()),
+                returnLabel(result),
                 formatPercent(result.fundReturn()),
                 formatPercent(result.benchmarkReturn())));
     if (result.checkType() == MODEL_PORTFOLIO) {
@@ -126,19 +131,22 @@ class TrackingDifferenceNotifier {
   private String formatBreach(TrackingDifferenceResult result, boolean escalation) {
     var sb = new StringBuilder();
     sb.append(
-        "\n[%s] %s %s: TD=%s%% (fund=%s%%, benchmark=%s%%)"
+        "\n[%s] %s %s: TD=%s%% (%s=%s%%, benchmark=%s%%)"
             .formatted(
                 result.fund(),
                 result.checkType(),
                 result.checkDate(),
                 formatPercent(result.trackingDifference()),
+                returnLabel(result),
                 formatPercent(result.fundReturn()),
                 formatPercent(result.benchmarkReturn())));
 
     if (result.checkType() == MODEL_PORTFOLIO) {
       sb.append("\n  Action: check NAV calculation — weights, prices, cash, fees");
     } else if (result.checkType() == BENCHMARK_MODEL) {
-      sb.append("\n  Action: review instrument prices and benchmark data for pricing errors");
+      sb.append(
+          "\n  Holdings vs MSCI World/EM index. Regional/ESG spread is expected;"
+              + " check an outsized contribution for a stale price.");
     }
 
     if (result.checkType() == MODEL_PORTFOLIO) {
@@ -168,7 +176,7 @@ class TrackingDifferenceNotifier {
       if (result.checkType() == BENCHMARK_MODEL) {
         for (var attr : sorted) {
           sb.append(
-              "\n  %s: instrument %s%%, benchmark %s%%, diff %s%%"
+              "\n  %s: instrument %s%%, index %s%%, contributes %s%% to TD"
                   .formatted(
                       attr.isin(),
                       formatPercent(attr.securityReturn()),

--- a/src/main/java/ee/tuleva/onboarding/investment/check/tracking/TrackingDifferenceQueryService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/check/tracking/TrackingDifferenceQueryService.java
@@ -1,6 +1,7 @@
 package ee.tuleva.onboarding.investment.check.tracking;
 
 import static ee.tuleva.onboarding.investment.check.tracking.TrackingCheckType.BENCHMARK_MODEL;
+import static ee.tuleva.onboarding.investment.check.tracking.TrackingCheckType.MODEL_PORTFOLIO;
 
 import ee.tuleva.onboarding.fund.TulevaFund;
 import java.time.LocalDate;
@@ -15,15 +16,25 @@ public class TrackingDifferenceQueryService {
   private final TrackingDifferenceEventRepository eventRepository;
   private final TrackingDifferenceCalculator calculator;
 
-  public Optional<BenchmarkModelTrackingDifference> findLatestBenchmarkModel(
+  public Optional<TrackingDifferenceSummary> findLatestModelPortfolio(
       TulevaFund fund, LocalDate navDate) {
+    return findLatest(fund, MODEL_PORTFOLIO, navDate);
+  }
+
+  public Optional<TrackingDifferenceSummary> findLatestBenchmarkModel(
+      TulevaFund fund, LocalDate navDate) {
+    return findLatest(fund, BENCHMARK_MODEL, navDate);
+  }
+
+  private Optional<TrackingDifferenceSummary> findLatest(
+      TulevaFund fund, TrackingCheckType checkType, LocalDate navDate) {
     return eventRepository
-        .findDeduplicatedEventsForPeriod(fund, BENCHMARK_MODEL, navDate, navDate)
+        .findDeduplicatedEventsForPeriod(fund, checkType, navDate, navDate)
         .stream()
         .findFirst()
         .map(
             event ->
-                new BenchmarkModelTrackingDifference(
+                new TrackingDifferenceSummary(
                     event.getTrackingDifference(), calculator.breachThreshold(navDate)));
   }
 }

--- a/src/main/java/ee/tuleva/onboarding/investment/check/tracking/TrackingDifferenceSummary.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/check/tracking/TrackingDifferenceSummary.java
@@ -2,7 +2,7 @@ package ee.tuleva.onboarding.investment.check.tracking;
 
 import java.math.BigDecimal;
 
-public record BenchmarkModelTrackingDifference(BigDecimal trackingDifference, BigDecimal limit) {
+public record TrackingDifferenceSummary(BigDecimal trackingDifference, BigDecimal limit) {
 
   public boolean breachesLimit() {
     return trackingDifference.abs().compareTo(limit) >= 0;

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/nav/NavNotifier.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/nav/NavNotifier.java
@@ -6,8 +6,9 @@ import static java.time.format.DateTimeFormatter.ofPattern;
 import static java.util.Locale.US;
 
 import ee.tuleva.onboarding.deadline.PublicHolidays;
-import ee.tuleva.onboarding.investment.check.tracking.BenchmarkModelTrackingDifference;
+import ee.tuleva.onboarding.fund.TulevaFund;
 import ee.tuleva.onboarding.investment.check.tracking.TrackingDifferenceQueryService;
+import ee.tuleva.onboarding.investment.check.tracking.TrackingDifferenceSummary;
 import ee.tuleva.onboarding.notification.OperationsNotificationService;
 import ee.tuleva.onboarding.savings.fund.nav.NavCalculationResult.SecurityDetail;
 import java.math.BigDecimal;
@@ -15,6 +16,7 @@ import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.Optional;
+import java.util.function.BiFunction;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -35,7 +37,11 @@ class NavNotifier {
   void notify(NavCalculationResult result) {
     try {
       var message =
-          formatMessage(result, dayChangeRatio(result), benchmarkModelTrackingDifference(result));
+          formatMessage(
+              result,
+              dayChangeRatio(result),
+              modelPortfolioTrackingDifference(result),
+              benchmarkModelTrackingDifference(result));
       log.info(message);
       notificationService.sendMessage(message, SAVINGS);
     } catch (Exception e) {
@@ -50,7 +56,8 @@ class NavNotifier {
   String formatMessage(
       NavCalculationResult result,
       Optional<BigDecimal> dayChangeRatio,
-      Optional<BenchmarkModelTrackingDifference> trackingDifference) {
+      Optional<TrackingDifferenceSummary> modelPortfolioTrackingDifference,
+      Optional<TrackingDifferenceSummary> benchmarkModelTrackingDifference) {
     var message = new StringBuilder();
 
     message.append("NAV Calculation — %s\n\n".formatted(result.fund().getCode()));
@@ -86,7 +93,8 @@ class NavNotifier {
             .formatted(
                 result.navPerUnit().toPlainString(),
                 dayChangeRatio.map(ratio -> " (" + formatSignedPercent(ratio) + ")").orElse("")));
-    appendTrackingDifference(message, trackingDifference);
+    appendTrackingDifference(message, "model portfolio", modelPortfolioTrackingDifference);
+    appendTrackingDifference(message, "holdings vs index", benchmarkModelTrackingDifference);
 
     appendSecuritiesDetail(message, result);
 
@@ -112,11 +120,21 @@ class NavNotifier {
     }
   }
 
-  private Optional<BenchmarkModelTrackingDifference> benchmarkModelTrackingDifference(
+  private Optional<TrackingDifferenceSummary> modelPortfolioTrackingDifference(
       NavCalculationResult result) {
+    return trackingDifference(result, trackingDifferenceQueryService::findLatestModelPortfolio);
+  }
+
+  private Optional<TrackingDifferenceSummary> benchmarkModelTrackingDifference(
+      NavCalculationResult result) {
+    return trackingDifference(result, trackingDifferenceQueryService::findLatestBenchmarkModel);
+  }
+
+  private Optional<TrackingDifferenceSummary> trackingDifference(
+      NavCalculationResult result,
+      BiFunction<TulevaFund, LocalDate, Optional<TrackingDifferenceSummary>> query) {
     try {
-      return trackingDifferenceQueryService.findLatestBenchmarkModel(
-          result.fund(), result.positionReportDate());
+      return query.apply(result.fund(), result.positionReportDate());
     } catch (Exception e) {
       log.warn(
           "Failed to fetch tracking difference: fund={}, date={}",
@@ -128,7 +146,7 @@ class NavNotifier {
   }
 
   private void appendTrackingDifference(
-      StringBuilder message, Optional<BenchmarkModelTrackingDifference> trackingDifference) {
+      StringBuilder message, String label, Optional<TrackingDifferenceSummary> trackingDifference) {
     var value =
         trackingDifference
             .map(
@@ -138,7 +156,7 @@ class NavNotifier {
                             formatSignedPercent(difference.trackingDifference()),
                             difference.breachesLimit() ? "🔴" : "✅"))
             .orElse("n/a");
-    message.append("  Tracking Difference (BENCHMARK_MODEL): %s\n".formatted(value));
+    message.append("  Tracking Difference (%s): %s\n".formatted(label, value));
   }
 
   private String formatSignedPercent(BigDecimal ratio) {

--- a/src/test/groovy/ee/tuleva/onboarding/investment/check/tracking/TrackingDifferenceNotifierTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/check/tracking/TrackingDifferenceNotifierTest.java
@@ -494,9 +494,10 @@ class TrackingDifferenceNotifierTest {
     var captor = org.mockito.ArgumentCaptor.forClass(String.class);
     then(notificationService).should().sendMessage(captor.capture(), eq(INVESTMENT));
     var message = captor.getValue();
-    assertThat(message).contains("review instrument prices and benchmark data");
+    assertThat(message).contains("Holdings vs MSCI World/EM index");
+    assertThat(message).contains("check an outsized contribution for a stale price");
     assertThat(message).contains("IE00BFG1TM61").contains("IE00BKPTWY98");
-    assertThat(message).contains("instrument").contains("benchmark").contains("diff");
+    assertThat(message).contains("instrument").contains("index").contains("contributes");
   }
 
   @Test

--- a/src/test/groovy/ee/tuleva/onboarding/investment/check/tracking/TrackingDifferenceQueryServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/check/tracking/TrackingDifferenceQueryServiceTest.java
@@ -2,6 +2,7 @@ package ee.tuleva.onboarding.investment.check.tracking;
 
 import static ee.tuleva.onboarding.fund.TulevaFund.TUK00;
 import static ee.tuleva.onboarding.investment.check.tracking.TrackingCheckType.BENCHMARK_MODEL;
+import static ee.tuleva.onboarding.investment.check.tracking.TrackingCheckType.MODEL_PORTFOLIO;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 
@@ -42,8 +43,7 @@ class TrackingDifferenceQueryServiceTest {
 
     assertThat(result)
         .contains(
-            new BenchmarkModelTrackingDifference(
-                new BigDecimal("0.001073"), new BigDecimal("0.001")));
+            new TrackingDifferenceSummary(new BigDecimal("0.001073"), new BigDecimal("0.001")));
   }
 
   @Test
@@ -52,6 +52,38 @@ class TrackingDifferenceQueryServiceTest {
         .willReturn(List.of());
 
     var result = queryService.findLatestBenchmarkModel(TUK00, DATE);
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void findLatestModelPortfolio_returnsTrackingDifferenceAndLimit() {
+    var event =
+        TrackingDifferenceEvent.builder()
+            .fund(TUK00)
+            .checkDate(DATE)
+            .checkType(MODEL_PORTFOLIO)
+            .trackingDifference(new BigDecimal("0.001500"))
+            .fundReturn(new BigDecimal("0.010000"))
+            .benchmarkReturn(new BigDecimal("0.008500"))
+            .build();
+    given(eventRepository.findDeduplicatedEventsForPeriod(TUK00, MODEL_PORTFOLIO, DATE, DATE))
+        .willReturn(List.of(event));
+    given(calculator.breachThreshold(DATE)).willReturn(new BigDecimal("0.001"));
+
+    var result = queryService.findLatestModelPortfolio(TUK00, DATE);
+
+    assertThat(result)
+        .contains(
+            new TrackingDifferenceSummary(new BigDecimal("0.001500"), new BigDecimal("0.001")));
+  }
+
+  @Test
+  void findLatestModelPortfolio_returnsEmptyWhenNoEvent() {
+    given(eventRepository.findDeduplicatedEventsForPeriod(TUK00, MODEL_PORTFOLIO, DATE, DATE))
+        .willReturn(List.of());
+
+    var result = queryService.findLatestModelPortfolio(TUK00, DATE);
 
     assertThat(result).isEmpty();
   }

--- a/src/test/groovy/ee/tuleva/onboarding/investment/check/tracking/TrackingDifferenceSummaryTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/check/tracking/TrackingDifferenceSummaryTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.math.BigDecimal;
 import org.junit.jupiter.api.Test;
 
-class BenchmarkModelTrackingDifferenceTest {
+class TrackingDifferenceSummaryTest {
 
   private static final BigDecimal LIMIT = new BigDecimal("0.001");
 
@@ -22,7 +22,7 @@ class BenchmarkModelTrackingDifferenceTest {
     assertThat(trackingDifference("-0.000999").breachesLimit()).isFalse();
   }
 
-  private BenchmarkModelTrackingDifference trackingDifference(String value) {
-    return new BenchmarkModelTrackingDifference(new BigDecimal(value), LIMIT);
+  private TrackingDifferenceSummary trackingDifference(String value) {
+    return new TrackingDifferenceSummary(new BigDecimal(value), LIMIT);
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/nav/NavNotifierTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/nav/NavNotifierTest.java
@@ -12,8 +12,8 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 
 import ee.tuleva.onboarding.deadline.PublicHolidays;
-import ee.tuleva.onboarding.investment.check.tracking.BenchmarkModelTrackingDifference;
 import ee.tuleva.onboarding.investment.check.tracking.TrackingDifferenceQueryService;
+import ee.tuleva.onboarding.investment.check.tracking.TrackingDifferenceSummary;
 import ee.tuleva.onboarding.notification.OperationsNotificationService;
 import ee.tuleva.onboarding.savings.fund.nav.NavCalculationResult.SecurityDetail;
 import java.math.BigDecimal;
@@ -51,7 +51,8 @@ class NavNotifierTest {
   void formatMessage_includesAllComponentsAndSecuritiesDetail() {
     var result = aNavCalculationResult();
 
-    var message = navNotifier.formatMessage(result, Optional.empty(), Optional.empty());
+    var message =
+        navNotifier.formatMessage(result, Optional.empty(), Optional.empty(), Optional.empty());
 
     assertThat(message)
         .contains("TKF100")
@@ -74,7 +75,8 @@ class NavNotifierTest {
         .contains("*NAV/Unit: 9.8440*")
         .contains("✅", "IE00BMDBMY19", "ESGM.XETRA", "13288", "43.38", "576,433.44", "2026-02-17")
         .contains("❌", "IE00BJZ2DC62", "XRSM.XETRA", "21180", "49.55", "1,049,469.00", "2026-02-12")
-        .contains("Tracking Difference (BENCHMARK_MODEL): n/a");
+        .contains("Tracking Difference (model portfolio): n/a")
+        .contains("Tracking Difference (holdings vs index): n/a");
   }
 
   @Test
@@ -86,12 +88,15 @@ class NavNotifierTest {
             result,
             Optional.of(new BigDecimal("-0.014095")),
             Optional.of(
-                new BenchmarkModelTrackingDifference(
+                new TrackingDifferenceSummary(new BigDecimal("0.000300"), new BigDecimal("0.001"))),
+            Optional.of(
+                new TrackingDifferenceSummary(
                     new BigDecimal("-0.000751"), new BigDecimal("0.001"))));
 
     assertThat(message)
         .contains("*NAV/Unit: 9.8440 (-1.41%)*")
-        .contains("Tracking Difference (BENCHMARK_MODEL): -0.08% ✅");
+        .contains("Tracking Difference (model portfolio): +0.03% ✅")
+        .contains("Tracking Difference (holdings vs index): -0.08% ✅");
   }
 
   @Test
@@ -103,12 +108,15 @@ class NavNotifierTest {
             result,
             Optional.of(new BigDecimal("0.000245")),
             Optional.of(
-                new BenchmarkModelTrackingDifference(
+                new TrackingDifferenceSummary(new BigDecimal("0.001500"), new BigDecimal("0.001"))),
+            Optional.of(
+                new TrackingDifferenceSummary(
                     new BigDecimal("0.001073"), new BigDecimal("0.001"))));
 
     assertThat(message)
         .contains("*NAV/Unit: 9.8440 (+0.02%)*")
-        .contains("Tracking Difference (BENCHMARK_MODEL): +0.11% 🔴");
+        .contains("Tracking Difference (model portfolio): +0.15% 🔴")
+        .contains("Tracking Difference (holdings vs index): +0.11% 🔴");
   }
 
   @Test
@@ -135,18 +143,27 @@ class NavNotifierTest {
     given(fundNavQueryService.findNavPerUnit("TKF100", previousNavDate))
         .willReturn(Optional.of(new BigDecimal("9.8000")));
     given(
+            trackingDifferenceQueryService.findLatestModelPortfolio(
+                TKF100, result.positionReportDate()))
+        .willReturn(
+            Optional.of(
+                new TrackingDifferenceSummary(
+                    new BigDecimal("0.001500"), new BigDecimal("0.001"))));
+    given(
             trackingDifferenceQueryService.findLatestBenchmarkModel(
                 TKF100, result.positionReportDate()))
         .willReturn(
             Optional.of(
-                new BenchmarkModelTrackingDifference(
+                new TrackingDifferenceSummary(
                     new BigDecimal("0.000500"), new BigDecimal("0.001"))));
 
     navNotifier.notify(result);
 
     verify(notificationService).sendMessage(contains("*NAV/Unit: 9.8440 (+0.45%)*"), eq(SAVINGS));
     verify(notificationService)
-        .sendMessage(contains("Tracking Difference (BENCHMARK_MODEL): +0.05% ✅"), eq(SAVINGS));
+        .sendMessage(contains("Tracking Difference (model portfolio): +0.15% 🔴"), eq(SAVINGS));
+    verify(notificationService)
+        .sendMessage(contains("Tracking Difference (holdings vs index): +0.05% ✅"), eq(SAVINGS));
   }
 
   @Test


### PR DESCRIPTION
## Why
The tracking-difference Slack alert and the NAV report (SAVINGS channel) leaked the internal enum name `BENCHMARK_MODEL` and used a misleading `diff` column. That per-instrument value is the **weight-scaled contribution to total TD**, not `instrument − index`, so readers compute e.g. `0.42 − 0.11 = 0.31` and are confused when it prints `0.06`. The check compares regional/ESG-screened holdings to a single MSCI World/EM index, so day-to-day per-instrument spread is **expected** — the old "review prices for pricing errors" framing implied every breach was an error.

## What changed
**Breach alert (`TrackingDifferenceNotifier`)**
- `fund=` → `holdings=` for BENCHMARK_MODEL (the value is the weighted holdings return, not the fund NAV)
- One-line explanation replaces the old action line
- Per-instrument line: `diff` → `contributes X% to TD`, `benchmark` → `index`

Before:
```
[TKF100] BENCHMARK_MODEL 2026-06-29: TD=+0.11% (fund=+0.16%, benchmark=+0.06%)
  Action: review instrument prices and benchmark data for pricing errors
  IE000F60HVH9: instrument +0.42%, benchmark +0.11%, diff +0.06%
```
After:
```
[TKF100] BENCHMARK_MODEL 2026-06-29: TD=+0.11% (holdings=+0.16%, benchmark=+0.06%)
  Holdings vs MSCI World/EM index. Regional/ESG spread is expected; check an outsized contribution for a stale price.
  IE000F60HVH9: instrument +0.42%, index +0.11%, contributes +0.06% to TD
```

**NAV report (`NavNotifier`, SAVINGS channel)**
- `Tracking Difference (BENCHMARK_MODEL)` → `Tracking Difference (holdings vs index)`
- Added a `Tracking Difference (model portfolio)` line **above** it:
```
  Tracking Difference (model portfolio): +0.15% 🔴
  Tracking Difference (holdings vs index): +0.11% 🔴
```

**Supporting refactor**
- Generalized `BenchmarkModelTrackingDifference` → `TrackingDifferenceSummary` (same shape, now used for both check types)
- Added `TrackingDifferenceQueryService.findLatestModelPortfolio`

## Tests
Updated `TrackingDifferenceNotifierTest`, `NavNotifierTest`, `TrackingDifferenceQueryServiceTest`, `TrackingDifferenceSummaryTest`; all green. No behavior change beyond message text + the added NAV line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)