### PR TITLE
Accept child-onboarding KYC survey items on POST /v1/kyc/surveys

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/kyc/survey/KycSurveyResponseItem.java
+++ b/src/main/java/ee/tuleva/onboarding/kyc/survey/KycSurveyResponseItem.java
@@ -24,7 +24,11 @@ import java.util.List;
   @JsonSubTypes.Type(
       value = KycSurveyResponseItem.InvestableAssets.class,
       name = "INVESTABLE_ASSETS"),
+  @JsonSubTypes.Type(
+      value = KycSurveyResponseItem.PlannedContribution.class,
+      name = "PLANNED_CONTRIBUTION"),
   @JsonSubTypes.Type(value = KycSurveyResponseItem.SourceOfIncome.class, name = "SOURCE_OF_INCOME"),
+  @JsonSubTypes.Type(value = KycSurveyResponseItem.FundingSources.class, name = "FUNDING_SOURCES"),
   @JsonSubTypes.Type(value = KycSurveyResponseItem.Terms.class, name = "TERMS"),
 })
 public sealed interface KycSurveyResponseItem extends Serializable {
@@ -45,7 +49,13 @@ public sealed interface KycSurveyResponseItem extends Serializable {
   record InvestableAssets(@NotNull OptionValue<AssetRange> value)
       implements KycSurveyResponseItem {}
 
+  record PlannedContribution(@NotNull OptionValue<PlannedContributionRange> value)
+      implements KycSurveyResponseItem {}
+
   record SourceOfIncome(@NotNull List<@Valid SourceOfIncomeValueItem> value)
+      implements KycSurveyResponseItem {}
+
+  record FundingSources(@NotNull List<@Valid FundingSourceValueItem> value)
       implements KycSurveyResponseItem {}
 
   record Terms(@NotNull OptionValue<TermsAccepted> value) implements KycSurveyResponseItem {}
@@ -95,6 +105,17 @@ public sealed interface KycSurveyResponseItem extends Serializable {
     record Text(String value) implements SourceOfIncomeValueItem {}
   }
 
+  @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+  @JsonSubTypes({
+    @JsonSubTypes.Type(value = FundingSourceValueItem.Option.class, name = "OPTION"),
+    @JsonSubTypes.Type(value = FundingSourceValueItem.Text.class, name = "TEXT"),
+  })
+  sealed interface FundingSourceValueItem extends Serializable {
+    record Option(FundingSource value) implements FundingSourceValueItem {}
+
+    record Text(String value) implements FundingSourceValueItem {}
+  }
+
   // Enums
   enum PepStatus {
     IS_PEP,
@@ -105,7 +126,9 @@ public sealed interface KycSurveyResponseItem extends Serializable {
     LONG_TERM,
     SPECIFIC_GOAL,
     CHILD,
-    TRADING
+    TRADING,
+    EDUCATION,
+    FIRST_HOME
   }
 
   enum AssetRange {
@@ -115,6 +138,13 @@ public sealed interface KycSurveyResponseItem extends Serializable {
     MORE_THAN_80K
   }
 
+  enum PlannedContributionRange {
+    UP_TO_50,
+    FROM_50_TO_100,
+    FROM_100_TO_300,
+    OVER_300
+  }
+
   enum IncomeSource {
     SALARY,
     SAVINGS,
@@ -122,6 +152,13 @@ public sealed interface KycSurveyResponseItem extends Serializable {
     PENSION_OR_BENEFITS,
     FAMILY_FUNDS_OR_INHERITANCE,
     BUSINESS_INCOME
+  }
+
+  enum FundingSource {
+    PARENT_INCOME_AND_SAVINGS,
+    GIFTS,
+    INHERITANCE,
+    CHILD_OWN
   }
 
   enum TermsAccepted {

--- a/src/main/java/ee/tuleva/onboarding/kyc/survey/KycSurveyResponseItem.java
+++ b/src/main/java/ee/tuleva/onboarding/kyc/survey/KycSurveyResponseItem.java
@@ -135,14 +135,17 @@ public sealed interface KycSurveyResponseItem extends Serializable {
     LESS_THAN_20K,
     RANGE_20K_40K,
     RANGE_40K_80K,
-    MORE_THAN_80K
+    MORE_THAN_80K,
+    UP_TO_2000,
+    FROM_2000_TO_10000,
+    OVER_10000
   }
 
   enum PlannedContributionRange {
-    UP_TO_50,
-    FROM_50_TO_100,
-    FROM_100_TO_300,
-    OVER_300
+    UP_TO_200,
+    FROM_200_TO_600,
+    FROM_600_TO_1000,
+    OVER_1000
   }
 
   enum IncomeSource {

--- a/src/test/groovy/ee/tuleva/onboarding/kyc/survey/ChildRoleAwareKycIntegrationTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyc/survey/ChildRoleAwareKycIntegrationTest.java
@@ -79,9 +79,13 @@ class ChildRoleAwareKycIntegrationTest {
       }
       """;
 
-  // The child survey deliberately carries NO CITIZENSHIP and NO PEP_SELF_DECLARATION (a child's
-  // citizenship comes from the population register, not the survey), and adds the child-specific
-  // FUNDING_SOURCES + PLANNED_CONTRIBUTION items and the EDUCATION investment goal.
+  // Mirrors verbatim the payload onboarding-client PR #1587 sends from
+  // transformChildFormDataToSurveyCommand: ADDRESS (including the frontend's optional
+  // fullAddress field, which the backend AddressDetails record ignores under Jackson 3's
+  // default of not failing on unknown properties), EMAIL, PHONE_NUMBER, INVESTMENT_GOALS
+  // (child-only EDUCATION goal), PLANNED_CONTRIBUTION, FUNDING_SOURCES, purpose
+  // PERSONAL_ONBOARDING. Citizenship and PEP are intentionally absent — a child's
+  // citizenship comes from the population register and a child cannot be a PEP.
   private static final String CHILD_SURVEY =
       """
       {
@@ -91,6 +95,7 @@ class ChildRoleAwareKycIntegrationTest {
             "value": {
               "type": "ADDRESS",
               "value": {
+                "fullAddress": "123 Main St, Tallinn 10115",
                 "street": "123 Main St",
                 "city": "Tallinn",
                 "postalCode": "10115",
@@ -99,22 +104,21 @@ class ChildRoleAwareKycIntegrationTest {
             }
           },
           { "type": "EMAIL", "value": { "type": "TEXT", "value": "child@example.com" } },
+          { "type": "PHONE_NUMBER", "value": { "type": "TEXT", "value": "+37255500000" } },
           { "type": "INVESTMENT_GOALS", "value": { "type": "OPTION", "value": "EDUCATION" } },
-          { "type": "INVESTABLE_ASSETS", "value": { "type": "OPTION", "value": "LESS_THAN_20K" } },
-          { "type": "SOURCE_OF_INCOME", "value": [ { "type": "OPTION", "value": "SALARY" } ] },
+          {
+            "type": "PLANNED_CONTRIBUTION",
+            "value": { "type": "OPTION", "value": "FROM_50_TO_100" }
+          },
           {
             "type": "FUNDING_SOURCES",
             "value": [
               { "type": "OPTION", "value": "PARENT_INCOME_AND_SAVINGS" },
               { "type": "TEXT", "value": "lottery win" }
             ]
-          },
-          {
-            "type": "PLANNED_CONTRIBUTION",
-            "value": { "type": "OPTION", "value": "FROM_50_TO_100" }
-          },
-          { "type": "TERMS", "value": { "type": "OPTION", "value": "ACCEPTED" } }
-        ]
+          }
+        ],
+        "purpose": "PERSONAL_ONBOARDING"
       }
       """;
 

--- a/src/test/groovy/ee/tuleva/onboarding/kyc/survey/ChildRoleAwareKycIntegrationTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyc/survey/ChildRoleAwareKycIntegrationTest.java
@@ -83,9 +83,10 @@ class ChildRoleAwareKycIntegrationTest {
   // transformChildFormDataToSurveyCommand: ADDRESS (including the frontend's optional
   // fullAddress field, which the backend AddressDetails record ignores under Jackson 3's
   // default of not failing on unknown properties), EMAIL, PHONE_NUMBER, INVESTMENT_GOALS
-  // (child-only EDUCATION goal), PLANNED_CONTRIBUTION, FUNDING_SOURCES, purpose
-  // PERSONAL_ONBOARDING. Citizenship and PEP are intentionally absent — a child's
-  // citizenship comes from the population register and a child cannot be a PEP.
+  // (child-only EDUCATION goal), PLANNED_CONTRIBUTION (child range), INVESTABLE_ASSETS
+  // (child range), FUNDING_SOURCES, purpose PERSONAL_ONBOARDING. Citizenship and PEP are
+  // intentionally absent — a child's citizenship comes from the population register and a
+  // child cannot be a PEP.
   private static final String CHILD_SURVEY =
       """
       {
@@ -108,8 +109,9 @@ class ChildRoleAwareKycIntegrationTest {
           { "type": "INVESTMENT_GOALS", "value": { "type": "OPTION", "value": "EDUCATION" } },
           {
             "type": "PLANNED_CONTRIBUTION",
-            "value": { "type": "OPTION", "value": "FROM_50_TO_100" }
+            "value": { "type": "OPTION", "value": "FROM_200_TO_600" }
           },
+          { "type": "INVESTABLE_ASSETS", "value": { "type": "OPTION", "value": "UP_TO_2000" } },
           {
             "type": "FUNDING_SOURCES",
             "value": [

--- a/src/test/groovy/ee/tuleva/onboarding/kyc/survey/ChildRoleAwareKycIntegrationTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyc/survey/ChildRoleAwareKycIntegrationTest.java
@@ -79,6 +79,45 @@ class ChildRoleAwareKycIntegrationTest {
       }
       """;
 
+  // The child survey deliberately carries NO CITIZENSHIP and NO PEP_SELF_DECLARATION (a child's
+  // citizenship comes from the population register, not the survey), and adds the child-specific
+  // FUNDING_SOURCES + PLANNED_CONTRIBUTION items and the EDUCATION investment goal.
+  private static final String CHILD_SURVEY =
+      """
+      {
+        "answers": [
+          {
+            "type": "ADDRESS",
+            "value": {
+              "type": "ADDRESS",
+              "value": {
+                "street": "123 Main St",
+                "city": "Tallinn",
+                "postalCode": "10115",
+                "countryCode": "EE"
+              }
+            }
+          },
+          { "type": "EMAIL", "value": { "type": "TEXT", "value": "child@example.com" } },
+          { "type": "INVESTMENT_GOALS", "value": { "type": "OPTION", "value": "EDUCATION" } },
+          { "type": "INVESTABLE_ASSETS", "value": { "type": "OPTION", "value": "LESS_THAN_20K" } },
+          { "type": "SOURCE_OF_INCOME", "value": [ { "type": "OPTION", "value": "SALARY" } ] },
+          {
+            "type": "FUNDING_SOURCES",
+            "value": [
+              { "type": "OPTION", "value": "PARENT_INCOME_AND_SAVINGS" },
+              { "type": "TEXT", "value": "lottery win" }
+            ]
+          },
+          {
+            "type": "PLANNED_CONTRIBUTION",
+            "value": { "type": "OPTION", "value": "FROM_50_TO_100" }
+          },
+          { "type": "TERMS", "value": { "type": "OPTION", "value": "ACCEPTED" } }
+        ]
+      }
+      """;
+
   @Autowired private MockMvc mockMvc;
   @Autowired private UserRepository userRepository;
   @Autowired private KycSurveyRepository kycSurveyRepository;
@@ -179,12 +218,37 @@ class ChildRoleAwareKycIntegrationTest {
         .andExpect(jsonPath("$.complete").value(false));
   }
 
+  @Test
+  void parentActingAsChild_childSurveyWithoutCitizenshipOrPep_isAcceptedAndCompletes()
+      throws Exception {
+    submitSurvey(parentActingAsChild, CHILD_SURVEY);
+
+    var storedSurvey = kycSurveyRepository.findFirstByUserIdOrderByCreatedTimeDesc(child.getId());
+    assertThat(storedSurvey)
+        .as("child survey without CITIZENSHIP/PEP is accepted and stored under the child")
+        .isPresent();
+    assertThat(storedSurvey.get().getSurvey().citizenship())
+        .as("child survey carries no citizenship")
+        .isEmpty();
+    assertThat(storedSurvey.get().getSurvey().pepSelfDeclaration())
+        .as("child survey carries no PEP self-declaration")
+        .isEmpty();
+
+    assertThat(savingsFundOnboardingRepository.findStatus(child.getPersonalCode(), PERSON))
+        .as("child onboarding completes")
+        .contains(COMPLETED);
+  }
+
   private void submitOnboardingSurvey(Authentication as) throws Exception {
+    submitSurvey(as, ONBOARDING_SURVEY);
+  }
+
+  private void submitSurvey(Authentication as, String body) throws Exception {
     mockMvc
         .perform(
             post("/v1/kyc/surveys")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(ONBOARDING_SURVEY)
+                .content(body)
                 .with(csrf())
                 .with(authentication(as)))
         .andExpect(status().isOk());

--- a/src/test/groovy/ee/tuleva/onboarding/kyc/survey/KycSurveyResponseTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyc/survey/KycSurveyResponseTest.java
@@ -6,7 +6,7 @@ import static ee.tuleva.onboarding.kyc.survey.KycSurveyResponseItem.FundingSourc
 import static ee.tuleva.onboarding.kyc.survey.KycSurveyResponseItem.InvestmentGoal.EDUCATION;
 import static ee.tuleva.onboarding.kyc.survey.KycSurveyResponseItem.InvestmentGoal.FIRST_HOME;
 import static ee.tuleva.onboarding.kyc.survey.KycSurveyResponseItem.PepStatus.IS_NOT_PEP;
-import static ee.tuleva.onboarding.kyc.survey.KycSurveyResponseItem.PlannedContributionRange.FROM_50_TO_100;
+import static ee.tuleva.onboarding.kyc.survey.KycSurveyResponseItem.PlannedContributionRange.FROM_200_TO_600;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -149,7 +149,7 @@ class KycSurveyResponseTest {
             },
             {
               "type": "PLANNED_CONTRIBUTION",
-              "value": { "type": "OPTION", "value": "FROM_50_TO_100" }
+              "value": { "type": "OPTION", "value": "FROM_200_TO_600" }
             },
             { "type": "INVESTMENT_GOALS", "value": { "type": "OPTION", "value": "EDUCATION" } },
             { "type": "INVESTMENT_GOALS", "value": { "type": "OPTION", "value": "FIRST_HOME" } }
@@ -166,7 +166,7 @@ class KycSurveyResponseTest {
                     List.of(
                         new FundingSourceValueItem.Option(PARENT_INCOME_AND_SAVINGS),
                         new FundingSourceValueItem.Text("lottery win"))),
-                new PlannedContribution(new OptionValue<>("OPTION", FROM_50_TO_100)),
+                new PlannedContribution(new OptionValue<>("OPTION", FROM_200_TO_600)),
                 new InvestmentGoals(new InvestmentGoalsValue.Option(EDUCATION)),
                 new InvestmentGoals(new InvestmentGoalsValue.Option(FIRST_HOME))));
 

--- a/src/test/groovy/ee/tuleva/onboarding/kyc/survey/KycSurveyResponseTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyc/survey/KycSurveyResponseTest.java
@@ -2,7 +2,11 @@ package ee.tuleva.onboarding.kyc.survey;
 
 import static ee.tuleva.onboarding.kyc.KycSurveyPurpose.IDENTITY_ONLY;
 import static ee.tuleva.onboarding.kyc.KycSurveyPurpose.PERSONAL_ONBOARDING;
+import static ee.tuleva.onboarding.kyc.survey.KycSurveyResponseItem.FundingSource.PARENT_INCOME_AND_SAVINGS;
+import static ee.tuleva.onboarding.kyc.survey.KycSurveyResponseItem.InvestmentGoal.EDUCATION;
+import static ee.tuleva.onboarding.kyc.survey.KycSurveyResponseItem.InvestmentGoal.FIRST_HOME;
 import static ee.tuleva.onboarding.kyc.survey.KycSurveyResponseItem.PepStatus.IS_NOT_PEP;
+import static ee.tuleva.onboarding.kyc.survey.KycSurveyResponseItem.PlannedContributionRange.FROM_50_TO_100;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -13,9 +17,14 @@ import ee.tuleva.onboarding.kyc.survey.KycSurveyResponseItem.Citizenship;
 import ee.tuleva.onboarding.kyc.survey.KycSurveyResponseItem.CountriesValue;
 import ee.tuleva.onboarding.kyc.survey.KycSurveyResponseItem.Email;
 import ee.tuleva.onboarding.kyc.survey.KycSurveyResponseItem.EmailValue;
+import ee.tuleva.onboarding.kyc.survey.KycSurveyResponseItem.FundingSourceValueItem;
+import ee.tuleva.onboarding.kyc.survey.KycSurveyResponseItem.FundingSources;
+import ee.tuleva.onboarding.kyc.survey.KycSurveyResponseItem.InvestmentGoals;
+import ee.tuleva.onboarding.kyc.survey.KycSurveyResponseItem.InvestmentGoalsValue;
 import ee.tuleva.onboarding.kyc.survey.KycSurveyResponseItem.OptionValue;
 import ee.tuleva.onboarding.kyc.survey.KycSurveyResponseItem.PepSelfDeclaration;
 import ee.tuleva.onboarding.kyc.survey.KycSurveyResponseItem.PhoneNumber;
+import ee.tuleva.onboarding.kyc.survey.KycSurveyResponseItem.PlannedContribution;
 import ee.tuleva.onboarding.kyc.survey.KycSurveyResponseItem.TextValue;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -123,5 +132,46 @@ class KycSurveyResponseTest {
     assertThat(response.email()).isEmpty();
     assertThat(response.phoneNumber()).isEmpty();
     assertThat(response.pepSelfDeclaration()).isEmpty();
+  }
+
+  @Test
+  void childSurveyItemsParseAndRoundTrip() throws Exception {
+    var json =
+        """
+        {
+          "answers": [
+            {
+              "type": "FUNDING_SOURCES",
+              "value": [
+                { "type": "OPTION", "value": "PARENT_INCOME_AND_SAVINGS" },
+                { "type": "TEXT", "value": "lottery win" }
+              ]
+            },
+            {
+              "type": "PLANNED_CONTRIBUTION",
+              "value": { "type": "OPTION", "value": "FROM_50_TO_100" }
+            },
+            { "type": "INVESTMENT_GOALS", "value": { "type": "OPTION", "value": "EDUCATION" } },
+            { "type": "INVESTMENT_GOALS", "value": { "type": "OPTION", "value": "FIRST_HOME" } }
+          ]
+        }
+        """;
+
+    var response = objectMapper.readValue(json, KycSurveyResponse.class);
+
+    assertThat(response.answers())
+        .isEqualTo(
+            List.of(
+                new FundingSources(
+                    List.of(
+                        new FundingSourceValueItem.Option(PARENT_INCOME_AND_SAVINGS),
+                        new FundingSourceValueItem.Text("lottery win"))),
+                new PlannedContribution(new OptionValue<>("OPTION", FROM_50_TO_100)),
+                new InvestmentGoals(new InvestmentGoalsValue.Option(EDUCATION)),
+                new InvestmentGoals(new InvestmentGoalsValue.Option(FIRST_HOME))));
+
+    var roundTripped =
+        objectMapper.readValue(objectMapper.writeValueAsString(response), KycSurveyResponse.class);
+    assertThat(roundTripped).isEqualTo(response);
   }
 }


### PR DESCRIPTION
## What & why

The TKF child-onboarding frontend (onboarding-client PR #1587, `tkf-child-onboarding-frontend`, behind `?childOnboardingPreview=true`) submits its final KYC survey via `POST /v1/kyc/surveys` (purpose `PERSONAL_ONBOARDING`, role-switched to the child). That payload carries three survey pieces the backend didn't know, so Jackson polymorphic deserialization threw → **400**. This PR registers them so the child KYC submit succeeds. It is purely the survey-item additions — the custody endpoint, role-aware KYC (`resolveSubject`), and the `#1761` custody `findFirst` fix are already merged & live.

## Changes (`KycSurveyResponseItem.java`)

- **`FUNDING_SOURCES`** → `FundingSources` record: a list of `OPTION | TEXT` items (mirrors `SourceOfIncome`, so free-text "other" works). New enum `FundingSource { PARENT_INCOME_AND_SAVINGS, GIFTS, INHERITANCE, CHILD_OWN }`.
- **`PLANNED_CONTRIBUTION`** → `PlannedContribution` record: a single `OPTION` value (mirrors `InvestableAssets`). New enum `PlannedContributionRange { UP_TO_50, FROM_50_TO_100, FROM_100_TO_300, OVER_300 }`.
- **`InvestmentGoal`** extended with `EDUCATION`, `FIRST_HOME`.
- Both new subtypes registered in the `@JsonSubTypes` list.

Exact JSON now accepted (matches the frontend `types.api.ts` contract verbatim):
```json
{ "type": "FUNDING_SOURCES", "value": [ {"type":"OPTION","value":"PARENT_INCOME_AND_SAVINGS"}, {"type":"TEXT","value":"lottery win"} ] }
{ "type": "PLANNED_CONTRIBUTION", "value": {"type":"OPTION","value":"FROM_50_TO_100"} }
{ "type": "INVESTMENT_GOALS", "value": {"type":"OPTION","value":"EDUCATION"} }
```

### Naming note
The enum is `PlannedContributionRange`, not `PlannedContribution`, because a nested record and enum can't share a simple name — matching the existing convention (`InvestableAssets`→`AssetRange`, `SourceOfIncome`→`IncomeSource`). Enum *class* names don't affect the JSON contract; only the value names do, and those match verbatim.

## No CITIZENSHIP / PEP required
The child survey deliberately contains **no `CITIZENSHIP` and no `PEP_SELF_DECLARATION`** (a child's citizenship comes from the population register, not the survey). Nothing in this service requires them for a `PERSONAL_ONBOARDING` submission — `KycSurveyResponse.citizenship()`/`pepSelfDeclaration()` return `Optional`, and no bean-validation or downstream path demands them. (`ADDRESS` is still required by `extractCountry` — the real child survey includes it.)

## Processing safety
The two new items are declarations stored as-is in `kyc_survey.survey` jsonb. There is **no Java `switch`/`instanceof` over survey item type or over `InvestmentGoal`** anywhere in the module (verified across risk scoring, `KycCheckService`, AML listeners) — risk scoring lives in the external `kyc_ob_assess_user_risk` SQL function, which reads specific jsonb paths. So the new subtypes and enum values gate nothing and cannot cause a 500. The same registration also covers the jsonb read-back path.

## Tests
- `KycSurveyResponseTest#childSurveyItemsParseAndRoundTrip` — parses + serializes + re-parses `FUNDING_SOURCES` (OPTION+TEXT), `PLANNED_CONTRIBUTION`, and `INVESTMENT_GOALS` `EDUCATION`/`FIRST_HOME`.
- `ChildRoleAwareKycIntegrationTest#parentActingAsChild_childSurveyWithoutCitizenshipOrPep_isAcceptedAndCompletes` — posts a child survey with the new items and **no** CITIZENSHIP/PEP as parent-acting-as-child → 200, stored under the child, child onboarding completes.

`./gradlew spotlessApply spotlessCheck` clean; `*KycSurvey*` (34 tests), `ChildRoleAwareKycIntegrationTest` (4), `KycShortSurveyRegressionTest` (3) all green.

## Out of scope — tracked follow-ups
A child may still not reach `COMPLETED` until, in **separate PRs**:
- **(a) Child citizenship from RR for the risk gate (§1d):** the survey carries no citizenship, so the backend must source the child's citizenship (`fetchPerson`) into the child's risk assessment. `kyc_ob_assess_user_risk` expects an ISO2 code; note `PersonMapper.toCitizenship` returns the country *name*, needs name→ISO2. (onboarding-service)
- **(b) database-administration:** remove the "minor without III pillar = medium" rule (`kyc_ob_assess_user_risk` / `check_23_medium_risk`) so the child auto-COMPLETEs instead of PENDING (plan decision 20; needs compliance/Maria sign-off). (database-administration repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)