### PR TITLE
Exclude fully-liquidated instruments from NAV securities balances

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/ledger/NavLedgerRepository.java
+++ b/src/main/java/ee/tuleva/onboarding/ledger/NavLedgerRepository.java
@@ -122,6 +122,7 @@ public class NavLedgerRepository {
               AND a.purpose = 'SYSTEM_ACCOUNT'
               AND t.transaction_date <= :cutoff
             GROUP BY a.name
+            HAVING SUM(e.amount) <> 0
             """)
         .param("prefix", prefix + "%")
         .param("cutoff", Timestamp.from(cutoff))

--- a/src/test/groovy/ee/tuleva/onboarding/ledger/NavLedgerRepositoryTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/ledger/NavLedgerRepositoryTest.java
@@ -61,6 +61,23 @@ class NavLedgerRepositoryTest {
   }
 
   @Test
+  void getSecuritiesUnitBalancesAt_excludesFullyLiquidatedInstruments() {
+    createSecuritiesUnitsBalance("IE00BFG1TM61", new BigDecimal("1000.00000"));
+    createSecuritiesUnitsBalance("IE00BFNM3D14", new BigDecimal("500.00000"));
+    createSecuritiesUnitsBalance("IE00BFNM3D14", new BigDecimal("-500.00000"));
+    entityManager.flush();
+
+    Instant cutoff = Instant.now().plusSeconds(3600);
+
+    Map<String, BigDecimal> balances =
+        navLedgerRepository.getSecuritiesUnitBalancesAt(cutoff, TKF100);
+
+    assertThat(balances).hasSize(1);
+    assertThat(balances.get("IE00BFG1TM61")).isEqualByComparingTo("1000.00000");
+    assertThat(balances).doesNotContainKey("IE00BFNM3D14");
+  }
+
+  @Test
   void getSystemAccountBalanceBefore_excludesEntriesAtOrAfterCutoff() {
     ZoneId eet = ZoneId.of("Europe/Tallinn");
     LedgerAccount feeAccount =


### PR DESCRIPTION
## Problem

The NAV calculation Slack message from onboarding-service kept listing old **deinvested** instruments from the previous model portfolio, even after they were sold to 0 in a switch — e.g.:

```
✅ IE00BFNM3D14 (SLMC.XETRA): 0 × 10.866 = 0.00 EUR [2026-06-29]
✅ IE00BFNM3G45 (SGAS.XETRA): 0 × 13.492 = 0.00 EUR [2026-06-29]
✅ IE00BFNM3L97 (SGAJ.XETRA): 0 × 8.451 = 0.00 EUR [2026-06-29]
```

They also appeared as zero rows in `nav_report`, requiring manual cleanup on every run.

## Root cause

The list is built from the **ledger**, not the model portfolio. `NavLedgerRepository.getSecuritiesUnitBalancesAt` groups entries by account and sums them. Selling an instrument to 0 leaves its `…SECURITIES_UNITS:<isin>` account in place with entries summing to exactly `0`, so the row keeps coming back and `NavCalculationService.buildSecuritiesDetail` mapped it with no zero filter.

## Fix

Add `HAVING SUM(e.amount) <> 0` to the cutoff query. Liquidated holdings now drop out automatically — no manual updates ever again.

- A zero-unit holding contributes `0 × price = 0` to AUM, so **the NAV value is unchanged**.
- Also stops price resolution for sold/delisted ISINs in `SecuritiesValueComponent`, removing a latent risk.
- `<> 0` (not `> 0`) is deliberate: a securities-units account should never go negative, so any negative net still surfaces rather than being silently hidden.
- Only rows with an **exactly-zero net balance** are removed — any real (nonzero) position is always kept.

## Scope / safety

The no-cutoff `getSecuritiesUnitBalances` is **left untouched** on purpose: its consumers (`NavLedgerReconciliation`, `FundPositionLedgerService`) rely on seeing zero balances to detect ledger-vs-custodian discrepancies.

## Test

Added `NavLedgerRepositoryTest.getSecuritiesUnitBalancesAt_excludesFullyLiquidatedInstruments` (RED → GREEN). Repository, NAV calc, value-component, reconciliation, and position-ledger suites all pass on H2 (confirms `HAVING … <> 0` is H2/PostgreSQL compatible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)