### PR TITLE
Add severity icons to TD and limit-breach notifications

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/investment/check/limit/LimitCheckNotifier.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/check/limit/LimitCheckNotifier.java
@@ -1,6 +1,7 @@
 package ee.tuleva.onboarding.investment.check.limit;
 
 import static ee.tuleva.onboarding.investment.check.limit.BreachSeverity.OK;
+import static ee.tuleva.onboarding.investment.check.limit.BreachSeverity.SOFT;
 import static ee.tuleva.onboarding.notification.OperationsNotificationService.Channel.INVESTMENT;
 
 import ee.tuleva.onboarding.notification.OperationsNotificationService;
@@ -28,11 +29,12 @@ class LimitCheckNotifier {
         var fundNames =
             results.stream().map(r -> r.fund().getCode()).collect(Collectors.joining(", "));
         notificationService.sendMessage(
-            "Limit check completed: %s within limits".formatted(fundNames), INVESTMENT);
+            "✅ Limit check completed: %s within limits".formatted(fundNames), INVESTMENT);
         return;
       }
 
-      var message = new StringBuilder("LIMIT BREACH DETECTED\n");
+      var body = new StringBuilder();
+      var worst = SOFT;
 
       for (var result : results) {
         if (!result.hasBreaches()) {
@@ -41,9 +43,11 @@ class LimitCheckNotifier {
 
         for (var breach : result.positionBreaches()) {
           if (breach.severity() != OK) {
-            message.append(
-                "\n[%s] POSITION %s: %s=%s%%, soft=%s%%, hard=%s%%"
+            worst = worse(worst, breach.severity());
+            body.append(
+                "\n%s [%s] POSITION %s: %s=%s%%, soft=%s%%, hard=%s%%"
                     .formatted(
+                        severityIcon(breach.severity()),
                         breach.severity(),
                         result.fund(),
                         breach.label(),
@@ -55,9 +59,11 @@ class LimitCheckNotifier {
 
         for (var breach : result.providerBreaches()) {
           if (breach.severity() != OK) {
-            message.append(
-                "\n[%s] PROVIDER %s: %s=%s%%, soft=%s%%, hard=%s%%"
+            worst = worse(worst, breach.severity());
+            body.append(
+                "\n%s [%s] PROVIDER %s: %s=%s%%, soft=%s%%, hard=%s%%"
                     .formatted(
+                        severityIcon(breach.severity()),
                         breach.severity(),
                         result.fund(),
                         breach.provider(),
@@ -69,9 +75,11 @@ class LimitCheckNotifier {
 
         if (result.reserveBreach() != null && result.reserveBreach().severity() != OK) {
           var breach = result.reserveBreach();
-          message.append(
-              "\n[%s] RESERVE %s: cash=%s, soft=%s, hard=%s"
+          worst = worse(worst, breach.severity());
+          body.append(
+              "\n%s [%s] RESERVE %s: cash=%s, soft=%s, hard=%s"
                   .formatted(
+                      severityIcon(breach.severity()),
                       breach.severity(),
                       result.fund(),
                       breach.cashBalance(),
@@ -80,10 +88,23 @@ class LimitCheckNotifier {
         }
       }
 
-      notificationService.sendMessage(message.toString(), INVESTMENT);
+      var message = "%s LIMIT BREACH DETECTED\n".formatted(severityIcon(worst)) + body;
+      notificationService.sendMessage(message, INVESTMENT);
 
     } catch (Exception e) {
       log.error("Failed to send limit check notification", e);
     }
+  }
+
+  private BreachSeverity worse(BreachSeverity a, BreachSeverity b) {
+    return a.compareTo(b) >= 0 ? a : b;
+  }
+
+  private String severityIcon(BreachSeverity severity) {
+    return switch (severity) {
+      case HARD -> "🛑";
+      case SOFT -> "⚠️";
+      case OK -> "✅";
+    };
   }
 }

--- a/src/main/java/ee/tuleva/onboarding/investment/check/tracking/TrackingDifferenceNotifier.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/check/tracking/TrackingDifferenceNotifier.java
@@ -33,7 +33,7 @@ class TrackingDifferenceNotifier {
   void notifyCheckCouldNotRun(TulevaFund fund, LocalDate navDate) {
     try {
       notificationService.sendMessage(
-          "TD CHECK DID NOT RUN: fund=%s, date=%s — missing NAV, prices, or model data; NAV report published WITHOUT tracking-difference validation"
+          "⚠️ TD CHECK DID NOT RUN: fund=%s, date=%s — missing NAV, prices, or model data; NAV report published WITHOUT tracking-difference validation"
               .formatted(fund.getCode(), navDate),
           INVESTMENT);
     } catch (Exception e) {
@@ -61,14 +61,14 @@ class TrackingDifferenceNotifier {
                   .distinct()
                   .sorted()
                   .collect(Collectors.joining(", "));
-          message.append("%s TD check completed: within limits".formatted(fundCodes));
+          message.append("✅ %s TD check completed: within limits".formatted(fundCodes));
         }
         byFund.forEach(
             (fundCode, fundResults) -> {
               if (message.length() > 0) {
                 message.append("\n");
               }
-              message.append("%s TD check completed: within limits".formatted(fundCode));
+              message.append("✅ %s TD check completed: within limits".formatted(fundCode));
               fundResults.stream()
                   .sorted(Comparator.comparing(r -> r.checkType().name()))
                   .forEach(r -> message.append(formatWithinLimits(r)));
@@ -77,7 +77,7 @@ class TrackingDifferenceNotifier {
         return;
       }
 
-      var message = new StringBuilder("TD BREACH DETECTED\n");
+      var message = new StringBuilder("🛑 TD BREACH DETECTED\n");
       var hasEscalation = false;
 
       for (var result : alertableResults) {
@@ -94,7 +94,7 @@ class TrackingDifferenceNotifier {
       }
 
       if (hasEscalation) {
-        message.insert(0, "TD ESCALATION — CONSECUTIVE BREACH DAYS\n");
+        message.insert(0, "🛑 TD ESCALATION — CONSECUTIVE BREACH DAYS\n");
       }
 
       notificationService.sendMessage(message.toString(), INVESTMENT);
@@ -131,7 +131,7 @@ class TrackingDifferenceNotifier {
   private String formatBreach(TrackingDifferenceResult result, boolean escalation) {
     var sb = new StringBuilder();
     sb.append(
-        "\n[%s] %s %s: TD=%s%% (%s=%s%%, benchmark=%s%%)"
+        "\n🛑 [%s] %s %s: TD=%s%% (%s=%s%%, benchmark=%s%%)"
             .formatted(
                 result.fund(),
                 result.checkType(),

--- a/src/test/groovy/ee/tuleva/onboarding/investment/check/limit/LimitCheckNotifierTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/check/limit/LimitCheckNotifierTest.java
@@ -4,6 +4,7 @@ import static ee.tuleva.onboarding.fund.TulevaFund.TUK75;
 import static ee.tuleva.onboarding.investment.check.limit.BreachSeverity.*;
 import static ee.tuleva.onboarding.investment.portfolio.Provider.ISHARES;
 import static ee.tuleva.onboarding.notification.OperationsNotificationService.Channel.INVESTMENT;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
@@ -90,6 +91,72 @@ class LimitCheckNotifierTest {
     notifier.notify(List.of(result));
 
     verify(notificationService).sendMessage(contains("within limits"), eq(INVESTMENT));
+  }
+
+  @Test
+  void withinLimitsMessageShowsGreenIcon() {
+    var result =
+        new LimitCheckResult(TUK75, LocalDate.of(2026, 3, 4), List.of(), List.of(), null, null);
+
+    notifier.notify(List.of(result));
+
+    verify(notificationService).sendMessage(contains("✅"), eq(INVESTMENT));
+  }
+
+  @Test
+  void softBreachShowsYellowIcon() {
+    var breach =
+        new ReserveBreach(
+            TUK75, new BigDecimal("40000"), new BigDecimal("50000"), new BigDecimal("30000"), SOFT);
+    var result =
+        new LimitCheckResult(TUK75, LocalDate.of(2026, 3, 4), List.of(), List.of(), breach, null);
+
+    notifier.notify(List.of(result));
+
+    var captor = org.mockito.ArgumentCaptor.forClass(String.class);
+    verify(notificationService).sendMessage(captor.capture(), eq(INVESTMENT));
+    var message = captor.getValue();
+    assertThat(message).contains("⚠️ LIMIT BREACH DETECTED");
+    assertThat(message).contains("⚠️ [SOFT] RESERVE");
+    assertThat(message).doesNotContain("🛑");
+  }
+
+  @Test
+  void hardBreachShowsRedIconInHeaderAndLine() {
+    var breach =
+        new ReserveBreach(
+            TUK75, new BigDecimal("20000"), new BigDecimal("50000"), new BigDecimal("30000"), HARD);
+    var result =
+        new LimitCheckResult(TUK75, LocalDate.of(2026, 3, 4), List.of(), List.of(), breach, null);
+
+    notifier.notify(List.of(result));
+
+    var captor = org.mockito.ArgumentCaptor.forClass(String.class);
+    verify(notificationService).sendMessage(captor.capture(), eq(INVESTMENT));
+    var message = captor.getValue();
+    assertThat(message).contains("🛑 LIMIT BREACH DETECTED");
+    assertThat(message).contains("🛑 [HARD] RESERVE");
+  }
+
+  @Test
+  void headerReflectsWorstSeverityWhenSoftAndHardMixed() {
+    var soft =
+        new ProviderBreach(
+            TUK75, ISHARES, new BigDecimal("35"), new BigDecimal("30"), new BigDecimal("40"), SOFT);
+    var hard =
+        new ReserveBreach(
+            TUK75, new BigDecimal("20000"), new BigDecimal("50000"), new BigDecimal("30000"), HARD);
+    var result =
+        new LimitCheckResult(TUK75, LocalDate.of(2026, 3, 4), List.of(), List.of(soft), hard, null);
+
+    notifier.notify(List.of(result));
+
+    var captor = org.mockito.ArgumentCaptor.forClass(String.class);
+    verify(notificationService).sendMessage(captor.capture(), eq(INVESTMENT));
+    var message = captor.getValue();
+    assertThat(message).contains("🛑 LIMIT BREACH DETECTED");
+    assertThat(message).contains("⚠️ [SOFT] PROVIDER");
+    assertThat(message).contains("🛑 [HARD] RESERVE");
   }
 
   @Test

--- a/src/test/groovy/ee/tuleva/onboarding/investment/check/tracking/TrackingDifferenceNotifierTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/check/tracking/TrackingDifferenceNotifierTest.java
@@ -62,6 +62,35 @@ class TrackingDifferenceNotifierTest {
   }
 
   @Test
+  void withinLimitsShowsGreenIcon() {
+    var result = result(false, 0, BigDecimal.ZERO);
+
+    notifier.notify(List.of(result));
+
+    then(notificationService).should().sendMessage(contains("✅"), eq(INVESTMENT));
+  }
+
+  @Test
+  void breachShowsRedIconInHeaderAndLine() {
+    var result = result(true, 1, new BigDecimal("0.0015"));
+
+    notifier.notify(List.of(result));
+
+    var captor = org.mockito.ArgumentCaptor.forClass(String.class);
+    then(notificationService).should().sendMessage(captor.capture(), eq(INVESTMENT));
+    var message = captor.getValue();
+    assertThat(message).contains("🛑 TD BREACH DETECTED");
+    assertThat(message).contains("🛑 [TUK75]");
+  }
+
+  @Test
+  void checkCouldNotRunShowsYellowIcon() {
+    notifier.notifyCheckCouldNotRun(TUK75, LocalDate.of(2026, 6, 25));
+
+    then(notificationService).should().sendMessage(contains("⚠️"), eq(INVESTMENT));
+  }
+
+  @Test
   void includesFullAttributionDetail() {
     var attributions =
         List.of(


### PR DESCRIPTION
## Why

TD-check and limit-breach Slack messages in the `INVESTMENT` channel were a wall of text — a meaningful breach was easy to miss. NAV-calculation and import-health messages already use red/yellow/green icons (`NavNotifier`, `HealthCheckNotifier`); this applies the **same convention** to the TD and limit notifiers so severity is scannable at a glance.

- 🛑 red — hard limit breach
- ⚠️ yellow — soft breach / degraded (check did not run)
- ✅ green — within limits

## Changes

**`LimitCheckNotifier`**
- `LIMIT BREACH DETECTED` header carries the icon of the **worst** severity present (🛑 if any HARD, else ⚠️)
- Each POSITION / PROVIDER / RESERVE breach line is prefixed with its own severity icon
- "within limits" summary prefixed ✅
- Added `worse(...)` / `severityIcon(...)` helpers over the existing `BreachSeverity` enum

**`TrackingDifferenceNotifier`** (TD breach is binary per `TrackingDifferenceResult.hasAnyBreach()`)
- `TD check completed: within limits` → ✅
- `TD BREACH DETECTED` / `TD ESCALATION` header and each breach line → 🛑
- `TD CHECK DID NOT RUN` (NAV published without TD validation) → ⚠️

### Before / after

```
LIMIT BREACH DETECTED                 →   ⚠️ LIMIT BREACH DETECTED
[SOFT] RESERVE TUK00: cash=...             ⚠️ [SOFT] RESERVE TUK00: cash=...
```

## Tests

Added icon assertions to both `*NotifierTest` files, including a mixed soft+hard case verifying the header reflects the worst severity. All affected tests + Spotless pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)