### PR TITLE
Stop tracking CUSTODY_RIGHT in AML health delay alerts

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/aml/health/ScheduledAmlHealthCheckJob.java
+++ b/src/main/java/ee/tuleva/onboarding/aml/health/ScheduledAmlHealthCheckJob.java
@@ -28,6 +28,7 @@ public class ScheduledAmlHealthCheckJob {
           AmlCheckType.SANCTION_OVERRIDE,
           AmlCheckType.INTERNAL_ESCALATION,
           AmlCheckType.MANUAL_EVENT,
+          AmlCheckType.CUSTODY_RIGHT,
           AmlCheckType.KYB_COMPANY_STRUCTURE,
           AmlCheckType.KYB_SOLE_MEMBER_OWNERSHIP,
           AmlCheckType.KYB_DUAL_MEMBER_OWNERSHIP,

--- a/src/test/groovy/ee/tuleva/onboarding/aml/health/ScheduledAmlHealthCheckJobTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/aml/health/ScheduledAmlHealthCheckJobTest.java
@@ -27,6 +27,7 @@ class ScheduledAmlHealthCheckJobTest {
           AmlCheckType.SANCTION_OVERRIDE,
           AmlCheckType.INTERNAL_ESCALATION,
           AmlCheckType.MANUAL_EVENT,
+          AmlCheckType.CUSTODY_RIGHT,
           AmlCheckType.KYB_COMPANY_STRUCTURE,
           AmlCheckType.KYB_SOLE_MEMBER_OWNERSHIP,
           AmlCheckType.KYB_DUAL_MEMBER_OWNERSHIP,


### PR DESCRIPTION
## Why

Slack has been firing `🔴 AML Health Alert: Check type 'CUSTODY_RIGHT' is delayed.`

This is a **benign false positive**, not a real AML failure. `CUSTODY_RIGHT` is a brand-new check (merged `bf81ab0e7`, 2026-06-30) that fires **only on demand** when a parent self-service onboards a child via `POST /v1/me/children` (`ChildOnboardingService` → `AmlService.addCustodyRightCheck`). It's sporadic and low-volume by design.

`ScheduledAmlHealthCheckJob` runs hourly and flags any `AmlCheckType` whose newest `aml_check` row is older than ~3× that type's recent typical cadence (threshold derived daily from the max 30-day gap between rows, +200% grace). That model fits high-cadence automated checks, but structurally mis-flags a low-volume, user-driven check like `CUSTODY_RIGHT` during any normal quiet stretch.

## What

Add `AmlCheckType.CUSTODY_RIGHT` to `SKIPPED_CHECK_TYPES` (and the test's mirror set `SKIPPED_IN_JOB`), exactly mirroring how `KYB_COMPANY_AGE` and every `KYB_*` type were already silenced — precedent commit `706652667` "Stop tracking KYB_COMPANY_AGE in AML health delay alerts". `CUSTODY_RIGHT` shipped two weeks later and was simply never added.

2-line change. No enum/message/migration/config edits.

## Verification

- `./gradlew spotlessJavaCheck test --tests "…ScheduledAmlHealthCheckJobTest"` → green.
- After deploy the hourly job stops logging the error and the Sentry issue (→ Slack) auto-resolves.

## Note

`CUSTODY_RIGHT` checks still run and still write `aml_check` rows and per-check Slack notifications on failure — this only removes the type from the *freshness/delay* monitor, which is the wrong model for an on-demand check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)