### PR TITLE
AML(#78): scope KYB DATA_CHANGED history to the company

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/aml/AmlCheckRepository.java
+++ b/src/main/java/ee/tuleva/onboarding/aml/AmlCheckRepository.java
@@ -2,6 +2,7 @@ package ee.tuleva.onboarding.aml;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface AmlCheckRepository extends JpaRepository<AmlCheck, Long> {
@@ -11,6 +12,9 @@ public interface AmlCheckRepository extends JpaRepository<AmlCheck, Long> {
 
   List<AmlCheck> findAllByPersonalCodeAndCreatedTimeAfter(
       String personalCode, Instant createdAfter);
+
+  List<AmlCheck> findAllByPersonalCodeAndCompanyIdAndCreatedTimeAfter(
+      String personalCode, UUID companyId, Instant createdAfter);
 
   List<AmlCheck> findAllByTypeIn(List<AmlCheckType> types);
 

--- a/src/main/java/ee/tuleva/onboarding/aml/AmlKybCheckHistory.java
+++ b/src/main/java/ee/tuleva/onboarding/aml/AmlKybCheckHistory.java
@@ -3,13 +3,17 @@ package ee.tuleva.onboarding.aml;
 import static ee.tuleva.onboarding.time.ClockHolder.aYearAgo;
 import static java.util.Map.entry;
 
+import ee.tuleva.onboarding.company.Company;
+import ee.tuleva.onboarding.company.CompanyRepository;
 import ee.tuleva.onboarding.kyb.KybCheck;
 import ee.tuleva.onboarding.kyb.KybCheckHistory;
 import ee.tuleva.onboarding.kyb.KybCheckType;
 import ee.tuleva.onboarding.kyb.PersonalCode;
+import ee.tuleva.onboarding.kyb.RegistryCode;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -38,16 +42,26 @@ public class AmlKybCheckHistory implements KybCheckHistory {
           entry(AmlCheckType.KYB_SELF_CERTIFICATION, KybCheckType.SELF_CERTIFICATION));
 
   private final AmlCheckRepository amlCheckRepository;
+  private final CompanyRepository companyRepository;
 
   @Override
-  public List<KybCheck> getLatestChecks(PersonalCode personalCode) {
+  public List<KybCheck> getLatestChecks(PersonalCode personalCode, RegistryCode registryCode) {
+    UUID companyId = resolveCompanyId(registryCode);
     return amlCheckRepository
-        .findAllByPersonalCodeAndCreatedTimeAfter(personalCode.value(), aYearAgo())
+        .findAllByPersonalCodeAndCompanyIdAndCreatedTimeAfter(
+            personalCode.value(), companyId, aYearAgo())
         .stream()
         .filter(check -> REVERSE_TYPE_MAPPING.containsKey(check.getType()))
         .sorted(Comparator.comparing(AmlCheck::getCreatedTime).reversed())
         .map(this::toKybCheck)
         .toList();
+  }
+
+  private UUID resolveCompanyId(RegistryCode registryCode) {
+    return companyRepository
+        .findByRegistryCode(registryCode.value())
+        .map(Company::getId)
+        .orElse(null);
   }
 
   private KybCheck toKybCheck(AmlCheck amlCheck) {

--- a/src/main/java/ee/tuleva/onboarding/kyb/KybCheckHistory.java
+++ b/src/main/java/ee/tuleva/onboarding/kyb/KybCheckHistory.java
@@ -4,5 +4,5 @@ import java.util.List;
 
 public interface KybCheckHistory {
 
-  List<KybCheck> getLatestChecks(PersonalCode personalCode);
+  List<KybCheck> getLatestChecks(PersonalCode personalCode, RegistryCode registryCode);
 }

--- a/src/main/java/ee/tuleva/onboarding/kyb/KybDataChangeDetector.java
+++ b/src/main/java/ee/tuleva/onboarding/kyb/KybDataChangeDetector.java
@@ -22,8 +22,9 @@ public class KybDataChangeDetector {
 
   private final KybCheckHistory checkHistory;
 
-  public KybCheck detect(PersonalCode personalCode, List<KybCheck> currentChecks) {
-    var previousChecks = checkHistory.getLatestChecks(personalCode);
+  public KybCheck detect(
+      PersonalCode personalCode, RegistryCode registryCode, List<KybCheck> currentChecks) {
+    var previousChecks = checkHistory.getLatestChecks(personalCode, registryCode);
 
     if (previousChecks.isEmpty()) {
       return new KybCheck(DATA_CHANGED, true, Map.of("changes", List.of()));

--- a/src/main/java/ee/tuleva/onboarding/kyb/KybScreeningService.java
+++ b/src/main/java/ee/tuleva/onboarding/kyb/KybScreeningService.java
@@ -23,7 +23,9 @@ public class KybScreeningService {
   public List<KybCheck> screen(KybCompanyData companyData) {
     var screenerResults = validate(companyData);
 
-    var dataChangedCheck = dataChangeDetector.detect(companyData.personalCode(), screenerResults);
+    var dataChangedCheck =
+        dataChangeDetector.detect(
+            companyData.personalCode(), companyData.company().registryCode(), screenerResults);
 
     var results = Stream.concat(screenerResults.stream(), Stream.of(dataChangedCheck)).toList();
 

--- a/src/test/groovy/ee/tuleva/onboarding/aml/AmlKybCheckHistoryTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/aml/AmlKybCheckHistoryTest.java
@@ -8,27 +8,43 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import ee.tuleva.onboarding.company.Company;
+import ee.tuleva.onboarding.company.CompanyRepository;
 import ee.tuleva.onboarding.kyb.KybCheck;
 import ee.tuleva.onboarding.kyb.KybCheckType;
 import ee.tuleva.onboarding.kyb.PersonalCode;
+import ee.tuleva.onboarding.kyb.RegistryCode;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class AmlKybCheckHistoryTest {
 
   private final AmlCheckRepository repository = mock(AmlCheckRepository.class);
-  private final AmlKybCheckHistory history = new AmlKybCheckHistory(repository);
+  private final CompanyRepository companyRepository = mock(CompanyRepository.class);
+  private final AmlKybCheckHistory history = new AmlKybCheckHistory(repository, companyRepository);
 
   private static final PersonalCode PERSONAL_CODE = new PersonalCode("38501010001");
+  private static final RegistryCode REGISTRY_CODE = new RegistryCode("12345678");
+  private static final UUID COMPANY_ID = UUID.fromString("00000000-0000-0000-0000-0000000000a1");
+
+  @BeforeEach
+  void setUp() {
+    when(companyRepository.findByRegistryCode("12345678"))
+        .thenReturn(Optional.of(Company.builder().id(COMPANY_ID).registryCode("12345678").build()));
+  }
 
   @Test
   void returnsEmptyWhenNoChecks() {
-    when(repository.findAllByPersonalCodeAndCreatedTimeAfter(eq("38501010001"), any()))
+    when(repository.findAllByPersonalCodeAndCompanyIdAndCreatedTimeAfter(
+            eq("38501010001"), eq(COMPANY_ID), any()))
         .thenReturn(List.of());
 
-    var result = history.getLatestChecks(PERSONAL_CODE);
+    var result = history.getLatestChecks(PERSONAL_CODE, REGISTRY_CODE);
 
     assertThat(result).isEmpty();
   }
@@ -38,17 +54,52 @@ class AmlKybCheckHistoryTest {
     var amlCheck =
         AmlCheck.builder()
             .personalCode("38501010001")
+            .companyId(COMPANY_ID)
             .type(KYB_COMPANY_ACTIVE)
             .success(true)
             .metadata(Map.of("status", "R"))
             .build();
     amlCheck.setCreatedTime(Instant.now());
-    when(repository.findAllByPersonalCodeAndCreatedTimeAfter(eq("38501010001"), any()))
+    when(repository.findAllByPersonalCodeAndCompanyIdAndCreatedTimeAfter(
+            eq("38501010001"), eq(COMPANY_ID), any()))
         .thenReturn(List.of(amlCheck));
 
-    var result = history.getLatestChecks(PERSONAL_CODE);
+    var result = history.getLatestChecks(PERSONAL_CODE, REGISTRY_CODE);
 
     assertThat(result).containsExactly(new KybCheck(COMPANY_ACTIVE, true, Map.of("status", "R")));
+  }
+
+  @Test
+  void scopesHistoryToTheCompanyResolvedFromTheRegistryCode() {
+    // AML #78: a representative tied to several companies must not bleed one company's checks into
+    // another's history. getLatestChecks resolves the registry code to a company id and reads only
+    // that company's checks, so the change detector never compares one company against another.
+    var companyCheck =
+        AmlCheck.builder()
+            .personalCode("38501010001")
+            .companyId(COMPANY_ID)
+            .type(KYB_HIGH_RISK_NACE)
+            .success(true)
+            .metadata(Map.of("naceCode", "62011"))
+            .build();
+    companyCheck.setCreatedTime(Instant.now());
+    when(repository.findAllByPersonalCodeAndCompanyIdAndCreatedTimeAfter(
+            eq("38501010001"), eq(COMPANY_ID), any()))
+        .thenReturn(List.of(companyCheck));
+
+    var result = history.getLatestChecks(PERSONAL_CODE, REGISTRY_CODE);
+
+    assertThat(result)
+        .containsExactly(new KybCheck(HIGH_RISK_NACE, true, Map.of("naceCode", "62011")));
+  }
+
+  @Test
+  void returnsEmptyWhenTheCompanyIsNotYetPersisted() {
+    when(companyRepository.findByRegistryCode("12345678")).thenReturn(Optional.empty());
+
+    var result = history.getLatestChecks(PERSONAL_CODE, REGISTRY_CODE);
+
+    assertThat(result).isEmpty();
   }
 
   @Test
@@ -56,6 +107,7 @@ class AmlKybCheckHistoryTest {
     var sanctionCheck =
         AmlCheck.builder()
             .personalCode("38501010001")
+            .companyId(COMPANY_ID)
             .type(SANCTION)
             .success(true)
             .metadata(Map.of())
@@ -64,15 +116,17 @@ class AmlKybCheckHistoryTest {
     var kybCheck =
         AmlCheck.builder()
             .personalCode("38501010001")
+            .companyId(COMPANY_ID)
             .type(KYB_COMPANY_ACTIVE)
             .success(true)
             .metadata(Map.of("status", "R"))
             .build();
     kybCheck.setCreatedTime(Instant.now());
-    when(repository.findAllByPersonalCodeAndCreatedTimeAfter(eq("38501010001"), any()))
+    when(repository.findAllByPersonalCodeAndCompanyIdAndCreatedTimeAfter(
+            eq("38501010001"), eq(COMPANY_ID), any()))
         .thenReturn(List.of(sanctionCheck, kybCheck));
 
-    var result = history.getLatestChecks(PERSONAL_CODE);
+    var result = history.getLatestChecks(PERSONAL_CODE, REGISTRY_CODE);
 
     assertThat(result).hasSize(1);
     assertThat(result.getFirst().type()).isEqualTo(COMPANY_ACTIVE);
@@ -92,15 +146,17 @@ class AmlKybCheckHistoryTest {
       var check =
           AmlCheck.builder()
               .personalCode("38501010001")
+              .companyId(COMPANY_ID)
               .type(amlType)
               .success(true)
               .metadata(Map.of())
               .build();
       check.setCreatedTime(Instant.now());
-      when(repository.findAllByPersonalCodeAndCreatedTimeAfter(eq("38501010001"), any()))
+      when(repository.findAllByPersonalCodeAndCompanyIdAndCreatedTimeAfter(
+              eq("38501010001"), eq(COMPANY_ID), any()))
           .thenReturn(List.of(check));
 
-      var result = history.getLatestChecks(PERSONAL_CODE);
+      var result = history.getLatestChecks(PERSONAL_CODE, REGISTRY_CODE);
 
       assertThat(result)
           .as("screener check %s must reverse-map through AmlKybCheckHistory", kybType)

--- a/src/test/groovy/ee/tuleva/onboarding/kyb/KybDataChangeDetectorTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyb/KybDataChangeDetectorTest.java
@@ -15,13 +15,14 @@ class KybDataChangeDetectorTest {
   private final KybDataChangeDetector detector = new KybDataChangeDetector(checkHistory);
 
   private static final PersonalCode PERSONAL_CODE = new PersonalCode("38501010001");
+  private static final RegistryCode REGISTRY_CODE = new RegistryCode("12345678");
 
   @Test
   void noPreviousChecksReturnsSuccess() {
-    when(checkHistory.getLatestChecks(PERSONAL_CODE)).thenReturn(List.of());
+    when(checkHistory.getLatestChecks(PERSONAL_CODE, REGISTRY_CODE)).thenReturn(List.of());
 
     var currentChecks = List.of(new KybCheck(COMPANY_ACTIVE, true, Map.of("status", "R")));
-    var result = detector.detect(PERSONAL_CODE, currentChecks);
+    var result = detector.detect(PERSONAL_CODE, REGISTRY_CODE, currentChecks);
 
     assertThat(result.type()).isEqualTo(DATA_CHANGED);
     assertThat(result.success()).isTrue();
@@ -32,9 +33,9 @@ class KybDataChangeDetectorTest {
   @Test
   void identicalResultsReturnsSuccess() {
     var checks = List.of(new KybCheck(COMPANY_ACTIVE, true, Map.of("status", "R")));
-    when(checkHistory.getLatestChecks(PERSONAL_CODE)).thenReturn(checks);
+    when(checkHistory.getLatestChecks(PERSONAL_CODE, REGISTRY_CODE)).thenReturn(checks);
 
-    var result = detector.detect(PERSONAL_CODE, checks);
+    var result = detector.detect(PERSONAL_CODE, REGISTRY_CODE, checks);
 
     assertThat(result.success()).isTrue();
     assertThat((List<?>) result.metadata().get("changes")).isEmpty();
@@ -44,9 +45,9 @@ class KybDataChangeDetectorTest {
   void successFlipDetected() {
     var previousChecks = List.of(new KybCheck(COMPANY_ACTIVE, true, Map.of("status", "R")));
     var currentChecks = List.of(new KybCheck(COMPANY_ACTIVE, false, Map.of("status", "L")));
-    when(checkHistory.getLatestChecks(PERSONAL_CODE)).thenReturn(previousChecks);
+    when(checkHistory.getLatestChecks(PERSONAL_CODE, REGISTRY_CODE)).thenReturn(previousChecks);
 
-    var result = detector.detect(PERSONAL_CODE, currentChecks);
+    var result = detector.detect(PERSONAL_CODE, REGISTRY_CODE, currentChecks);
 
     assertThat(result.success()).isFalse();
     var changes = (List<Map<String, Object>>) result.metadata().get("changes");
@@ -71,9 +72,9 @@ class KybDataChangeDetectorTest {
                 SOLE_MEMBER_OWNERSHIP,
                 true,
                 Map.of("personalCode", "38501010001", "ownershipPercent", 50)));
-    when(checkHistory.getLatestChecks(PERSONAL_CODE)).thenReturn(previousChecks);
+    when(checkHistory.getLatestChecks(PERSONAL_CODE, REGISTRY_CODE)).thenReturn(previousChecks);
 
-    var result = detector.detect(PERSONAL_CODE, currentChecks);
+    var result = detector.detect(PERSONAL_CODE, REGISTRY_CODE, currentChecks);
 
     assertThat(result.success()).isFalse();
     var changes = (List<Map<String, Object>>) result.metadata().get("changes");
@@ -91,9 +92,9 @@ class KybDataChangeDetectorTest {
         List.of(
             new KybCheck(COMPANY_ACTIVE, true, Map.of("status", "R")),
             new KybCheck(COMPANY_AGE, true, Map.of()));
-    when(checkHistory.getLatestChecks(PERSONAL_CODE)).thenReturn(previousChecks);
+    when(checkHistory.getLatestChecks(PERSONAL_CODE, REGISTRY_CODE)).thenReturn(previousChecks);
 
-    var result = detector.detect(PERSONAL_CODE, currentChecks);
+    var result = detector.detect(PERSONAL_CODE, REGISTRY_CODE, currentChecks);
 
     assertThat(result.success()).isTrue();
     assertThat((List<?>) result.metadata().get("changes")).isEmpty();
@@ -108,9 +109,9 @@ class KybDataChangeDetectorTest {
         List.of(
             new KybCheck(COMPANY_ACTIVE, true, Map.of("status", "R")),
             new KybCheck(COMPANY_AGE, false, Map.of()));
-    when(checkHistory.getLatestChecks(PERSONAL_CODE)).thenReturn(previousChecks);
+    when(checkHistory.getLatestChecks(PERSONAL_CODE, REGISTRY_CODE)).thenReturn(previousChecks);
 
-    var result = detector.detect(PERSONAL_CODE, currentChecks);
+    var result = detector.detect(PERSONAL_CODE, REGISTRY_CODE, currentChecks);
 
     assertThat(result.success()).isTrue();
     assertThat((List<?>) result.metadata().get("changes")).isEmpty();
@@ -130,9 +131,9 @@ class KybDataChangeDetectorTest {
         List.of(
             new KybCheck(COMPANY_ACTIVE, true, Map.of("status", "R")),
             new KybCheck(DUAL_MEMBER_OWNERSHIP, true, Map.of()));
-    when(checkHistory.getLatestChecks(PERSONAL_CODE)).thenReturn(previousChecks);
+    when(checkHistory.getLatestChecks(PERSONAL_CODE, REGISTRY_CODE)).thenReturn(previousChecks);
 
-    var result = detector.detect(PERSONAL_CODE, currentChecks);
+    var result = detector.detect(PERSONAL_CODE, REGISTRY_CODE, currentChecks);
 
     assertThat(result.success()).isFalse();
     var changes = (List<Map<String, Object>>) result.metadata().get("changes");
@@ -153,9 +154,9 @@ class KybDataChangeDetectorTest {
         List.of(
             new KybCheck(COMPANY_ACTIVE, false, Map.of("status", "L")),
             new KybCheck(SOLE_MEMBER_OWNERSHIP, false, Map.of()));
-    when(checkHistory.getLatestChecks(PERSONAL_CODE)).thenReturn(previousChecks);
+    when(checkHistory.getLatestChecks(PERSONAL_CODE, REGISTRY_CODE)).thenReturn(previousChecks);
 
-    var result = detector.detect(PERSONAL_CODE, currentChecks);
+    var result = detector.detect(PERSONAL_CODE, REGISTRY_CODE, currentChecks);
 
     assertThat(result.success()).isFalse();
     var changes = (List<Map<String, Object>>) result.metadata().get("changes");
@@ -168,9 +169,9 @@ class KybDataChangeDetectorTest {
         List.of(new KybCheck(COMPANY_SANCTION, true, Map.of("results", "[{id=Q1, score=0.31}]")));
     var currentChecks =
         List.of(new KybCheck(COMPANY_SANCTION, true, Map.of("results", "[{id=Q2, score=0.62}]")));
-    when(checkHistory.getLatestChecks(PERSONAL_CODE)).thenReturn(previousChecks);
+    when(checkHistory.getLatestChecks(PERSONAL_CODE, REGISTRY_CODE)).thenReturn(previousChecks);
 
-    var result = detector.detect(PERSONAL_CODE, currentChecks);
+    var result = detector.detect(PERSONAL_CODE, REGISTRY_CODE, currentChecks);
 
     assertThat(result.success()).isTrue();
     assertThat((List<?>) result.metadata().get("changes")).isEmpty();
@@ -181,9 +182,9 @@ class KybDataChangeDetectorTest {
     var previousChecks = List.of(new KybCheck(COMPANY_SANCTION, true, Map.of("results", "[]")));
     var currentChecks =
         List.of(new KybCheck(COMPANY_SANCTION, false, Map.of("results", "[{match=true}]")));
-    when(checkHistory.getLatestChecks(PERSONAL_CODE)).thenReturn(previousChecks);
+    when(checkHistory.getLatestChecks(PERSONAL_CODE, REGISTRY_CODE)).thenReturn(previousChecks);
 
-    var result = detector.detect(PERSONAL_CODE, currentChecks);
+    var result = detector.detect(PERSONAL_CODE, REGISTRY_CODE, currentChecks);
 
     assertThat(result.success()).isFalse();
   }

--- a/src/test/groovy/ee/tuleva/onboarding/kyb/KybScreeningIntegrationTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyb/KybScreeningIntegrationTest.java
@@ -7,6 +7,7 @@ import static ee.tuleva.onboarding.kyb.KybTestFixtures.boardMemberOwner;
 import static ee.tuleva.onboarding.kyb.KybTestFixtures.companyWith;
 import static ee.tuleva.onboarding.kyb.KybTestFixtures.kybPerson;
 import static ee.tuleva.onboarding.time.ClockHolder.aYearAgo;
+import static java.time.temporal.ChronoUnit.DAYS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
@@ -15,12 +16,16 @@ import ee.tuleva.onboarding.aml.AmlCheck;
 import ee.tuleva.onboarding.aml.AmlCheckRepository;
 import ee.tuleva.onboarding.aml.sanctions.MatchResponse;
 import ee.tuleva.onboarding.aml.sanctions.PepAndSanctionCheckService;
+import ee.tuleva.onboarding.time.ClockHolder;
 import jakarta.persistence.EntityManager;
 import java.math.BigDecimal;
 import java.time.Clock;
+import java.time.Instant;
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -34,6 +39,7 @@ import tools.jackson.databind.json.JsonMapper;
 class KybScreeningIntegrationTest {
 
   private static final PersonalCode PERSONAL_CODE = new PersonalCode("38501010002");
+  private static final Instant NOW = Instant.parse("2025-06-01T00:00:00Z");
 
   @Autowired private KybScreeningService kybScreeningService;
   @Autowired private AmlCheckRepository amlCheckRepository;
@@ -47,6 +53,11 @@ class KybScreeningIntegrationTest {
     when(sanctionCheckService.matchCompany(any()))
         .thenReturn(
             new MatchResponse(objectMapper.createArrayNode(), objectMapper.createObjectNode()));
+  }
+
+  @AfterEach
+  void resetClock() {
+    ClockHolder.setDefaultClock();
   }
 
   @Test
@@ -296,5 +307,52 @@ class KybScreeningIntegrationTest {
     var ageCheck = amlChecks.stream().filter(c -> c.getType() == KYB_COMPANY_AGE).findFirst();
     assertThat(ageCheck).as("KYB_COMPANY_AGE AmlCheck should be persisted").isPresent();
     assertThat(ageCheck.get().isSuccess()).isFalse();
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void rescreeningACompanyIgnoresAnotherCompanyOfTheSameRepresentative() {
+    // AML #78: KybDataChangeDetector read history by personal_code only, so a representative tied
+    // to
+    // two companies had each company's checks compared against the other company's most recent row.
+    // Identical nightly re-screenings then flagged DATA_CHANGED for every such company. History is
+    // now scoped to the company, so another company of the same representative is ignored. The
+    // clock
+    // is advanced between screenings so the other company's row is unambiguously the most recent.
+    var owner = boardMemberOwner(PERSONAL_CODE, 100.0).build();
+
+    ClockHolder.setClock(Clock.fixed(NOW, ZoneOffset.UTC));
+    kybScreeningService.screen(companyFor("11111111", "62011", owner));
+    entityManager.flush();
+    entityManager.clear();
+
+    ClockHolder.setClock(Clock.fixed(NOW.plus(1, DAYS), ZoneOffset.UTC));
+    kybScreeningService.screen(companyFor("22222222", "41201", owner));
+    entityManager.flush();
+    entityManager.clear();
+
+    ClockHolder.setClock(Clock.fixed(NOW.plus(2, DAYS), ZoneOffset.UTC));
+    var rescreenFirstCompany = kybScreeningService.screen(companyFor("11111111", "62011", owner));
+
+    var dataChanged =
+        rescreenFirstCompany.stream()
+            .filter(c -> c.type() == KybCheckType.DATA_CHANGED)
+            .findFirst()
+            .orElseThrow();
+    assertThat(dataChanged.success()).isTrue();
+    assertThat((List<Map<String, Object>>) dataChanged.metadata().get("changes")).isEmpty();
+  }
+
+  private KybCompanyData companyFor(String registryCode, String naceCode, KybRelatedPerson owner) {
+    return new KybCompanyData(
+        new CompanyDto(new RegistryCode(registryCode), "Test OÜ", naceCode, LegalForm.OÜ),
+        PERSONAL_CODE,
+        R,
+        List.of(owner),
+        new SelfCertification(true, true, true),
+        "EE",
+        "Harju maakond, Tallinn, Pärnu mnt 1",
+        null,
+        List.of());
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/kyb/KybScreeningServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyb/KybScreeningServiceTest.java
@@ -58,7 +58,7 @@ class KybScreeningServiceTest {
     when(sanctionCheckService.matchCompany(any()))
         .thenReturn(
             new MatchResponse(objectMapper.createArrayNode(), objectMapper.createObjectNode()));
-    when(checkHistory.getLatestChecks(any())).thenReturn(List.of());
+    when(checkHistory.getLatestChecks(any(), any())).thenReturn(List.of());
   }
 
   @Test


### PR DESCRIPTION
## Problem
`KybDataChangeDetector` read previous checks by **personal_code only** (`AmlKybCheckHistory.getLatestChecks` → `findAllByPersonalCodeAndCreatedTimeAfter`). A representative tied to 2+ companies therefore had each company's fresh checks compared against the most-recent stored row of a *different* company, so identical nightly re-screenings raised `DATA_CHANGED` (`KYB_DATA_CHANGED` → company score `tkr_related_changed +10` → potentially wrong KESKMINE) even though nothing changed. Scope: ~19 companies / 10 representatives.

This is the same cross-company contamination class that M1 (`aml_check.company_id`, V1_207) fixed for **scoring**; the change detector's history query was simply never scoped. Different from #1727 (new-check-type `DATA_CHANGED` fix).

## Fix
- `AmlCheckRepository`: add `findAllByPersonalCodeAndCompanyIdAndCreatedTimeAfter`.
- Thread `RegistryCode` through `KybCheckHistory.getLatestChecks` and `KybDataChangeDetector.detect`.
- `KybScreeningService` passes `companyData.company().registryCode()`.
- `AmlKybCheckHistory` resolves the registry code to a `companyId` (mirroring `AmlKybCheckEventListener.resolveCompanyId`) and reads only that company's history.

Extends M1 `company_id` attribution from scoring to the `DATA_CHANGED` detector. After deploy + a clean re-screening, the false `KYB_DATA_CHANGED` rows stop appearing (stale rows may need a re-screen).

## Tests
- New macro reproduction in `KybScreeningIntegrationTest`: same representative, two companies with different NACE; screen both, re-screen the first → asserts `DATA_CHANGED.success == true` (was `false` before the fix).
- New unit coverage in `AmlKybCheckHistoryTest` for company-scoping and the not-yet-persisted (null `companyId`) branch.
- Existing rerun integration tests pass unmodified — `CompanyOnboardingEventListener` (order 100) creates the Company before the AML listener (order 200), so the second screen resolves a non-null `companyId`.

CI green on the branch (build + appscript-test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)