### PR TITLE
Transaction registry §4.8/§4.7 correctness fixes: trade-calc, FT price, EPIS markers, finalize + audit-dedup guards

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/investment/epis/R45ReportService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/epis/R45ReportService.java
@@ -11,6 +11,7 @@ import ee.tuleva.onboarding.fund.TulevaFund;
 import ee.tuleva.onboarding.investment.epis.parser.EpisCsvParser;
 import ee.tuleva.onboarding.investment.epis.parser.R45ParseResult;
 import ee.tuleva.onboarding.investment.epis.parser.R45ReportParser;
+import ee.tuleva.onboarding.investment.epis.parser.R45UnknownRow;
 import ee.tuleva.onboarding.investment.epis.parser.R45UnvaluedRow;
 import ee.tuleva.onboarding.investment.report.InvestmentReport;
 import ee.tuleva.onboarding.investment.report.InvestmentReportRepository;
@@ -23,9 +24,11 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.Nullable;
@@ -63,8 +66,9 @@ public class R45ReportService {
     LocalDate reportDate = report.getReportDate();
     R45ParseResult parsed = r45ReportParser.parse(csv, reportDate, fallbackNavsByIsin(reportDate));
     Set<String> incompleteFundCodes =
-        parsed.unvaluedRows().stream()
-            .map(R45UnvaluedRow::fundCode)
+        Stream.concat(
+                parsed.unvaluedRows().stream().map(R45UnvaluedRow::fundCode),
+                parsed.unknownRows().stream().map(R45UnknownRow::fundCode).filter(Objects::nonNull))
             .collect(Collectors.toUnmodifiableSet());
     if (!parsed.unvaluedRows().isEmpty()) {
       log.warn(
@@ -72,6 +76,13 @@ public class R45ReportService {
           reportId,
           parsed.unvaluedRows());
       notificationService.sendMessage(unvaluedAlertMessage(reportId, parsed), INVESTMENT);
+    }
+    if (!parsed.unknownRows().isEmpty()) {
+      log.warn(
+          "R45 rows with unknown transaction type or unmapped ISIN: reportId={}, unknownRows={}",
+          reportId,
+          parsed.unknownRows());
+      notificationService.sendMessage(unknownRowsAlertMessage(reportId, parsed), INVESTMENT);
     }
     Map<String, List<LocalDate>> redRowDates = redRowSettlementDatesByFundCode(csv);
 
@@ -161,6 +172,20 @@ public class R45ReportService {
       message.append(
           "\n%s %s: %s osakut, ISIN %s"
               .formatted(row.fundCode(), row.transactionType(), row.units(), row.isin()));
+    }
+    return message.toString();
+  }
+
+  private static String unknownRowsAlertMessage(Long reportId, R45ParseResult parsed) {
+    StringBuilder message =
+        new StringBuilder(
+            "⚠️ R45 tundmatu tehingu liik või kaardistamata ISIN (likviidsus võib olla alahinnatud): reportId=%s"
+                .formatted(reportId));
+    for (R45UnknownRow row : parsed.unknownRows()) {
+      message.append(
+          "\ntehingu liik %s, ISIN %s, fond %s"
+              .formatted(
+                  row.typeCode(), row.isin(), row.fundCode() == null ? "?" : row.fundCode()));
     }
     return message.toString();
   }

--- a/src/main/java/ee/tuleva/onboarding/investment/epis/parser/R17ReportParser.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/epis/parser/R17ReportParser.java
@@ -73,22 +73,31 @@ public class R17ReportParser {
 
   private static void validateSeisugaDate(
       List<String> preHeaderLines, LocalDate lockDate, LocalDate execDate) {
-    for (String line : preHeaderLines) {
-      LocalDate seisuga = findDate(line);
-      if (seisuga == null) {
-        continue;
-      }
-      if (seisuga.isBefore(lockDate) || seisuga.isAfter(execDate)) {
-        throw new IllegalArgumentException(
-            "R17 Seisuga date outside active cycle window: seisuga="
-                + seisuga
-                + ", lockDate="
-                + lockDate
-                + ", execDate="
-                + execDate);
-      }
-      return;
+    LocalDate seisuga = findSeisugaDate(preHeaderLines);
+    if (seisuga == null) {
+      throw new IllegalArgumentException(
+          "R17 Seisuga date marker missing or unparseable: preHeaderLineCount="
+              + preHeaderLines.size());
     }
+    if (seisuga.isBefore(lockDate) || seisuga.isAfter(execDate)) {
+      throw new IllegalArgumentException(
+          "R17 Seisuga date outside active cycle window: seisuga="
+              + seisuga
+              + ", lockDate="
+              + lockDate
+              + ", execDate="
+              + execDate);
+    }
+  }
+
+  @Nullable
+  private static LocalDate findSeisugaDate(List<String> preHeaderLines) {
+    for (String line : preHeaderLines) {
+      if (line.toLowerCase(Locale.ROOT).contains("seisuga")) {
+        return findDate(line);
+      }
+    }
+    return null;
   }
 
   private static BigDecimal unitsOrZero(Map<String, String> row) {

--- a/src/main/java/ee/tuleva/onboarding/investment/epis/parser/R21ReportParser.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/epis/parser/R21ReportParser.java
@@ -15,6 +15,7 @@ import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.Nullable;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -59,21 +60,29 @@ public class R21ReportParser {
 
   private static void validateMakseteKuu(
       List<String> preHeaderLines, YearMonth expectedExecutionMonth) {
+    String makseteKuu = findMakseteKuu(preHeaderLines);
+    if (makseteKuu == null) {
+      throw new IllegalArgumentException(
+          "R21 Maksete kuu marker missing: preHeaderLineCount=" + preHeaderLines.size());
+    }
+    String expected = expectedExecutionMonth.format(YEAR_MONTH);
+    if (!makseteKuu.equals(expected)) {
+      throw new IllegalArgumentException(
+          "R21 Maksete kuu does not match expected execution month: makseteKuu="
+              + makseteKuu
+              + ", expected="
+              + expected);
+    }
+  }
+
+  @Nullable
+  private static String findMakseteKuu(List<String> preHeaderLines) {
     for (String line : preHeaderLines) {
       Matcher matcher = MAKSETE_KUU.matcher(line);
-      if (!matcher.find()) {
-        continue;
+      if (matcher.find()) {
+        return matcher.group(1);
       }
-      String makseteKuu = matcher.group(1);
-      String expected = expectedExecutionMonth.format(YEAR_MONTH);
-      if (!makseteKuu.equals(expected)) {
-        throw new IllegalArgumentException(
-            "R21 Maksete kuu does not match expected execution month: makseteKuu="
-                + makseteKuu
-                + ", expected="
-                + expected);
-      }
-      return;
     }
+    return null;
   }
 }

--- a/src/main/java/ee/tuleva/onboarding/investment/epis/parser/R45ParseResult.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/epis/parser/R45ParseResult.java
@@ -5,4 +5,6 @@ import java.util.List;
 import java.util.Map;
 
 public record R45ParseResult(
-    Map<String, R45Result> fundResults, List<R45UnvaluedRow> unvaluedRows) {}
+    Map<String, R45Result> fundResults,
+    List<R45UnvaluedRow> unvaluedRows,
+    List<R45UnknownRow> unknownRows) {}

--- a/src/main/java/ee/tuleva/onboarding/investment/epis/parser/R45ReportParser.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/epis/parser/R45ReportParser.java
@@ -38,6 +38,7 @@ public class R45ReportParser {
     Map<String, BigDecimal> navByIsin = collectNavs(parsed.rows(), fallbackNavByIsin);
     Map<String, FlowAccumulator> flows = new LinkedHashMap<>();
     List<R45UnvaluedRow> unvaluedRows = new ArrayList<>();
+    List<R45UnknownRow> unknownRows = new ArrayList<>();
 
     for (Map<String, String> row : parsed.rows()) {
       String typeCode = trimmedUpperCase(findValue(row, "tehingu liik"));
@@ -57,6 +58,11 @@ public class R45ReportParser {
       Optional<TulevaFund> fund = TulevaFund.findByIsin(isin);
       Optional<R45TransactionType> type = R45TransactionType.find(typeCode);
       if (fund.isEmpty() || type.isEmpty()) {
+        String knownFundCode = fund.map(TulevaFund::getCode).orElse(null);
+        unknownRows.add(new R45UnknownRow(typeCode, isin, knownFundCode));
+        if (knownFundCode != null) {
+          flows.computeIfAbsent(knownFundCode, code -> new FlowAccumulator());
+        }
         continue;
       }
       String fundCode = fund.get().getCode();
@@ -81,7 +87,7 @@ public class R45ReportParser {
 
     Map<String, R45Result> fundResults = new LinkedHashMap<>();
     flows.forEach((fundCode, accumulator) -> fundResults.put(fundCode, accumulator.toResult()));
-    return new R45ParseResult(fundResults, List.copyOf(unvaluedRows));
+    return new R45ParseResult(fundResults, List.copyOf(unvaluedRows), List.copyOf(unknownRows));
   }
 
   private static Map<String, BigDecimal> collectNavs(

--- a/src/main/java/ee/tuleva/onboarding/investment/epis/parser/R45ReportParser.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/epis/parser/R45ReportParser.java
@@ -116,20 +116,26 @@ public class R45ReportParser {
   }
 
   private static void validateTehtudDate(List<String> preHeaderLines, LocalDate today) {
-    for (String line : preHeaderLines) {
-      if (!line.toLowerCase(Locale.ROOT).contains("tehtud")) {
-        continue;
-      }
-      LocalDate tehtud = findDate(line);
-      if (tehtud == null) {
-        continue;
-      }
-      if (!tehtud.equals(today)) {
-        throw new IllegalArgumentException(
-            "R45 report is stale: tehtud=" + tehtud + ", today=" + today);
-      }
-      return;
+    LocalDate tehtud = findTehtudDate(preHeaderLines);
+    if (tehtud == null) {
+      throw new IllegalArgumentException(
+          "R45 Tehtud date marker missing or unparseable: preHeaderLineCount="
+              + preHeaderLines.size());
     }
+    if (!tehtud.equals(today)) {
+      throw new IllegalArgumentException(
+          "R45 report is stale: tehtud=" + tehtud + ", today=" + today);
+    }
+  }
+
+  @Nullable
+  private static LocalDate findTehtudDate(List<String> preHeaderLines) {
+    for (String line : preHeaderLines) {
+      if (line.toLowerCase(Locale.ROOT).contains("tehtud")) {
+        return findDate(line);
+      }
+    }
+    return null;
   }
 
   private static void validateMagnitude(BigDecimal units, BigDecimal amount) {

--- a/src/main/java/ee/tuleva/onboarding/investment/epis/parser/R45UnknownRow.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/epis/parser/R45UnknownRow.java
@@ -1,0 +1,5 @@
+package ee.tuleva.onboarding.investment.epis.parser;
+
+import org.jspecify.annotations.Nullable;
+
+public record R45UnknownRow(String typeCode, String isin, @Nullable String fundCode) {}

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionAdminService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionAdminService.java
@@ -81,6 +81,7 @@ class TransactionAdminService {
                 TransactionBatchResponse.from(batch, orderRepository.findByBatchId(batch.getId())));
   }
 
+  @Transactional
   TransactionBatchResponse confirmAndFinalize(Long id, String actor) {
     TransactionBatch batch =
         batchRepository

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionAuditEvent.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionAuditEvent.java
@@ -42,6 +42,9 @@ public class TransactionAuditEvent {
 
   @NotNull private String eventType;
 
+  @Column(name = "dedup_key")
+  private String dedupKey;
+
   private String actor;
 
   @NotNull

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionAuditEventRepository.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionAuditEventRepository.java
@@ -10,5 +10,7 @@ public interface TransactionAuditEventRepository
 
   List<TransactionAuditEvent> findByEventType(String eventType);
 
+  List<TransactionAuditEvent> findByEventTypeAndDedupKey(String eventType, String dedupKey);
+
   List<TransactionAuditEvent> findByOrderIdAndEventType(Long orderId, String eventType);
 }

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionPreparationService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionPreparationService.java
@@ -124,6 +124,10 @@ public class TransactionPreparationService {
 
   @Transactional
   public void finalizeConfirmedBatch(TransactionBatch batch) {
+    if (batch.getStatus() == BatchStatus.SENT) {
+      throw new IllegalStateException(
+          "Batch already finalized: id=" + batch.getId() + ", status=" + batch.getStatus());
+    }
     log.info("Finalizing batch: id={}", batch.getId());
 
     Instant now = Instant.now(clock);

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/calculation/TradeCalculationEngine.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/calculation/TradeCalculationEngine.java
@@ -192,7 +192,7 @@ public class TradeCalculationEngine {
     }
 
     BigDecimal targetSellAmount = input.freeCash().abs();
-    BigDecimal reducedNet = netInvestable(input).subtract(targetSellAmount);
+    BigDecimal targetNet = netInvestable(input);
     Map<String, BigDecimal> weightMap = buildWeightMap(input.modelWeights());
 
     List<BigDecimal> standardScores =
@@ -201,7 +201,7 @@ public class TradeCalculationEngine {
                 position -> {
                   BigDecimal weight = weightMap.getOrDefault(position.isin(), ZERO);
                   BigDecimal idealOverweight =
-                      position.marketValue().subtract(weight.multiply(reducedNet));
+                      position.marketValue().subtract(weight.multiply(targetNet));
                   return position.marketValue().min(idealOverweight.max(ZERO));
                 })
             .toList();

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/calculation/TradeCalculationEngine.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/calculation/TradeCalculationEngine.java
@@ -92,31 +92,76 @@ public class TradeCalculationEngine {
       return List.of(capped);
     }
 
-    List<BigDecimal> runnerScores = new ArrayList<>();
-    for (int i = 0; i < size; i++) {
-      BigDecimal headroom = hardLimitHeadroom(input, input.positions().get(i));
-      BigDecimal remaining = headroom == null ? null : headroom.subtract(capped[i]).max(ZERO);
-      boolean eligible =
-          scores.get(i).compareTo(ZERO) > 0
-              && (remaining == null || remaining.compareTo(threshold) >= 0);
-      runnerScores.add(eligible ? scores.get(i) : ZERO);
-    }
+    BigDecimal undistributed = waterFillExcessAcrossRunners(input, scores, capped, totalExcess);
 
-    List<BigDecimal> subAllocations =
-        distributeAmountWithThreshold(runnerScores, totalExcess, threshold);
-    BigDecimal subTotal = subAllocations.stream().reduce(ZERO, BigDecimal::add);
-
-    if (subTotal.compareTo(new BigDecimal("0.01")) > 0) {
-      for (int i = 0; i < size; i++) {
-        capped[i] = capped[i].add(subAllocations.get(i));
-      }
-      return List.of(capped);
-    }
-
-    if (input.freeCash().compareTo(threshold) >= 0) {
-      topUpBestRunnerToThreshold(capped, runnerScores, totalExcess, threshold);
+    if (undistributed.compareTo(new BigDecimal("0.01")) > 0
+        && input.freeCash().compareTo(threshold) >= 0) {
+      topUpBestRunnerToThreshold(
+          capped, runnerScores(input, scores, capped), undistributed, threshold);
     }
     return List.of(capped);
+  }
+
+  private BigDecimal waterFillExcessAcrossRunners(
+      FundTransactionInput input, List<BigDecimal> scores, BigDecimal[] capped, BigDecimal excess) {
+    int size = capped.length;
+    BigDecimal threshold = input.minTransactionThreshold();
+    BigDecimal remaining = excess;
+
+    for (int iteration = 0; iteration < MAX_ITERATIONS; iteration++) {
+      if (remaining.compareTo(new BigDecimal("0.01")) <= 0) {
+        break;
+      }
+
+      List<BigDecimal> roundScores = runnerScores(input, scores, capped);
+      if (roundScores.stream().allMatch(score -> score.compareTo(ZERO) == 0)) {
+        break;
+      }
+
+      List<BigDecimal> round = distributeAmountWithThreshold(roundScores, remaining, threshold);
+
+      boolean newlyCapped = false;
+      for (int i = 0; i < size; i++) {
+        if (round.get(i).compareTo(ZERO) <= 0) {
+          continue;
+        }
+        BigDecimal headroom = remainingHeadroom(input, capped, i);
+        if (headroom != null && round.get(i).compareTo(headroom) >= 0) {
+          capped[i] = capped[i].add(headroom);
+          remaining = remaining.subtract(headroom);
+          newlyCapped = true;
+        } else {
+          capped[i] = capped[i].add(round.get(i));
+          remaining = remaining.subtract(round.get(i));
+        }
+      }
+
+      if (!newlyCapped) {
+        break;
+      }
+    }
+
+    return remaining;
+  }
+
+  private List<BigDecimal> runnerScores(
+      FundTransactionInput input, List<BigDecimal> scores, BigDecimal[] capped) {
+    BigDecimal threshold = input.minTransactionThreshold();
+    return IntStream.range(0, capped.length)
+        .mapToObj(
+            i -> {
+              BigDecimal remaining = remainingHeadroom(input, capped, i);
+              boolean eligible =
+                  scores.get(i).compareTo(ZERO) > 0
+                      && (remaining == null || remaining.compareTo(threshold) >= 0);
+              return eligible ? scores.get(i) : ZERO;
+            })
+        .toList();
+  }
+
+  private BigDecimal remainingHeadroom(FundTransactionInput input, BigDecimal[] capped, int index) {
+    BigDecimal headroom = hardLimitHeadroom(input, input.positions().get(index));
+    return headroom == null ? null : headroom.subtract(capped[index]).max(ZERO);
   }
 
   private void topUpBestRunnerToThreshold(

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/calculation/TradeCalculationEngine.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/calculation/TradeCalculationEngine.java
@@ -26,6 +26,7 @@ public class TradeCalculationEngine {
 
   private static final int SCALE = 2;
   private static final int MAX_ITERATIONS = 20;
+  private static final BigDecimal MIN_MEANINGFUL_AMOUNT = new BigDecimal("0.01");
 
   public FundCalculationResult calculate(FundTransactionInput input, TransactionMode mode) {
     List<BigDecimal> rawTrades =
@@ -88,13 +89,13 @@ public class TradeCalculationEngine {
       }
     }
 
-    if (totalExcess.compareTo(new BigDecimal("0.01")) <= 0) {
+    if (totalExcess.compareTo(MIN_MEANINGFUL_AMOUNT) <= 0) {
       return List.of(capped);
     }
 
     BigDecimal undistributed = waterFillExcessAcrossRunners(input, scores, capped, totalExcess);
 
-    if (undistributed.compareTo(new BigDecimal("0.01")) > 0
+    if (undistributed.compareTo(MIN_MEANINGFUL_AMOUNT) > 0
         && input.freeCash().compareTo(threshold) >= 0) {
       topUpBestRunnerToThreshold(
           capped, runnerScores(input, scores, capped), undistributed, threshold);
@@ -109,7 +110,7 @@ public class TradeCalculationEngine {
     BigDecimal remaining = excess;
 
     for (int iteration = 0; iteration < MAX_ITERATIONS; iteration++) {
-      if (remaining.compareTo(new BigDecimal("0.01")) <= 0) {
+      if (remaining.compareTo(MIN_MEANINGFUL_AMOUNT) <= 0) {
         break;
       }
 
@@ -280,7 +281,7 @@ public class TradeCalculationEngine {
 
     BigDecimal totalSellableMarketValue =
         input.positions().stream().map(PositionSnapshot::marketValue).reduce(ZERO, BigDecimal::add);
-    if (targetSellAmount.subtract(totalSellableMarketValue).compareTo(new BigDecimal("0.01")) > 0) {
+    if (targetSellAmount.subtract(totalSellableMarketValue).compareTo(MIN_MEANINGFUL_AMOUNT) > 0) {
       throw new IllegalStateException(
           "Insufficient liquidity to satisfy sell: fund="
               + input.fund()
@@ -300,7 +301,7 @@ public class TradeCalculationEngine {
     BigDecimal remainingNeed = targetSellAmount;
 
     for (int iteration = 0; iteration < MAX_ITERATIONS; iteration++) {
-      if (remainingNeed.compareTo(new BigDecimal("0.01")) <= 0) {
+      if (remainingNeed.compareTo(MIN_MEANINGFUL_AMOUNT) <= 0) {
         break;
       }
 
@@ -401,7 +402,7 @@ public class TradeCalculationEngine {
     }
 
     BigDecimal remainingNeed = targetAmount.subtract(amountFromFast);
-    if (remainingNeed.compareTo(new BigDecimal("0.01")) > 0 && !slowIndices.isEmpty()) {
+    if (remainingNeed.compareTo(MIN_MEANINGFUL_AMOUNT) > 0 && !slowIndices.isEmpty()) {
       distributeSellByOverweight(input, slowIndices, targetValues, remainingNeed, results);
     }
 
@@ -415,13 +416,13 @@ public class TradeCalculationEngine {
       BigDecimal amount,
       BigDecimal[] results) {
     BigDecimal threshold = input.minTransactionThreshold();
-    BigDecimal thresholdTolerance = threshold.subtract(new BigDecimal("0.01"));
+    BigDecimal thresholdTolerance = threshold.subtract(MIN_MEANINGFUL_AMOUNT);
     List<Integer> active = new ArrayList<>(bucketIndices);
     Map<Integer, BigDecimal> filled = new HashMap<>();
     BigDecimal remaining = amount;
 
     for (int iteration = 0; iteration < MAX_ITERATIONS && !active.isEmpty(); iteration++) {
-      if (remaining.compareTo(new BigDecimal("0.01")) <= 0) {
+      if (remaining.compareTo(MIN_MEANINGFUL_AMOUNT) <= 0) {
         break;
       }
 
@@ -434,7 +435,7 @@ public class TradeCalculationEngine {
         totalScore = totalScore.add(overweight);
       }
 
-      if (totalScore.compareTo(new BigDecimal("0.01")) < 0) {
+      if (totalScore.compareTo(MIN_MEANINGFUL_AMOUNT) < 0) {
         totalScore = ZERO;
         for (int i : active) {
           BigDecimal headroom = headroom(input, filled, i);
@@ -551,7 +552,7 @@ public class TradeCalculationEngine {
   private List<BigDecimal> distributeBucketWithThreshold(
       List<BigDecimal> scores, BigDecimal threshold) {
     BigDecimal total = scores.stream().reduce(ZERO, BigDecimal::add);
-    if (total.compareTo(new BigDecimal("0.01")) <= 0) {
+    if (total.compareTo(MIN_MEANINGFUL_AMOUNT) <= 0) {
       return scores.stream().map(score -> ZERO).toList();
     }
     return distributeAmountWithThreshold(scores, total, threshold);
@@ -635,7 +636,7 @@ public class TradeCalculationEngine {
         }
       }
 
-      BigDecimal thresholdTolerance = threshold.subtract(new BigDecimal("0.01"));
+      BigDecimal thresholdTolerance = threshold.subtract(MIN_MEANINGFUL_AMOUNT);
       if (minAllocation != null && minAllocation.compareTo(thresholdTolerance) >= 0) {
         allocations = tempAllocations;
         break;

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationAuditRecorder.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationAuditRecorder.java
@@ -45,6 +45,7 @@ class FtConfirmationAuditRecorder {
             .batch(order == null ? null : order.getBatch())
             .eventType(FT_CONFIRMATION_VERIFIED)
             .actor(actor)
+            .dedupKey(dedupKey(confirmation))
             .payload(payload(confirmation, result))
             .createdAt(clock.instant())
             .build());
@@ -52,8 +53,9 @@ class FtConfirmationAuditRecorder {
   }
 
   boolean alreadyAlerted(FtConfirmation confirmation, FtConfirmationResult result) {
-    return auditEventRepository.findByEventType(FT_CONFIRMATION_ALERTED).stream()
-        .filter(event -> sameConfirmation(event.getPayload(), confirmation))
+    return auditEventRepository
+        .findByEventTypeAndDedupKey(FT_CONFIRMATION_ALERTED, dedupKey(confirmation))
+        .stream()
         .map(event -> statusPair(event.getPayload()))
         .anyMatch(statusPair(result)::equals);
   }
@@ -63,6 +65,7 @@ class FtConfirmationAuditRecorder {
         TransactionAuditEvent.builder()
             .eventType(FT_CONFIRMATION_ALERTED)
             .actor(ALERT_ACTOR)
+            .dedupKey(dedupKey(confirmation))
             .payload(payload(confirmation, result))
             .createdAt(clock.instant())
             .build());
@@ -74,24 +77,26 @@ class FtConfirmationAuditRecorder {
   }
 
   private Optional<List<String>> lastRecordedStatus(FtConfirmation confirmation) {
-    return auditEventRepository.findByEventType(FT_CONFIRMATION_VERIFIED).stream()
-        .filter(event -> sameConfirmation(event.getPayload(), confirmation))
+    return auditEventRepository
+        .findByEventTypeAndDedupKey(FT_CONFIRMATION_VERIFIED, dedupKey(confirmation))
+        .stream()
         .max(comparing(TransactionAuditEvent::getCreatedAt))
         .map(event -> statusPair(event.getPayload()));
   }
 
-  private static boolean sameConfirmation(
-      Map<String, Object> payload, FtConfirmation confirmation) {
-    return confirmation.fund().name().equals(payload.get("fund"))
-        && confirmation.isin().equals(payload.get("isin"))
-        && confirmation.tradeDate().toString().equals(payload.get("tradeDate"))
-        && sameAmount(confirmation.quantity(), payload.get("quantity"))
-        && sameAmount(confirmation.grossPrice(), payload.get("grossPrice"))
-        && confirmation.type().name().equals(payload.get("type"));
+  private static String dedupKey(FtConfirmation confirmation) {
+    return String.join(
+        "|",
+        confirmation.fund().name(),
+        confirmation.isin(),
+        confirmation.tradeDate().toString(),
+        normalized(confirmation.quantity()),
+        normalized(confirmation.grossPrice()),
+        confirmation.type().name());
   }
 
-  private static boolean sameAmount(BigDecimal value, @Nullable Object stored) {
-    return stored != null && value.compareTo(new BigDecimal(stored.toString())) == 0;
+  private static String normalized(BigDecimal amount) {
+    return amount.stripTrailingZeros().toPlainString();
   }
 
   private static List<String> statusPair(FtConfirmationResult result) {

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationVerificationService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationVerificationService.java
@@ -298,16 +298,18 @@ public class FtConfirmationVerificationService {
       return PENDING_NAV;
     }
 
-    details.put("referencePrice", referencePrice.get().toPlainString());
-    if (priceValidator.isWithinTolerance(
-        confirmation.grossPrice(), referencePrice.get(), priceTolerance)) {
+    BigDecimal reference = referencePrice.get();
+    details.put("referencePrice", reference.toPlainString());
+    if (reference.signum() <= 0) {
+      details.put("invalidReferencePrice", "true");
+      return ERROR;
+    }
+    if (priceValidator.isWithinTolerance(confirmation.grossPrice(), reference, priceTolerance)) {
       return OK;
     }
     details.put(
         "priceDeltaPercent",
-        priceValidator
-            .computeDeltaPercent(confirmation.grossPrice(), referencePrice.get())
-            .toPlainString());
+        priceValidator.computeDeltaPercent(confirmation.grossPrice(), reference).toPlainString());
     return ERROR;
   }
 }

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/PriceValidator.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/PriceValidator.java
@@ -12,6 +12,9 @@ class PriceValidator {
   private static final BigDecimal ONE_HUNDRED = new BigDecimal("100");
 
   boolean isWithinTolerance(BigDecimal execPrice, BigDecimal navPrice, BigDecimal tolerance) {
+    if (navPrice.signum() <= 0) {
+      return false;
+    }
     BigDecimal ratio = absoluteRatio(execPrice, navPrice);
     return ratio.compareTo(tolerance) <= 0;
   }

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/ReconciliationAuditRecorder.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/ReconciliationAuditRecorder.java
@@ -46,13 +46,15 @@ class ReconciliationAuditRecorder {
   }
 
   void recordUnmatched(SebPendingTransactionRow row, LocalDate reportDate) {
+    String dedupKey = unmatchedDedupKey(row, reportDate);
     boolean alreadyRecorded =
-        auditEventRepository.findByEventType(UNMATCHED_SEB_TRANSACTION).stream()
-            .anyMatch(event -> sameRowIdentity(event.getPayload(), row, reportDate));
+        !auditEventRepository
+            .findByEventTypeAndDedupKey(UNMATCHED_SEB_TRANSACTION, dedupKey)
+            .isEmpty();
     if (alreadyRecorded) {
       return;
     }
-    save(UNMATCHED_SEB_TRANSACTION, null, rowPayload(row, reportDate));
+    save(UNMATCHED_SEB_TRANSACTION, null, rowPayload(row, reportDate), dedupKey);
   }
 
   void recordQuantityAmountMismatch(QuantityAmountMismatchEvent mismatch) {
@@ -95,24 +97,30 @@ class ReconciliationAuditRecorder {
   }
 
   private void save(String eventType, TransactionOrder order, Map<String, Object> payload) {
+    save(eventType, order, payload, null);
+  }
+
+  private void save(
+      String eventType, TransactionOrder order, Map<String, Object> payload, String dedupKey) {
     auditEventRepository.save(
         TransactionAuditEvent.builder()
             .orderId(order == null ? null : order.getId())
             .batch(order == null ? null : order.getBatch())
             .eventType(eventType)
             .actor(SYSTEM_ACTOR)
+            .dedupKey(dedupKey)
             .payload(payload)
             .createdAt(clock.instant())
             .build());
   }
 
-  private static boolean sameRowIdentity(
-      Map<String, Object> payload, SebPendingTransactionRow row, LocalDate reportDate) {
-    return Objects.equals(payload.get("reportDate"), reportDate.toString())
-        && Objects.equals(payload.get("ourRef"), row.ourRef())
-        && Objects.equals(
-            payload.get("clientRef"), row.clientRef() == null ? null : row.clientRef().toString())
-        && Objects.equals(payload.get("isin"), row.isin());
+  private static String unmatchedDedupKey(SebPendingTransactionRow row, LocalDate reportDate) {
+    return String.join(
+        "|",
+        reportDate.toString(),
+        Objects.toString(row.ourRef(), ""),
+        Objects.toString(row.clientRef(), ""),
+        Objects.toString(row.isin(), ""));
   }
 
   private static Map<String, Object> rowPayload(

--- a/src/main/resources/db/migration/V1_226__audit_event_dedup_key.sql
+++ b/src/main/resources/db/migration/V1_226__audit_event_dedup_key.sql
@@ -1,0 +1,4 @@
+ALTER TABLE investment_transaction_audit_event ADD COLUMN dedup_key text;
+
+CREATE INDEX idx_audit_event_type_dedup_key
+    ON investment_transaction_audit_event (event_type, dedup_key);

--- a/src/test/groovy/ee/tuleva/onboarding/investment/epis/R45ReportServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/epis/R45ReportServiceTest.java
@@ -137,6 +137,35 @@ class R45ReportServiceTest {
   }
 
   @Test
+  void marksFundIncompleteAndAlertsWhenTransactionTypeUnknown() {
+    String csv =
+        """
+        Tehtud: 14.08.2026;;;;;
+        Tehingu liik;ISIN;NAV;Osakuid;Summa;Täitmise kuupäev
+        XXX;EE3600109435;0,80000;0;1500,00;18.08.2026
+        """;
+    givenStoredReport(csv);
+
+    service.processAndStore(REPORT_ID);
+
+    verify(summaryRepository)
+        .saveAll(
+            List.of(
+                incompleteSummary(
+                    TUK75,
+                    Map.of(
+                        "inflowEur",
+                        BigDecimal.ZERO,
+                        "outflowEur",
+                        BigDecimal.ZERO,
+                        "netEur",
+                        BigDecimal.ZERO,
+                        "redRowSettlementDates",
+                        List.of()))));
+    verify(notificationService).sendMessage(contains("XXX"), eq(INVESTMENT));
+  }
+
+  @Test
   void usesOwnFundNavAsFallbackWhenReportRowHasNoNavOrAmount() {
     String csv =
         """

--- a/src/test/groovy/ee/tuleva/onboarding/investment/epis/R45ReportServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/epis/R45ReportServiceTest.java
@@ -166,6 +166,36 @@ class R45ReportServiceTest {
   }
 
   @Test
+  void alertsButKeepsMappedFundsCompleteWhenIsinUnmapped() {
+    String csv =
+        """
+        Tehtud: 14.08.2026;;;;;
+        Tehingu liik;ISIN;NAV;Osakuid;Summa;Täitmise kuupäev
+        SUB;XX0000000000;0,80000;0;1500,00;18.08.2026
+        SUB;EE3600109435;0,80000;0;2000,00;18.08.2026
+        """;
+    givenStoredReport(csv);
+
+    service.processAndStore(REPORT_ID);
+
+    verify(summaryRepository)
+        .saveAll(
+            List.of(
+                summary(
+                    TUK75,
+                    Map.of(
+                        "inflowEur",
+                        new BigDecimal("2000.00"),
+                        "outflowEur",
+                        BigDecimal.ZERO,
+                        "netEur",
+                        new BigDecimal("2000.00"),
+                        "redRowSettlementDates",
+                        List.of()))));
+    verify(notificationService).sendMessage(contains("XX0000000000"), eq(INVESTMENT));
+  }
+
+  @Test
   void usesOwnFundNavAsFallbackWhenReportRowHasNoNavOrAmount() {
     String csv =
         """

--- a/src/test/groovy/ee/tuleva/onboarding/investment/epis/parser/R17ReportParserTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/epis/parser/R17ReportParserTest.java
@@ -65,6 +65,47 @@ class R17ReportParserTest {
   }
 
   @Test
+  void throwsWhenSeisugaDateAfterExecutionDate() {
+    String csv =
+        """
+        Seisuga: 15.05.2026;;;
+        Väärtpaber;Toiming;PF valitseja/PIK;Osakud (teenustasuga)
+        Tuleva Maailma Aktsiate Pensionifond;Tagasivõtt;PIK;100,000
+        """;
+
+    assertThatThrownBy(() -> parser.parse(csv, LOCK_DATE, EXEC_DATE))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void throwsWhenSeisugaLinePresentButHasNoDate() {
+    String csv =
+        """
+        Seisuga: teadmata;;;
+        Väärtpaber;Toiming;PF valitseja/PIK;Osakud (teenustasuga)
+        Tuleva Maailma Aktsiate Pensionifond;Tagasivõtt;PIK;100,000
+        """;
+
+    assertThatThrownBy(() -> parser.parse(csv, LOCK_DATE, EXEC_DATE))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void skipsNonSeisugaPreHeaderLinesBeforeSeisugaLine() {
+    String csv =
+        """
+        Fondi aruanne;;;
+        Seisuga: 15.04.2026;;;
+        Väärtpaber;Toiming;PF valitseja/PIK;Osakud (teenustasuga)
+        Tuleva Maailma Aktsiate Pensionifond;Tagasivõtt;PIK;100,000
+        """;
+
+    Map<String, R17Result> result = parser.parse(csv, LOCK_DATE, EXEC_DATE);
+
+    assertThat(result.get("TUK75").pikUnits()).isEqualByComparingTo("100.000");
+  }
+
+  @Test
   void throwsWhenSeisugaMarkerMissing() {
     String csv =
         """

--- a/src/test/groovy/ee/tuleva/onboarding/investment/epis/parser/R17ReportParserTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/epis/parser/R17ReportParserTest.java
@@ -65,22 +65,22 @@ class R17ReportParserTest {
   }
 
   @Test
-  void parsesWhenSeisugaDateMissing() {
+  void throwsWhenSeisugaMarkerMissing() {
     String csv =
         """
         Väärtpaber;Toiming;PF valitseja/PIK;Osakud (teenustasuga)
         Tuleva Maailma Aktsiate Pensionifond;Tagasivõtt;PIK;100,000
         """;
 
-    Map<String, R17Result> result = parser.parse(csv, LOCK_DATE, EXEC_DATE);
-
-    assertThat(result.get("TUK75").pikUnits()).isEqualByComparingTo("100.000");
+    assertThatThrownBy(() -> parser.parse(csv, LOCK_DATE, EXEC_DATE))
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
   void usesAbsoluteUnits() {
     String csv =
         """
+        Seisuga: 15.04.2026;;;
         Väärtpaber;Toiming;PF valitseja/PIK;Osakud (teenustasuga)
         Tuleva Maailma Aktsiate Pensionifond;Tagasivõtt;Teine PF valitseja;-50,000
         """;
@@ -94,6 +94,7 @@ class R17ReportParserTest {
   void fallsBackToOsakuidColumnWhenTeenustasugaColumnMissing() {
     String csv =
         """
+        Seisuga: 15.04.2026;;;
         Väärtpaber;Toiming;PF valitseja/PIK;Osakuid
         Tuleva Maailma Aktsiate Pensionifond;Väljalase;Oma;200,000
         """;
@@ -107,6 +108,7 @@ class R17ReportParserTest {
   void skipsRowsWithZeroUnitsOrUnknownFund() {
     String csv =
         """
+        Seisuga: 15.04.2026;;;
         Väärtpaber;Toiming;PF valitseja/PIK;Osakud (teenustasuga)
         Tuleva Maailma Aktsiate Pensionifond;Väljalase;Oma;0
         Mingi Muu Fond;Väljalase;Oma;100,000
@@ -121,6 +123,7 @@ class R17ReportParserTest {
   void throwsWhenUnitsExceedHundredMillion() {
     String csv =
         """
+        Seisuga: 15.04.2026;;;
         Väärtpaber;Toiming;PF valitseja/PIK;Osakud (teenustasuga)
         Tuleva Maailma Aktsiate Pensionifond;Väljalase;Oma;150000000,000
         """;

--- a/src/test/groovy/ee/tuleva/onboarding/investment/epis/parser/R21ReportParserTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/epis/parser/R21ReportParserTest.java
@@ -47,16 +47,15 @@ class R21ReportParserTest {
   }
 
   @Test
-  void parsesWhenMakseteKuuMissing() {
+  void throwsWhenMakseteKuuMissing() {
     String csv =
         """
         Väärtpaber;Jooksev NAV;Osakud;Summa;Valuuta
         Tuleva Maailma Aktsiate Pensionifond;0,80;100,000;80,00;EUR
         """;
 
-    Map<String, R21Result> result = parser.parse(csv, EXECUTION_MONTH);
-
-    assertThat(result.get("TUK75").ravaUnits()).isEqualByComparingTo("100.000");
+    assertThatThrownBy(() -> parser.parse(csv, EXECUTION_MONTH))
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test

--- a/src/test/groovy/ee/tuleva/onboarding/investment/epis/parser/R21ReportParserTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/epis/parser/R21ReportParserTest.java
@@ -59,6 +59,21 @@ class R21ReportParserTest {
   }
 
   @Test
+  void skipsNonMakseteKuuPreHeaderLinesBeforeMarker() {
+    String csv =
+        """
+        Fondi aruanne;;;;
+        Maksete kuu: 202609;;;;
+        Väärtpaber;Jooksev NAV;Osakud;Summa;Valuuta
+        Tuleva Maailma Aktsiate Pensionifond;0,80;100,000;80,00;EUR
+        """;
+
+    Map<String, R21Result> result = parser.parse(csv, EXECUTION_MONTH);
+
+    assertThat(result.get("TUK75").ravaUnits()).isEqualByComparingTo("100.000");
+  }
+
+  @Test
   void skipsRowsWithZeroUnitsOrUnknownFund() {
     String csv =
         """

--- a/src/test/groovy/ee/tuleva/onboarding/investment/epis/parser/R45ReportParserTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/epis/parser/R45ReportParserTest.java
@@ -143,7 +143,7 @@ class R45ReportParserTest {
   }
 
   @Test
-  void skipsRowsWithUnknownIsinOrUnknownTransactionType() {
+  void recordsRowsWithUnknownIsinOrUnknownTransactionType() {
     String csv =
         """
         Tehtud: 12.06.2026;;;;;
@@ -154,7 +154,12 @@ class R45ReportParserTest {
 
     R45ParseResult result = parser.parse(csv, TODAY, Map.of());
 
-    assertThat(result.fundResults()).isEmpty();
+    assertThat(result.unknownRows())
+        .containsExactly(
+            new R45UnknownRow("SUB", "XX0000000000", null),
+            new R45UnknownRow("XXX", "EE3600109435", "TUK75"));
+    // the row with a known fund but unknown type surfaces a zero entry so it can be blocked
+    assertResult(result.fundResults().get("TUK75"), "0", "0", "0");
   }
 
   @Test

--- a/src/test/groovy/ee/tuleva/onboarding/investment/epis/parser/R45ReportParserTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/epis/parser/R45ReportParserTest.java
@@ -201,6 +201,21 @@ class R45ReportParserTest {
   }
 
   @Test
+  void skipsNonTehtudPreHeaderLinesBeforeMarker() {
+    String csv =
+        """
+        Fondi aruanne;;;;;
+        Tehtud: 12.06.2026;;;;;
+        Tehingu liik;ISIN;NAV;Osakuid;Summa;Täitmise kuupäev
+        SUB;EE3600109435;0,80000;0;1500,00;15.06.2026
+        """;
+
+    R45ParseResult result = parser.parse(csv, TODAY, Map.of());
+
+    assertResult(result.fundResults().get("TUK75"), "1500.00", "0", "1500.00");
+  }
+
+  @Test
   void throwsWhenTehtudMarkerMissing() {
     String csv =
         """

--- a/src/test/groovy/ee/tuleva/onboarding/investment/epis/parser/R45ReportParserTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/epis/parser/R45ReportParserTest.java
@@ -40,6 +40,7 @@ class R45ReportParserTest {
   void usesAbsoluteUnitsTimesRowNavWhenSummaIsZero() {
     String csv =
         """
+        Tehtud: 12.06.2026;;;;;
         Tehingu liik;ISIN;NAV;Osakuid;Summa;Täitmise kuupäev
         RED;EE3600109443;0,70000;-1000,000;0;15.06.2026
         """;
@@ -53,6 +54,7 @@ class R45ReportParserTest {
   void usesCallerSuppliedFallbackNavWhenRowNavIsZero() {
     String csv =
         """
+        Tehtud: 12.06.2026;;;;;
         Tehingu liik;ISIN;NAV;Osakuid;Summa;Täitmise kuupäev
         RED;EE3600109443;0;1000,000;0;15.06.2026
         """;
@@ -67,6 +69,7 @@ class R45ReportParserTest {
   void usesNavFromAnotherRowOfSameIsinWhenFallbackMissing() {
     String csv =
         """
+        Tehtud: 12.06.2026;;;;;
         Tehingu liik;ISIN;NAV;Osakuid;Summa;Täitmise kuupäev
         SUB;EE3600109443;0,70000;0;200,00;15.06.2026
         RED;EE3600109443;0;1000,000;0;15.06.2026
@@ -81,6 +84,7 @@ class R45ReportParserTest {
   void recordsUnvaluedRowAndZeroFundEntryWhenNoNavAvailable() {
     String csv =
         """
+        Tehtud: 12.06.2026;;;;;
         Tehingu liik;ISIN;NAV;Osakuid;Summa;Täitmise kuupäev
         RED;EE3600109435;0;1000,000;0;15.06.2026
         """;
@@ -99,6 +103,7 @@ class R45ReportParserTest {
   void skipsSwsRowsWithZeroSummaAndZeroUnits() {
     String csv =
         """
+        Tehtud: 12.06.2026;;;;;
         Tehingu liik;ISIN;NAV;Osakuid;Summa;Täitmise kuupäev
         SWS;EE3600109435;0,80000;0;0;15.06.2026
         """;
@@ -113,6 +118,7 @@ class R45ReportParserTest {
   void skipsRowsWithSettlementDateBeforeToday() {
     String csv =
         """
+        Tehtud: 12.06.2026;;;;;
         Tehingu liik;ISIN;NAV;Osakuid;Summa;Täitmise kuupäev
         SUB;EE3600109435;0,80000;0;1500,00;11.06.2026
         """;
@@ -126,6 +132,7 @@ class R45ReportParserTest {
   void keepsRowsWithSettlementDateTodayOrLater() {
     String csv =
         """
+        Tehtud: 12.06.2026;;;;;
         Tehingu liik;ISIN;NAV;Osakuid;Summa;Täitmise kuupäev
         SUB;EE3600109435;0,80000;0;1500,00;12.06.2026
         """;
@@ -139,6 +146,7 @@ class R45ReportParserTest {
   void skipsRowsWithUnknownIsinOrUnknownTransactionType() {
     String csv =
         """
+        Tehtud: 12.06.2026;;;;;
         Tehingu liik;ISIN;NAV;Osakuid;Summa;Täitmise kuupäev
         SUB;XX0000000000;0,80000;0;1500,00;15.06.2026
         XXX;EE3600109435;0,80000;0;1500,00;15.06.2026
@@ -153,6 +161,7 @@ class R45ReportParserTest {
   void throwsWhenSummaExceedsHundredMillion() {
     String csv =
         """
+        Tehtud: 12.06.2026;;;;;
         Tehingu liik;ISIN;NAV;Osakuid;Summa;Täitmise kuupäev
         SUB;EE3600109435;0,80000;0;150000000,00;15.06.2026
         """;
@@ -165,6 +174,7 @@ class R45ReportParserTest {
   void throwsWhenUnitsExceedHundredMillion() {
     String csv =
         """
+        Tehtud: 12.06.2026;;;;;
         Tehingu liik;ISIN;NAV;Osakuid;Summa;Täitmise kuupäev
         SUB;EE3600109435;0,80000;150000000,000;0;15.06.2026
         """;
@@ -187,9 +197,22 @@ class R45ReportParserTest {
   }
 
   @Test
+  void throwsWhenTehtudMarkerMissing() {
+    String csv =
+        """
+        Tehingu liik;ISIN;NAV;Osakuid;Summa;Täitmise kuupäev
+        SUB;EE3600109435;0,80000;0;1500,00;15.06.2026
+        """;
+
+    assertThatThrownBy(() -> parser.parse(csv, TODAY, Map.of()))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
   void parsesEnglishFormatReport() {
     String csv =
         """
+        Tehtud: 12.06.2026
         Tehingu liik,ISIN,NAV,Osakuid,Summa,Täitmise kuupäev
         SUB,EE3600109435,0.80000,0,1500.00,15.06.2026
         """;

--- a/src/test/groovy/ee/tuleva/onboarding/investment/epis/parser/R45ReportParserTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/epis/parser/R45ReportParserTest.java
@@ -158,7 +158,6 @@ class R45ReportParserTest {
         .containsExactly(
             new R45UnknownRow("SUB", "XX0000000000", null),
             new R45UnknownRow("XXX", "EE3600109435", "TUK75"));
-    // the row with a known fund but unknown type surfaces a zero entry so it can be blocked
     assertResult(result.fundResults().get("TUK75"), "0", "0", "0");
   }
 

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionPreparationServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionPreparationServiceTest.java
@@ -632,6 +632,24 @@ class TransactionPreparationServiceTest {
     verify(orderRepository, never()).saveAll(any());
   }
 
+  @Test
+  void finalizeConfirmedBatch_alreadySentBatch_doesNotReFinalizeOrReSend() {
+    var batch =
+        TransactionBatch.builder()
+            .id(1L)
+            .fund(TUV100)
+            .status(SENT)
+            .createdBy("system")
+            .metadata(new HashMap<>(Map.of("commandId", 1L)))
+            .build();
+
+    assertThatThrownBy(() -> service.finalizeConfirmedBatch(batch))
+        .isInstanceOf(IllegalStateException.class);
+
+    verifyNoInteractions(exportService);
+    verify(orderRepository, never()).saveAll(any());
+  }
+
   private TransactionCommand givenSingleEtfBuyCommandPricedAt(BigDecimal price) {
     var command =
         TransactionCommand.builder()

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/calculation/TradeCalculationEngineTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/calculation/TradeCalculationEngineTest.java
@@ -244,10 +244,6 @@ class TradeCalculationEngineTest {
 
   @Test
   void buy_waterFillsHardLimitExcessAcrossRunnersInsteadOfStrandingCash() {
-    // IE00X overflows its 0.26 hard limit, producing ~60197 of excess to redistribute.
-    // Both IE00P and IE00Q are eligible runners, but a score-proportional split hands IE00P far
-    // more than its remaining ~5336 headroom (it caps at its 0.15 hard limit), while IE00Q has
-    // ample room. The clipped overflow must cascade to IE00Q, not strand — the full 100000 deploys.
     var input =
         FundTransactionInput.builder()
             .fund(TUV100)
@@ -355,11 +351,6 @@ class TradeCalculationEngineTest {
 
   @Test
   void sell_targetsOnlyOverweightPositionsAndLeavesOnTargetPositionUntouched() {
-    // securityValue 900k, cash 0 -> gross 900k; buffer 100k drives the shortfall.
-    // freeCash = cash - buffer - liabilities + receivables = 0 - 100000 = -100000 (pendingCash 0).
-    // netInvestable = gross - buffer = 800000, so 50/50 target = 400000 each.
-    // IE00A (500000) is 100000 overweight; IE00B (400000) is exactly on target.
-    // A sell to cover the 100000 shortfall must come entirely from IE00A.
     var input =
         FundTransactionInput.builder()
             .fund(TUV100)

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/calculation/TradeCalculationEngineTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/calculation/TradeCalculationEngineTest.java
@@ -304,6 +304,44 @@ class TradeCalculationEngineTest {
   }
 
   @Test
+  void sell_targetsOnlyOverweightPositionsAndLeavesOnTargetPositionUntouched() {
+    // securityValue 900k, cash 0 -> gross 900k; buffer 100k drives the shortfall.
+    // freeCash = cash - buffer - liabilities + receivables = 0 - 100000 = -100000 (pendingCash 0).
+    // netInvestable = gross - buffer = 800000, so 50/50 target = 400000 each.
+    // IE00A (500000) is 100000 overweight; IE00B (400000) is exactly on target.
+    // A sell to cover the 100000 shortfall must come entirely from IE00A.
+    var input =
+        FundTransactionInput.builder()
+            .fund(TUV100)
+            .positions(
+                List.of(
+                    new PositionSnapshot("IE00A", new BigDecimal("500000")),
+                    new PositionSnapshot("IE00B", new BigDecimal("400000"))))
+            .modelWeights(
+                List.of(
+                    new ModelWeight("IE00A", new BigDecimal("0.50")),
+                    new ModelWeight("IE00B", new BigDecimal("0.50"))))
+            .grossPortfolioValue(new BigDecimal("900000"))
+            .cashBuffer(new BigDecimal("100000"))
+            .liabilities(ZERO)
+            .freeCash(new BigDecimal("-100000"))
+            .minTransactionThreshold(new BigDecimal("5000"))
+            .positionLimits(Map.of())
+            .fastSellIsins(Set.of())
+            .build();
+
+    var result = engine.calculate(input, SELL);
+
+    var tradeA =
+        result.trades().stream().filter(t -> t.isin().equals("IE00A")).findFirst().orElseThrow();
+    var tradeB =
+        result.trades().stream().filter(t -> t.isin().equals("IE00B")).findFirst().orElseThrow();
+
+    assertThat(tradeA.tradeAmount()).isEqualByComparingTo(new BigDecimal("-100000"));
+    assertThat(tradeB.tradeAmount()).isEqualByComparingTo(ZERO);
+  }
+
+  @Test
   void sell_withPositiveFreeCash_returnsZeroTrades() {
     var input =
         FundTransactionInput.builder()

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/calculation/TradeCalculationEngineTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/calculation/TradeCalculationEngineTest.java
@@ -243,6 +243,56 @@ class TradeCalculationEngineTest {
   }
 
   @Test
+  void buy_waterFillsHardLimitExcessAcrossRunnersInsteadOfStrandingCash() {
+    // IE00X overflows its 0.26 hard limit, producing ~60197 of excess to redistribute.
+    // Both IE00P and IE00Q are eligible runners, but a score-proportional split hands IE00P far
+    // more than its remaining ~5336 headroom (it caps at its 0.15 hard limit), while IE00Q has
+    // ample room. The clipped overflow must cascade to IE00Q, not strand — the full 100000 deploys.
+    var input =
+        FundTransactionInput.builder()
+            .fund(TUV100)
+            .positions(
+                List.of(
+                    new PositionSnapshot("IE00X", new BigDecimal("240000")),
+                    new PositionSnapshot("IE00P", new BigDecimal("130000")),
+                    new PositionSnapshot("IE00Q", new BigDecimal("130000"))))
+            .modelWeights(
+                List.of(
+                    new ModelWeight("IE00X", new BigDecimal("0.60")),
+                    new ModelWeight("IE00P", new BigDecimal("0.20")),
+                    new ModelWeight("IE00Q", new BigDecimal("0.16"))))
+            .grossPortfolioValue(new BigDecimal("1000000"))
+            .cashBuffer(new BigDecimal("50000"))
+            .liabilities(ZERO)
+            .freeCash(new BigDecimal("100000"))
+            .minTransactionThreshold(new BigDecimal("5000"))
+            .positionLimits(
+                Map.of(
+                    "IE00X",
+                        new PositionLimitSnapshot(new BigDecimal("0.25"), new BigDecimal("0.26")),
+                    "IE00P",
+                        new PositionLimitSnapshot(new BigDecimal("0.14"), new BigDecimal("0.15")),
+                    "IE00Q",
+                        new PositionLimitSnapshot(new BigDecimal("0.39"), new BigDecimal("0.40"))))
+            .fastSellIsins(Set.of())
+            .build();
+
+    var result = engine.calculate(input, BUY);
+
+    BigDecimal totalInvested =
+        result.trades().stream().map(TradeCalculation::tradeAmount).reduce(ZERO, BigDecimal::add);
+    assertThat(totalInvested)
+        .isCloseTo(new BigDecimal("100000"), org.assertj.core.data.Offset.offset(BigDecimal.ONE));
+
+    result
+        .trades()
+        .forEach(
+            trade ->
+                assertThat(trade.projectedWeight())
+                    .isLessThanOrEqualTo(input.positionLimits().get(trade.isin()).hardLimit()));
+  }
+
+  @Test
   void buy_flagsSoftLimitExceeded() {
     var input =
         FundTransactionInput.builder()

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/calculation/TradeCalculationEngineTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/calculation/TradeCalculationEngineTest.java
@@ -289,6 +289,191 @@ class TradeCalculationEngineTest {
   }
 
   @Test
+  void buy_topsUpBestRunnerWithSubThresholdHardLimitLeftover() {
+    var input =
+        FundTransactionInput.builder()
+            .fund(TUV100)
+            .positions(
+                List.of(
+                    new PositionSnapshot("IE00A", new BigDecimal("400000")),
+                    new PositionSnapshot("IE00B", new BigDecimal("400000"))))
+            .modelWeights(
+                List.of(
+                    new ModelWeight("IE00A", new BigDecimal("0.50")),
+                    new ModelWeight("IE00B", new BigDecimal("0.50"))))
+            .grossPortfolioValue(new BigDecimal("1000000"))
+            .cashBuffer(ZERO)
+            .liabilities(ZERO)
+            .freeCash(new BigDecimal("50000"))
+            .minTransactionThreshold(new BigDecimal("5000"))
+            .positionLimits(
+                Map.of(
+                    "IE00A",
+                    new PositionLimitSnapshot(new BigDecimal("0.40"), new BigDecimal("0.4221"))))
+            .fastSellIsins(Set.of())
+            .build();
+
+    var result = engine.calculate(input, BUY);
+
+    var tradeA =
+        result.trades().stream().filter(t -> t.isin().equals("IE00A")).findFirst().orElseThrow();
+    var tradeB =
+        result.trades().stream().filter(t -> t.isin().equals("IE00B")).findFirst().orElseThrow();
+
+    assertThat(tradeA.tradeAmount()).isEqualByComparingTo(new BigDecimal("22000.00"));
+    assertThat(tradeB.tradeAmount()).isEqualByComparingTo(new BigDecimal("28000.00"));
+
+    BigDecimal totalInvested =
+        result.trades().stream().map(TradeCalculation::tradeAmount).reduce(ZERO, BigDecimal::add);
+    assertThat(totalInvested).isEqualByComparingTo(new BigDecimal("50000.00"));
+  }
+
+  @Test
+  void buy_strandsExcessWhenEveryRunnerHitsItsHardLimit() {
+    var input =
+        FundTransactionInput.builder()
+            .fund(TUV100)
+            .positions(
+                List.of(
+                    new PositionSnapshot("IE00A", new BigDecimal("100000")),
+                    new PositionSnapshot("IE00B", new BigDecimal("50000")),
+                    new PositionSnapshot("IE00C", new BigDecimal("50000"))))
+            .modelWeights(
+                List.of(
+                    new ModelWeight("IE00A", new BigDecimal("0.80")),
+                    new ModelWeight("IE00B", new BigDecimal("0.10")),
+                    new ModelWeight("IE00C", new BigDecimal("0.10"))))
+            .grossPortfolioValue(new BigDecimal("1000000"))
+            .cashBuffer(ZERO)
+            .liabilities(ZERO)
+            .freeCash(new BigDecimal("100000"))
+            .minTransactionThreshold(new BigDecimal("5000"))
+            .positionLimits(
+                Map.of(
+                    "IE00A",
+                        new PositionLimitSnapshot(new BigDecimal("0.10"), new BigDecimal("0.13")),
+                    "IE00B",
+                        new PositionLimitSnapshot(new BigDecimal("0.05"), new BigDecimal("0.056")),
+                    "IE00C",
+                        new PositionLimitSnapshot(new BigDecimal("0.05"), new BigDecimal("0.056"))))
+            .fastSellIsins(Set.of())
+            .build();
+
+    var result = engine.calculate(input, BUY);
+
+    var tradeA =
+        result.trades().stream().filter(t -> t.isin().equals("IE00A")).findFirst().orElseThrow();
+    var tradeB =
+        result.trades().stream().filter(t -> t.isin().equals("IE00B")).findFirst().orElseThrow();
+    var tradeC =
+        result.trades().stream().filter(t -> t.isin().equals("IE00C")).findFirst().orElseThrow();
+
+    assertThat(tradeA.tradeAmount()).isEqualByComparingTo(new BigDecimal("29900.00"));
+    assertThat(tradeB.tradeAmount()).isEqualByComparingTo(new BigDecimal("5900.00"));
+    assertThat(tradeC.tradeAmount()).isEqualByComparingTo(new BigDecimal("5900.00"));
+
+    BigDecimal totalInvested =
+        result.trades().stream().map(TradeCalculation::tradeAmount).reduce(ZERO, BigDecimal::add);
+    assertThat(totalInvested).isEqualByComparingTo(new BigDecimal("41700.00"));
+    assertThat(totalInvested).isLessThan(input.freeCash());
+
+    result
+        .trades()
+        .forEach(
+            trade ->
+                assertThat(trade.projectedWeight())
+                    .isLessThanOrEqualTo(input.positionLimits().get(trade.isin()).hardLimit()));
+  }
+
+  @Test
+  void buy_stopsWaterFillOnceLeftoverExcessIsFullyAbsorbed() {
+    var input =
+        FundTransactionInput.builder()
+            .fund(TUV100)
+            .positions(
+                List.of(
+                    new PositionSnapshot("IE00A", new BigDecimal("300000")),
+                    new PositionSnapshot("IE00B", new BigDecimal("300000"))))
+            .modelWeights(
+                List.of(
+                    new ModelWeight("IE00A", new BigDecimal("0.60")),
+                    new ModelWeight("IE00B", new BigDecimal("0.40"))))
+            .grossPortfolioValue(new BigDecimal("1000000"))
+            .cashBuffer(ZERO)
+            .liabilities(ZERO)
+            .freeCash(new BigDecimal("50000"))
+            .minTransactionThreshold(new BigDecimal("5000"))
+            .positionLimits(
+                Map.of(
+                    "IE00A",
+                        new PositionLimitSnapshot(new BigDecimal("0.30"), new BigDecimal("0.31")),
+                    "IE00B",
+                        new PositionLimitSnapshot(
+                            new BigDecimal("0.33"), new BigDecimal("0.3402"))))
+            .fastSellIsins(Set.of())
+            .build();
+
+    var result = engine.calculate(input, BUY);
+
+    var tradeA =
+        result.trades().stream().filter(t -> t.isin().equals("IE00A")).findFirst().orElseThrow();
+    var tradeB =
+        result.trades().stream().filter(t -> t.isin().equals("IE00B")).findFirst().orElseThrow();
+
+    assertThat(tradeA.tradeAmount()).isEqualByComparingTo(new BigDecimal("9900.00"));
+    assertThat(tradeB.tradeAmount()).isEqualByComparingTo(new BigDecimal("40100.00"));
+
+    BigDecimal totalInvested =
+        result.trades().stream().map(TradeCalculation::tradeAmount).reduce(ZERO, BigDecimal::add);
+    assertThat(totalInvested).isEqualByComparingTo(new BigDecimal("50000.00"));
+  }
+
+  @Test
+  void buy_ignoresOnTargetPositionsWhenRedistributingHardLimitExcess() {
+    var input =
+        FundTransactionInput.builder()
+            .fund(TUV100)
+            .positions(
+                List.of(
+                    new PositionSnapshot("IE00A", new BigDecimal("350000")),
+                    new PositionSnapshot("IE00B", new BigDecimal("200000")),
+                    new PositionSnapshot("IE00C", new BigDecimal("300000"))))
+            .modelWeights(
+                List.of(
+                    new ModelWeight("IE00A", new BigDecimal("0.40")),
+                    new ModelWeight("IE00B", new BigDecimal("0.30")),
+                    new ModelWeight("IE00C", new BigDecimal("0.30"))))
+            .grossPortfolioValue(new BigDecimal("1000000"))
+            .cashBuffer(ZERO)
+            .liabilities(ZERO)
+            .freeCash(new BigDecimal("50000"))
+            .minTransactionThreshold(new BigDecimal("5000"))
+            .positionLimits(
+                Map.of(
+                    "IE00A",
+                    new PositionLimitSnapshot(new BigDecimal("0.35"), new BigDecimal("0.36"))))
+            .fastSellIsins(Set.of())
+            .build();
+
+    var result = engine.calculate(input, BUY);
+
+    var tradeA =
+        result.trades().stream().filter(t -> t.isin().equals("IE00A")).findFirst().orElseThrow();
+    var tradeB =
+        result.trades().stream().filter(t -> t.isin().equals("IE00B")).findFirst().orElseThrow();
+    var tradeC =
+        result.trades().stream().filter(t -> t.isin().equals("IE00C")).findFirst().orElseThrow();
+
+    assertThat(tradeA.tradeAmount()).isEqualByComparingTo(new BigDecimal("9900.00"));
+    assertThat(tradeB.tradeAmount()).isEqualByComparingTo(new BigDecimal("40100.00"));
+    assertThat(tradeC.tradeAmount()).isEqualByComparingTo(ZERO);
+
+    BigDecimal totalInvested =
+        result.trades().stream().map(TradeCalculation::tradeAmount).reduce(ZERO, BigDecimal::add);
+    assertThat(totalInvested).isEqualByComparingTo(new BigDecimal("50000.00"));
+  }
+
+  @Test
   void buy_flagsSoftLimitExceeded() {
     var input =
         FundTransactionInput.builder()
@@ -663,6 +848,102 @@ class TradeCalculationEngineTest {
     assertThat(tradeC.tradeAmount()).isEqualByComparingTo(ZERO);
     assertThat(tradeA.tradeAmount()).isEqualByComparingTo(new BigDecimal("32000.00"));
     assertThat(tradeB.tradeAmount()).isEqualByComparingTo(new BigDecimal("-32000.00"));
+  }
+
+  @Test
+  void rebalance_producesNoBuysWhenNoPositionIsUnderTarget() {
+    var input =
+        FundTransactionInput.builder()
+            .fund(TUV100)
+            .positions(
+                List.of(
+                    new PositionSnapshot("IE00A", new BigDecimal("600000")),
+                    new PositionSnapshot("IE00B", new BigDecimal("500000"))))
+            .modelWeights(
+                List.of(
+                    new ModelWeight("IE00A", new BigDecimal("0.50")),
+                    new ModelWeight("IE00B", new BigDecimal("0.50"))))
+            .grossPortfolioValue(new BigDecimal("1000000"))
+            .cashBuffer(ZERO)
+            .liabilities(ZERO)
+            .freeCash(ZERO)
+            .minTransactionThreshold(new BigDecimal("5000"))
+            .positionLimits(Map.of())
+            .fastSellIsins(Set.of())
+            .build();
+
+    var result = engine.calculate(input, REBALANCE);
+
+    var tradeA =
+        result.trades().stream().filter(t -> t.isin().equals("IE00A")).findFirst().orElseThrow();
+    var tradeB =
+        result.trades().stream().filter(t -> t.isin().equals("IE00B")).findFirst().orElseThrow();
+
+    assertThat(tradeA.tradeAmount()).isEqualByComparingTo(new BigDecimal("-100000"));
+    assertThat(tradeB.tradeAmount()).isEqualByComparingTo(ZERO);
+  }
+
+  @Test
+  void sell_stopsWhenNeedFullyCoveredByExactMarketValueCap() {
+    var input =
+        FundTransactionInput.builder()
+            .fund(TUV100)
+            .positions(
+                List.of(
+                    new PositionSnapshot("IE00OVER", new BigDecimal("40000")),
+                    new PositionSnapshot("IE00ATTARGET", new BigDecimal("100000"))))
+            .modelWeights(
+                List.of(
+                    new ModelWeight("IE00OVER", ZERO),
+                    new ModelWeight("IE00ATTARGET", new BigDecimal("1.00"))))
+            .grossPortfolioValue(new BigDecimal("1000000"))
+            .cashBuffer(ZERO)
+            .liabilities(ZERO)
+            .freeCash(new BigDecimal("-40000"))
+            .minTransactionThreshold(new BigDecimal("5000"))
+            .positionLimits(Map.of())
+            .fastSellIsins(Set.of())
+            .build();
+
+    var result = engine.calculate(input, SELL);
+
+    var overTrade =
+        result.trades().stream().filter(t -> t.isin().equals("IE00OVER")).findFirst().orElseThrow();
+    var atTargetTrade =
+        result.trades().stream()
+            .filter(t -> t.isin().equals("IE00ATTARGET"))
+            .findFirst()
+            .orElseThrow();
+
+    assertThat(overTrade.tradeAmount()).isEqualByComparingTo(new BigDecimal("-40000"));
+    assertThat(atTargetTrade.tradeAmount()).isEqualByComparingTo(ZERO);
+  }
+
+  @Test
+  void sellFast_leavesShortfallWhenNoSlowInstrumentsRemain() {
+    var input =
+        FundTransactionInput.builder()
+            .fund(TUV100)
+            .positions(List.of(new PositionSnapshot("IE00FAST", new BigDecimal("50000"))))
+            .modelWeights(List.of(new ModelWeight("IE00FAST", new BigDecimal("1.00"))))
+            .grossPortfolioValue(new BigDecimal("1000000"))
+            .cashBuffer(ZERO)
+            .liabilities(ZERO)
+            .freeCash(new BigDecimal("-80000"))
+            .minTransactionThreshold(new BigDecimal("5000"))
+            .positionLimits(Map.of())
+            .fastSellIsins(Set.of("IE00FAST"))
+            .build();
+
+    var result = engine.calculate(input, SELL_FAST);
+
+    var fastTrade =
+        result.trades().stream().filter(t -> t.isin().equals("IE00FAST")).findFirst().orElseThrow();
+    assertThat(fastTrade.tradeAmount()).isEqualByComparingTo(new BigDecimal("-50000"));
+
+    BigDecimal totalSold =
+        result.trades().stream().map(TradeCalculation::tradeAmount).reduce(ZERO, BigDecimal::add);
+    assertThat(totalSold).isEqualByComparingTo(new BigDecimal("-50000"));
   }
 
   @Test

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationAuditRecorderTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationAuditRecorderTest.java
@@ -39,6 +39,7 @@ class FtConfirmationAuditRecorderTest {
 
   private static final Instant NOW = Instant.parse("2026-06-09T08:00:00Z");
   private static final UUID ORDER_UUID = UUID.fromString("bd83f551-8c79-4193-b92b-18e1dfd0bd29");
+  private static final String DEDUP_KEY = "TUK75|IE000F60HVH9|2026-06-08|40434|10.09|NORMAL";
 
   @Mock private TransactionAuditEventRepository auditEventRepository;
 
@@ -63,6 +64,7 @@ class FtConfirmationAuditRecorderTest {
                 .orderId(42L)
                 .eventType("FT_CONFIRMATION_VERIFIED")
                 .actor("admin")
+                .dedupKey(DEDUP_KEY)
                 .payload(
                     Map.of(
                         "fund", "TUK75",
@@ -101,6 +103,7 @@ class FtConfirmationAuditRecorderTest {
                 .orderId(42L)
                 .eventType("FT_CONFIRMATION_VERIFIED")
                 .actor("admin")
+                .dedupKey("TUK75|IE000F60HVH9|2026-06-08|40434|10.09|CANCELLATION")
                 .payload(
                     Map.of(
                         "fund", "TUK75",
@@ -119,7 +122,7 @@ class FtConfirmationAuditRecorderTest {
 
   @Test
   void recordOutcome_sameStatusAlreadyRecorded_skipsSaveAndReturnsFalse() {
-    given(auditEventRepository.findByEventType("FT_CONFIRMATION_VERIFIED"))
+    given(auditEventRepository.findByEventTypeAndDedupKey("FT_CONFIRMATION_VERIFIED", DEDUP_KEY))
         .willReturn(List.of(priorEvent("ERROR", "OK")));
 
     boolean recorded =
@@ -133,7 +136,7 @@ class FtConfirmationAuditRecorderTest {
 
   @Test
   void recordOutcome_statusChangedSinceLastRecord_savesAndReturnsTrue() {
-    given(auditEventRepository.findByEventType("FT_CONFIRMATION_VERIFIED"))
+    given(auditEventRepository.findByEventTypeAndDedupKey("FT_CONFIRMATION_VERIFIED", DEDUP_KEY))
         .willReturn(List.of(priorEvent("PENDING_EXECUTION", "PENDING_NAV")));
 
     boolean recorded =
@@ -159,6 +162,7 @@ class FtConfirmationAuditRecorderTest {
             TransactionAuditEvent.builder()
                 .eventType("FT_CONFIRMATION_VERIFIED")
                 .actor("ops-person")
+                .dedupKey(DEDUP_KEY)
                 .payload(
                     Map.of(
                         "fund", "TUK75",
@@ -176,7 +180,8 @@ class FtConfirmationAuditRecorderTest {
 
   @Test
   void alreadyAlerted_noPriorAlert_returnsFalse() {
-    given(auditEventRepository.findByEventType("FT_CONFIRMATION_ALERTED")).willReturn(List.of());
+    given(auditEventRepository.findByEventTypeAndDedupKey("FT_CONFIRMATION_ALERTED", DEDUP_KEY))
+        .willReturn(List.of());
 
     boolean alerted =
         recorder().alreadyAlerted(confirmation(), new FtConfirmationResult(ERROR, OK, Map.of()));
@@ -186,7 +191,7 @@ class FtConfirmationAuditRecorderTest {
 
   @Test
   void alreadyAlerted_priorAlertWithSameStatus_returnsTrue() {
-    given(auditEventRepository.findByEventType("FT_CONFIRMATION_ALERTED"))
+    given(auditEventRepository.findByEventTypeAndDedupKey("FT_CONFIRMATION_ALERTED", DEDUP_KEY))
         .willReturn(List.of(priorAlert("ERROR", "OK")));
 
     boolean alerted =
@@ -197,7 +202,7 @@ class FtConfirmationAuditRecorderTest {
 
   @Test
   void alreadyAlerted_priorAlertWithDifferentStatus_returnsFalse() {
-    given(auditEventRepository.findByEventType("FT_CONFIRMATION_ALERTED"))
+    given(auditEventRepository.findByEventTypeAndDedupKey("FT_CONFIRMATION_ALERTED", DEDUP_KEY))
         .willReturn(List.of(priorAlert("AMBIGUOUS", "AMBIGUOUS")));
 
     boolean alerted =
@@ -207,12 +212,20 @@ class FtConfirmationAuditRecorderTest {
   }
 
   @Test
-  void alreadyAlerted_priorAlertWithDifferentDecimalScale_returnsTrue() {
-    given(auditEventRepository.findByEventType("FT_CONFIRMATION_ALERTED"))
-        .willReturn(List.of(priorAlert("ERROR", "OK", "40434.0", "10.090")));
+  void alreadyAlerted_normalizesAmountScaleWhenBuildingDedupKey() {
+    given(auditEventRepository.findByEventTypeAndDedupKey("FT_CONFIRMATION_ALERTED", DEDUP_KEY))
+        .willReturn(List.of(priorAlert("ERROR", "OK")));
 
     boolean alerted =
-        recorder().alreadyAlerted(confirmation(), new FtConfirmationResult(ERROR, OK, Map.of()));
+        recorder()
+            .alreadyAlerted(
+                new FtConfirmation(
+                    TUK75,
+                    "IE000F60HVH9",
+                    LocalDate.parse("2026-06-08"),
+                    new BigDecimal("40434.000"),
+                    new BigDecimal("10.0900")),
+                new FtConfirmationResult(ERROR, OK, Map.of()));
 
     assertThat(alerted).isTrue();
   }
@@ -226,6 +239,7 @@ class FtConfirmationAuditRecorderTest {
             TransactionAuditEvent.builder()
                 .eventType("FT_CONFIRMATION_ALERTED")
                 .actor("system")
+                .dedupKey(DEDUP_KEY)
                 .payload(
                     Map.of(
                         "fund", "TUK75",

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationVerificationServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationVerificationServiceTest.java
@@ -293,6 +293,19 @@ class FtConfirmationVerificationServiceTest {
   }
 
   @Test
+  void negativeReferencePrice_returnsError() {
+    givenOrderAndExecution(new BigDecimal("40434"), new BigDecimal("40434"));
+    givenReferencePrice(new BigDecimal("-10.09"), TRADE_DATE);
+
+    FtConfirmationResult result =
+        service(DAY_AFTER_TRADE)
+            .verify(confirmation(new BigDecimal("40434"), new BigDecimal("10.09")));
+
+    assertThat(result.priceStatus()).isEqualTo(ERROR);
+    assertThat(result.details()).containsKey("invalidReferencePrice");
+  }
+
+  @Test
   void priceExactlyAtToleranceBoundary_returnsOk() {
     givenOrderAndExecution(new BigDecimal("40434"), new BigDecimal("40434"));
     givenReferencePrice(new BigDecimal("10.09"), TRADE_DATE);

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/PriceValidatorTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/PriceValidatorTest.java
@@ -51,6 +51,15 @@ class PriceValidatorTest {
   }
 
   @Test
+  void negativeNavPrice_isOutsideTolerance() {
+    // A negative reference price is invalid: |exec - nav| / nav yields a negative ratio that
+    // would silently pass the <= tolerance comparison.
+    assertThat(
+            validator.isWithinTolerance(new BigDecimal("100"), new BigDecimal("-100"), TOLERANCE))
+        .isFalse();
+  }
+
+  @Test
   void computeDeltaPercent_returnsAbsoluteRatioTimes100() {
     // |4.7255 - 4.7800| / 4.7800 ≈ 0.011401673
     BigDecimal delta =

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/PriceValidatorTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/PriceValidatorTest.java
@@ -52,8 +52,6 @@ class PriceValidatorTest {
 
   @Test
   void negativeNavPrice_isOutsideTolerance() {
-    // A negative reference price is invalid: |exec - nav| / nav yields a negative ratio that
-    // would silently pass the <= tolerance comparison.
     assertThat(
             validator.isWithinTolerance(new BigDecimal("100"), new BigDecimal("-100"), TOLERANCE))
         .isFalse();

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/ReconciliationAuditRecorderTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/ReconciliationAuditRecorderTest.java
@@ -69,28 +69,21 @@ class ReconciliationAuditRecorderTest {
                     "UNMATCHED_SEB_TRANSACTION".equals(event.getEventType())
                         && event.getOrderId() == null
                         && event.getBatch() == null
+                        && "2026-05-13|DLA0799512|bd83f551-8c79-4193-b92b-18e1dfd0bd29|IE000F60HVH9"
+                            .equals(event.getDedupKey())
                         && "IE000F60HVH9".equals(event.getPayload().get("isin"))
                         && REPORT_DATE.toString().equals(event.getPayload().get("reportDate"))));
   }
 
   @Test
   void recordUnmatched_skipsDuplicateForSameRowAndReportDate() {
-    given(auditEventRepository.findByEventType("UNMATCHED_SEB_TRANSACTION"))
+    given(
+            auditEventRepository.findByEventTypeAndDedupKey(
+                "UNMATCHED_SEB_TRANSACTION",
+                "2026-05-13|DLA0799512|bd83f551-8c79-4193-b92b-18e1dfd0bd29|IE000F60HVH9"))
         .willReturn(
             List.of(
-                TransactionAuditEvent.builder()
-                    .eventType("UNMATCHED_SEB_TRANSACTION")
-                    .payload(
-                        Map.of(
-                            "reportDate",
-                            REPORT_DATE.toString(),
-                            "ourRef",
-                            "DLA0799512",
-                            "clientRef",
-                            CLIENT_REF.toString(),
-                            "isin",
-                            "IE000F60HVH9"))
-                    .build()));
+                TransactionAuditEvent.builder().eventType("UNMATCHED_SEB_TRANSACTION").build()));
 
     newRecorder().recordUnmatched(sampleRow(), REPORT_DATE);
 


### PR DESCRIPTION
Seven correctness fixes from the Transaction Registry gap analysis (§4.8/§4.7), each test-first (failing test reproduces the bug, then the minimal fix). Full suite green (H2). One migration (V1_226).

## Trade calculation (`TradeCalculationEngine`)
- **SELL double-subtracts the cash shortfall** — sized overweights against `netInvestable − sellAmount`, double-counting the shortfall, so it sold from an *on-target* position. Fixed to target `netInvestable` directly.
- **BUY excess redistribution strands cash** — hard-limit surplus was redistributed proportional to score but ignored each runner's headroom, so it was over-allocated, clipped, and stranded. Replaced with a capped water-fill (`waterFillExcessAcrossRunners`).

## FT confirmation price (`PriceValidator` / `FtConfirmationVerificationService`)
- **Negative reference price passed tolerance** — `abs()` was on the numerator only, so a negative reference NAV yielded a negative ratio that silently passed. Guard `signum() <= 0` in `checkPrice` (actionable ERROR + detail) + hardened `isWithinTolerance`.

## EPIS report markers (`R17`/`R21`/`R45ReportParser`)
- **Stale-report markers were optional** — R17 `Seisuga` / R21 `Maksete kuu` / R45 `Tehtud` skipped when absent, bypassing the staleness guard. Now required; absence throws through the existing window rejection.
- **R45 silently dropped unknown transaction types / unmapped ISINs** — invisibly understated liquidity. Now recorded (`R45UnknownRow`), alerted, and the attributable fund marked incomplete (unmapped ISIN alerts only).

## Batch finalization (`TransactionAdminService` / `TransactionPreparationService`)
- **`confirmAndFinalize` could re-finalize / re-send** — `finalizeConfirmedBatch` never re-checked status. Now throws when the batch is already `SENT`, and `confirmAndFinalize` is `@Transactional`.

## Audit dedup keyed-finder (`FtConfirmationAuditRecorder` / `ReconciliationAuditRecorder`) — §4.7/§4.8 items 18 + 29
- Both recorders loaded **every** event of a type and filtered the natural key (in `payload` jsonb) in memory — an unbounded scan per row. Added a persisted **`dedup_key`** column (**V1_226**, indexed `(event_type, dedup_key)`), populated on save with BigDecimals `stripTrailingZeros`-normalized (so `40434 == 40434.0`), and switched both dedup paths to `findByEventTypeAndDedupKey`. The now-redundant `sameConfirmation`/`sameRowIdentity` in-memory filters are removed. Behaviour unchanged.
  - **Deploy caveat (accepted):** pre-migration rows have a null key, so at deploy an already-handled row can produce one duplicate audit/alert until re-recorded — self-healing. No jsonb backfill (not H2-portable).

## Clean-code + coverage
- Removed the explanatory test comments; extracted the repeated `new BigDecimal("0.01")` → `MIN_MEANINGFUL_AMOUNT`.
- Added targeted tests closing the flagged patch-coverage gaps (BUY water-fill edge branches, EPIS marker-absent/unparseable branches, R45 unmapped-ISIN path). Two residual `TradeCalculationEngine` guard branches are unreachable by construction.

## Notes for review — deliberate scoping calls
1. Unmapped R45 ISIN alerts but does **not** hard-block a specific fund (no fund to attribute) — say if you'd rather block the whole report.
2. Item 19 closes the sequential/direct re-send; the *concurrent* double-confirm race (two callers both read `AWAITING`) needs `@Version` on `TransactionBatch` (a migration) — noted, not done.
3. Item 18's deploy caveat above (one-time duplicate alert). Say if you'd prefer a Java backfill migration to eliminate it.

Fixture-realism cleanups (SELL / R17 / R45 tests that exploited lax behaviour made realistic) are hygiene, not behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)