### PR TITLE
Offer eligible children for account opening via GET /v1/me/children

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/party/ChildController.java
+++ b/src/main/java/ee/tuleva/onboarding/party/ChildController.java
@@ -3,10 +3,12 @@ package ee.tuleva.onboarding.party;
 import ee.tuleva.onboarding.auth.principal.AuthenticatedPerson;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -18,6 +20,15 @@ import org.springframework.web.bind.annotation.RestController;
 class ChildController {
 
   private final ChildOnboardingService childOnboardingService;
+
+  @GetMapping
+  @Operation(summary = "List children the user can open a savings fund account for")
+  public List<EligibleChildResponse> listChildren(
+      @AuthenticationPrincipal AuthenticatedPerson authenticatedPerson) {
+    return childOnboardingService.findEligibleChildren(authenticatedPerson).stream()
+        .map(EligibleChildResponse::new)
+        .toList();
+  }
 
   @PostMapping
   @Operation(summary = "Open a savings fund account for a represented child")

--- a/src/main/java/ee/tuleva/onboarding/party/ChildOnboardingService.java
+++ b/src/main/java/ee/tuleva/onboarding/party/ChildOnboardingService.java
@@ -6,7 +6,11 @@ import ee.tuleva.onboarding.event.TrackableEvent;
 import ee.tuleva.onboarding.event.TrackableEventType;
 import ee.tuleva.onboarding.populationregister.PopulationRegisterPerson;
 import ee.tuleva.onboarding.savings.fund.SavingsFundOnboardingService;
+import ee.tuleva.onboarding.user.personalcode.PersonalCode;
+import java.time.Clock;
 import java.time.Duration;
+import java.time.LocalDate;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
@@ -25,6 +29,16 @@ public class ChildOnboardingService {
   private final SavingsFundOnboardingService savingsFundOnboardingService;
   private final AmlService amlService;
   private final ApplicationEventPublisher applicationEventPublisher;
+  private final Clock clock;
+
+  public List<String> findEligibleChildren(AuthenticatedPerson parent) {
+    LocalDate today = LocalDate.now(clock);
+    return custodyVerificationService
+        .findChildrenWithAssetManagementCustody(parent.getPersonalCode(), CUSTODY_MAX_AGE)
+        .stream()
+        .filter(childPersonalCode -> PersonalCode.isMinor(childPersonalCode, today))
+        .toList();
+  }
 
   @Transactional
   public ChildOnboardingResult onboardChild(AuthenticatedPerson parent, String childPersonalCode) {

--- a/src/main/java/ee/tuleva/onboarding/party/CustodyVerificationService.java
+++ b/src/main/java/ee/tuleva/onboarding/party/CustodyVerificationService.java
@@ -26,6 +26,15 @@ public class CustodyVerificationService {
 
   private final PopulationRegisterClient populationRegisterClient;
 
+  public List<String> findChildrenWithAssetManagementCustody(
+      String parentPersonalCode, Duration maxAge) {
+    return populationRegisterClient.fetchCustodyRights(parentPersonalCode, maxAge).data().stream()
+        .filter(CustodyRight::grantsAssetManagement)
+        .map(CustodyRight::childPersonalCode)
+        .distinct()
+        .toList();
+  }
+
   public CustodyVerification verify(
       String parentPersonalCode, String childPersonalCode, Duration maxAge) {
     PopulationRegisterResult<List<CustodyRight>> custodyResult =

--- a/src/main/java/ee/tuleva/onboarding/party/EligibleChildResponse.java
+++ b/src/main/java/ee/tuleva/onboarding/party/EligibleChildResponse.java
@@ -1,0 +1,3 @@
+package ee.tuleva.onboarding.party;
+
+public record EligibleChildResponse(String personalCode) {}

--- a/src/main/java/ee/tuleva/onboarding/party/ParentChildLinkRegistrationService.java
+++ b/src/main/java/ee/tuleva/onboarding/party/ParentChildLinkRegistrationService.java
@@ -32,12 +32,10 @@ public class ParentChildLinkRegistrationService {
       String childFirstName,
       String childLastName) {
 
-    LocalDate dateOfBirth = PersonalCode.getDateOfBirth(childPersonalCode);
-    LocalDate eighteenthBirthday = dateOfBirth.plusYears(18);
-    LocalDate today = LocalDate.now(clock);
-    if (dateOfBirth.isAfter(today) || !eighteenthBirthday.isAfter(today)) {
+    if (!PersonalCode.isMinor(childPersonalCode, LocalDate.now(clock))) {
       throw new ChildIsNotAMinorException(childPersonalCode);
     }
+    LocalDate eighteenthBirthday = PersonalCode.getDateOfBirth(childPersonalCode).plusYears(18);
 
     upsertPerson(childPersonalCode, childFirstName, childLastName);
     return findOrCreateLink(

--- a/src/main/java/ee/tuleva/onboarding/user/personalcode/PersonalCode.java
+++ b/src/main/java/ee/tuleva/onboarding/user/personalcode/PersonalCode.java
@@ -35,6 +35,11 @@ public class PersonalCode {
     return period.getYears();
   }
 
+  public static boolean isMinor(String personalCode, LocalDate today) {
+    LocalDate dateOfBirth = getDateOfBirth(personalCode);
+    return !dateOfBirth.isAfter(today) && dateOfBirth.plusYears(18).isAfter(today);
+  }
+
   public static int getRetirementAge(String personalCode) {
     return Period.between(getDateOfBirth(personalCode), getRetirementDate(personalCode)).getYears();
   }

--- a/src/test/groovy/ee/tuleva/onboarding/party/ChildControllerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/party/ChildControllerTest.java
@@ -6,6 +6,7 @@ import static org.mockito.BDDMockito.given;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -41,6 +42,18 @@ class ChildControllerTest {
   private final Authentication authentication =
       new UsernamePasswordAuthenticationToken(
           parent, null, List.of(new SimpleGrantedAuthority(USER)));
+
+  @Test
+  void listChildren_returnsEligibleChildPersonalCodes() throws Exception {
+    given(childOnboardingService.findEligibleChildren(parent))
+        .willReturn(List.of(CHILD, "61001010000"));
+
+    mvc.perform(get("/v1/me/children").with(authentication(authentication)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.length()").value(2))
+        .andExpect(jsonPath("$[0].personalCode").value(CHILD))
+        .andExpect(jsonPath("$[1].personalCode").value("61001010000"));
+  }
 
   @Test
   void verifiedCustody_returnsOkWithChildIdentity() throws Exception {

--- a/src/test/groovy/ee/tuleva/onboarding/party/ChildOnboardingServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/party/ChildOnboardingServiceTest.java
@@ -17,11 +17,15 @@ import ee.tuleva.onboarding.event.TrackableEvent;
 import ee.tuleva.onboarding.event.TrackableEventType;
 import ee.tuleva.onboarding.populationregister.PopulationRegisterPerson;
 import ee.tuleva.onboarding.savings.fund.SavingsFundOnboardingService;
+import java.time.Clock;
+import java.time.Instant;
 import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.List;
 import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
@@ -31,6 +35,7 @@ class ChildOnboardingServiceTest {
 
   private static final String PARENT = "38812121215";
   private static final String CHILD = "61506150006";
+  private static final String ADULT = "39912310015";
 
   @Mock private CustodyVerificationService custodyVerificationService;
   @Mock private ParentChildLinkRegistrationService parentChildLinkRegistrationService;
@@ -38,7 +43,21 @@ class ChildOnboardingServiceTest {
   @Mock private AmlService amlService;
   @Mock private ApplicationEventPublisher applicationEventPublisher;
 
-  @InjectMocks private ChildOnboardingService service;
+  private final Clock clock = Clock.fixed(Instant.parse("2026-05-22T00:00:00Z"), ZoneOffset.UTC);
+
+  private ChildOnboardingService service;
+
+  @BeforeEach
+  void setUp() {
+    service =
+        new ChildOnboardingService(
+            custodyVerificationService,
+            parentChildLinkRegistrationService,
+            savingsFundOnboardingService,
+            amlService,
+            applicationEventPublisher,
+            clock);
+  }
 
   private final AuthenticatedPerson parent = sampleAuthenticatedPersonNonMember().build();
 
@@ -47,6 +66,26 @@ class ChildOnboardingServiceTest {
           CHILD, "MARI", "MAASIKAS", LocalDate.of(2015, 6, 15), ALIVE, "EESTI VABARIIK");
 
   private static final String CUSTODY_MESSAGE_ID = "11111111-1111-1111-1111-111111111111";
+
+  @Test
+  void findEligibleChildren_returnsChildrenWithAssetManagementCustody() {
+    given(
+            custodyVerificationService.findChildrenWithAssetManagementCustody(
+                PARENT, CUSTODY_MAX_AGE))
+        .willReturn(List.of(CHILD));
+
+    assertThat(service.findEligibleChildren(parent)).containsExactly(CHILD);
+  }
+
+  @Test
+  void findEligibleChildren_excludesChildrenWhoAreNoLongerMinors() {
+    given(
+            custodyVerificationService.findChildrenWithAssetManagementCustody(
+                PARENT, CUSTODY_MAX_AGE))
+        .willReturn(List.of(CHILD, ADULT));
+
+    assertThat(service.findEligibleChildren(parent)).containsExactly(CHILD);
+  }
 
   @Test
   void verifiedCustody_createsLinkSeedsOnboardingRecordsCheckReturnsChild() {

--- a/src/test/groovy/ee/tuleva/onboarding/party/CustodyVerificationServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/party/CustodyVerificationServiceTest.java
@@ -178,6 +178,21 @@ class CustodyVerificationServiceTest {
                 CHILD_MESSAGE_ID.toString()));
   }
 
+  @Test
+  void listsDistinctChildrenWhoseCustodyGrantsAssetManagement() {
+    givenCustodyRights(
+        new CustodyRight(CHILD, PERSONAL, true, true),
+        new CustodyRight(CHILD, PROPERTY, true, true),
+        new CustodyRight(CHILD, PROPERTY, true, true),
+        new CustodyRight(OTHER_CHILD, PERSONAL, true, true),
+        new CustodyRight("60303030004", PROPERTY, false, true),
+        new CustodyRight("60404040005", PROPERTY, true, false));
+
+    List<String> children = service.findChildrenWithAssetManagementCustody(PARENT, MAX_AGE);
+
+    assertThat(children).containsExactly(CHILD);
+  }
+
   private void givenCustodyRights(CustodyRight... rights) {
     given(populationRegisterClient.fetchCustodyRights(PARENT, MAX_AGE))
         .willReturn(new PopulationRegisterResult<>(List.of(rights), CUSTODY_MESSAGE_ID));

--- a/src/test/groovy/ee/tuleva/onboarding/user/personalcode/PersonalCodeTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/user/personalcode/PersonalCodeTest.java
@@ -33,6 +33,26 @@ class PersonalCodeTest {
   }
 
   @Test
+  void isMinor_trueForAChildUnderEighteen() {
+    assertThat(PersonalCode.isMinor("61506150006", LocalDate.of(2026, 5, 22))).isTrue();
+  }
+
+  @Test
+  void isMinor_trueOnTheDayBeforeTheEighteenthBirthday() {
+    assertThat(PersonalCode.isMinor("50805230009", LocalDate.of(2026, 5, 22))).isTrue();
+  }
+
+  @Test
+  void isMinor_falseFromTheEighteenthBirthday() {
+    assertThat(PersonalCode.isMinor("50805220008", LocalDate.of(2026, 5, 22))).isFalse();
+  }
+
+  @Test
+  void isMinor_falseForADateOfBirthInTheFuture() {
+    assertThat(PersonalCode.isMinor("62701010004", LocalDate.of(2026, 5, 22))).isFalse();
+  }
+
+  @Test
   void testGetRetirementAge() {
     String personalCode = "39912310015";
     assertEquals(65, PersonalCode.getRetirementAge(personalCode));


### PR DESCRIPTION
## What

Adds `GET /v1/me/children` returning the personal codes of children the authenticated user can open a savings fund account for, so the client can offer a dropdown instead of manual personal code entry (TulevaEE/onboarding-client counterpart branch: `TKF-offer-dropdown-for-children`).

## How

- `CustodyVerificationService.findChildrenWithAssetManagementCustody` reuses the existing population register custody query (same 24h max-age as the POST flow, so the stored-response reuse means no extra register traffic between listing and verifying) and returns distinct child codes with a valid property custody (H20) right for a living child.
- `ChildOnboardingService.findEligibleChildren` filters the list to minors via a new shared `PersonalCode.isMinor`, which the `ParentChildLinkRegistrationService` registration guard now reuses — the listing and the POST-time check cannot drift apart.
- Codes only for now; the `EligibleChildResponse` record leaves room to add names later.

Children already onboarded are intentionally not excluded — the POST is idempotent for them.