### PR TITLE
Don't reject onboarded companies when beneficial-owner data is missing

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/account/AccountStatementController.java
+++ b/src/main/java/ee/tuleva/onboarding/account/AccountStatementController.java
@@ -43,14 +43,13 @@ public class AccountStatementController {
   @GetMapping("/savings-account-statement")
   public ResponseEntity<ApiFundBalanceResponse> getMySavingsAccountStatement(
       @AuthenticationPrincipal AuthenticatedPerson authenticatedPerson) {
-    try {
-      FundBalance fundBalance =
-          savingsFundStatementService.getAccountStatement(authenticatedPerson);
-      return ResponseEntity.ok(
-          ApiFundBalanceResponse.from(fundBalance, localeService.getCurrentLocale()));
-    } catch (Exception e) {
-      return ResponseEntity.noContent().build();
-    }
+    return savingsFundStatementService
+        .getAccountStatement(authenticatedPerson)
+        .map(
+            fundBalance ->
+                ResponseEntity.ok(
+                    ApiFundBalanceResponse.from(fundBalance, localeService.getCurrentLocale())))
+        .orElseGet(() -> ResponseEntity.noContent().build());
   }
 
   private List<ApiFundBalanceResponse> convertToDtos(

--- a/src/main/java/ee/tuleva/onboarding/account/SavingsFundStatementService.java
+++ b/src/main/java/ee/tuleva/onboarding/account/SavingsFundStatementService.java
@@ -47,18 +47,22 @@ public class SavingsFundStatementService {
             fundUnitsAccount ->
                 statement(
                     account ->
-                        ledgerService
-                            .findPartyAccount(ownerCode, partyType, account)
-                            .map(LedgerAccount::getBalance)
-                            .orElse(BigDecimal.ZERO)));
+                        account == FUND_UNITS
+                            ? fundUnitsAccount.getBalance()
+                            : ledgerService
+                                .findPartyAccount(ownerCode, partyType, account)
+                                .map(LedgerAccount::getBalance)
+                                .orElse(BigDecimal.ZERO)));
   }
 
   private FundBalance statement(Function<UserAccount, BigDecimal> balances) {
+    BigDecimal nav = getNAV();
+
     BigDecimal units = balances.apply(FUND_UNITS).negate();
-    BigDecimal value = getNAV().multiply(units).setScale(2, HALF_UP);
+    BigDecimal value = nav.multiply(units).setScale(2, HALF_UP);
 
     BigDecimal reservedUnits = balances.apply(FUND_UNITS_RESERVED).negate();
-    BigDecimal reservedValue = getNAV().multiply(reservedUnits).setScale(2, HALF_UP);
+    BigDecimal reservedValue = nav.multiply(reservedUnits).setScale(2, HALF_UP);
 
     return FundBalance.builder()
         .fund(getSavingsFund())

--- a/src/main/java/ee/tuleva/onboarding/account/SavingsFundStatementService.java
+++ b/src/main/java/ee/tuleva/onboarding/account/SavingsFundStatementService.java
@@ -8,12 +8,16 @@ import static java.math.RoundingMode.HALF_UP;
 import ee.tuleva.onboarding.auth.principal.AuthenticatedPerson;
 import ee.tuleva.onboarding.fund.Fund;
 import ee.tuleva.onboarding.fund.FundRepository;
+import ee.tuleva.onboarding.ledger.LedgerAccount;
 import ee.tuleva.onboarding.ledger.LedgerParty.PartyType;
 import ee.tuleva.onboarding.ledger.LedgerService;
+import ee.tuleva.onboarding.ledger.UserAccount;
 import ee.tuleva.onboarding.savings.fund.SavingsFundConfiguration;
 import ee.tuleva.onboarding.savings.fund.SavingsFundOnboardingService;
 import ee.tuleva.onboarding.savings.fund.nav.FundNavProvider;
 import java.math.BigDecimal;
+import java.util.Optional;
+import java.util.function.Function;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -27,18 +31,33 @@ public class SavingsFundStatementService {
   private final FundRepository fundRepository;
   private final SavingsFundConfiguration savingsFundConfiguration;
 
-  public FundBalance getAccountStatement(AuthenticatedPerson person) {
+  public Optional<FundBalance> getAccountStatement(AuthenticatedPerson person) {
     String ownerCode = person.getRoleCode();
     PartyType partyType = PartyType.from(person.getRoleType());
 
-    if (!savingsFundOnboardingService.isOnboardingCompleted(person.toPartyId())) {
-      throw new IllegalStateException("Not onboarded: code=" + ownerCode);
+    if (savingsFundOnboardingService.isOnboardingCompleted(person.toPartyId())) {
+      return Optional.of(
+          statement(
+              account ->
+                  ledgerService.getPartyAccount(ownerCode, partyType, account).getBalance()));
     }
+    return ledgerService
+        .findPartyAccount(ownerCode, partyType, FUND_UNITS)
+        .map(
+            fundUnitsAccount ->
+                statement(
+                    account ->
+                        ledgerService
+                            .findPartyAccount(ownerCode, partyType, account)
+                            .map(LedgerAccount::getBalance)
+                            .orElse(BigDecimal.ZERO)));
+  }
 
-    BigDecimal units = getUnits(ownerCode, partyType);
+  private FundBalance statement(Function<UserAccount, BigDecimal> balances) {
+    BigDecimal units = balances.apply(FUND_UNITS).negate();
     BigDecimal value = getNAV().multiply(units).setScale(2, HALF_UP);
 
-    BigDecimal reservedUnits = getReservedUnits(ownerCode, partyType);
+    BigDecimal reservedUnits = balances.apply(FUND_UNITS_RESERVED).negate();
     BigDecimal reservedValue = getNAV().multiply(reservedUnits).setScale(2, HALF_UP);
 
     return FundBalance.builder()
@@ -48,8 +67,8 @@ public class SavingsFundStatementService {
         .value(value)
         .unavailableUnits(reservedUnits)
         .unavailableValue(reservedValue)
-        .contributions(getSubscriptions(ownerCode, partyType))
-        .subtractions(getRedemptions(ownerCode, partyType))
+        .contributions(balances.apply(SUBSCRIPTIONS).negate())
+        .subtractions(balances.apply(REDEMPTIONS).negate())
         .build();
   }
 
@@ -60,25 +79,6 @@ public class SavingsFundStatementService {
           "Savings fund not found: isin=" + savingsFundConfiguration.getIsin());
     }
     return fund;
-  }
-
-  private BigDecimal getUnits(String ownerCode, PartyType partyType) {
-    return ledgerService.getPartyAccount(ownerCode, partyType, FUND_UNITS).getBalance().negate();
-  }
-
-  private BigDecimal getReservedUnits(String ownerCode, PartyType partyType) {
-    return ledgerService
-        .getPartyAccount(ownerCode, partyType, FUND_UNITS_RESERVED)
-        .getBalance()
-        .negate();
-  }
-
-  private BigDecimal getSubscriptions(String ownerCode, PartyType partyType) {
-    return ledgerService.getPartyAccount(ownerCode, partyType, SUBSCRIPTIONS).getBalance().negate();
-  }
-
-  private BigDecimal getRedemptions(String ownerCode, PartyType partyType) {
-    return ledgerService.getPartyAccount(ownerCode, partyType, REDEMPTIONS).getBalance().negate();
   }
 
   private BigDecimal getNAV() {

--- a/src/main/java/ee/tuleva/onboarding/kyb/KybCheckPerformedEvent.java
+++ b/src/main/java/ee/tuleva/onboarding/kyb/KybCheckPerformedEvent.java
@@ -1,7 +1,11 @@
 package ee.tuleva.onboarding.kyb;
 
+import static ee.tuleva.onboarding.kyb.KybCheckType.DATA_CHANGED;
+
 import ee.tuleva.onboarding.ariregister.RepresentationRight;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import lombok.Getter;
 import org.springframework.context.ApplicationEvent;
@@ -29,5 +33,30 @@ public class KybCheckPerformedEvent extends ApplicationEvent {
     this.relatedPersons = Objects.requireNonNull(relatedPersons);
     this.checks = Objects.requireNonNull(checks);
     this.representationRights = Objects.requireNonNull(representationRights);
+  }
+
+  public boolean hasOwnershipEvidenceChange() {
+    return checks.stream()
+        .filter(check -> check.type() == DATA_CHANGED)
+        .flatMap(check -> changeEntries(check).stream())
+        .filter(entry -> isOwnershipCheckName(entry.get("check")))
+        .anyMatch(entry -> Boolean.TRUE.equals(entry.get("metadataChanged")));
+  }
+
+  @SuppressWarnings("unchecked")
+  private static List<Map<String, Object>> changeEntries(KybCheck dataChanged) {
+    if (dataChanged.metadata().get("changes") instanceof List<?> changes) {
+      return changes.stream()
+          .filter(Map.class::isInstance)
+          .map(entry -> (Map<String, Object>) entry)
+          .toList();
+    }
+    return List.of();
+  }
+
+  private static boolean isOwnershipCheckName(Object checkName) {
+    return Arrays.stream(KybCheckType.values())
+        .filter(KybCheckType::isOwnershipCheck)
+        .anyMatch(type -> type.name().equals(checkName));
   }
 }

--- a/src/main/java/ee/tuleva/onboarding/kyb/KybCheckPerformedEvent.java
+++ b/src/main/java/ee/tuleva/onboarding/kyb/KybCheckPerformedEvent.java
@@ -1,12 +1,14 @@
 package ee.tuleva.onboarding.kyb;
 
 import static ee.tuleva.onboarding.kyb.KybCheckType.DATA_CHANGED;
+import static java.util.stream.Collectors.toSet;
 
 import ee.tuleva.onboarding.ariregister.RepresentationRight;
-import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import lombok.Getter;
 import org.springframework.context.ApplicationEvent;
 
@@ -35,11 +37,14 @@ public class KybCheckPerformedEvent extends ApplicationEvent {
     this.representationRights = Objects.requireNonNull(representationRights);
   }
 
-  public boolean hasOwnershipEvidenceChange() {
+  public boolean hasMetadataChangeFor(Collection<KybCheckType> checkTypes) {
+    Set<String> checkNames = checkTypes.stream().map(KybCheckType::name).collect(toSet());
     return checks.stream()
         .filter(check -> check.type() == DATA_CHANGED)
         .flatMap(check -> changeEntries(check).stream())
-        .filter(entry -> isOwnershipCheckName(entry.get("check")))
+        .filter(
+            entry ->
+                entry.get("check") instanceof String checkName && checkNames.contains(checkName))
         .anyMatch(entry -> Boolean.TRUE.equals(entry.get("metadataChanged")));
   }
 
@@ -52,11 +57,5 @@ public class KybCheckPerformedEvent extends ApplicationEvent {
           .toList();
     }
     return List.of();
-  }
-
-  private static boolean isOwnershipCheckName(Object checkName) {
-    return Arrays.stream(KybCheckType.values())
-        .filter(KybCheckType::isOwnershipCheck)
-        .anyMatch(type -> type.name().equals(checkName));
   }
 }

--- a/src/main/java/ee/tuleva/onboarding/kyb/KybCheckType.java
+++ b/src/main/java/ee/tuleva/onboarding/kyb/KybCheckType.java
@@ -29,4 +29,10 @@ public enum KybCheckType {
   public boolean isOnboardingGate() {
     return onboardingGate;
   }
+
+  public boolean isOwnershipCheck() {
+    return this == SOLE_MEMBER_OWNERSHIP
+        || this == DUAL_MEMBER_OWNERSHIP
+        || this == SINGLE_BOARD_MEMBER_OWNERSHIP;
+  }
 }

--- a/src/main/java/ee/tuleva/onboarding/kyb/KybDataChangeDetector.java
+++ b/src/main/java/ee/tuleva/onboarding/kyb/KybDataChangeDetector.java
@@ -43,13 +43,18 @@ public class KybDataChangeDetector {
     for (var current : currentChecks) {
       var previous = previousByType.get(current.type());
       if (isExistingCheck(previous) && changed(previous, current)) {
-        changes.add(change(current.type(), previous.success(), current.success()));
+        changes.add(
+            change(
+                current.type(),
+                previous.success(),
+                current.success(),
+                metadataChanged(previous, current)));
       }
     }
 
     for (var previous : previousChecks) {
       if (isRemovedCheck(previous, currentByType)) {
-        changes.add(change(previous.type(), previous.success(), "N/A"));
+        changes.add(change(previous.type(), previous.success(), "N/A", true));
       }
     }
 
@@ -65,17 +70,22 @@ public class KybDataChangeDetector {
   }
 
   private Map<String, Object> change(
-      KybCheckType type, Object previousSuccess, Object currentSuccess) {
+      KybCheckType type, Object previousSuccess, Object currentSuccess, boolean metadataChanged) {
     return Map.of(
         "check", type.name(),
         "previousSuccess", previousSuccess,
-        "currentSuccess", currentSuccess);
+        "currentSuccess", currentSuccess,
+        "metadataChanged", metadataChanged);
   }
 
   private boolean changed(KybCheck previous, KybCheck current) {
     if (previous.success() != current.success()) {
       return true;
     }
+    return metadataChanged(previous, current);
+  }
+
+  private boolean metadataChanged(KybCheck previous, KybCheck current) {
     return !AUDIT_ONLY_METADATA.contains(current.type())
         && !previous.metadata().equals(current.metadata());
   }

--- a/src/main/java/ee/tuleva/onboarding/kyb/KybDataChangeDetector.java
+++ b/src/main/java/ee/tuleva/onboarding/kyb/KybDataChangeDetector.java
@@ -43,18 +43,13 @@ public class KybDataChangeDetector {
     for (var current : currentChecks) {
       var previous = previousByType.get(current.type());
       if (isExistingCheck(previous) && changed(previous, current)) {
-        changes.add(
-            change(
-                current.type(),
-                previous.success(),
-                current.success(),
-                metadataChanged(previous, current)));
+        changes.add(changedCheckEntry(previous, current));
       }
     }
 
     for (var previous : previousChecks) {
       if (isRemovedCheck(previous, currentByType)) {
-        changes.add(change(previous.type(), previous.success(), "N/A", true));
+        changes.add(removedCheckEntry(previous));
       }
     }
 
@@ -69,13 +64,24 @@ public class KybDataChangeDetector {
     return !currentByType.containsKey(previous.type());
   }
 
-  private Map<String, Object> change(
-      KybCheckType type, Object previousSuccess, Object currentSuccess, boolean metadataChanged) {
+  private Map<String, Object> changedCheckEntry(KybCheck previous, KybCheck current) {
     return Map.of(
-        "check", type.name(),
-        "previousSuccess", previousSuccess,
-        "currentSuccess", currentSuccess,
-        "metadataChanged", metadataChanged);
+        "check", current.type().name(),
+        "previousSuccess", previous.success(),
+        "currentSuccess", current.success(),
+        "metadataChanged", metadataChanged(previous, current));
+  }
+
+  private Map<String, Object> removedCheckEntry(KybCheck previous) {
+    return Map.of(
+        "check",
+        previous.type().name(),
+        "previousSuccess",
+        previous.success(),
+        "currentSuccess",
+        "N/A",
+        "metadataChanged",
+        true);
   }
 
   private boolean changed(KybCheck previous, KybCheck current) {

--- a/src/main/java/ee/tuleva/onboarding/kyb/KybMonitoringCompletedEvent.java
+++ b/src/main/java/ee/tuleva/onboarding/kyb/KybMonitoringCompletedEvent.java
@@ -1,0 +1,5 @@
+package ee.tuleva.onboarding.kyb;
+
+import java.time.Instant;
+
+public record KybMonitoringCompletedEvent(Instant startedAt) {}

--- a/src/main/java/ee/tuleva/onboarding/kyb/KybMonitoringService.java
+++ b/src/main/java/ee/tuleva/onboarding/kyb/KybMonitoringService.java
@@ -1,8 +1,10 @@
 package ee.tuleva.onboarding.kyb;
 
 import ee.tuleva.onboarding.company.CompanyRepository;
+import java.time.Clock;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 
 @Slf4j
@@ -12,8 +14,11 @@ public class KybMonitoringService {
 
   private final LegalEntityScreener legalEntityScreener;
   private final CompanyRepository companyRepository;
+  private final ApplicationEventPublisher eventPublisher;
+  private final Clock clock;
 
   public void screenAllCompanies() {
+    var startedAt = clock.instant();
     var companies = companyRepository.findAll();
     log.info("Starting daily KYB monitoring: companyCount={}", companies.size());
     int successCount = 0;
@@ -32,5 +37,6 @@ public class KybMonitoringService {
         "Daily KYB monitoring completed: successCount={}, failureCount={}",
         successCount,
         failureCount);
+    eventPublisher.publishEvent(new KybMonitoringCompletedEvent(startedAt));
   }
 }

--- a/src/main/java/ee/tuleva/onboarding/ledger/LedgerService.java
+++ b/src/main/java/ee/tuleva/onboarding/ledger/LedgerService.java
@@ -3,6 +3,7 @@ package ee.tuleva.onboarding.ledger;
 import ee.tuleva.onboarding.fund.TulevaFund;
 import ee.tuleva.onboarding.ledger.LedgerParty.PartyType;
 import ee.tuleva.onboarding.party.PartyId;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -30,6 +31,13 @@ public class LedgerService {
     return ledgerAccountService
         .findUserAccount(party, userAccount)
         .orElseGet(() -> ledgerAccountService.createUserAccount(party, userAccount));
+  }
+
+  public Optional<LedgerAccount> findPartyAccount(
+      String ownerId, PartyType partyType, UserAccount userAccount) {
+    return ledgerPartyService
+        .getParty(ownerId, partyType)
+        .flatMap(party -> ledgerAccountService.findUserAccount(party, userAccount));
   }
 
   public int countAccountsWithPositiveBalance(UserAccount userAccount) {

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/LegalEntityManualReviewNotifier.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/LegalEntityManualReviewNotifier.java
@@ -6,9 +6,13 @@ import ee.tuleva.onboarding.kyb.KybMonitoringCompletedEvent;
 import ee.tuleva.onboarding.notification.OperationsNotificationService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NullMarked;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
+@Slf4j
+@NullMarked
 @Component
 @RequiredArgsConstructor
 class LegalEntityManualReviewNotifier {
@@ -18,6 +22,14 @@ class LegalEntityManualReviewNotifier {
 
   @EventListener
   public void onKybMonitoringCompleted(KybMonitoringCompletedEvent event) {
+    try {
+      notifyIfCompaniesNeedManualReview(event);
+    } catch (Exception e) {
+      log.error("Manual review digest failed: startedAt={}", event.startedAt(), e);
+    }
+  }
+
+  private void notifyIfCompaniesNeedManualReview(KybMonitoringCompletedEvent event) {
     List<String> registryCodes =
         savingsFundOnboardingRepository.findCompletedLegalEntitiesWithFailedOwnershipChecksSince(
             event.startedAt());

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/LegalEntityManualReviewNotifier.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/LegalEntityManualReviewNotifier.java
@@ -1,0 +1,32 @@
+package ee.tuleva.onboarding.savings.fund;
+
+import static ee.tuleva.onboarding.notification.OperationsNotificationService.Channel.AML;
+
+import ee.tuleva.onboarding.kyb.KybMonitoringCompletedEvent;
+import ee.tuleva.onboarding.notification.OperationsNotificationService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+class LegalEntityManualReviewNotifier {
+
+  private final SavingsFundOnboardingRepository savingsFundOnboardingRepository;
+  private final OperationsNotificationService notificationService;
+
+  @EventListener
+  public void onKybMonitoringCompleted(KybMonitoringCompletedEvent event) {
+    List<String> registryCodes =
+        savingsFundOnboardingRepository.findCompletedLegalEntitiesWithFailedOwnershipChecksSince(
+            event.startedAt());
+    if (registryCodes.isEmpty()) {
+      return;
+    }
+    notificationService.sendMessage(
+        "KYB ownership verification inconclusive, manual review needed: companyCount=%d, registryCodes=%s"
+            .formatted(registryCodes.size(), String.join(", ", registryCodes)),
+        AML);
+  }
+}

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/LegalEntityOnboardingEventListener.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/LegalEntityOnboardingEventListener.java
@@ -28,9 +28,19 @@ class LegalEntityOnboardingEventListener {
     var personalCode = event.getPersonalCode().value();
     var oldStatus =
         savingsFundOnboardingRepository.findStatus(registryCode, LEGAL_ENTITY).orElse(null);
-    var newStatus = allGateChecksPassed(event) ? COMPLETED : REJECTED;
+    var failedGateChecks = failedGateChecks(event);
+    var newStatus = failedGateChecks.isEmpty() ? COMPLETED : REJECTED;
 
     if (newStatus == oldStatus) {
+      return;
+    }
+
+    if (oldStatus == COMPLETED && isInconclusiveOwnershipFailure(failedGateChecks, event)) {
+      log.error(
+          "KYB ownership verification inconclusive, keeping completed status for manual review: registryCode={}, personalCode={}, failedChecks={}",
+          registryCode,
+          personalCode,
+          formatFailedChecks(event.getChecks()));
       return;
     }
 
@@ -52,10 +62,17 @@ class LegalEntityOnboardingEventListener {
     }
   }
 
-  private boolean allGateChecksPassed(KybCheckPerformedEvent event) {
+  private List<KybCheck> failedGateChecks(KybCheckPerformedEvent event) {
     return event.getChecks().stream()
-        .filter(check -> check.type().isOnboardingGate())
-        .allMatch(KybCheck::success);
+        .filter(check -> check.type().isOnboardingGate() && !check.success())
+        .toList();
+  }
+
+  private boolean isInconclusiveOwnershipFailure(
+      List<KybCheck> failedGateChecks, KybCheckPerformedEvent event) {
+    return !failedGateChecks.isEmpty()
+        && failedGateChecks.stream().allMatch(check -> check.type().isOwnershipCheck())
+        && !event.hasOwnershipEvidenceChange();
   }
 
   private static String formatFailedChecks(List<KybCheck> checks) {

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/LegalEntityOnboardingEventListener.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/LegalEntityOnboardingEventListener.java
@@ -52,6 +52,12 @@ class LegalEntityOnboardingEventListener {
           registryCode,
           personalCode,
           oldStatus);
+    } else if (oldStatus == COMPLETED) {
+      log.error(
+          "Legal entity onboarding rejected after being completed: registryCode={}, personalCode={}, failedChecks={}",
+          registryCode,
+          personalCode,
+          formatFailedChecks(event.getChecks()));
     } else {
       log.info(
           "Legal entity onboarding rejected: registryCode={}, personalCode={}, oldStatus={}, failedChecks={}",
@@ -72,7 +78,7 @@ class LegalEntityOnboardingEventListener {
       List<KybCheck> failedGateChecks, KybCheckPerformedEvent event) {
     return !failedGateChecks.isEmpty()
         && failedGateChecks.stream().allMatch(check -> check.type().isOwnershipCheck())
-        && !event.hasOwnershipEvidenceChange();
+        && !event.hasMetadataChangeFor(failedGateChecks.stream().map(KybCheck::type).toList());
   }
 
   private static String formatFailedChecks(List<KybCheck> checks) {

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/SavingsFundOnboardingRepository.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/SavingsFundOnboardingRepository.java
@@ -2,8 +2,11 @@ package ee.tuleva.onboarding.savings.fund;
 
 import static ee.tuleva.onboarding.savings.fund.SavingsFundOnboardingStatus.COMPLETED;
 
+import ee.tuleva.onboarding.kyb.KybCheckType;
 import ee.tuleva.onboarding.party.PartyId;
+import java.sql.Timestamp;
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -44,17 +47,23 @@ public class SavingsFundOnboardingRepository {
                 FROM aml_check ac
                 JOIN company c ON ac.company_id = c.id
                 WHERE c.registry_code = o.code
-                  AND ac.type IN ('KYB_SOLE_MEMBER_OWNERSHIP',
-                                  'KYB_DUAL_MEMBER_OWNERSHIP',
-                                  'KYB_SINGLE_BOARD_MEMBER_OWNERSHIP')
+                  AND ac.type IN (:ownershipCheckTypes)
                   AND ac.success = false
                   AND ac.created_time >= :since
               )
             ORDER BY o.code
             """)
-        .param("since", since)
+        .param("ownershipCheckTypes", ownershipCheckTypeNames())
+        .param("since", Timestamp.from(since))
         .query(String.class)
         .list();
+  }
+
+  private static List<String> ownershipCheckTypeNames() {
+    return Arrays.stream(KybCheckType.values())
+        .filter(KybCheckType::isOwnershipCheck)
+        .map(type -> "KYB_" + type.name())
+        .toList();
   }
 
   @Transactional

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/SavingsFundOnboardingRepository.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/SavingsFundOnboardingRepository.java
@@ -3,6 +3,8 @@ package ee.tuleva.onboarding.savings.fund;
 import static ee.tuleva.onboarding.savings.fund.SavingsFundOnboardingStatus.COMPLETED;
 
 import ee.tuleva.onboarding.party.PartyId;
+import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.jdbc.core.simple.JdbcClient;
@@ -27,6 +29,32 @@ public class SavingsFundOnboardingRepository {
         .query(String.class)
         .optional()
         .map(SavingsFundOnboardingStatus::valueOf);
+  }
+
+  public List<String> findCompletedLegalEntitiesWithFailedOwnershipChecksSince(Instant since) {
+    return jdbcClient
+        .sql(
+            """
+            SELECT o.code
+            FROM savings_fund_onboarding o
+            WHERE o.type = 'LEGAL_ENTITY'
+              AND o.status = 'COMPLETED'
+              AND EXISTS (
+                SELECT 1
+                FROM aml_check ac
+                JOIN company c ON ac.company_id = c.id
+                WHERE c.registry_code = o.code
+                  AND ac.type IN ('KYB_SOLE_MEMBER_OWNERSHIP',
+                                  'KYB_DUAL_MEMBER_OWNERSHIP',
+                                  'KYB_SINGLE_BOARD_MEMBER_OWNERSHIP')
+                  AND ac.success = false
+                  AND ac.created_time >= :since
+              )
+            ORDER BY o.code
+            """)
+        .param("since", since)
+        .query(String.class)
+        .list();
   }
 
   @Transactional

--- a/src/test/groovy/ee/tuleva/onboarding/account/AccountStatementControllerSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/account/AccountStatementControllerSpec.groovy
@@ -102,7 +102,7 @@ class AccountStatementControllerSpec extends BaseControllerSpec {
     0 * accountStatementService.getAccountStatement(_, _, _)
   }
 
-  def "/savings-account-statement endpoint returns savings account balance if onboarded"() {
+  def "/savings-account-statement endpoint returns savings account balance when a statement exists"() {
     given:
     FundBalance fundBalance = FundBalance.builder()
         .fund(FundFixture.additionalSavingsFund())
@@ -112,7 +112,7 @@ class AccountStatementControllerSpec extends BaseControllerSpec {
         .contributions(10)
         .subtractions(0)
         .build()
-    1 * savingsFundStatementService.getAccountStatement(_ as Person) >> fundBalance
+    1 * savingsFundStatementService.getAccountStatement(_ as Person) >> Optional.of(fundBalance)
     localeService.getCurrentLocale() >> LocaleConfiguration.DEFAULT_LOCALE
 
     expect:
@@ -121,13 +121,26 @@ class AccountStatementControllerSpec extends BaseControllerSpec {
         .andExpect(jsonPath('fund.name', is(fundBalance.fund.nameEstonian)))
   }
 
-  def "/savings-account-statement endpoint returns no content if not onboarded"() {
+  def "/savings-account-statement endpoint returns no content when there is no savings account"() {
     given:
-    1 * savingsFundStatementService.getAccountStatement(_ as Person) >> { throw new IllegalStateException("not onboarded") }
+    1 * savingsFundStatementService.getAccountStatement(_ as Person) >> Optional.empty()
     localeService.getCurrentLocale() >> LocaleConfiguration.DEFAULT_LOCALE
 
     expect:
     mockMvc.perform(get("/v1/savings-account-statement"))
         .andExpect(status().isNoContent())
+  }
+
+  def "/savings-account-statement endpoint propagates errors instead of swallowing them as no content"() {
+    given:
+    1 * savingsFundStatementService.getAccountStatement(_ as Person) >> { throw new IllegalStateException("boom") }
+    localeService.getCurrentLocale() >> LocaleConfiguration.DEFAULT_LOCALE
+
+    when:
+    mockMvc.perform(get("/v1/savings-account-statement"))
+
+    then:
+    def exception = thrown(Exception)
+    exception.cause instanceof IllegalStateException
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/account/SavingsFundStatementServiceSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/account/SavingsFundStatementServiceSpec.groovy
@@ -43,7 +43,7 @@ class SavingsFundStatementServiceSpec extends Specification {
     fundRepository.findByIsin(savingsFund.isin) >> savingsFund
 
     when:
-    FundBalance savingsAccountStatement = service.getAccountStatement(person)
+    FundBalance savingsAccountStatement = service.getAccountStatement(person).get()
 
     then:
     savingsAccountStatement.fund == savingsFund
@@ -71,7 +71,7 @@ class SavingsFundStatementServiceSpec extends Specification {
     fundRepository.findByIsin(savingsFund.isin) >> savingsFund
 
     when:
-    FundBalance savingsAccountStatement = service.getAccountStatement(person)
+    FundBalance savingsAccountStatement = service.getAccountStatement(person).get()
 
     then:
     savingsAccountStatement.fund == savingsFund
@@ -79,16 +79,73 @@ class SavingsFundStatementServiceSpec extends Specification {
     savingsAccountStatement.value == 2.25
   }
 
-  def "throws exception if user is not onboarded"() {
+  def "returns balance for a not-onboarded party that has a ledger account"() {
+    given:
+    def person = sampleAuthenticatedPersonLegalEntity().build()
+    def registryCode = person.role.code()
+    def savingsFund = additionalSavingsFund()
+
+    savingsFundOnboardingService.isOnboardingCompleted(_ as PartyId) >> false
+    navProvider.getDisplayNav(_ as TulevaFund) >> new BigDecimal("1.12345")
+    ledgerService.findPartyAccount(registryCode, LEGAL_ENTITY, FUND_UNITS) >> Optional.of(fundUnitsAccountWithBalance(2.0))
+    ledgerService.findPartyAccount(registryCode, LEGAL_ENTITY, FUND_UNITS_RESERVED) >> Optional.of(fundUnitsReservedAccountWithBalance(1.0))
+    ledgerService.findPartyAccount(registryCode, LEGAL_ENTITY, SUBSCRIPTIONS) >> Optional.of(subscriptionsAccountWithBalance(3.0))
+    ledgerService.findPartyAccount(registryCode, LEGAL_ENTITY, REDEMPTIONS) >> Optional.of(redemptionsAccountWithBalance(1.0))
+    savingsFundConfiguration.getIsin() >> savingsFund.isin
+    fundRepository.findByIsin(savingsFund.isin) >> savingsFund
+
+    when:
+    def statement = service.getAccountStatement(person)
+
+    then:
+    statement.present
+    statement.get().fund == savingsFund
+    statement.get().units == 2
+    statement.get().value == 2.25
+    statement.get().unavailableUnits == 1
+    statement.get().contributions == 3
+    statement.get().subtractions == -1
+    0 * ledgerService.getPartyAccount(_, _, _)
+  }
+
+  def "missing secondary accounts default to zero for a not-onboarded party"() {
+    given:
+    def person = sampleAuthenticatedPersonLegalEntity().build()
+    def registryCode = person.role.code()
+    def savingsFund = additionalSavingsFund()
+
+    savingsFundOnboardingService.isOnboardingCompleted(_ as PartyId) >> false
+    navProvider.getDisplayNav(_ as TulevaFund) >> new BigDecimal("1.12345")
+    ledgerService.findPartyAccount(registryCode, LEGAL_ENTITY, FUND_UNITS) >> Optional.of(fundUnitsAccountWithBalance(2.0))
+    ledgerService.findPartyAccount(registryCode, LEGAL_ENTITY, FUND_UNITS_RESERVED) >> Optional.empty()
+    ledgerService.findPartyAccount(registryCode, LEGAL_ENTITY, SUBSCRIPTIONS) >> Optional.empty()
+    ledgerService.findPartyAccount(registryCode, LEGAL_ENTITY, REDEMPTIONS) >> Optional.empty()
+    savingsFundConfiguration.getIsin() >> savingsFund.isin
+    fundRepository.findByIsin(savingsFund.isin) >> savingsFund
+
+    when:
+    def statement = service.getAccountStatement(person)
+
+    then:
+    statement.present
+    statement.get().units == 2
+    statement.get().unavailableUnits == 0
+    statement.get().contributions == 0
+    statement.get().subtractions == 0
+  }
+
+  def "returns empty for a not-onboarded party without a ledger account"() {
     given:
     def person = sampleAuthenticatedPersonAndMember().build()
 
     savingsFundOnboardingService.isOnboardingCompleted(_ as PartyId) >> false
+    ledgerService.findPartyAccount(person.personalCode, PERSON, FUND_UNITS) >> Optional.empty()
 
     when:
-    service.getAccountStatement(person)
+    def statement = service.getAccountStatement(person)
 
     then:
-    thrown(IllegalStateException)
+    statement.empty
+    0 * ledgerService.getPartyAccount(_, _, _)
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/kyb/KybDataChangeDetectorTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyb/KybDataChangeDetectorTest.java
@@ -164,6 +164,71 @@ class KybDataChangeDetectorTest {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
+  void successFlipWithUnchangedMetadataIsMarkedInconclusive() {
+    var metadata = Map.<String, Object>of("personalCode", "38501010001", "ownershipPercent", "100");
+    var previousChecks = List.of(new KybCheck(SOLE_MEMBER_OWNERSHIP, true, metadata));
+    var currentChecks = List.of(new KybCheck(SOLE_MEMBER_OWNERSHIP, false, metadata));
+    when(checkHistory.getLatestChecks(PERSONAL_CODE, REGISTRY_CODE)).thenReturn(previousChecks);
+
+    var result = detector.detect(PERSONAL_CODE, REGISTRY_CODE, currentChecks);
+
+    var changes = (List<Map<String, Object>>) result.metadata().get("changes");
+    assertThat(changes).hasSize(1);
+    assertThat(changes.getFirst())
+        .containsEntry("check", "SOLE_MEMBER_OWNERSHIP")
+        .containsEntry("metadataChanged", false);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void metadataChangeIsMarkedAsEvidence() {
+    var previousChecks =
+        List.of(
+            new KybCheck(
+                SOLE_MEMBER_OWNERSHIP,
+                true,
+                Map.of("personalCode", "38501010001", "ownershipPercent", "100")));
+    var currentChecks =
+        List.of(
+            new KybCheck(
+                SOLE_MEMBER_OWNERSHIP,
+                false,
+                Map.of("personalCode", "39901010000", "ownershipPercent", "100")));
+    when(checkHistory.getLatestChecks(PERSONAL_CODE, REGISTRY_CODE)).thenReturn(previousChecks);
+
+    var result = detector.detect(PERSONAL_CODE, REGISTRY_CODE, currentChecks);
+
+    var changes = (List<Map<String, Object>>) result.metadata().get("changes");
+    assertThat(changes).hasSize(1);
+    assertThat(changes.getFirst())
+        .containsEntry("check", "SOLE_MEMBER_OWNERSHIP")
+        .containsEntry("metadataChanged", true);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void removedCheckIsMarkedAsMetadataChanged() {
+    var previousChecks =
+        List.of(
+            new KybCheck(COMPANY_ACTIVE, true, Map.of("status", "R")),
+            new KybCheck(SOLE_MEMBER_OWNERSHIP, true, Map.of()));
+    var currentChecks =
+        List.of(
+            new KybCheck(COMPANY_ACTIVE, true, Map.of("status", "R")),
+            new KybCheck(DUAL_MEMBER_OWNERSHIP, true, Map.of()));
+    when(checkHistory.getLatestChecks(PERSONAL_CODE, REGISTRY_CODE)).thenReturn(previousChecks);
+
+    var result = detector.detect(PERSONAL_CODE, REGISTRY_CODE, currentChecks);
+
+    var changes = (List<Map<String, Object>>) result.metadata().get("changes");
+    assertThat(changes).hasSize(1);
+    assertThat(changes.getFirst())
+        .containsEntry("check", "SOLE_MEMBER_OWNERSHIP")
+        .containsEntry("metadataChanged", true);
+  }
+
+  @Test
   void volatileSanctionMetadataAloneDoesNotCountAsChange() {
     var previousChecks =
         List.of(new KybCheck(COMPANY_SANCTION, true, Map.of("results", "[{id=Q1, score=0.31}]")));

--- a/src/test/groovy/ee/tuleva/onboarding/kyb/KybMonitoringServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyb/KybMonitoringServiceTest.java
@@ -5,16 +5,24 @@ import static org.mockito.Mockito.*;
 
 import ee.tuleva.onboarding.company.Company;
 import ee.tuleva.onboarding.company.CompanyRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationEventPublisher;
 
 class KybMonitoringServiceTest {
 
+  private static final Instant NOW = Instant.parse("2026-07-02T00:00:00Z");
+
   private final LegalEntityScreener legalEntityScreener = mock(LegalEntityScreener.class);
   private final CompanyRepository companyRepository = mock(CompanyRepository.class);
+  private final ApplicationEventPublisher eventPublisher = mock(ApplicationEventPublisher.class);
 
   private final KybMonitoringService service =
-      new KybMonitoringService(legalEntityScreener, companyRepository);
+      new KybMonitoringService(
+          legalEntityScreener, companyRepository, eventPublisher, Clock.fixed(NOW, ZoneOffset.UTC));
 
   @Test
   void screenAllCompaniesScreensEachCompany() {
@@ -48,5 +56,26 @@ class KybMonitoringServiceTest {
     service.screenAllCompanies();
 
     verifyNoInteractions(legalEntityScreener);
+  }
+
+  @Test
+  void screenAllCompaniesPublishesCompletionEventWithRunStartTime() {
+    var company = Company.builder().registryCode("11111111").name("Company 1").build();
+    given(companyRepository.findAll()).willReturn(List.of(company));
+
+    service.screenAllCompanies();
+
+    verify(eventPublisher).publishEvent(new KybMonitoringCompletedEvent(NOW));
+  }
+
+  @Test
+  void screenAllCompaniesPublishesCompletionEventEvenWhenScreeningsFail() {
+    var company = Company.builder().registryCode("11111111").name("Company 1").build();
+    given(companyRepository.findAll()).willReturn(List.of(company));
+    doThrow(new IllegalStateException("boom")).when(legalEntityScreener).screenLatest("11111111");
+
+    service.screenAllCompanies();
+
+    verify(eventPublisher).publishEvent(new KybMonitoringCompletedEvent(NOW));
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/kyb/KybScreeningIntegrationTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyb/KybScreeningIntegrationTest.java
@@ -2,10 +2,12 @@ package ee.tuleva.onboarding.kyb;
 
 import static ee.tuleva.onboarding.aml.AmlCheckType.*;
 import static ee.tuleva.onboarding.kyb.CompanyStatus.R;
-import static ee.tuleva.onboarding.kyb.KybKycStatus.*;
 import static ee.tuleva.onboarding.kyb.KybTestFixtures.boardMemberOwner;
 import static ee.tuleva.onboarding.kyb.KybTestFixtures.companyWith;
 import static ee.tuleva.onboarding.kyb.KybTestFixtures.kybPerson;
+import static ee.tuleva.onboarding.party.PartyId.Type.LEGAL_ENTITY;
+import static ee.tuleva.onboarding.savings.fund.SavingsFundOnboardingStatus.COMPLETED;
+import static ee.tuleva.onboarding.savings.fund.SavingsFundOnboardingStatus.REJECTED;
 import static ee.tuleva.onboarding.time.ClockHolder.aYearAgo;
 import static java.time.temporal.ChronoUnit.DAYS;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -16,9 +18,7 @@ import ee.tuleva.onboarding.aml.AmlCheck;
 import ee.tuleva.onboarding.aml.AmlCheckRepository;
 import ee.tuleva.onboarding.aml.sanctions.MatchResponse;
 import ee.tuleva.onboarding.aml.sanctions.PepAndSanctionCheckService;
-import ee.tuleva.onboarding.party.PartyId;
 import ee.tuleva.onboarding.savings.fund.SavingsFundOnboardingRepository;
-import ee.tuleva.onboarding.savings.fund.SavingsFundOnboardingStatus;
 import ee.tuleva.onboarding.time.ClockHolder;
 import jakarta.persistence.EntityManager;
 import java.math.BigDecimal;
@@ -102,7 +102,7 @@ class KybScreeningIntegrationTest {
             .boardMember(true)
             .shareholder(true)
             .ownershipPercent(BigDecimal.valueOf(100))
-            .kycStatus(COMPLETED)
+            .kycStatus(KybKycStatus.COMPLETED)
             .build();
     var data = companyWith(person);
 
@@ -153,7 +153,7 @@ class KybScreeningIntegrationTest {
 
   @Test
   void relatedPersonWithRejectedKycCreatesFailedKycCheck() {
-    var person = boardMemberOwner(PERSONAL_CODE, 100.0).kycStatus(REJECTED).build();
+    var person = boardMemberOwner(PERSONAL_CODE, 100.0).kycStatus(KybKycStatus.REJECTED).build();
     var data = companyWith(person);
 
     var results = kybScreeningService.screen(data);
@@ -174,7 +174,8 @@ class KybScreeningIntegrationTest {
 
   @Test
   void companyWithUnidentifiedRelatedPersonIsBlockedWithoutCrashing() {
-    var unidentified = boardMemberOwner((PersonalCode) null, 100.0).kycStatus(UNKNOWN).build();
+    var unidentified =
+        boardMemberOwner((PersonalCode) null, 100.0).kycStatus(KybKycStatus.UNKNOWN).build();
     var data = companyWith(unidentified);
 
     var results = kybScreeningService.screen(data);
@@ -239,8 +240,7 @@ class KybScreeningIntegrationTest {
     var registryCode = "12345678";
     var owner = boardMemberOwner(PERSONAL_CODE, 100.0).build();
     kybScreeningService.screen(companyWith(owner));
-    assertThat(onboardingRepository.findStatus(registryCode, PartyId.Type.LEGAL_ENTITY))
-        .contains(SavingsFundOnboardingStatus.COMPLETED);
+    assertThat(onboardingRepository.findStatus(registryCode, LEGAL_ENTITY)).contains(COMPLETED);
 
     entityManager.flush();
     entityManager.clear();
@@ -251,8 +251,7 @@ class KybScreeningIntegrationTest {
 
     assertThat(results)
         .anyMatch(check -> check.type() == KybCheckType.SOLE_MEMBER_OWNERSHIP && !check.success());
-    assertThat(onboardingRepository.findStatus(registryCode, PartyId.Type.LEGAL_ENTITY))
-        .contains(SavingsFundOnboardingStatus.COMPLETED);
+    assertThat(onboardingRepository.findStatus(registryCode, LEGAL_ENTITY)).contains(COMPLETED);
   }
 
   @Test
@@ -268,8 +267,7 @@ class KybScreeningIntegrationTest {
         boardMemberOwner("49001010001", 100.0).beneficialOwner(false).build();
     kybScreeningService.screen(companyWith(newOwnerWithoutBeneficialOwnerEvidence));
 
-    assertThat(onboardingRepository.findStatus(registryCode, PartyId.Type.LEGAL_ENTITY))
-        .contains(SavingsFundOnboardingStatus.REJECTED);
+    assertThat(onboardingRepository.findStatus(registryCode, LEGAL_ENTITY)).contains(REJECTED);
   }
 
   @Test

--- a/src/test/groovy/ee/tuleva/onboarding/kyb/KybScreeningIntegrationTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyb/KybScreeningIntegrationTest.java
@@ -16,6 +16,9 @@ import ee.tuleva.onboarding.aml.AmlCheck;
 import ee.tuleva.onboarding.aml.AmlCheckRepository;
 import ee.tuleva.onboarding.aml.sanctions.MatchResponse;
 import ee.tuleva.onboarding.aml.sanctions.PepAndSanctionCheckService;
+import ee.tuleva.onboarding.party.PartyId;
+import ee.tuleva.onboarding.savings.fund.SavingsFundOnboardingRepository;
+import ee.tuleva.onboarding.savings.fund.SavingsFundOnboardingStatus;
 import ee.tuleva.onboarding.time.ClockHolder;
 import jakarta.persistence.EntityManager;
 import java.math.BigDecimal;
@@ -43,6 +46,8 @@ class KybScreeningIntegrationTest {
 
   @Autowired private KybScreeningService kybScreeningService;
   @Autowired private AmlCheckRepository amlCheckRepository;
+
+  @Autowired private SavingsFundOnboardingRepository onboardingRepository;
   @Autowired private JsonMapper objectMapper;
   @Autowired private Clock clock;
   @Autowired private EntityManager entityManager;
@@ -227,6 +232,44 @@ class KybScreeningIntegrationTest {
             .orElseThrow();
     assertThat(dataChanged.success()).isTrue();
     assertThat((List<Map<String, Object>>) dataChanged.metadata().get("changes")).isEmpty();
+  }
+
+  @Test
+  void missingBeneficialOwnerEvidenceKeepsCompletedCompanyCompleted() {
+    var registryCode = "12345678";
+    var owner = boardMemberOwner(PERSONAL_CODE, 100.0).build();
+    kybScreeningService.screen(companyWith(owner));
+    assertThat(onboardingRepository.findStatus(registryCode, PartyId.Type.LEGAL_ENTITY))
+        .contains(SavingsFundOnboardingStatus.COMPLETED);
+
+    entityManager.flush();
+    entityManager.clear();
+
+    var ownerWithoutBeneficialOwnerEvidence =
+        boardMemberOwner(PERSONAL_CODE, 100.0).beneficialOwner(false).build();
+    var results = kybScreeningService.screen(companyWith(ownerWithoutBeneficialOwnerEvidence));
+
+    assertThat(results)
+        .anyMatch(check -> check.type() == KybCheckType.SOLE_MEMBER_OWNERSHIP && !check.success());
+    assertThat(onboardingRepository.findStatus(registryCode, PartyId.Type.LEGAL_ENTITY))
+        .contains(SavingsFundOnboardingStatus.COMPLETED);
+  }
+
+  @Test
+  void ownerChangeStillRejectsCompletedCompany() {
+    var registryCode = "12345678";
+    var owner = boardMemberOwner(PERSONAL_CODE, 100.0).build();
+    kybScreeningService.screen(companyWith(owner));
+
+    entityManager.flush();
+    entityManager.clear();
+
+    var newOwnerWithoutBeneficialOwnerEvidence =
+        boardMemberOwner("49001010001", 100.0).beneficialOwner(false).build();
+    kybScreeningService.screen(companyWith(newOwnerWithoutBeneficialOwnerEvidence));
+
+    assertThat(onboardingRepository.findStatus(registryCode, PartyId.Type.LEGAL_ENTITY))
+        .contains(SavingsFundOnboardingStatus.REJECTED);
   }
 
   @Test

--- a/src/test/groovy/ee/tuleva/onboarding/ledger/LedgerServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/ledger/LedgerServiceTest.java
@@ -62,6 +62,44 @@ class LedgerServiceTest {
   }
 
   @Test
+  void findPartyAccount_returnsAccountWithoutCreating() {
+    when(ledgerPartyService.getParty(testParty.code(), PERSON))
+        .thenReturn(Optional.of(ledgerParty));
+    when(ledgerAccountService.findUserAccount(ledgerParty, SUBSCRIPTIONS))
+        .thenReturn(Optional.of(account));
+
+    var result = ledgerService.findPartyAccount(testParty.code(), PERSON, SUBSCRIPTIONS);
+
+    assertThat(result).contains(account);
+    verify(ledgerPartyService, never()).getOrCreate(any(), any());
+    verify(ledgerAccountService, never()).createUserAccount(any(), any());
+  }
+
+  @Test
+  void findPartyAccount_returnsEmptyWhenPartyMissing() {
+    when(ledgerPartyService.getParty(testParty.code(), PERSON)).thenReturn(Optional.empty());
+
+    var result = ledgerService.findPartyAccount(testParty.code(), PERSON, SUBSCRIPTIONS);
+
+    assertThat(result).isEmpty();
+    verify(ledgerPartyService, never()).getOrCreate(any(), any());
+    verify(ledgerAccountService, never()).createUserAccount(any(), any());
+  }
+
+  @Test
+  void findPartyAccount_returnsEmptyWhenAccountMissing() {
+    when(ledgerPartyService.getParty(testParty.code(), PERSON))
+        .thenReturn(Optional.of(ledgerParty));
+    when(ledgerAccountService.findUserAccount(ledgerParty, SUBSCRIPTIONS))
+        .thenReturn(Optional.empty());
+
+    var result = ledgerService.findPartyAccount(testParty.code(), PERSON, SUBSCRIPTIONS);
+
+    assertThat(result).isEmpty();
+    verify(ledgerAccountService, never()).createUserAccount(any(), any());
+  }
+
+  @Test
   void getPartyAccount_createsAccountWhenNotFound() {
     when(ledgerPartyService.getOrCreate(testParty.code(), PERSON)).thenReturn(ledgerParty);
     when(ledgerAccountService.findUserAccount(ledgerParty, SUBSCRIPTIONS))

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/LegalEntityManualReviewNotifierTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/LegalEntityManualReviewNotifierTest.java
@@ -1,0 +1,48 @@
+package ee.tuleva.onboarding.savings.fund;
+
+import static ee.tuleva.onboarding.notification.OperationsNotificationService.Channel.AML;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import ee.tuleva.onboarding.kyb.KybMonitoringCompletedEvent;
+import ee.tuleva.onboarding.notification.OperationsNotificationService;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class LegalEntityManualReviewNotifierTest {
+
+  private static final Instant RUN_STARTED_AT = Instant.parse("2026-07-02T00:00:00Z");
+
+  private final SavingsFundOnboardingRepository repository =
+      mock(SavingsFundOnboardingRepository.class);
+  private final OperationsNotificationService notificationService =
+      mock(OperationsNotificationService.class);
+  private final LegalEntityManualReviewNotifier notifier =
+      new LegalEntityManualReviewNotifier(repository, notificationService);
+
+  @Test
+  void sendsOneSummaryMessageToAmlChannelWhenCompaniesNeedManualReview() {
+    given(repository.findCompletedLegalEntitiesWithFailedOwnershipChecksSince(RUN_STARTED_AT))
+        .willReturn(List.of("11111111", "22222222"));
+
+    notifier.onKybMonitoringCompleted(new KybMonitoringCompletedEvent(RUN_STARTED_AT));
+
+    verify(notificationService)
+        .sendMessage(
+            "KYB ownership verification inconclusive, manual review needed: companyCount=2, registryCodes=11111111, 22222222",
+            AML);
+  }
+
+  @Test
+  void sendsNothingWhenNoCompaniesNeedManualReview() {
+    given(repository.findCompletedLegalEntitiesWithFailedOwnershipChecksSince(RUN_STARTED_AT))
+        .willReturn(List.of());
+
+    notifier.onKybMonitoringCompleted(new KybMonitoringCompletedEvent(RUN_STARTED_AT));
+
+    verifyNoInteractions(notificationService);
+  }
+}

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/LegalEntityManualReviewNotifierTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/LegalEntityManualReviewNotifierTest.java
@@ -1,7 +1,9 @@
 package ee.tuleva.onboarding.savings.fund;
 
 import static ee.tuleva.onboarding.notification.OperationsNotificationService.Channel.AML;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -34,6 +36,27 @@ class LegalEntityManualReviewNotifierTest {
         .sendMessage(
             "KYB ownership verification inconclusive, manual review needed: companyCount=2, registryCodes=11111111, 22222222",
             AML);
+  }
+
+  @Test
+  void doesNotPropagateNotificationFailures() {
+    given(repository.findCompletedLegalEntitiesWithFailedOwnershipChecksSince(RUN_STARTED_AT))
+        .willReturn(List.of("11111111"));
+    willThrow(new IllegalStateException("slack down"))
+        .given(notificationService)
+        .sendMessage(any(), any());
+
+    notifier.onKybMonitoringCompleted(new KybMonitoringCompletedEvent(RUN_STARTED_AT));
+  }
+
+  @Test
+  void doesNotPropagateQueryFailures() {
+    given(repository.findCompletedLegalEntitiesWithFailedOwnershipChecksSince(RUN_STARTED_AT))
+        .willThrow(new IllegalStateException("db down"));
+
+    notifier.onKybMonitoringCompleted(new KybMonitoringCompletedEvent(RUN_STARTED_AT));
+
+    verifyNoInteractions(notificationService);
   }
 
   @Test

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/LegalEntityOnboardingEventListenerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/LegalEntityOnboardingEventListenerTest.java
@@ -78,12 +78,120 @@ class LegalEntityOnboardingEventListenerTest {
   }
 
   @Test
-  void setsStatusRejectedEvenIfPreviouslyCompleted() {
+  void setsStatusRejectedEvenIfPreviouslyCompletedWhenNonOwnershipGateCheckFails() {
     when(repository.findStatus("12345678", LEGAL_ENTITY)).thenReturn(Optional.of(COMPLETED));
     var checks =
         List.of(
             new KybCheck(COMPANY_ACTIVE, true, Map.of()),
             new KybCheck(COMPANY_STRUCTURE, false, Map.of()));
+
+    listener.onKybCheckPerformed(eventWith(checks));
+
+    verify(repository).saveOnboardingStatus("12345678", LEGAL_ENTITY, REJECTED);
+  }
+
+  @Test
+  void keepsCompletedWhenOwnershipCheckFailsWithoutEvidenceOfChange() {
+    when(repository.findStatus("12345678", LEGAL_ENTITY)).thenReturn(Optional.of(COMPLETED));
+    var checks =
+        List.of(
+            new KybCheck(COMPANY_ACTIVE, true, Map.of()),
+            new KybCheck(
+                SOLE_MEMBER_OWNERSHIP,
+                false,
+                Map.of("personalCode", "38501010001", "ownershipPercent", "100")),
+            new KybCheck(
+                DATA_CHANGED,
+                false,
+                Map.of(
+                    "changes",
+                    List.of(
+                        Map.of(
+                            "check", "SOLE_MEMBER_OWNERSHIP",
+                            "previousSuccess", true,
+                            "currentSuccess", false,
+                            "metadataChanged", false)))));
+
+    listener.onKybCheckPerformed(eventWith(checks));
+
+    verify(repository, never()).saveOnboardingStatus(any(), any(), any());
+  }
+
+  @Test
+  void keepsCompletedWhenOwnershipCheckFailsAndNoDataChangedCheckPresent() {
+    when(repository.findStatus("12345678", LEGAL_ENTITY)).thenReturn(Optional.of(COMPLETED));
+    var checks =
+        List.of(
+            new KybCheck(COMPANY_ACTIVE, true, Map.of()),
+            new KybCheck(SINGLE_BOARD_MEMBER_OWNERSHIP, false, Map.of()));
+
+    listener.onKybCheckPerformed(eventWith(checks));
+
+    verify(repository, never()).saveOnboardingStatus(any(), any(), any());
+  }
+
+  @Test
+  void setsStatusRejectedWhenOwnershipDataActuallyChanged() {
+    when(repository.findStatus("12345678", LEGAL_ENTITY)).thenReturn(Optional.of(COMPLETED));
+    var checks =
+        List.of(
+            new KybCheck(COMPANY_ACTIVE, true, Map.of()),
+            new KybCheck(
+                SOLE_MEMBER_OWNERSHIP,
+                false,
+                Map.of("personalCode", "39901010000", "ownershipPercent", "100")),
+            new KybCheck(
+                DATA_CHANGED,
+                false,
+                Map.of(
+                    "changes",
+                    List.of(
+                        Map.of(
+                            "check", "SOLE_MEMBER_OWNERSHIP",
+                            "previousSuccess", true,
+                            "currentSuccess", false,
+                            "metadataChanged", true)))));
+
+    listener.onKybCheckPerformed(eventWith(checks));
+
+    verify(repository).saveOnboardingStatus("12345678", LEGAL_ENTITY, REJECTED);
+  }
+
+  @Test
+  void setsStatusRejectedWhenOwnershipCheckOfCompletedCompanyDisappears() {
+    when(repository.findStatus("12345678", LEGAL_ENTITY)).thenReturn(Optional.of(COMPLETED));
+    var checks =
+        List.of(
+            new KybCheck(COMPANY_ACTIVE, true, Map.of()),
+            new KybCheck(DUAL_MEMBER_OWNERSHIP, false, Map.of("totalOwnership", "100")),
+            new KybCheck(
+                DATA_CHANGED,
+                false,
+                Map.of(
+                    "changes",
+                    List.of(
+                        Map.of(
+                            "check",
+                            "SOLE_MEMBER_OWNERSHIP",
+                            "previousSuccess",
+                            true,
+                            "currentSuccess",
+                            "N/A",
+                            "metadataChanged",
+                            true)))));
+
+    listener.onKybCheckPerformed(eventWith(checks));
+
+    verify(repository).saveOnboardingStatus("12345678", LEGAL_ENTITY, REJECTED);
+  }
+
+  @Test
+  void setsStatusRejectedForNewCompanyWhenOwnershipCheckFails() {
+    when(repository.findStatus("12345678", LEGAL_ENTITY)).thenReturn(Optional.empty());
+    var checks =
+        List.of(
+            new KybCheck(COMPANY_ACTIVE, true, Map.of()),
+            new KybCheck(SOLE_MEMBER_OWNERSHIP, false, Map.of()));
 
     listener.onKybCheckPerformed(eventWith(checks));
 

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/LegalEntityOnboardingEventListenerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/LegalEntityOnboardingEventListenerTest.java
@@ -158,7 +158,7 @@ class LegalEntityOnboardingEventListenerTest {
   }
 
   @Test
-  void setsStatusRejectedWhenOwnershipCheckOfCompletedCompanyDisappears() {
+  void keepsCompletedWhenFailingOwnershipCheckHasNoOwnEvidenceDespiteStaleRemovedCheckEntry() {
     when(repository.findStatus("12345678", LEGAL_ENTITY)).thenReturn(Optional.of(COMPLETED));
     var checks =
         List.of(
@@ -177,6 +177,34 @@ class LegalEntityOnboardingEventListenerTest {
                             true,
                             "currentSuccess",
                             "N/A",
+                            "metadataChanged",
+                            true)))));
+
+    listener.onKybCheckPerformed(eventWith(checks));
+
+    verify(repository, never()).saveOnboardingStatus(any(), any(), any());
+  }
+
+  @Test
+  void setsStatusRejectedWhenFailingOwnershipCheckItselfShowsMetadataChange() {
+    when(repository.findStatus("12345678", LEGAL_ENTITY)).thenReturn(Optional.of(COMPLETED));
+    var checks =
+        List.of(
+            new KybCheck(COMPANY_ACTIVE, true, Map.of()),
+            new KybCheck(DUAL_MEMBER_OWNERSHIP, false, Map.of("totalOwnership", "60")),
+            new KybCheck(
+                DATA_CHANGED,
+                false,
+                Map.of(
+                    "changes",
+                    List.of(
+                        Map.of(
+                            "check",
+                            "DUAL_MEMBER_OWNERSHIP",
+                            "previousSuccess",
+                            true,
+                            "currentSuccess",
+                            false,
                             "metadataChanged",
                             true)))));
 

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/SavingsFundOnboardingRepositoryTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/SavingsFundOnboardingRepositoryTest.java
@@ -1,13 +1,23 @@
 package ee.tuleva.onboarding.savings.fund;
 
+import static ee.tuleva.onboarding.aml.AmlCheckType.*;
 import static ee.tuleva.onboarding.party.PartyId.Type.LEGAL_ENTITY;
 import static ee.tuleva.onboarding.party.PartyId.Type.PERSON;
 import static ee.tuleva.onboarding.savings.fund.SavingsFundOnboardingStatus.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import ee.tuleva.onboarding.aml.AmlCheck;
+import ee.tuleva.onboarding.aml.AmlCheckType;
+import ee.tuleva.onboarding.company.Company;
+import ee.tuleva.onboarding.time.ClockHolder;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jpa.test.autoconfigure.TestEntityManager;
 import org.springframework.context.annotation.Import;
 
 @DataJpaTest
@@ -15,6 +25,58 @@ import org.springframework.context.annotation.Import;
 class SavingsFundOnboardingRepositoryTest {
 
   @Autowired SavingsFundOnboardingRepository repository;
+  @Autowired TestEntityManager entityManager;
+
+  @AfterEach
+  void resetClock() {
+    ClockHolder.setDefaultClock();
+  }
+
+  @Test
+  void findsCompletedLegalEntitiesWithFailedOwnershipChecksSince() {
+    var since = Instant.parse("2026-07-02T00:00:00Z");
+
+    var flagged = company("11111111");
+    repository.saveOnboardingStatus("11111111", LEGAL_ENTITY, COMPLETED);
+    amlCheck(flagged, KYB_SOLE_MEMBER_OWNERSHIP, false, since.plusSeconds(60));
+
+    var passing = company("22222222");
+    repository.saveOnboardingStatus("22222222", LEGAL_ENTITY, COMPLETED);
+    amlCheck(passing, KYB_DUAL_MEMBER_OWNERSHIP, true, since.plusSeconds(60));
+
+    var alreadyRejected = company("33333333");
+    repository.saveOnboardingStatus("33333333", LEGAL_ENTITY, REJECTED);
+    amlCheck(alreadyRejected, KYB_SOLE_MEMBER_OWNERSHIP, false, since.plusSeconds(60));
+
+    var staleFailure = company("44444444");
+    repository.saveOnboardingStatus("44444444", LEGAL_ENTITY, COMPLETED);
+    amlCheck(staleFailure, KYB_SINGLE_BOARD_MEMBER_OWNERSHIP, false, since.minusSeconds(3600));
+
+    var nonOwnershipFailure = company("55555555");
+    repository.saveOnboardingStatus("55555555", LEGAL_ENTITY, COMPLETED);
+    amlCheck(nonOwnershipFailure, KYB_COMPANY_ACTIVE, false, since.plusSeconds(60));
+
+    var result = repository.findCompletedLegalEntitiesWithFailedOwnershipChecksSince(since);
+
+    assertThat(result).containsExactly("11111111");
+  }
+
+  private Company company(String registryCode) {
+    return entityManager.persist(
+        Company.builder().registryCode(registryCode).name("Test OÜ " + registryCode).build());
+  }
+
+  private void amlCheck(Company company, AmlCheckType type, boolean success, Instant createdTime) {
+    ClockHolder.setClock(Clock.fixed(createdTime, ZoneOffset.UTC));
+    entityManager.persist(
+        AmlCheck.builder()
+            .personalCode("38501010002")
+            .companyId(company.getId())
+            .type(type)
+            .success(success)
+            .build());
+    entityManager.flush();
+  }
 
   @Test
   void isOnboardingCompleted_returnsTrueOnlyWhenStatusIsCompleted() {


### PR DESCRIPTION
On 2026-07-01 the business registry stopped returning beneficial-owner (tegelik kasusaaja) rows in the ettevottegaSeotudIsikud_v1 response, so every ownership gate check failed and the nightly KYB monitoring flipped all 139 COMPLETED legal entities to REJECTED. The savings account statement endpoint then swallowed the resulting "Not onboarded" exception and returned 204 No Content, so companies saw 0 balances, and one company payment was returned as "not onboarded".

- LegalEntityOnboardingEventListener no longer downgrades a COMPLETED company when the only failing gate checks are ownership checks with no evidence of an actual change; it logs an error for manual review instead. Real changes (owner personal code, ownership percentage, structure swap) still reject, and new companies still cannot complete onboarding without beneficial-owner verification.
- KybDataChangeDetector change entries now carry a metadataChanged flag and KybCheckPerformedEvent exposes hasOwnershipEvidenceChange(), so the change evidence is computed before the event is published instead of re-reading persisted check history in a listener (which would race with the AML listener that persists the current run).
- AccountStatementController no longer swallows exceptions as 204: SavingsFundStatementService returns Optional, empty means 204 (no savings account), and errors propagate as 500 with a stack trace.
- SavingsFundStatementService returns the real balance for any party with a ledger FUND_UNITS account regardless of onboarding status, via the new read-only LedgerService.findPartyAccount (no account-creation side effects for parties that never had one). Pay-ins and pay-outs for rejected companies remain blocked by the existing verification checks.

- After each nightly KYB monitoring run, a single digest message goes to the AML Slack channel (KybMonitoringCompletedEvent -> LegalEntityManualReviewNotifier): the count and registry codes of COMPLETED companies whose ownership checks failed in that run and were kept for manual review. No message when there are none.

Known gap: DUAL/SINGLE_BOARD ownership check metadata does not record owner identities, so a same-total owner swap while beneficial-owner data is unavailable is flagged for manual review rather than auto-rejected. Do not close it by enriching stored metadata shapes - the next nightly comparison would flag every company as changed and mass-downgrade again; add a self-baselining identity fingerprint check instead.