### PR TITLE
Transaction registry: cutover hardening (FT alerting, price/economics guards, cost-basis snapshot)

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/FtConfirmationBatchResult.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/FtConfirmationBatchResult.java
@@ -5,14 +5,17 @@ import org.jspecify.annotations.Nullable;
 
 @NullMarked
 public record FtConfirmationBatchResult(
-    int index, String isin, @Nullable FtConfirmationResult result, @Nullable String error) {
+    int index,
+    @Nullable String isin,
+    @Nullable FtConfirmationResult result,
+    @Nullable String error) {
 
   public static FtConfirmationBatchResult verified(
       int index, String isin, FtConfirmationResult result) {
     return new FtConfirmationBatchResult(index, isin, result, null);
   }
 
-  public static FtConfirmationBatchResult failed(int index, String isin, String error) {
+  public static FtConfirmationBatchResult failed(int index, @Nullable String isin, String error) {
     return new FtConfirmationBatchResult(index, isin, null, error);
   }
 }

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/FtConfirmationResult.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/FtConfirmationResult.java
@@ -1,5 +1,10 @@
 package ee.tuleva.onboarding.investment.transaction;
 
+import static ee.tuleva.onboarding.investment.transaction.FtVerificationStatus.AMBIGUOUS;
+import static ee.tuleva.onboarding.investment.transaction.FtVerificationStatus.CANCELLED;
+import static ee.tuleva.onboarding.investment.transaction.FtVerificationStatus.ERROR;
+import static ee.tuleva.onboarding.investment.transaction.FtVerificationStatus.ORPHAN;
+
 import java.util.Map;
 import org.jspecify.annotations.NullMarked;
 
@@ -7,4 +12,17 @@ import org.jspecify.annotations.NullMarked;
 public record FtConfirmationResult(
     FtVerificationStatus quantityStatus,
     FtVerificationStatus priceStatus,
-    Map<String, String> details) {}
+    Map<String, String> details) {
+
+  public boolean isActionable() {
+    return isActionable(quantityStatus) || isActionable(priceStatus);
+  }
+
+  public boolean isCancellation() {
+    return quantityStatus == CANCELLED;
+  }
+
+  private static boolean isActionable(FtVerificationStatus status) {
+    return status == ERROR || status == AMBIGUOUS || status == ORPHAN || status == CANCELLED;
+  }
+}

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/PortfolioCostBasisService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/PortfolioCostBasisService.java
@@ -58,8 +58,27 @@ public class PortfolioCostBasisService {
     isins.addAll(executionIsins(dayExecutions));
     isins.addAll(carriedForwardIsins(fundIsin, asOfDate));
 
+    Set<String> persistedIsins = new HashSet<>();
     for (String isin : isins) {
-      computeAndUpsert(fund, asOfDate, isin, baseline, dayExecutions);
+      if (computeAndUpsert(fund, asOfDate, isin, baseline, dayExecutions)) {
+        persistedIsins.add(isin);
+      }
+    }
+    deleteStaleRows(fundIsin, asOfDate, persistedIsins);
+  }
+
+  private void deleteStaleRows(String fundIsin, LocalDate asOfDate, Set<String> persistedIsins) {
+    List<PortfolioCostBasis> stale =
+        costBasisRepository.findByFundIsinAndAsOfDate(fundIsin, asOfDate).stream()
+            .filter(row -> !persistedIsins.contains(row.getInstrumentIsin()))
+            .toList();
+    if (!stale.isEmpty()) {
+      log.info(
+          "Deleting stale cost-basis rows: fundIsin={}, asOfDate={}, count={}",
+          fundIsin,
+          asOfDate,
+          stale.size());
+      costBasisRepository.deleteAll(stale);
     }
   }
 
@@ -96,7 +115,7 @@ public class PortfolioCostBasisService {
         row.getAsOfDate());
   }
 
-  private void computeAndUpsert(
+  private boolean computeAndUpsert(
       TulevaFund fund,
       LocalDate asOfDate,
       String isin,
@@ -107,7 +126,7 @@ public class PortfolioCostBasisService {
     List<ExecutionEvent> events = executionsFor(isin, dayExecutions);
 
     if (prior.isEmpty() && events.isEmpty()) {
-      return;
+      return false;
     }
 
     PortfolioCostBasis computed = calculator.calculate(prior, events, fundIsin, isin, asOfDate);
@@ -125,6 +144,7 @@ public class PortfolioCostBasisService {
     } else {
       costBasisRepository.save(computed);
     }
+    return true;
   }
 
   private Optional<PriorPosition> priorPosition(

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/PortfolioCostBasisService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/PortfolioCostBasisService.java
@@ -56,10 +56,18 @@ public class PortfolioCostBasisService {
     List<TransactionExecution> dayExecutions = findExecutionsByTradeDate(fund, asOfDate);
     Set<String> isins = new HashSet<>(baselineEntryIsins(baseline));
     isins.addAll(executionIsins(dayExecutions));
+    isins.addAll(carriedForwardIsins(fundIsin, asOfDate));
 
     for (String isin : isins) {
       computeAndUpsert(fund, asOfDate, isin, baseline, dayExecutions);
     }
+  }
+
+  private List<String> carriedForwardIsins(String fundIsin, LocalDate asOfDate) {
+    return costBasisRepository.findLatestSnapshotBefore(fundIsin, asOfDate).stream()
+        .filter(row -> row.getQuantity() != null && row.getQuantity().signum() != 0)
+        .map(PortfolioCostBasis::getInstrumentIsin)
+        .toList();
   }
 
   @Transactional

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/PortfolioCostBasisService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/PortfolioCostBasisService.java
@@ -84,7 +84,7 @@ public class PortfolioCostBasisService {
 
   private List<String> carriedForwardIsins(String fundIsin, LocalDate asOfDate) {
     return costBasisRepository.findLatestSnapshotBefore(fundIsin, asOfDate).stream()
-        .filter(row -> row.getQuantity() != null && row.getQuantity().signum() != 0)
+        .filter(row -> row.getQuantity().signum() != 0)
         .map(PortfolioCostBasis::getInstrumentIsin)
         .toList();
   }

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionPreparationService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionPreparationService.java
@@ -112,7 +112,7 @@ public class TransactionPreparationService {
 
       return new ProcessCommandResult(batch, orders);
 
-    } catch (IllegalStateException | IllegalArgumentException e) {
+    } catch (RuntimeException e) {
       log.error("Command processing failed: id={}", command.getId(), e);
       command.setStatus(CommandStatus.FAILED);
       command.setErrorMessage(e.getMessage());
@@ -130,6 +130,7 @@ public class TransactionPreparationService {
     LocalDate tradeDate = now.atZone(clock.getZone()).toLocalDate();
 
     List<TransactionOrder> orders = orderRepository.findByBatchId(batch.getId());
+    requireQuantitiesForNonAmountOrders(batch, orders);
     orders.forEach(
         order -> {
           order.setOrderTimestamp(now);
@@ -267,24 +268,50 @@ public class TransactionPreparationService {
     if (isAmountBasedOrder(instrumentType, transactionType)) {
       return null;
     }
-    return positionPriceResolver
-        .resolve(isin, asOfDate)
-        .map(ResolvedPrice::usedPrice)
-        .map(price -> orderAmount.divide(price, 6, RoundingMode.HALF_UP))
-        .orElseGet(
-            () -> {
-              log.warn(
-                  "No price found for order quantity: isin={}, instrumentType={}, asOfDate={}",
-                  isin,
-                  instrumentType,
-                  asOfDate);
-              return null;
-            });
+    BigDecimal price =
+        positionPriceResolver.resolve(isin, asOfDate).map(ResolvedPrice::usedPrice).orElse(null);
+    if (price == null) {
+      log.warn(
+          "No price found for order quantity: isin={}, instrumentType={}, asOfDate={}",
+          isin,
+          instrumentType,
+          asOfDate);
+      return null;
+    }
+    if (price.signum() <= 0) {
+      log.warn(
+          "Non-positive price for order quantity, leaving quantity unset:"
+              + " isin={}, instrumentType={}, price={}, asOfDate={}",
+          isin,
+          instrumentType,
+          price.toPlainString(),
+          asOfDate);
+      return null;
+    }
+    return orderAmount.divide(price, 6, RoundingMode.HALF_UP);
   }
 
   private boolean isAmountBasedOrder(
       InstrumentType instrumentType, TransactionType transactionType) {
     return instrumentType == InstrumentType.FUND && transactionType == TransactionType.BUY;
+  }
+
+  private void requireQuantitiesForNonAmountOrders(
+      TransactionBatch batch, List<TransactionOrder> orders) {
+    List<String> missingQuantity =
+        orders.stream()
+            .filter(
+                order -> !isAmountBasedOrder(order.getInstrumentType(), order.getTransactionType()))
+            .filter(order -> order.getOrderQuantity() == null)
+            .map(TransactionOrder::getInstrumentIsin)
+            .toList();
+    if (!missingQuantity.isEmpty()) {
+      throw new IllegalStateException(
+          "Cannot finalize batch: orders require a quantity but have none: batchId="
+              + batch.getId()
+              + ", isins="
+              + missingQuantity);
+    }
   }
 
   static Map<String, Object> serializeInput(

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionRegistryController.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionRegistryController.java
@@ -25,6 +25,7 @@ import ee.tuleva.onboarding.investment.report.ReportType;
 import ee.tuleva.onboarding.investment.transaction.ingest.FtConfirmationVerificationService;
 import ee.tuleva.onboarding.investment.transaction.ingest.HistoricalRegistryImportService;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
@@ -106,7 +107,7 @@ public class TransactionRegistryController {
   public List<FtConfirmationBatchResult> verifyFtConfirmations(
       @RequestHeader("X-Admin-Token") String token,
       @RequestHeader(name = "X-Admin-Actor", required = false, defaultValue = "admin") String actor,
-      @RequestBody List<FtConfirmation> confirmations) {
+      @Valid @RequestBody List<@NotNull @Valid FtConfirmation> confirmations) {
 
     validateToken(token);
 

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionRegistryController.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionRegistryController.java
@@ -25,7 +25,6 @@ import ee.tuleva.onboarding.investment.report.ReportType;
 import ee.tuleva.onboarding.investment.transaction.ingest.FtConfirmationVerificationService;
 import ee.tuleva.onboarding.investment.transaction.ingest.HistoricalRegistryImportService;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
@@ -107,7 +106,7 @@ public class TransactionRegistryController {
   public List<FtConfirmationBatchResult> verifyFtConfirmations(
       @RequestHeader("X-Admin-Token") String token,
       @RequestHeader(name = "X-Admin-Actor", required = false, defaultValue = "admin") String actor,
-      @Valid @RequestBody List<@NotNull @Valid FtConfirmation> confirmations) {
+      @RequestBody List<FtConfirmation> confirmations) {
 
     validateToken(token);
 

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationAuditRecorder.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationAuditRecorder.java
@@ -7,6 +7,7 @@ import ee.tuleva.onboarding.investment.transaction.FtConfirmationResult;
 import ee.tuleva.onboarding.investment.transaction.TransactionAuditEvent;
 import ee.tuleva.onboarding.investment.transaction.TransactionAuditEventRepository;
 import ee.tuleva.onboarding.investment.transaction.TransactionOrder;
+import java.math.BigDecimal;
 import java.time.Clock;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -84,9 +85,13 @@ class FtConfirmationAuditRecorder {
     return confirmation.fund().name().equals(payload.get("fund"))
         && confirmation.isin().equals(payload.get("isin"))
         && confirmation.tradeDate().toString().equals(payload.get("tradeDate"))
-        && confirmation.quantity().toPlainString().equals(payload.get("quantity"))
-        && confirmation.grossPrice().toPlainString().equals(payload.get("grossPrice"))
+        && sameAmount(confirmation.quantity(), payload.get("quantity"))
+        && sameAmount(confirmation.grossPrice(), payload.get("grossPrice"))
         && confirmation.type().name().equals(payload.get("type"));
+  }
+
+  private static boolean sameAmount(BigDecimal value, @Nullable Object stored) {
+    return stored != null && value.compareTo(new BigDecimal(stored.toString())) == 0;
   }
 
   private static List<String> statusPair(FtConfirmationResult result) {

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationAuditRecorder.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationAuditRecorder.java
@@ -23,6 +23,8 @@ import org.springframework.stereotype.Component;
 class FtConfirmationAuditRecorder {
 
   static final String FT_CONFIRMATION_VERIFIED = "FT_CONFIRMATION_VERIFIED";
+  static final String FT_CONFIRMATION_ALERTED = "FT_CONFIRMATION_ALERTED";
+  private static final String ALERT_ACTOR = "system";
 
   private final TransactionAuditEventRepository auditEventRepository;
   private final Clock clock;
@@ -46,6 +48,23 @@ class FtConfirmationAuditRecorder {
             .createdAt(clock.instant())
             .build());
     return true;
+  }
+
+  boolean alreadyAlerted(FtConfirmation confirmation, FtConfirmationResult result) {
+    return auditEventRepository.findByEventType(FT_CONFIRMATION_ALERTED).stream()
+        .filter(event -> sameConfirmation(event.getPayload(), confirmation))
+        .map(event -> statusPair(event.getPayload()))
+        .anyMatch(statusPair(result)::equals);
+  }
+
+  void recordAlerted(FtConfirmation confirmation, FtConfirmationResult result) {
+    auditEventRepository.save(
+        TransactionAuditEvent.builder()
+            .eventType(FT_CONFIRMATION_ALERTED)
+            .actor(ALERT_ACTOR)
+            .payload(payload(confirmation, result))
+            .createdAt(clock.instant())
+            .build());
   }
 
   private boolean statusUnchangedSinceLastRecord(

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationDigest.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationDigest.java
@@ -1,13 +1,9 @@
 package ee.tuleva.onboarding.investment.transaction.ingest;
 
-import static ee.tuleva.onboarding.investment.transaction.FtVerificationStatus.AMBIGUOUS;
-import static ee.tuleva.onboarding.investment.transaction.FtVerificationStatus.ERROR;
-import static ee.tuleva.onboarding.investment.transaction.FtVerificationStatus.ORPHAN;
 import static ee.tuleva.onboarding.notification.OperationsNotificationService.Channel.INVESTMENT;
 
 import ee.tuleva.onboarding.investment.transaction.FtConfirmation;
 import ee.tuleva.onboarding.investment.transaction.FtConfirmationResult;
-import ee.tuleva.onboarding.investment.transaction.FtVerificationStatus;
 import ee.tuleva.onboarding.notification.OperationsNotificationService;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
@@ -21,40 +17,47 @@ import org.springframework.stereotype.Component;
 class FtConfirmationDigest {
 
   private final OperationsNotificationService notificationService;
+  private final FtConfirmationAuditRecorder auditRecorder;
   private final boolean registryAuthoritative;
 
   FtConfirmationDigest(
       OperationsNotificationService notificationService,
+      FtConfirmationAuditRecorder auditRecorder,
       @Value("${transaction-registry.ft-confirmation.registry-authoritative:false}")
           boolean registryAuthoritative) {
     this.notificationService = notificationService;
+    this.auditRecorder = auditRecorder;
     this.registryAuthoritative = registryAuthoritative;
   }
 
-  void publish(List<FtConfirmationOutcome> changedOutcomes) {
+  void publish(List<FtConfirmationOutcome> outcomes) {
     if (!registryAuthoritative) {
       return;
     }
-    List<FtConfirmationOutcome> actionable =
-        changedOutcomes.stream().filter(FtConfirmationDigest::isActionable).toList();
-    if (actionable.isEmpty()) {
+    List<FtConfirmationOutcome> unalerted =
+        outcomes.stream()
+            .filter(outcome -> outcome.result().isActionable())
+            .filter(
+                outcome -> !auditRecorder.alreadyAlerted(outcome.confirmation(), outcome.result()))
+            .toList();
+    if (unalerted.isEmpty()) {
       return;
     }
-    String message = buildMessage(actionable);
+    if (!send(buildMessage(unalerted))) {
+      return;
+    }
+    unalerted.forEach(
+        outcome -> auditRecorder.recordAlerted(outcome.confirmation(), outcome.result()));
+  }
+
+  private boolean send(String message) {
     try {
       notificationService.sendMessage(message, INVESTMENT);
+      return true;
     } catch (RuntimeException e) {
       log.error("Failed to send FT confirmation digest to Slack: error={}", e.getMessage(), e);
+      return false;
     }
-  }
-
-  private static boolean isActionable(FtConfirmationOutcome outcome) {
-    FtConfirmationResult result = outcome.result();
-    return isActionable(result.quantityStatus()) || isActionable(result.priceStatus());
-  }
-
-  private static boolean isActionable(FtVerificationStatus status) {
-    return status == ERROR || status == AMBIGUOUS || status == ORPHAN;
   }
 
   private static String buildMessage(List<FtConfirmationOutcome> actionable) {
@@ -70,6 +73,15 @@ class FtConfirmationDigest {
   private static String describe(FtConfirmationOutcome outcome) {
     FtConfirmation confirmation = outcome.confirmation();
     FtConfirmationResult result = outcome.result();
+    if (result.isCancellation()) {
+      return String.format(
+          "FT broker cancellation: fund=%s, isin=%s, tradeDate=%s, quantity=%s"
+              + " — verify and cancel in registry",
+          confirmation.fund().name(),
+          confirmation.isin(),
+          confirmation.tradeDate(),
+          confirmation.quantity().toPlainString());
+    }
     return String.format(
         "FT issue: fund=%s, isin=%s, tradeDate=%s, quantity=%s, quantityStatus=%s, priceStatus=%s",
         confirmation.fund().name(),

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationDigest.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationDigest.java
@@ -37,6 +37,7 @@ class FtConfirmationDigest {
     List<FtConfirmationOutcome> unalerted =
         outcomes.stream()
             .filter(outcome -> outcome.result().isActionable())
+            .distinct()
             .filter(
                 outcome -> !auditRecorder.alreadyAlerted(outcome.confirmation(), outcome.result()))
             .toList();

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationVerificationService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationVerificationService.java
@@ -66,7 +66,9 @@ public class FtConfirmationVerificationService {
   private BigDecimal priceTolerance = DEFAULT_PRICE_TOLERANCE;
 
   public FtConfirmationResult verify(FtConfirmation confirmation) {
-    return verifyAndRecord(confirmation, ADMIN_ACTOR);
+    FtConfirmationResult result = verifyAndRecord(confirmation, ADMIN_ACTOR);
+    digest.publish(List.of(new FtConfirmationOutcome(confirmation, result)));
+    return result;
   }
 
   public List<FtConfirmationBatchResult> verifyAll(
@@ -75,6 +77,10 @@ public class FtConfirmationVerificationService {
     List<FtConfirmationOutcome> outcomes = new ArrayList<>();
     for (int index = 0; index < confirmations.size(); index++) {
       FtConfirmation confirmation = confirmations.get(index);
+      if (confirmation == null) {
+        results.add(FtConfirmationBatchResult.failed(index, null, "null confirmation row"));
+        continue;
+      }
       try {
         FtConfirmationResult result = verifyAndRecord(confirmation, actor);
         results.add(FtConfirmationBatchResult.verified(index, confirmation.isin(), result));

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationVerificationService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationVerificationService.java
@@ -19,6 +19,7 @@ import ee.tuleva.onboarding.investment.transaction.FtConfirmation;
 import ee.tuleva.onboarding.investment.transaction.FtConfirmationBatchResult;
 import ee.tuleva.onboarding.investment.transaction.FtConfirmationResult;
 import ee.tuleva.onboarding.investment.transaction.FtVerificationStatus;
+import ee.tuleva.onboarding.investment.transaction.OrderVenue;
 import ee.tuleva.onboarding.investment.transaction.TransactionExecution;
 import ee.tuleva.onboarding.investment.transaction.TransactionExecutionRepository;
 import ee.tuleva.onboarding.investment.transaction.TransactionOrder;
@@ -27,7 +28,7 @@ import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
-import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -49,7 +50,6 @@ public class FtConfirmationVerificationService {
 
   private static final BigDecimal QUANTITY_TOLERANCE = BigDecimal.ONE;
   private static final BigDecimal DEFAULT_PRICE_TOLERANCE = new BigDecimal("0.001");
-  private static final ZoneId TALLINN = ZoneId.of("Europe/Tallinn");
   private static final int EXECUTION_PENDING_BUSINESS_DAYS = 1;
   private static final String ADMIN_ACTOR = "admin";
 
@@ -194,6 +194,7 @@ public class FtConfirmationVerificationService {
 
   private List<TransactionOrder> candidateOrders(FtConfirmation confirmation) {
     return orderRepository.findByInstrumentIsin(confirmation.isin()).stream()
+        .filter(order -> order.getOrderVenue() == OrderVenue.FT)
         .filter(order -> order.getFund() == confirmation.fund())
         .filter(order -> hasTradeDate(order, confirmation.tradeDate()))
         .collect(toList());
@@ -225,9 +226,10 @@ public class FtConfirmationVerificationService {
 
   private record OrderSelection(TransactionOrder order, boolean ambiguous, int matchCount) {}
 
-  private static boolean hasTradeDate(TransactionOrder order, LocalDate tradeDate) {
-    return order.getOrderTimestamp() != null
-        && order.getOrderTimestamp().atZone(TALLINN).toLocalDate().equals(tradeDate);
+  private static boolean hasTradeDate(TransactionOrder order, LocalDate ftUtcTradeDate) {
+    var timestamp = order.getOrderTimestamp();
+    return timestamp != null
+        && LocalDate.ofInstant(timestamp, ZoneOffset.UTC).equals(ftUtcTradeDate);
   }
 
   private FtVerificationStatus checkQuantity(

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationVerificationService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationVerificationService.java
@@ -139,6 +139,10 @@ public class FtConfirmationVerificationService {
     details.put("orderUuid", order.getOrderUuid().toString());
 
     if (confirmation.isCancellation()) {
+      if (selection.matchCount() > 1) {
+        details.put("ambiguousOrderCount", String.valueOf(selection.matchCount()));
+        return new Computed(result(AMBIGUOUS, AMBIGUOUS, details), order);
+      }
       details.put("cancellationSignature", confirmation.cancellationSignature());
       return new Computed(result(CANCELLED, CANCELLED, details), order);
     }

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationVerificationService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationVerificationService.java
@@ -66,23 +66,19 @@ public class FtConfirmationVerificationService {
   private BigDecimal priceTolerance = DEFAULT_PRICE_TOLERANCE;
 
   public FtConfirmationResult verify(FtConfirmation confirmation) {
-    Verification verification = verifyAndRecord(confirmation, ADMIN_ACTOR);
-    return verification.result();
+    return verifyAndRecord(confirmation, ADMIN_ACTOR);
   }
 
   public List<FtConfirmationBatchResult> verifyAll(
       List<FtConfirmation> confirmations, String actor) {
     List<FtConfirmationBatchResult> results = new ArrayList<>();
-    List<FtConfirmationOutcome> changedOutcomes = new ArrayList<>();
+    List<FtConfirmationOutcome> outcomes = new ArrayList<>();
     for (int index = 0; index < confirmations.size(); index++) {
       FtConfirmation confirmation = confirmations.get(index);
       try {
-        Verification verification = verifyAndRecord(confirmation, actor);
-        results.add(
-            FtConfirmationBatchResult.verified(index, confirmation.isin(), verification.result()));
-        if (verification.statusChanged()) {
-          changedOutcomes.add(new FtConfirmationOutcome(confirmation, verification.result()));
-        }
+        FtConfirmationResult result = verifyAndRecord(confirmation, actor);
+        results.add(FtConfirmationBatchResult.verified(index, confirmation.isin(), result));
+        outcomes.add(new FtConfirmationOutcome(confirmation, result));
       } catch (RuntimeException e) {
         log.error(
             "FT confirmation row failed: index={}, isin={}, error={}",
@@ -93,19 +89,19 @@ public class FtConfirmationVerificationService {
         results.add(FtConfirmationBatchResult.failed(index, confirmation.isin(), e.getMessage()));
       }
     }
-    digest.publish(changedOutcomes);
+    digest.publish(outcomes);
     return results;
   }
 
-  private Verification verifyAndRecord(FtConfirmation confirmation, String actor) {
+  private FtConfirmationResult verifyAndRecord(FtConfirmation confirmation, String actor) {
     Computed computed = compute(confirmation);
-    boolean statusChanged = record(confirmation, computed, actor);
-    return new Verification(computed.result(), statusChanged);
+    record(confirmation, computed, actor);
+    return computed.result();
   }
 
-  private boolean record(FtConfirmation confirmation, Computed computed, String actor) {
+  private void record(FtConfirmation confirmation, Computed computed, String actor) {
     if (computed.result().quantityStatus() == IGNORED) {
-      return false;
+      return;
     }
     boolean recorded =
         auditRecorder.recordOutcome(computed.order(), confirmation, computed.result(), actor);
@@ -118,7 +114,6 @@ public class FtConfirmationVerificationService {
           computed.result().quantityStatus(),
           computed.result().priceStatus());
     }
-    return recorded;
   }
 
   private Computed compute(FtConfirmation confirmation) {
@@ -157,8 +152,6 @@ public class FtConfirmationVerificationService {
     FtVerificationStatus priceStatus = checkPrice(confirmation, details);
     return new Computed(result(quantityStatus, priceStatus, details), order);
   }
-
-  private record Verification(FtConfirmationResult result, boolean statusChanged) {}
 
   private record Computed(FtConfirmationResult result, @Nullable TransactionOrder order) {}
 

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/QuantityAmountValidator.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/QuantityAmountValidator.java
@@ -46,18 +46,7 @@ class QuantityAmountValidator {
       TransactionOrder order,
       SebPendingTransactionRow row,
       TransactionMatchingProperties properties) {
-    BigDecimal expected = expected(order);
-    BigDecimal actual = actual(order, row);
-    return new QuantityAmountMismatchEvent(
-        row,
-        order,
-        kind(order),
-        expected,
-        actual,
-        actual.subtract(expected).abs(),
-        tolerance(kind(order), properties),
-        properties.nearMissMultiplier(),
-        null);
+    return mismatchEvent(row, order, kind(order), expected(order), actual(order, row), properties);
   }
 
   Optional<QuantityAmountMismatchEvent> detectBlankEconomics(
@@ -67,18 +56,7 @@ class QuantityAmountValidator {
     if (actual(order, row) != null) {
       return Optional.empty();
     }
-    MismatchKind kind = kind(order);
-    return Optional.of(
-        new QuantityAmountMismatchEvent(
-            row,
-            order,
-            kind,
-            expected(order),
-            null,
-            null,
-            tolerance(kind, properties),
-            properties.nearMissMultiplier(),
-            null));
+    return Optional.of(mismatchEvent(row, order, kind(order), expected(order), null, properties));
   }
 
   Optional<QuantityAmountMismatchEvent> validateCumulative(
@@ -94,21 +72,30 @@ class QuantityAmountValidator {
     MismatchKind kind = kind(order);
     BigDecimal previouslyExecuted = sumExecutedValue(order, existingExecutions, row.ourRef());
     BigDecimal cumulative = previouslyExecuted.add(rowValue);
-    BigDecimal tolerance = tolerance(kind, properties);
-    if (!isOverfill(kind, target, cumulative, tolerance)) {
+    if (!isOverfill(kind, target, cumulative, tolerance(kind, properties))) {
       return Optional.empty();
     }
-    return Optional.of(
-        new QuantityAmountMismatchEvent(
-            row,
-            order,
-            kind,
-            target,
-            cumulative,
-            cumulative.subtract(target).abs(),
-            tolerance,
-            properties.nearMissMultiplier(),
-            null));
+    return Optional.of(mismatchEvent(row, order, kind, target, cumulative, properties));
+  }
+
+  private static QuantityAmountMismatchEvent mismatchEvent(
+      SebPendingTransactionRow row,
+      TransactionOrder order,
+      MismatchKind kind,
+      BigDecimal expected,
+      BigDecimal actual,
+      TransactionMatchingProperties properties) {
+    BigDecimal delta = expected == null || actual == null ? null : actual.subtract(expected).abs();
+    return new QuantityAmountMismatchEvent(
+        row,
+        order,
+        kind,
+        expected,
+        actual,
+        delta,
+        tolerance(kind, properties),
+        properties.nearMissMultiplier(),
+        null);
   }
 
   boolean isShortFill(

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/QuantityAmountValidator.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/QuantityAmountValidator.java
@@ -60,6 +60,27 @@ class QuantityAmountValidator {
         null);
   }
 
+  Optional<QuantityAmountMismatchEvent> detectBlankEconomics(
+      TransactionOrder order,
+      SebPendingTransactionRow row,
+      TransactionMatchingProperties properties) {
+    if (actual(order, row) != null) {
+      return Optional.empty();
+    }
+    MismatchKind kind = kind(order);
+    return Optional.of(
+        new QuantityAmountMismatchEvent(
+            row,
+            order,
+            kind,
+            expected(order),
+            null,
+            null,
+            tolerance(kind, properties),
+            properties.nearMissMultiplier(),
+            null));
+  }
+
   Optional<QuantityAmountMismatchEvent> validateCumulative(
       TransactionOrder order,
       SebPendingTransactionRow row,

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/SebPendingTransactionReconciliationService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/SebPendingTransactionReconciliationService.java
@@ -111,14 +111,6 @@ public class SebPendingTransactionReconciliationService {
       Optional<QuantityAmountMismatchEvent> blankEconomics =
           quantityAmountValidator.detectBlankEconomics(order, row, matchingProperties);
       if (blankEconomics.isPresent()) {
-        log.error(
-            "Matched SEB row has blank required economics, refusing to record as executed:"
-                + " orderId={}, isin={}, kind={}, ourRef={}, reportDate={}",
-            order.getId(),
-            row.isin(),
-            blankEconomics.get().kind(),
-            row.ourRef(),
-            reportDate);
         reportMismatch(blankEconomics.get().withReportDate(reportDate), row);
         matched++;
         continue;

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/SebPendingTransactionReconciliationService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/SebPendingTransactionReconciliationService.java
@@ -106,6 +106,21 @@ public class SebPendingTransactionReconciliationService {
         handleSettledOrderReappearance(order, settlement.get(), row, reportDate);
         continue;
       }
+      Optional<QuantityAmountMismatchEvent> blankEconomics =
+          quantityAmountValidator.detectBlankEconomics(order, row, matchingProperties);
+      if (blankEconomics.isPresent()) {
+        log.error(
+            "Matched SEB row has blank required economics, refusing to record as executed:"
+                + " orderId={}, isin={}, kind={}, ourRef={}, reportDate={}",
+            order.getId(),
+            row.isin(),
+            blankEconomics.get().kind(),
+            row.ourRef(),
+            reportDate);
+        reportMismatch(blankEconomics.get().withReportDate(reportDate), row);
+        matched++;
+        continue;
+      }
       Optional<QuantityAmountMismatchEvent> mismatch =
           quantityAmountValidator.validateCumulative(
               order, row, executionRepository.findAllByOrderId(order.getId()), matchingProperties);

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/SebPendingTransactionReconciliationService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/SebPendingTransactionReconciliationService.java
@@ -3,6 +3,7 @@ package ee.tuleva.onboarding.investment.transaction.ingest;
 import static ee.tuleva.onboarding.investment.report.ReportProvider.SEB;
 import static ee.tuleva.onboarding.investment.report.ReportType.PENDING_TRANSACTIONS;
 
+import ee.tuleva.onboarding.fund.TulevaFund;
 import ee.tuleva.onboarding.investment.report.InvestmentReport;
 import ee.tuleva.onboarding.investment.report.InvestmentReportService;
 import ee.tuleva.onboarding.investment.transaction.OrderStatus;
@@ -39,6 +40,7 @@ public class SebPendingTransactionReconciliationService {
   private final SebPendingTransactionMatcher matcher;
   private final SebPendingTransactionComplexMatcher complexMatcher;
   private final QuantityAmountValidator quantityAmountValidator;
+  private final SebClientNameToFundResolver fundResolver;
   private final ExecutionPriceConsistencyChecker priceConsistencyChecker;
   private final TransactionMatchingPolicy matchingPolicy;
   private final TransactionExecutionMapper executionMapper;
@@ -224,6 +226,19 @@ public class SebPendingTransactionReconciliationService {
           row.isin(),
           order.getTransactionType(),
           row.side(),
+          row.ourRef(),
+          reportDate);
+      return false;
+    }
+    Optional<TulevaFund> rowFund = fundResolver.resolve(row.clientName());
+    if (rowFund.isPresent() && rowFund.get() != order.getFund()) {
+      log.error(
+          "Matched SEB row client name resolves to a different fund than the order: orderId={},"
+              + " orderFund={}, rowFund={}, clientName={}, ourRef={}, reportDate={}",
+          order.getId(),
+          order.getFund(),
+          rowFund.get(),
+          row.clientName(),
           row.ourRef(),
           reportDate);
       return false;

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/portfolio/CostBasisCalculator.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/portfolio/CostBasisCalculator.java
@@ -31,12 +31,14 @@ public class CostBasisCalculator {
     BigDecimal totalCost = priorQty.multiply(priorAvg);
 
     for (ExecutionEvent event : executions) {
-      BigDecimal execQty = nullSafe(event.quantity());
-      BigDecimal execPrice = nullSafe(event.unitPrice());
+      BigDecimal execQty =
+          requirePositive(event.quantity(), "quantity", fundIsin, instrumentIsin, asOfDate);
 
       if (event.side() == TransactionType.BUY) {
         // Commission excluded to match legacy AppScript Portfolio_History; see remaining-tasks.md
         // F.7 for FI-practice divergence note
+        BigDecimal execPrice =
+            requirePositive(event.unitPrice(), "unitPrice", fundIsin, instrumentIsin, asOfDate);
         totalCost = totalCost.add(execQty.multiply(execPrice));
         qty = qty.add(execQty);
       } else {
@@ -83,8 +85,15 @@ public class CostBasisCalculator {
         .build();
   }
 
-  private static BigDecimal nullSafe(BigDecimal value) {
-    return value == null ? BigDecimal.ZERO : value;
+  private static BigDecimal requirePositive(
+      BigDecimal value, String field, String fundIsin, String instrumentIsin, LocalDate asOfDate) {
+    if (value == null || value.signum() <= 0) {
+      throw new IllegalStateException(
+          String.format(
+              "Cost-basis execution has non-positive %s: fund=%s, isin=%s, asOfDate=%s, value=%s",
+              field, fundIsin, instrumentIsin, asOfDate, value));
+    }
+    return value;
   }
 
   public record PriorPosition(BigDecimal quantity, BigDecimal avgUnitCost) {

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/portfolio/PortfolioCostBasisRepository.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/portfolio/PortfolioCostBasisRepository.java
@@ -32,4 +32,15 @@ public interface PortfolioCostBasisRepository extends JpaRepository<PortfolioCos
 
   List<PortfolioCostBasis> findByFundIsinAndAsOfDateGreaterThanEqual(
       String fundIsin, LocalDate asOfDate);
+
+  @Query(
+      """
+      SELECT c FROM PortfolioCostBasis c
+      WHERE c.fundIsin = :fundIsin
+        AND c.asOfDate = (
+          SELECT MAX(c2.asOfDate) FROM PortfolioCostBasis c2
+          WHERE c2.fundIsin = :fundIsin
+            AND c2.asOfDate < :asOfDate)
+      """)
+  List<PortfolioCostBasis> findLatestSnapshotBefore(String fundIsin, LocalDate asOfDate);
 }

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionPreparationServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionPreparationServiceTest.java
@@ -584,9 +584,9 @@ class TransactionPreparationServiceTest {
             .status(PROCESSING)
             .build();
 
-    when(clock.instant()).thenReturn(Instant.parse("2026-01-15T10:00:00Z"));
-    when(inputService.gatherInput(any(), any(), any()))
-        .thenThrow(new ArithmeticException("/ by zero"));
+    given(clock.instant()).willReturn(Instant.parse("2026-01-15T10:00:00Z"));
+    given(inputService.gatherInput(any(), any(), any()))
+        .willThrow(new ArithmeticException("/ by zero"));
 
     var result = service.processCommand(command);
 
@@ -598,8 +598,8 @@ class TransactionPreparationServiceTest {
 
   @Test
   void finalizeConfirmedBatch_failsWhenNonAmountOrderHasNullQuantity_withoutGeneratingExports() {
-    when(clock.instant()).thenReturn(Instant.parse("2026-01-15T10:00:00Z"));
-    when(clock.getZone()).thenReturn(ZoneId.of("Europe/Tallinn"));
+    given(clock.instant()).willReturn(Instant.parse("2026-01-15T10:00:00Z"));
+    given(clock.getZone()).willReturn(ZoneId.of("Europe/Tallinn"));
 
     var batch =
         TransactionBatch.builder()
@@ -621,11 +621,11 @@ class TransactionPreparationServiceTest {
             .orderStatus(OrderStatus.PENDING)
             .build();
 
-    when(orderRepository.findByBatchId(batch.getId())).thenReturn(List.of(etfOrderWithoutQuantity));
+    given(orderRepository.findByBatchId(batch.getId()))
+        .willReturn(List.of(etfOrderWithoutQuantity));
 
     assertThatThrownBy(() -> service.finalizeConfirmedBatch(batch))
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessageContaining("IE00A");
+        .isInstanceOf(IllegalStateException.class);
 
     assertThat(batch.getStatus()).isEqualTo(CONFIRMED);
     verifyNoInteractions(exportService);

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionPreparationServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionPreparationServiceTest.java
@@ -7,6 +7,7 @@ import static ee.tuleva.onboarding.investment.transaction.TransactionMode.BUY;
 import static ee.tuleva.onboarding.investment.transaction.TransactionMode.SELL;
 import static java.math.BigDecimal.ZERO;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
@@ -303,6 +304,7 @@ class TransactionPreparationServiceTest {
             .transactionType(TransactionType.BUY)
             .instrumentType(InstrumentType.ETF)
             .orderAmount(new BigDecimal("100000"))
+            .orderQuantity(new BigDecimal("9876.543210"))
             .orderVenue(OrderVenue.SEB)
             .orderStatus(OrderStatus.PENDING)
             .build();
@@ -553,6 +555,128 @@ class TransactionPreparationServiceTest {
   }
 
   @Test
+  void processCommand_leavesEtfOrderQuantityNullWhenPriceIsZero() {
+    var command = givenSingleEtfBuyCommandPricedAt(ZERO);
+
+    var result = service.processCommand(command);
+
+    assertThat(orderByIsin(result, "IE00ETF").getOrderQuantity()).isNull();
+  }
+
+  @Test
+  void processCommand_leavesEtfOrderQuantityNullWhenPriceIsNegative() {
+    var command = givenSingleEtfBuyCommandPricedAt(new BigDecimal("-3"));
+
+    var result = service.processCommand(command);
+
+    assertThat(orderByIsin(result, "IE00ETF").getOrderQuantity()).isNull();
+  }
+
+  @Test
+  void processCommand_onUnexpectedRuntimeException_setsFailedStatusInsteadOfPropagating() {
+    var command =
+        TransactionCommand.builder()
+            .id(10L)
+            .fund(TUV100)
+            .mode(BUY)
+            .asOfDate(LocalDate.of(2026, 1, 15))
+            .manualAdjustments(Map.of())
+            .status(PROCESSING)
+            .build();
+
+    when(clock.instant()).thenReturn(Instant.parse("2026-01-15T10:00:00Z"));
+    when(inputService.gatherInput(any(), any(), any()))
+        .thenThrow(new ArithmeticException("/ by zero"));
+
+    var result = service.processCommand(command);
+
+    assertThat(result).isNull();
+    assertThat(command.getStatus()).isEqualTo(FAILED);
+    assertThat(command.getErrorMessage()).isNotNull();
+    assertThat(command.getProcessedAt()).isNotNull();
+  }
+
+  @Test
+  void finalizeConfirmedBatch_failsWhenNonAmountOrderHasNullQuantity_withoutGeneratingExports() {
+    when(clock.instant()).thenReturn(Instant.parse("2026-01-15T10:00:00Z"));
+    when(clock.getZone()).thenReturn(ZoneId.of("Europe/Tallinn"));
+
+    var batch =
+        TransactionBatch.builder()
+            .id(1L)
+            .fund(TUV100)
+            .status(CONFIRMED)
+            .createdBy("system")
+            .metadata(new HashMap<>(Map.of("commandId", 1L)))
+            .build();
+    var etfOrderWithoutQuantity =
+        TransactionOrder.builder()
+            .batch(batch)
+            .fund(TUV100)
+            .instrumentIsin("IE00A")
+            .transactionType(TransactionType.BUY)
+            .instrumentType(InstrumentType.ETF)
+            .orderAmount(new BigDecimal("100000"))
+            .orderVenue(OrderVenue.SEB)
+            .orderStatus(OrderStatus.PENDING)
+            .build();
+
+    when(orderRepository.findByBatchId(batch.getId())).thenReturn(List.of(etfOrderWithoutQuantity));
+
+    assertThatThrownBy(() -> service.finalizeConfirmedBatch(batch))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("IE00A");
+
+    assertThat(batch.getStatus()).isEqualTo(CONFIRMED);
+    verifyNoInteractions(exportService);
+    verify(orderRepository, never()).saveAll(any());
+  }
+
+  private TransactionCommand givenSingleEtfBuyCommandPricedAt(BigDecimal price) {
+    var command =
+        TransactionCommand.builder()
+            .id(9L)
+            .fund(TUV100)
+            .mode(BUY)
+            .asOfDate(LocalDate.of(2026, 1, 15))
+            .manualAdjustments(Map.of())
+            .status(PROCESSING)
+            .build();
+    var input =
+        FundTransactionInput.builder()
+            .fund(TUV100)
+            .positions(List.of(new PositionSnapshot("IE00ETF", new BigDecimal("300000"))))
+            .modelWeights(List.of(new ModelWeight("IE00ETF", new BigDecimal("1.00"))))
+            .grossPortfolioValue(new BigDecimal("600000"))
+            .cashBuffer(new BigDecimal("10000"))
+            .liabilities(ZERO)
+            .freeCash(new BigDecimal("90000"))
+            .minTransactionThreshold(new BigDecimal("5000"))
+            .positionLimits(Map.of())
+            .fastSellIsins(Set.of())
+            .instrumentTypes(Map.of("IE00ETF", InstrumentType.ETF))
+            .orderVenues(Map.of())
+            .build();
+    var trades =
+        List.of(
+            new TradeCalculation(
+                "IE00ETF", new BigDecimal("50000"), new BigDecimal("0.55"), LimitStatus.OK));
+    var calculationResult = new FundCalculationResult(TUV100, BUY, input, trades);
+    given(inputService.gatherInput(TUV100, command.getAsOfDate(), Map.of())).willReturn(input);
+    given(calculationEngine.calculate(input, BUY)).willReturn(calculationResult);
+    given(batchRepository.save(any(TransactionBatch.class)))
+        .willAnswer(
+            invocation -> {
+              TransactionBatch batch = invocation.getArgument(0);
+              batch.setId(1L);
+              return batch;
+            });
+    given(positionPriceResolver.resolve("IE00ETF", LocalDate.of(2026, 1, 15)))
+        .willReturn(Optional.of(ResolvedPrice.builder().usedPrice(price).build()));
+    return command;
+  }
+
+  @Test
   void processCommand_setsFundSellOrderQuantityFromLatestPriceAndLeavesFundBuyQuantityNull() {
     var command =
         TransactionCommand.builder()
@@ -757,6 +881,7 @@ class TransactionPreparationServiceTest {
             .transactionType(TransactionType.BUY)
             .instrumentType(InstrumentType.ETF)
             .orderAmount(new BigDecimal("100000"))
+            .orderQuantity(new BigDecimal("9876.543210"))
             .orderVenue(OrderVenue.SEB)
             .orderStatus(OrderStatus.PENDING)
             .build();
@@ -803,6 +928,7 @@ class TransactionPreparationServiceTest {
             .transactionType(TransactionType.BUY)
             .instrumentType(InstrumentType.ETF)
             .orderAmount(new BigDecimal("100000"))
+            .orderQuantity(new BigDecimal("9876.543210"))
             .orderVenue(OrderVenue.SEB)
             .orderStatus(OrderStatus.PENDING)
             .build();

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationAuditRecorderTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationAuditRecorderTest.java
@@ -174,6 +174,79 @@ class FtConfirmationAuditRecorderTest {
                 .build());
   }
 
+  @Test
+  void alreadyAlerted_noPriorAlert_returnsFalse() {
+    given(auditEventRepository.findByEventType("FT_CONFIRMATION_ALERTED")).willReturn(List.of());
+
+    boolean alerted =
+        recorder().alreadyAlerted(confirmation(), new FtConfirmationResult(ERROR, OK, Map.of()));
+
+    assertThat(alerted).isFalse();
+  }
+
+  @Test
+  void alreadyAlerted_priorAlertWithSameStatus_returnsTrue() {
+    given(auditEventRepository.findByEventType("FT_CONFIRMATION_ALERTED"))
+        .willReturn(List.of(priorAlert("ERROR", "OK")));
+
+    boolean alerted =
+        recorder().alreadyAlerted(confirmation(), new FtConfirmationResult(ERROR, OK, Map.of()));
+
+    assertThat(alerted).isTrue();
+  }
+
+  @Test
+  void alreadyAlerted_priorAlertWithDifferentStatus_returnsFalse() {
+    given(auditEventRepository.findByEventType("FT_CONFIRMATION_ALERTED"))
+        .willReturn(List.of(priorAlert("AMBIGUOUS", "AMBIGUOUS")));
+
+    boolean alerted =
+        recorder().alreadyAlerted(confirmation(), new FtConfirmationResult(ERROR, OK, Map.of()));
+
+    assertThat(alerted).isFalse();
+  }
+
+  @Test
+  void recordAlerted_savesAlertedEventWithSystemActor() {
+    recorder().recordAlerted(confirmation(), new FtConfirmationResult(ERROR, OK, Map.of()));
+
+    verify(auditEventRepository)
+        .save(
+            TransactionAuditEvent.builder()
+                .eventType("FT_CONFIRMATION_ALERTED")
+                .actor("system")
+                .payload(
+                    Map.of(
+                        "fund", "TUK75",
+                        "isin", "IE000F60HVH9",
+                        "tradeDate", "2026-06-08",
+                        "quantity", "40434",
+                        "grossPrice", "10.09",
+                        "type", "NORMAL",
+                        "quantityStatus", "ERROR",
+                        "priceStatus", "OK",
+                        "details", Map.of()))
+                .createdAt(NOW)
+                .build());
+  }
+
+  private static TransactionAuditEvent priorAlert(String quantityStatus, String priceStatus) {
+    Map<String, Object> payload = new LinkedHashMap<>();
+    payload.put("fund", "TUK75");
+    payload.put("isin", "IE000F60HVH9");
+    payload.put("tradeDate", "2026-06-08");
+    payload.put("quantity", "40434");
+    payload.put("grossPrice", "10.09");
+    payload.put("type", "NORMAL");
+    payload.put("quantityStatus", quantityStatus);
+    payload.put("priceStatus", priceStatus);
+    return TransactionAuditEvent.builder()
+        .eventType("FT_CONFIRMATION_ALERTED")
+        .payload(payload)
+        .createdAt(NOW)
+        .build();
+  }
+
   private static TransactionOrder order() {
     return TransactionOrder.builder()
         .id(42L)

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationAuditRecorderTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationAuditRecorderTest.java
@@ -207,6 +207,17 @@ class FtConfirmationAuditRecorderTest {
   }
 
   @Test
+  void alreadyAlerted_priorAlertWithDifferentDecimalScale_returnsTrue() {
+    given(auditEventRepository.findByEventType("FT_CONFIRMATION_ALERTED"))
+        .willReturn(List.of(priorAlert("ERROR", "OK", "40434.0", "10.090")));
+
+    boolean alerted =
+        recorder().alreadyAlerted(confirmation(), new FtConfirmationResult(ERROR, OK, Map.of()));
+
+    assertThat(alerted).isTrue();
+  }
+
+  @Test
   void recordAlerted_savesAlertedEventWithSystemActor() {
     recorder().recordAlerted(confirmation(), new FtConfirmationResult(ERROR, OK, Map.of()));
 
@@ -231,12 +242,17 @@ class FtConfirmationAuditRecorderTest {
   }
 
   private static TransactionAuditEvent priorAlert(String quantityStatus, String priceStatus) {
+    return priorAlert(quantityStatus, priceStatus, "40434", "10.09");
+  }
+
+  private static TransactionAuditEvent priorAlert(
+      String quantityStatus, String priceStatus, String quantity, String grossPrice) {
     Map<String, Object> payload = new LinkedHashMap<>();
     payload.put("fund", "TUK75");
     payload.put("isin", "IE000F60HVH9");
     payload.put("tradeDate", "2026-06-08");
-    payload.put("quantity", "40434");
-    payload.put("grossPrice", "10.09");
+    payload.put("quantity", quantity);
+    payload.put("grossPrice", grossPrice);
     payload.put("type", "NORMAL");
     payload.put("quantityStatus", quantityStatus);
     payload.put("priceStatus", priceStatus);

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationDigestTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationDigestTest.java
@@ -116,6 +116,21 @@ class FtConfirmationDigestTest {
   }
 
   @Test
+  void duplicateActionableRowsInOneBatch_areAlertedOnce() {
+    FtConfirmationOutcome error = outcome(ERROR, OK);
+
+    digest(true).publish(List.of(error, error));
+
+    verify(notificationService)
+        .sendMessage(
+            "FT confirmation check: 1 issue(s) need attention\n"
+                + "FT issue: fund=TUK75, isin=IE000F60HVH9, tradeDate=2026-06-08, quantity=40434,"
+                + " quantityStatus=ERROR, priceStatus=OK",
+            INVESTMENT);
+    verify(auditRecorder).recordAlerted(error.confirmation(), error.result());
+  }
+
+  @Test
   void alreadyAlertedActionableRow_isNotSentAgain() {
     given(auditRecorder.alreadyAlerted(any(), any())).willReturn(true);
 

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationDigestTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationDigestTest.java
@@ -2,15 +2,19 @@ package ee.tuleva.onboarding.investment.transaction.ingest;
 
 import static ee.tuleva.onboarding.fund.TulevaFund.TUK75;
 import static ee.tuleva.onboarding.investment.transaction.FtVerificationStatus.AMBIGUOUS;
+import static ee.tuleva.onboarding.investment.transaction.FtVerificationStatus.CANCELLED;
 import static ee.tuleva.onboarding.investment.transaction.FtVerificationStatus.ERROR;
 import static ee.tuleva.onboarding.investment.transaction.FtVerificationStatus.OK;
 import static ee.tuleva.onboarding.investment.transaction.FtVerificationStatus.ORPHAN;
 import static ee.tuleva.onboarding.investment.transaction.FtVerificationStatus.PENDING_NAV;
 import static ee.tuleva.onboarding.notification.OperationsNotificationService.Channel.INVESTMENT;
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
@@ -34,9 +38,10 @@ class FtConfirmationDigestTest {
   private static final LocalDate TRADE_DATE = LocalDate.of(2026, 6, 8);
 
   @Mock private OperationsNotificationService notificationService;
+  @Mock private FtConfirmationAuditRecorder auditRecorder;
 
   private FtConfirmationDigest digest(boolean registryAuthoritative) {
-    return new FtConfirmationDigest(notificationService, registryAuthoritative);
+    return new FtConfirmationDigest(notificationService, auditRecorder, registryAuthoritative);
   }
 
   @Test
@@ -64,15 +69,6 @@ class FtConfirmationDigestTest {
   }
 
   @Test
-  void whileRegistryNotAuthoritative_nothingIsSent_evenForActionableRows() {
-    digest(false)
-        .publish(
-            List.of(outcome(ERROR, OK), outcome(AMBIGUOUS, AMBIGUOUS), outcome(ORPHAN, ORPHAN)));
-
-    verifyNoInteractions(notificationService);
-  }
-
-  @Test
   void orphanRow_whenRegistryAuthoritative_isSent() {
     digest(true).publish(List.of(outcome(ORPHAN, ORPHAN)));
 
@@ -82,6 +78,27 @@ class FtConfirmationDigestTest {
                 + "FT issue: fund=TUK75, isin=IE000F60HVH9, tradeDate=2026-06-08, quantity=40434,"
                 + " quantityStatus=ORPHAN, priceStatus=ORPHAN",
             INVESTMENT);
+  }
+
+  @Test
+  void cancellationRow_whenRegistryAuthoritative_isSentAsCancellationLine() {
+    digest(true).publish(List.of(outcome(CANCELLED, CANCELLED)));
+
+    verify(notificationService)
+        .sendMessage(
+            "FT confirmation check: 1 issue(s) need attention\n"
+                + "FT broker cancellation: fund=TUK75, isin=IE000F60HVH9, tradeDate=2026-06-08,"
+                + " quantity=40434 — verify and cancel in registry",
+            INVESTMENT);
+  }
+
+  @Test
+  void whileRegistryNotAuthoritative_nothingIsSentOrRecorded_evenForActionableRows() {
+    digest(false)
+        .publish(
+            List.of(outcome(ERROR, OK), outcome(AMBIGUOUS, AMBIGUOUS), outcome(ORPHAN, ORPHAN)));
+
+    verifyNoInteractions(notificationService, auditRecorder);
   }
 
   @Test
@@ -99,13 +116,48 @@ class FtConfirmationDigestTest {
   }
 
   @Test
-  void slackFailure_doesNotPropagate() {
+  void alreadyAlertedActionableRow_isNotSentAgain() {
+    given(auditRecorder.alreadyAlerted(any(), any())).willReturn(true);
+
+    digest(true).publish(List.of(outcome(ERROR, OK)));
+
+    verifyNoInteractions(notificationService);
+    verify(auditRecorder, never()).recordAlerted(any(), any());
+  }
+
+  @Test
+  void deliveredActionableRows_areRecordedAsAlerted() {
+    FtConfirmationOutcome error = outcome(ERROR, OK);
+
+    digest(true).publish(List.of(error));
+
+    verify(auditRecorder).recordAlerted(error.confirmation(), error.result());
+  }
+
+  @Test
+  void issueUnalertedInShadowMode_isAlertedOnceAfterFlagFlips() {
+    FtConfirmationOutcome error = outcome(ERROR, OK);
+
+    // Shadow mode: recorded elsewhere, but nothing is alerted or marked as alerted.
+    digest(false).publish(List.of(error));
+    verifyNoInteractions(notificationService, auditRecorder);
+
+    // Flag flips: the still-open issue was never alerted, so it alerts exactly once now.
+    digest(true).publish(List.of(error));
+    verify(notificationService).sendMessage(anyString(), eq(INVESTMENT));
+    verify(auditRecorder).recordAlerted(error.confirmation(), error.result());
+  }
+
+  @Test
+  void slackFailure_doesNotPropagate_andDoesNotRecordAlerted() {
     willThrow(new RuntimeException("slack down"))
         .given(notificationService)
         .sendMessage(anyString(), eq(INVESTMENT));
 
     assertThatCode(() -> digest(true).publish(List.of(outcome(ERROR, OK))))
         .doesNotThrowAnyException();
+
+    verify(auditRecorder, never()).recordAlerted(any(), any());
   }
 
   private static FtConfirmationOutcome outcome(

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationVerificationServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationVerificationServiceTest.java
@@ -341,6 +341,19 @@ class FtConfirmationVerificationServiceTest {
   }
 
   @Test
+  void cancellationConfirmation_multipleMatchingOrders_returnsAmbiguous_notCancelled() {
+    TransactionOrder first = order(10L, new BigDecimal("40434"));
+    TransactionOrder second = order(42L, new BigDecimal("40434"));
+    given(orderRepository.findByInstrumentIsin(ISIN)).willReturn(List.of(first, second));
+
+    FtConfirmationResult result = service(DAY_AFTER_TRADE).verify(cancellationConfirmation());
+
+    assertThat(result.quantityStatus()).isEqualTo(AMBIGUOUS);
+    assertThat(result.priceStatus()).isEqualTo(AMBIGUOUS);
+    assertThat(result.details()).containsEntry("ambiguousOrderCount", "2");
+  }
+
+  @Test
   void cancellationConfirmation_orderNotFound_returnsOrphan() {
     given(orderRepository.findByInstrumentIsin(ISIN)).willReturn(List.of());
 

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationVerificationServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationVerificationServiceTest.java
@@ -109,6 +109,31 @@ class FtConfirmationVerificationServiceTest {
   }
 
   @Test
+  void orderOnDifferentVenue_isNotAnFtCandidate_returnsOrphan() {
+    TransactionOrder sebOrder = order(new BigDecimal("40434"));
+    sebOrder.setOrderVenue(OrderVenue.SEB);
+    given(orderRepository.findByInstrumentIsin(ISIN)).willReturn(List.of(sebOrder));
+
+    FtConfirmationResult result = service(DAY_AFTER_TRADE).verify(confirmation());
+
+    assertThat(result.quantityStatus()).isEqualTo(ORPHAN);
+  }
+
+  @Test
+  void orderPlacedLateEveningUtc_matchesSameUtcTradeDate_notNextDayInTallinn() {
+    TransactionOrder order = order(new BigDecimal("40434"));
+    order.setOrderTimestamp(Instant.parse("2026-06-08T22:30:00Z")); // 01:30 on 06-09 in Tallinn
+    given(orderRepository.findByInstrumentIsin(ISIN)).willReturn(List.of(order));
+    given(executionRepository.findAllByOrderId(order.getId()))
+        .willReturn(List.of(execution(new BigDecimal("40434"))));
+    givenReferencePrice(new BigDecimal("10.09"), TRADE_DATE);
+
+    FtConfirmationResult result = service(DAY_AFTER_TRADE).verify(confirmation());
+
+    assertThat(result.quantityStatus()).isEqualTo(OK);
+  }
+
+  @Test
   void quantityAndPriceMatch_returnsOkOk() {
     givenOrderAndExecution(new BigDecimal("40434"), new BigDecimal("40434"));
     givenReferencePrice(new BigDecimal("10.09"), TRADE_DATE);

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationVerificationServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationVerificationServiceTest.java
@@ -39,6 +39,7 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -455,6 +456,34 @@ class FtConfirmationVerificationServiceTest {
     service(DAY_AFTER_TRADE).verifyAll(List.of(confirmation), "alice");
 
     verify(auditRecorder).recordOutcome(eq(order), eq(confirmation), any(), eq("alice"));
+  }
+
+  @Test
+  void verify_singleRow_publishesOutcomeToDigest() {
+    TransactionOrder order = order(new BigDecimal("40432"));
+    given(orderRepository.findByInstrumentIsin(ISIN)).willReturn(List.of(order));
+    given(executionRepository.findAllByOrderId(order.getId()))
+        .willReturn(List.of(execution(new BigDecimal("40432"))));
+    givenReferencePrice(new BigDecimal("10.09"), TRADE_DATE);
+    FtConfirmation confirmation = confirmation();
+
+    FtConfirmationResult result = service(DAY_AFTER_TRADE).verify(confirmation);
+
+    verify(digest).publish(List.of(new FtConfirmationOutcome(confirmation, result)));
+  }
+
+  @Test
+  void verifyAll_nullRow_isIsolatedWithoutAbortingOtherRows() {
+    givenOrderAndExecution(new BigDecimal("40434"), new BigDecimal("40434"));
+    givenReferencePrice(new BigDecimal("10.09"), TRADE_DATE);
+
+    List<FtConfirmationBatchResult> results =
+        service(DAY_AFTER_TRADE).verifyAll(Arrays.asList(null, confirmation()), "ops");
+
+    assertThat(results).hasSize(2);
+    assertThat(results.get(0).isin()).isNull();
+    assertThat(results.get(0).error()).isEqualTo("null confirmation row");
+    assertThat(results.get(1).result().quantityStatus()).isEqualTo(OK);
   }
 
   @Test

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationVerificationServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationVerificationServiceTest.java
@@ -435,13 +435,12 @@ class FtConfirmationVerificationServiceTest {
   }
 
   @Test
-  void verifyAll_changedActionableRows_arePublishedToDigest() {
+  void verifyAll_passesEveryVerifiedOutcomeToDigest() {
     TransactionOrder order = order(new BigDecimal("40432"));
     given(orderRepository.findByInstrumentIsin(ISIN)).willReturn(List.of(order));
     given(executionRepository.findAllByOrderId(order.getId()))
         .willReturn(List.of(execution(new BigDecimal("40432"))));
     givenReferencePrice(new BigDecimal("10.09"), TRADE_DATE);
-    given(auditRecorder.recordOutcome(any(), any(), any(), any())).willReturn(true);
     FtConfirmation confirmation = confirmation();
 
     List<FtConfirmationBatchResult> results =
@@ -453,13 +452,17 @@ class FtConfirmationVerificationServiceTest {
   }
 
   @Test
-  void verifyAll_unchangedRows_areNotPublishedToDigest() {
+  void verifyAll_passesCleanOutcomesToDigestToo_alertingIsTheDigestsDecision() {
     givenOrderAndExecution(new BigDecimal("40434"), new BigDecimal("40434"));
     givenReferencePrice(new BigDecimal("10.09"), TRADE_DATE);
+    FtConfirmation confirmation = confirmation();
 
-    service(DAY_AFTER_TRADE).verifyAll(List.of(confirmation()), "ops");
+    List<FtConfirmationBatchResult> results =
+        service(DAY_AFTER_TRADE).verifyAll(List.of(confirmation), "ops");
 
-    verify(digest).publish(List.of());
+    FtConfirmationResult result = results.get(0).result();
+    assertThat(result.quantityStatus()).isEqualTo(OK);
+    verify(digest).publish(List.of(new FtConfirmationOutcome(confirmation, result)));
   }
 
   private FtConfirmation confirmation() {

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/SebPendingTransactionReconciliationIT.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/SebPendingTransactionReconciliationIT.java
@@ -412,7 +412,8 @@ class SebPendingTransactionReconciliationIT {
     raw.put("Trade date", "2026-06-22T10:00:00Z");
     raw.put("Settlement date", "2026-06-24");
     raw.put("Settlement amount", amount);
-    raw.put("Client name", "Tuleva III Samba Pensionifond");
+    raw.put(
+        "Client name", "Tuleva Täiendav Kogumisfond"); // TKF100, matching the split order's fund
     raw.put("Instrument name", "Xtrackers MSCI World Screened UCITS ETF 1C");
     return raw;
   }

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/SebPendingTransactionReconciliationServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/SebPendingTransactionReconciliationServiceTest.java
@@ -76,6 +76,7 @@ class SebPendingTransactionReconciliationServiceTest {
         new SebPendingTransactionComplexMatcher(
             orderRepository, executionRepository, resolver, validator),
         validator,
+        resolver,
         new ExecutionPriceConsistencyChecker(),
         matchingPolicy,
         mapper,
@@ -620,6 +621,23 @@ class SebPendingTransactionReconciliationServiceTest {
     given(orderRepository.findByOrderUuid(clientRef)).willReturn(Optional.of(order));
 
     service.reconcile(reportWithSingleRow(clientRef));
+
+    verify(executionRepository, never()).save(any());
+    assertThat(order.getOrderStatus()).isEqualTo(SENT);
+  }
+
+  @Test
+  void reconcile_uuidMatchedRowWhoseClientNameResolvesToADifferentFund_isQuarantined() {
+    service = newService();
+    UUID clientRef = UUID.fromString("bd83f551-8c79-4193-b92b-18e1dfd0bd29");
+    TransactionOrder order = sampleOrder(clientRef); // fund TKF100
+    given(orderRepository.findByOrderUuid(clientRef)).willReturn(Optional.of(order));
+
+    // Row carries this order's Client ref but SEB's client name is a different fund → misrouted ref
+    Map<String, Object> raw = validRawRow(clientRef);
+    raw.put("Client name", "Tuleva Maailma Aktsiate Pensionifond"); // TUK75, not TKF100
+
+    service.reconcile(reportOf(raw));
 
     verify(executionRepository, never()).save(any());
     assertThat(order.getOrderStatus()).isEqualTo(SENT);

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/SebPendingTransactionReconciliationServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/SebPendingTransactionReconciliationServiceTest.java
@@ -314,6 +314,26 @@ class SebPendingTransactionReconciliationServiceTest {
   }
 
   @Test
+  void reconcile_uuidMatchedEtfRowWithBlankQuantity_isQuarantinedNotExecuted() {
+    service = newService();
+    UUID clientRef = UUID.fromString("bd83f551-8c79-4193-b92b-18e1dfd0bd29");
+    TransactionOrder order = orderWith(clientRef, ETF, BUY, new BigDecimal("15007"), null);
+    given(orderRepository.findByOrderUuid(clientRef)).willReturn(Optional.of(order));
+
+    service.reconcile(reportWithSingleRowQuantity(clientRef, null));
+
+    verify(eventPublisher)
+        .publishEvent(
+            argThat(
+                (Object e) ->
+                    e instanceof QuantityAmountMismatchEvent qe
+                        && qe.kind() == QuantityAmountMismatchEvent.MismatchKind.ETF_QUANTITY
+                        && qe.actual() == null));
+    verify(executionRepository, never()).save(any());
+    assertThat(order.getOrderStatus()).isEqualTo(SENT);
+  }
+
+  @Test
   void reconcile_uuidMatchWithNullOrderQuantity_publishesNoMismatch() {
     service = newService();
     UUID clientRef = UUID.fromString("bd83f551-8c79-4193-b92b-18e1dfd0bd29");

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/portfolio/CostBasisCalculatorSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/portfolio/CostBasisCalculatorSpec.groovy
@@ -195,6 +195,46 @@ class CostBasisCalculatorSpec extends Specification {
         result.avgUnitCost.compareTo(new BigDecimal("10.00000000")) == 0
     }
 
+    def "BUY with null unit price fails loudly instead of adding zero-cost units"() {
+        given:
+        def execs = [
+                new ExecutionEvent(TransactionType.BUY, new BigDecimal("1000"), null, BigDecimal.ZERO)
+        ]
+
+        when:
+        calculator.calculate(Optional.empty(), execs, FUND_ISIN, INSTRUMENT_ISIN, DATE)
+
+        then:
+        thrown(IllegalStateException)
+    }
+
+    def "BUY with non-positive unit price fails loudly"() {
+        given:
+        def execs = [
+                new ExecutionEvent(TransactionType.BUY, new BigDecimal("1000"), BigDecimal.ZERO, BigDecimal.ZERO)
+        ]
+
+        when:
+        calculator.calculate(Optional.empty(), execs, FUND_ISIN, INSTRUMENT_ISIN, DATE)
+
+        then:
+        thrown(IllegalStateException)
+    }
+
+    def "SELL with null quantity fails loudly instead of leaving holdings unchanged"() {
+        given:
+        def prior = Optional.of(new PriorPosition(new BigDecimal("1000"), new BigDecimal("10.00")))
+        def execs = [
+                new ExecutionEvent(TransactionType.SELL, null, new BigDecimal("12.00"), BigDecimal.ZERO)
+        ]
+
+        when:
+        calculator.calculate(prior, execs, FUND_ISIN, INSTRUMENT_ISIN, DATE)
+
+        then:
+        thrown(IllegalStateException)
+    }
+
     def "null commission treated as zero"() {
         given:
         def prior = Optional.empty()

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/portfolio/PortfolioCostBasisIT.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/portfolio/PortfolioCostBasisIT.java
@@ -104,6 +104,33 @@ class PortfolioCostBasisIT {
     assertThat(nextDayRow.getDeltaQuantity()).isEqualByComparingTo("0.0000");
   }
 
+  @Test
+  void runForFundAndDate_rebuild_deletesRowForACorrectedAwayExecution() {
+    seedBaseline(); // baseline holds INSTRUMENT_ISIN
+    seedBuyExecutionForIsin(
+        INSTRUMENT_ISIN_2, new BigDecimal("500.0000"), new BigDecimal("20.00000000"), TRADE_DATE);
+    service.runForFundAndDate(TUK75, TRADE_DATE);
+    assertThat(
+            costBasisRepository.findByFundIsinAndInstrumentIsinAndAsOfDate(
+                FUND_ISIN, INSTRUMENT_ISIN_2, TRADE_DATE))
+        .isPresent();
+
+    // The erroneous execution is corrected away, then the day is rebuilt (as the self-heal does)
+    executionRepository.deleteAll();
+    entityManager.flush();
+
+    service.runForFundAndDate(TUK75, TRADE_DATE);
+
+    assertThat(
+            costBasisRepository.findByFundIsinAndInstrumentIsinAndAsOfDate(
+                FUND_ISIN, INSTRUMENT_ISIN_2, TRADE_DATE))
+        .isEmpty();
+    assertThat(
+            costBasisRepository.findByFundIsinAndInstrumentIsinAndAsOfDate(
+                FUND_ISIN, INSTRUMENT_ISIN, TRADE_DATE))
+        .isPresent();
+  }
+
   private void seedBaseline() {
     PortfolioBaseline baseline =
         PortfolioBaseline.builder()

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/portfolio/PortfolioCostBasisIT.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/portfolio/PortfolioCostBasisIT.java
@@ -34,8 +34,10 @@ class PortfolioCostBasisIT {
 
   private static final String FUND_ISIN = TUK75.getIsin();
   private static final String INSTRUMENT_ISIN = "IE00BFNM3G45";
+  private static final String INSTRUMENT_ISIN_2 = "IE00B4L5Y983";
   private static final LocalDate BASELINE_DATE = LocalDate.of(2026, 4, 30);
   private static final LocalDate TRADE_DATE = LocalDate.of(2026, 5, 1);
+  private static final LocalDate NEXT_DATE = LocalDate.of(2026, 5, 2);
 
   @Autowired private PortfolioCostBasisService service;
   @Autowired private PortfolioCostBasisRepository costBasisRepository;
@@ -85,6 +87,23 @@ class PortfolioCostBasisIT {
     assertThat(rows.get(0).getQuantity()).isEqualByComparingTo("120000.0000");
   }
 
+  @Test
+  void runForFundAndDate_carriesForwardPostBaselineInstrumentOnNoTradeDay() {
+    seedBaseline(); // baseline holds INSTRUMENT_ISIN only
+    seedBuyExecutionForIsin(
+        INSTRUMENT_ISIN_2, new BigDecimal("500.0000"), new BigDecimal("20.00000000"), TRADE_DATE);
+
+    service.runForFundAndDate(TUK75, TRADE_DATE); // buys the post-baseline instrument
+    service.runForFundAndDate(TUK75, NEXT_DATE); // no execution this day
+
+    PortfolioCostBasis nextDayRow =
+        costBasisRepository
+            .findByFundIsinAndInstrumentIsinAndAsOfDate(FUND_ISIN, INSTRUMENT_ISIN_2, NEXT_DATE)
+            .orElseThrow();
+    assertThat(nextDayRow.getQuantity()).isEqualByComparingTo("500.0000");
+    assertThat(nextDayRow.getDeltaQuantity()).isEqualByComparingTo("0.0000");
+  }
+
   private void seedBaseline() {
     PortfolioBaseline baseline =
         PortfolioBaseline.builder()
@@ -121,18 +140,41 @@ class PortfolioCostBasisIT {
   }
 
   private TransactionOrder persistOrder(TransactionType type) {
+    return persistOrder(INSTRUMENT_ISIN, type, TRADE_DATE);
+  }
+
+  private void seedBuyExecutionForIsin(
+      String isin, BigDecimal qty, BigDecimal unitPrice, LocalDate date) {
+    TransactionOrder order = persistOrder(isin, BUY, date);
+    TransactionExecution exec =
+        TransactionExecution.builder()
+            .orderId(order.getId())
+            .brokerTransactionId("DLA" + UUID.randomUUID())
+            .executionTimestamp(date.atStartOfDay().toInstant(ZoneOffset.UTC))
+            .executedQuantity(qty)
+            .unitPrice(unitPrice)
+            .totalConsideration(qty.multiply(unitPrice))
+            .commissionAmount(BigDecimal.ZERO)
+            .actualSettlementDate(date.plusDays(2))
+            .source("SEB_OOTEL")
+            .build();
+    executionRepository.save(exec);
+    entityManager.flush();
+  }
+
+  private TransactionOrder persistOrder(String isin, TransactionType type, LocalDate date) {
     TransactionBatch batch =
         batchRepository.save(TransactionBatch.builder().fund(TUK75).createdBy("test").build());
     return orderRepository.save(
         TransactionOrder.builder()
             .batch(batch)
             .fund(TUK75)
-            .instrumentIsin(INSTRUMENT_ISIN)
+            .instrumentIsin(isin)
             .transactionType(type)
             .instrumentType(ETF)
             .orderQuantity(new BigDecimal("20000"))
             .orderVenue(SEB)
-            .orderTimestamp(TRADE_DATE.atStartOfDay().toInstant(ZoneOffset.UTC))
+            .orderTimestamp(date.atStartOfDay().toInstant(ZoneOffset.UTC))
             .orderUuid(UUID.randomUUID())
             .build());
   }


### PR DESCRIPTION
## Transaction registry — cutover hardening

Data-integrity and cutover-alerting fixes across the post-send transaction-registry pipeline, from the [Transaction Registry — Status & Open Items](https://github.com/TulevaEE/tuleva/blob/main/work/investeerimistegevus/docs/Transaction%20Registry%20Gap%20Analysis%20%26%20Remediation%20Plan.md) gap doc (§4.7 / §4.8). Each fix was written test-first (the `⚠️ candidate` items were each reproduced with a failing test before the fix), and the whole branch was run through a Clean Code audit.

### FT confirmation ingestion
- **Alert-loss at cutover** — issues recorded in shadow mode were seen as "unchanged" once `registry-authoritative` flipped and never alerted. Recorded state is now decoupled from *alerted* state (a separate `FT_CONFIRMATION_ALERTED` marker), so any still-open issue pages ops exactly once at the flip and stays idempotent. *(§4.8)*
- **Broker cancellations** now page ops (with a distinct "verify and cancel" line); no auto status-flip. *(§4.8 / §4.5d)*
- **Candidate matching** — filter to `OrderVenue.FT` so a same-day SEB order can't shadow an FT confirmation (H4); compare the trade date in **UTC**, not Europe/Tallinn, so a late-evening order no longer false-ORPHANs (H5). *(§4.7)*
- **Dedup by decimal value** not `toPlainString`, so `10.09` vs `10.090` no longer re-alerts a still-broken trade; collapse exact-duplicate rows within a batch (H6). *(§4.7)*
- Cancellation requires a **unique** order match (else `AMBIGUOUS`); single-row endpoint now routes through the digest; a null batch row is isolated instead of aborting the batch. *(§4.8)*

### Trade sizing & export
- **Price-sign guard** — a non-positive resolved price is treated identically to a missing price (quantity left unset, logged loudly), never a fallback price or a negative/zero quantity; the create path marks the command `FAILED` with a reason instead of a 500 + stranded `PROCESSING`. *(§4.7 H3)*
- **Finalization refuses** any non-amount-based order (ETF / fund sell) with a null quantity, before any state change or export — so a blank SEB quantity or a literal FT `QTY=0` order can never be sent. *(§4.8 export blank/0 — cutover blocker)*

### SEB reconciliation
- **Blank-economics rows** (blank required Quantity/Total for the order type) are quarantined with a durable audit + alert instead of being booked `EXECUTED` with null economics. *(§4.8)*
- **Cross-fund guard** — a direct UUID/broker-ref match now requires the row's resolved client-name fund to match the order's fund, so a misrouted Client ref can't book to the wrong fund. *(§4.8)*

### Cost-basis ledger
- Reject **null / non-positive** execution economics (throw) instead of coercing to zero — no more zero-cost BUYs or no-op SELLs. *(§4.8)*
- **Carry forward** open positions on no-trade days, so an instrument first bought after the baseline stays in the snapshot. *(§4.8)*
- Self-heal rebuilds each day as **desired state** — upserts expected rows **and deletes** stale ones — so a corrected-away execution's row no longer lingers. *(§4.8)*

### Notes
- No migration. Along the way the fixes surfaced three unrealistic test fixtures (finalize tests without a quantity; a split-order IT stamping a TKF100 order with TUV100's client name) — all corrected to realistic data.
- Known follow-ups (tracked separately, not in this PR): the FT/unmatched dedup queries still full-scan their audit history (§4.7/§4.8 keyed-finder item); FT negative reference price (§4.8 2.4); EPIS stale-report markers (§4.8 2.7); the trade-calc candidates (SELL double-subtract, BUY redistribution).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Kn5QDeFAbZNinwQydX6dk
