### PR TITLE
Fix custody verification for parents with both personal and property custody

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/party/CustodyVerificationService.java
+++ b/src/main/java/ee/tuleva/onboarding/party/CustodyVerificationService.java
@@ -8,7 +8,9 @@ import static ee.tuleva.onboarding.party.CustodyVerification.Outcome.OK;
 import ee.tuleva.onboarding.populationregister.CustodyRight;
 import ee.tuleva.onboarding.populationregister.PopulationRegisterClient;
 import ee.tuleva.onboarding.populationregister.PopulationRegisterPerson;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -21,28 +23,34 @@ public class CustodyVerificationService {
   private final PopulationRegisterClient populationRegisterClient;
 
   public CustodyVerification verify(String parentPersonalCode, String childPersonalCode) {
-    CustodyRight custody =
+    // The population register returns personal (H10) and property (H20) custody as
+    // separate entries, so a parent with full custody has BOTH for the same child.
+    // Asset management requires the property right specifically — look for it across
+    // all of the child's entries rather than inspecting whichever one comes first.
+    List<CustodyRight> childCustodies =
         populationRegisterClient.fetchCustodyRights(parentPersonalCode).stream()
             .filter(right -> right.childPersonalCode().equals(childPersonalCode))
-            .findFirst()
-            .orElse(null);
+            .toList();
 
-    if (custody == null) {
+    if (childCustodies.isEmpty()) {
       log.info(
           "No custody record for child: parentCode={}, childCode={}",
           parentPersonalCode,
           childPersonalCode);
       return CustodyVerification.notVerified(NO_CUSTODY);
     }
-    if (!custody.childAlive()) {
+    if (childCustodies.stream().noneMatch(CustodyRight::childAlive)) {
       return CustodyVerification.notVerified(CHILD_NOT_ALIVE);
     }
-    if (!custody.grantsAssetManagement()) {
+
+    Optional<CustodyRight> assetManagement =
+        childCustodies.stream().filter(CustodyRight::grantsAssetManagement).findFirst();
+    if (assetManagement.isEmpty()) {
       log.info(
-          "Custody does not grant asset management: parentCode={}, childCode={}, type={}",
+          "Custody does not grant asset management: parentCode={}, childCode={}, types={}",
           parentPersonalCode,
           childPersonalCode,
-          custody.type());
+          childCustodies.stream().map(CustodyRight::type).toList());
       return CustodyVerification.notVerified(NOT_ASSET_MANAGEMENT);
     }
 
@@ -50,7 +58,7 @@ public class CustodyVerificationService {
     if (!child.isAlive()) {
       return CustodyVerification.notVerified(CHILD_NOT_ALIVE);
     }
-    return new CustodyVerification(OK, child, evidence(custody));
+    return new CustodyVerification(OK, child, evidence(assetManagement.get()));
   }
 
   private Map<String, Object> evidence(CustodyRight custody) {

--- a/src/test/groovy/ee/tuleva/onboarding/party/CustodyVerificationServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/party/CustodyVerificationServiceTest.java
@@ -60,6 +60,25 @@ class CustodyVerificationServiceTest {
   }
 
   @Test
+  void verifiesWhenChildHasBothPersonalAndPropertyCustodyEvenWhenPersonalIsListedFirst() {
+    // A full-custody parent has both H10 (personal) and H20 (property) for the same
+    // child, and the register lists personal first — verification must still find the
+    // property (asset-management) right instead of stopping at the first entry.
+    given(populationRegisterClient.fetchCustodyRights(PARENT))
+        .willReturn(
+            List.of(
+                new CustodyRight(CHILD, PERSONAL, true, true),
+                new CustodyRight(CHILD, PROPERTY, true, true)));
+    given(populationRegisterClient.fetchPerson(CHILD)).willReturn(aliveChild);
+
+    CustodyVerification result = service.verify(PARENT, CHILD);
+
+    assertThat(result.isVerified()).isTrue();
+    assertThat(result.outcome()).isEqualTo(OK);
+    assertThat(result.evidence()).containsEntry("custodyType", "PROPERTY");
+  }
+
+  @Test
   void doesNotVerifyAndDoesNotFetchIdentityWhenNoCustodyForThatChild() {
     given(populationRegisterClient.fetchCustodyRights(PARENT))
         .willReturn(List.of(new CustodyRight(OTHER_CHILD, PROPERTY, true, true)));


### PR DESCRIPTION
## The bug
`CustodyVerificationService.verify` rejected legitimate full-`varahooldus` parents as `NOT_ASSET_MANAGEMENT`, so child onboarding always fell to "under review".

The population register returns **personal (H10)** and **property (H20)** custody as **separate entries** for the same child — a full-custody parent has *both*, and RR lists **personal first**. The code took the first matching entry with `findFirst()` and checked only that one:

```java
CustodyRight custody = fetchCustodyRights(parent).stream()
    .filter(r -> r.childPersonalCode().equals(childCode))
    .findFirst().orElse(null);          // ← grabs H10 (personal)
...
if (!custody.grantsAssetManagement())   // PERSONAL != PROPERTY → false
    return notVerified(NOT_ASSET_MANAGEMENT);
```

So the H20 asset-management right sitting in the *next* list element was never checked. This would reject essentially **every** full-custody parent.

## Confirmed against live RR
A live X-Road `/isikud` probe returned exactly two custody entries for the child — `H10 täielik isikuhooldusõigus` then `H20 täielik varahooldusõigus`, both `staatus=H1` (kehtiv), child `olek=E` (alive). The mapper constants were all correct; the verification logic was the fault.

## The fix
Look for the property (asset-management) right **across all** of the child's custody entries instead of inspecting whichever comes first. `NO_CUSTODY` / `CHILD_NOT_ALIVE` / `NOT_ASSET_MANAGEMENT` precedence is preserved.

## Test
Added `verifiesWhenChildHasBothPersonalAndPropertyCustodyEvenWhenPersonalIsListedFirst` — reproduces the real RR ordering (personal before property, same child). It **fails on the old `findFirst` code** and passes with the fix. The existing "verifies" test never caught this because it listed a *different* child first, so `findFirst` never tripped. Full `CustodyVerificationServiceTest` + spotless green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)