### PR TITLE
Match GAS trade calculator: sell safety-spill, no over-sell, no stranded cash (§4.12)

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionInputService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionInputService.java
@@ -332,6 +332,11 @@ public class TransactionInputService {
     BigDecimal bufferPercent =
         investmentParameterRepository.findLatestValue(R16_BUFFER_PERCENT, asOfDate);
     BigDecimal step = investmentParameterRepository.findLatestValue(R16_ROUNDING_STEP, asOfDate);
+    if (step.signum() <= 0) {
+      throw new IllegalStateException(
+          "Invalid investment parameter: parameter=R16_ROUNDING_STEP, value="
+              + step.toPlainString());
+    }
     return totalOutflowEur
         .abs()
         .multiply(ONE.add(bufferPercent))

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionInputService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionInputService.java
@@ -60,6 +60,7 @@ public class TransactionInputService {
 
   private static final Set<TulevaFund> PEVA_RAVA_FUNDS = Set.of(TUK75, TUK00);
   private static final Set<TulevaFund> R16_FUNDS = Set.of(TUK75, TUK00, TUV100);
+  private static final BigDecimal MODEL_WEIGHT_SUM_TOLERANCE = new BigDecimal("0.0001");
 
   private final FundPositionRepository fundPositionRepository;
   private final FeeAccrualRepository feeAccrualRepository;
@@ -101,6 +102,7 @@ public class TransactionInputService {
             .filter(a -> a.getIsin() != null)
             .toList();
     List<ModelWeight> modelWeights = toModelWeights(allocations);
+    assertModelWeightsSumToOne(fund, modelWeights);
     BigDecimal cashBuffer = getCashBuffer(fund, asOfDate);
     BigDecimal minTransaction = getMinTransaction(fund, asOfDate);
     Map<String, PositionLimitSnapshot> positionLimits = getPositionLimits(fund, asOfDate);
@@ -190,6 +192,18 @@ public class TransactionInputService {
     return allocations.stream()
         .map(allocation -> new ModelWeight(allocation.getIsin(), allocation.getWeight()))
         .toList();
+  }
+
+  private void assertModelWeightsSumToOne(TulevaFund fund, List<ModelWeight> modelWeights) {
+    if (modelWeights.isEmpty()) {
+      return;
+    }
+    BigDecimal totalWeight =
+        modelWeights.stream().map(ModelWeight::weight).reduce(ZERO, BigDecimal::add);
+    if (totalWeight.subtract(ONE).abs().compareTo(MODEL_WEIGHT_SUM_TOLERANCE) > 0) {
+      throw new IllegalStateException(
+          "Model weights do not sum to 1: fund=" + fund + ", sum=" + totalWeight.toPlainString());
+    }
   }
 
   private BigDecimal getCashBuffer(TulevaFund fund, LocalDate asOfDate) {

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionPreparationService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionPreparationService.java
@@ -17,6 +17,7 @@ import java.math.RoundingMode;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.HashMap;
@@ -36,6 +37,8 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 @Service
 @RequiredArgsConstructor
 public class TransactionPreparationService {
+
+  private static final int STALE_PRICE_THRESHOLD_DAYS = 3;
 
   private final TransactionInputService inputService;
   private final TradeCalculationEngine calculationEngine;
@@ -245,6 +248,9 @@ public class TransactionPreparationService {
                       ? TransactionType.BUY
                       : TransactionType.SELL;
               var orderAmount = trade.tradeAmount().abs();
+              var orderQuantity =
+                  resolveOrderQuantity(
+                      instrumentType, transactionType, trade.isin(), orderAmount, asOfDate);
               return TransactionOrder.builder()
                   .batch(batch)
                   .fund(result.fund())
@@ -252,9 +258,8 @@ public class TransactionPreparationService {
                   .transactionType(transactionType)
                   .instrumentType(instrumentType)
                   .orderAmount(orderAmount)
-                  .orderQuantity(
-                      calculateOrderQuantity(
-                          instrumentType, transactionType, trade.isin(), orderAmount, asOfDate))
+                  .orderQuantity(orderQuantity.quantity())
+                  .comment(orderQuantity.stalePriceComment())
                   .orderVenue(input.orderVenues().getOrDefault(trade.isin(), OrderVenue.SEB))
                   .createdAt(createdAt)
                   .build();
@@ -262,25 +267,26 @@ public class TransactionPreparationService {
         .toList();
   }
 
-  @Nullable
-  private BigDecimal calculateOrderQuantity(
+  private record OrderQuantity(@Nullable BigDecimal quantity, @Nullable String stalePriceComment) {}
+
+  private OrderQuantity resolveOrderQuantity(
       InstrumentType instrumentType,
       TransactionType transactionType,
       String isin,
       BigDecimal orderAmount,
       LocalDate asOfDate) {
     if (isAmountBasedOrder(instrumentType, transactionType)) {
-      return null;
+      return new OrderQuantity(null, null);
     }
-    BigDecimal price =
-        positionPriceResolver.resolve(isin, asOfDate).map(ResolvedPrice::usedPrice).orElse(null);
+    ResolvedPrice resolvedPrice = positionPriceResolver.resolve(isin, asOfDate).orElse(null);
+    BigDecimal price = resolvedPrice == null ? null : resolvedPrice.usedPrice();
     if (price == null) {
       log.warn(
           "No price found for order quantity: isin={}, instrumentType={}, asOfDate={}",
           isin,
           instrumentType,
           asOfDate);
-      return null;
+      return new OrderQuantity(null, null);
     }
     if (price.signum() <= 0) {
       log.warn(
@@ -290,9 +296,32 @@ public class TransactionPreparationService {
           instrumentType,
           price.toPlainString(),
           asOfDate);
+      return new OrderQuantity(null, null);
+    }
+    BigDecimal quantity = orderAmount.divide(price, 6, RoundingMode.HALF_UP);
+    String stalePriceComment = describeIfStale(isin, resolvedPrice, asOfDate);
+    return new OrderQuantity(quantity, stalePriceComment);
+  }
+
+  @Nullable
+  private String describeIfStale(String isin, ResolvedPrice resolvedPrice, LocalDate asOfDate) {
+    LocalDate priceDate = resolvedPrice.priceDate();
+    if (priceDate == null) {
       return null;
     }
-    return orderAmount.divide(price, 6, RoundingMode.HALF_UP);
+    long ageDays = ChronoUnit.DAYS.between(priceDate, asOfDate);
+    if (ageDays <= STALE_PRICE_THRESHOLD_DAYS) {
+      return null;
+    }
+    log.warn(
+        "Order sized on stale price: isin={}, priceDate={}, ageDays={}, source={}, asOfDate={}",
+        isin,
+        priceDate,
+        ageDays,
+        resolvedPrice.priceSource(),
+        asOfDate);
+    return "Sized on stale price: priceDate=%s, ageDays=%d, source=%s"
+        .formatted(priceDate, ageDays, resolvedPrice.priceSource());
   }
 
   private boolean isAmountBasedOrder(

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/calculation/TradeCalculationEngine.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/calculation/TradeCalculationEngine.java
@@ -26,6 +26,7 @@ public class TradeCalculationEngine {
 
   private static final int SCALE = 2;
   private static final int MAX_ITERATIONS = 20;
+  private static final int DISTRIBUTE_CAPPED_GUARD_MARGIN = 5;
   private static final BigDecimal MIN_MEANINGFUL_AMOUNT = new BigDecimal("0.01");
 
   public FundCalculationResult calculate(FundTransactionInput input, TransactionMode mode) {
@@ -265,13 +266,45 @@ public class TradeCalculationEngine {
             .toList();
 
     boolean anyOverSoftLimit = filteredScores.stream().anyMatch(score -> score.compareTo(ZERO) > 0);
-    List<BigDecimal> finalScores = anyOverSoftLimit ? filteredScores : standardScores;
 
-    List<BigDecimal> distributed = distributeSellWithCap(input, finalScores, targetSellAmount);
+    List<BigDecimal> distributed =
+        anyOverSoftLimit
+            ? distributeOverSoftReliefThenSpill(
+                input, filteredScores, standardScores, targetSellAmount)
+            : distributeSellWithCap(input, standardScores, targetSellAmount);
+    List<BigDecimal> raised =
+        applySellSafetySpill(distributed, input, standardScores, targetSellAmount);
 
-    return distributed.stream()
+    return raised.stream()
         .map(value -> value.compareTo(ZERO) == 0 ? ZERO : value.negate())
         .toList();
+  }
+
+  private List<BigDecimal> distributeOverSoftReliefThenSpill(
+      FundTransactionInput input,
+      List<BigDecimal> filteredScores,
+      List<BigDecimal> standardScores,
+      BigDecimal targetSellAmount) {
+    BigDecimal threshold = input.minTransactionThreshold();
+    BigDecimal[] relief =
+        distributeCapped(filteredScores, targetSellAmount, threshold, standardScores);
+    BigDecimal remaining = targetSellAmount.subtract(sum(relief));
+
+    if (remaining.compareTo(threshold.subtract(MIN_MEANINGFUL_AMOUNT)) < 0) {
+      return List.of(relief);
+    }
+
+    List<BigDecimal> spillScores =
+        IntStream.range(0, relief.length)
+            .mapToObj(i -> relief[i].compareTo(ZERO) > 0 ? ZERO : standardScores.get(i))
+            .toList();
+    List<BigDecimal> spillCaps =
+        IntStream.range(0, relief.length)
+            .mapToObj(
+                i -> relief[i].compareTo(ZERO) > 0 ? ZERO : input.positions().get(i).marketValue())
+            .toList();
+    addInto(relief, distributeCapped(spillScores, remaining, threshold, spillCaps));
+    return List.of(relief);
   }
 
   private List<BigDecimal> distributeSellWithCap(
@@ -307,17 +340,11 @@ public class TradeCalculationEngine {
 
       List<BigDecimal> roundScores =
           IntStream.range(0, size).mapToObj(i -> capped[i] ? ZERO : scores.get(i)).toList();
-      BigDecimal roundThreshold = threshold;
       if (roundScores.stream().allMatch(s -> s.compareTo(ZERO) == 0)) {
-        roundScores = remainingMarketValueScores(input, allocations, capped);
-        roundThreshold = ZERO;
-        if (roundScores.stream().allMatch(s -> s.compareTo(ZERO) == 0)) {
-          break;
-        }
+        break;
       }
 
-      List<BigDecimal> round =
-          distributeAmountWithThreshold(roundScores, remainingNeed, roundThreshold);
+      List<BigDecimal> round = distributeAmountWithThreshold(roundScores, remainingNeed, threshold);
 
       boolean newlyCapped = false;
       for (int i = 0; i < size; i++) {
@@ -347,15 +374,182 @@ public class TradeCalculationEngine {
     return List.of(allocations);
   }
 
-  private List<BigDecimal> remainingMarketValueScores(
-      FundTransactionInput input, BigDecimal[] allocations, boolean[] capped) {
-    return IntStream.range(0, input.positions().size())
-        .mapToObj(
-            i ->
-                capped[i]
-                    ? ZERO
-                    : input.positions().get(i).marketValue().subtract(allocations[i]).max(ZERO))
+  private List<BigDecimal> applySellSafetySpill(
+      List<BigDecimal> sells,
+      FundTransactionInput input,
+      List<BigDecimal> scores,
+      BigDecimal targetSellAmount) {
+    List<BigDecimal> marketValues =
+        input.positions().stream().map(PositionSnapshot::marketValue).toList();
+    BigDecimal threshold = input.minTransactionThreshold();
+    BigDecimal[] raisedSells = sells.toArray(new BigDecimal[0]);
+    BigDecimal residual = targetSellAmount.subtract(sum(raisedSells));
+
+    residual = spillOpenNewSells(raisedSells, marketValues, targetSellAmount, threshold, residual);
+    residual = spillTopUpSellingPositions(raisedSells, marketValues, targetSellAmount, residual);
+    spillLiquidateTrappedOddLots(raisedSells, marketValues, scores, threshold, residual);
+
+    return List.of(raisedSells);
+  }
+
+  private BigDecimal spillOpenNewSells(
+      BigDecimal[] sells,
+      List<BigDecimal> marketValues,
+      BigDecimal targetSellAmount,
+      BigDecimal threshold,
+      BigDecimal residual) {
+    if (residual.compareTo(threshold.subtract(MIN_MEANINGFUL_AMOUNT)) < 0) {
+      return residual;
+    }
+    List<BigDecimal> sellHeadroom = remainingSellHeadroom(sells, marketValues);
+    if (sellHeadroom.stream().noneMatch(v -> v.compareTo(MIN_MEANINGFUL_AMOUNT) > 0)) {
+      return residual;
+    }
+    addInto(sells, distributeCapped(sellHeadroom, residual, threshold, sellHeadroom));
+    return targetSellAmount.subtract(sum(sells));
+  }
+
+  private BigDecimal spillTopUpSellingPositions(
+      BigDecimal[] sells,
+      List<BigDecimal> marketValues,
+      BigDecimal targetSellAmount,
+      BigDecimal residual) {
+    if (residual.compareTo(MIN_MEANINGFUL_AMOUNT) <= 0) {
+      return residual;
+    }
+    List<BigDecimal> topUpHeadroom =
+        IntStream.range(0, sells.length)
+            .mapToObj(
+                i ->
+                    sells[i].compareTo(MIN_MEANINGFUL_AMOUNT) > 0
+                        ? marketValues.get(i).subtract(sells[i]).max(ZERO)
+                        : ZERO)
+            .toList();
+    if (topUpHeadroom.stream().noneMatch(v -> v.compareTo(MIN_MEANINGFUL_AMOUNT) > 0)) {
+      return residual;
+    }
+    addInto(sells, distributeCapped(topUpHeadroom, residual, ZERO, topUpHeadroom));
+    return targetSellAmount.subtract(sum(sells));
+  }
+
+  private void spillLiquidateTrappedOddLots(
+      BigDecimal[] sells,
+      List<BigDecimal> marketValues,
+      List<BigDecimal> scores,
+      BigDecimal threshold,
+      BigDecimal residual) {
+    if (residual.compareTo(MIN_MEANINGFUL_AMOUNT) <= 0) {
+      return;
+    }
+    BigDecimal thresholdTolerance = threshold.subtract(MIN_MEANINGFUL_AMOUNT);
+    List<Integer> oddLots = new ArrayList<>();
+    for (int i = 0; i < sells.length; i++) {
+      BigDecimal remaining = marketValues.get(i).subtract(sells[i]);
+      if (remaining.compareTo(MIN_MEANINGFUL_AMOUNT) > 0
+          && remaining.compareTo(thresholdTolerance) < 0) {
+        oddLots.add(i);
+      }
+    }
+    oddLots.sort(
+        (indexA, indexB) -> {
+          int byScore = scores.get(indexB).compareTo(scores.get(indexA));
+          return byScore != 0
+              ? byScore
+              : marketValues
+                  .get(indexB)
+                  .subtract(sells[indexB])
+                  .compareTo(marketValues.get(indexA).subtract(sells[indexA]));
+        });
+    BigDecimal remaining = residual;
+    for (int i : oddLots) {
+      if (remaining.compareTo(MIN_MEANINGFUL_AMOUNT) <= 0) {
+        break;
+      }
+      BigDecimal oddLot = marketValues.get(i).subtract(sells[i]);
+      sells[i] = sells[i].add(oddLot);
+      remaining = remaining.subtract(oddLot);
+    }
+  }
+
+  private BigDecimal[] distributeCapped(
+      List<BigDecimal> scores, BigDecimal amount, BigDecimal threshold, List<BigDecimal> caps) {
+    int size = scores.size();
+    BigDecimal thresholdTolerance = threshold.subtract(MIN_MEANINGFUL_AMOUNT);
+    Map<Integer, BigDecimal> fixed = new HashMap<>();
+    List<Integer> active = new ArrayList<>();
+    for (int i = 0; i < size; i++) {
+      if (scores.get(i).compareTo(ZERO) > 0 && caps.get(i).compareTo(thresholdTolerance) >= 0) {
+        active.add(i);
+      }
+    }
+
+    for (int guard = 0;
+        guard < size + DISTRIBUTE_CAPPED_GUARD_MARGIN && !active.isEmpty();
+        guard++) {
+      BigDecimal remaining = amount.subtract(fixed.values().stream().reduce(ZERO, BigDecimal::add));
+      if (remaining.compareTo(thresholdTolerance) < 0) {
+        break;
+      }
+      BigDecimal sumScores = active.stream().map(scores::get).reduce(ZERO, BigDecimal::add);
+      if (sumScores.compareTo(ZERO) == 0) {
+        break;
+      }
+
+      List<Integer> over = new ArrayList<>();
+      BigDecimal minAllocation = null;
+      int minPosition = -1;
+      for (int position = 0; position < active.size(); position++) {
+        int index = active.get(position);
+        BigDecimal allocation =
+            scores.get(index).multiply(remaining).divide(sumScores, SCALE, HALF_UP);
+        if (allocation.compareTo(caps.get(index)) > 0) {
+          over.add(index);
+        }
+        if (minAllocation == null || allocation.compareTo(minAllocation) < 0) {
+          minAllocation = allocation;
+          minPosition = position;
+        }
+      }
+
+      if (!over.isEmpty()) {
+        over.forEach(index -> fixed.put(index, caps.get(index)));
+        active.removeAll(over);
+        continue;
+      }
+      if (minAllocation.compareTo(thresholdTolerance) < 0) {
+        active.remove(minPosition);
+        continue;
+      }
+      for (int index : active) {
+        fixed.put(index, scores.get(index).multiply(remaining).divide(sumScores, SCALE, HALF_UP));
+      }
+      active.clear();
+    }
+
+    return IntStream.range(0, size)
+        .mapToObj(i -> fixed.getOrDefault(i, ZERO).setScale(SCALE, HALF_UP))
+        .toArray(BigDecimal[]::new);
+  }
+
+  private List<BigDecimal> remainingSellHeadroom(
+      BigDecimal[] sells, List<BigDecimal> marketValues) {
+    return IntStream.range(0, sells.length)
+        .mapToObj(i -> marketValues.get(i).subtract(sells[i]).max(ZERO))
         .toList();
+  }
+
+  private void addInto(BigDecimal[] out, BigDecimal[] delta) {
+    for (int i = 0; i < out.length; i++) {
+      out[i] = out[i].add(delta[i]);
+    }
+  }
+
+  private BigDecimal sum(BigDecimal[] values) {
+    BigDecimal total = ZERO;
+    for (BigDecimal value : values) {
+      total = total.add(value);
+    }
+    return total;
   }
 
   private List<BigDecimal> calculateSellFast(FundTransactionInput input) {
@@ -388,25 +582,32 @@ public class TradeCalculationEngine {
       }
     }
 
-    BigDecimal amountFromFast = ZERO;
     if (!fastIndices.isEmpty()) {
       if (targetAmount.compareTo(totalFastValue) >= 0) {
-        amountFromFast = totalFastValue;
         for (int i : fastIndices) {
           results[i] = input.positions().get(i).marketValue().negate();
         }
       } else {
-        amountFromFast = targetAmount;
-        distributeSellByOverweight(input, fastIndices, targetValues, amountFromFast, results);
+        distributeSellByOverweight(input, fastIndices, targetValues, targetAmount, results);
       }
     }
 
+    BigDecimal amountFromFast =
+        fastIndices.stream().map(i -> results[i].negate()).reduce(ZERO, BigDecimal::add);
     BigDecimal remainingNeed = targetAmount.subtract(amountFromFast);
     if (remainingNeed.compareTo(MIN_MEANINGFUL_AMOUNT) > 0 && !slowIndices.isEmpty()) {
       distributeSellByOverweight(input, slowIndices, targetValues, remainingNeed, results);
     }
 
-    return List.of(results);
+    List<BigDecimal> sells = IntStream.range(0, size).mapToObj(i -> results[i].negate()).toList();
+    List<BigDecimal> overweightScores =
+        IntStream.range(0, size)
+            .mapToObj(
+                i -> input.positions().get(i).marketValue().subtract(targetValues.get(i)).max(ZERO))
+            .toList();
+    List<BigDecimal> raised = applySellSafetySpill(sells, input, overweightScores, targetAmount);
+
+    return raised.stream().map(BigDecimal::negate).toList();
   }
 
   private void distributeSellByOverweight(
@@ -537,12 +738,23 @@ public class TradeCalculationEngine {
 
     List<BigDecimal> buyScores = rawTrades.stream().map(trade -> trade.max(ZERO)).toList();
     List<BigDecimal> sellScores =
-        rawTrades.stream().map(trade -> trade.negate().max(ZERO)).toList();
+        IntStream.range(0, rawTrades.size())
+            .mapToObj(
+                i ->
+                    rawTrades.get(i).negate().max(ZERO).min(input.positions().get(i).marketValue()))
+            .toList();
 
     List<BigDecimal> buyAllocations =
-        distributeBucketWithThreshold(buyScores, input.minTransactionThreshold());
-    List<BigDecimal> sellAllocations =
+        redistributeHardLimitExcess(
+            input,
+            buyScores,
+            distributeBucketWithThreshold(buyScores, input.minTransactionThreshold()));
+    List<BigDecimal> rawSellAllocations =
         distributeBucketWithThreshold(sellScores, input.minTransactionThreshold());
+    List<BigDecimal> sellAllocations =
+        IntStream.range(0, rawSellAllocations.size())
+            .mapToObj(i -> rawSellAllocations.get(i).min(input.positions().get(i).marketValue()))
+            .toList();
 
     return IntStream.range(0, rawTrades.size())
         .mapToObj(i -> buyAllocations.get(i).subtract(sellAllocations.get(i)))

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionInputServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionInputServiceTest.java
@@ -143,6 +143,36 @@ class TransactionInputServiceTest {
   }
 
   @Test
+  void gatherInput_rejectsModelWeightsThatDoNotSumToOne() {
+    var positionDate = AS_OF_DATE;
+    given(fundPositionRepository.findLatestNavDateByFundAndAsOfDate(TUV100, AS_OF_DATE))
+        .willReturn(Optional.of(positionDate));
+    given(fundPositionRepository.findByNavDateAndFundAndAccountType(positionDate, TUV100, SECURITY))
+        .willReturn(List.of());
+    given(fundPositionRepository.findByNavDateAndFundAndAccountType(positionDate, TUV100, CASH))
+        .willReturn(List.of());
+    given(
+            feeAccrualRepository.getAccruedFeesForMonth(
+                eq(TUV100), any(), eq(List.of(FeeType.MANAGEMENT, FeeType.DEPOT)), any()))
+        .willReturn(ZERO);
+
+    var underweightAllocation =
+        ModelPortfolioAllocation.builder()
+            .fund(TUV100)
+            .isin("IE00A")
+            .weight(new BigDecimal("0.90"))
+            .build();
+    given(modelPortfolioAllocationRepository.findLatestByFundAsOf(TUV100, AS_OF_DATE))
+        .willReturn(List.of(underweightAllocation));
+
+    assertThatThrownBy(() -> service.gatherInput(TUV100, AS_OF_DATE, Map.of()))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Model weights do not sum to 1")
+        .hasMessageContaining("fund=TUV100")
+        .hasMessageContaining("sum=0.90");
+  }
+
+  @Test
   void gatherInput_withNoPositionDate_throwsException() {
     when(fundPositionRepository.findLatestNavDateByFundAndAsOfDate(TUV100, AS_OF_DATE))
         .thenReturn(Optional.empty());
@@ -660,7 +690,7 @@ class TransactionInputServiceTest {
         ModelPortfolioAllocation.builder()
             .fund(TUV100)
             .isin("IE00A")
-            .weight(new BigDecimal("0.80"))
+            .weight(new BigDecimal("1.00"))
             .build();
     var allocationWithoutIsin =
         ModelPortfolioAllocation.builder()
@@ -678,7 +708,7 @@ class TransactionInputServiceTest {
     var result = service.gatherInput(TUV100, AS_OF_DATE, Map.of());
 
     assertThat(result.modelWeights())
-        .isEqualTo(List.of(new ModelWeight("IE00A", new BigDecimal("0.80"))));
+        .isEqualTo(List.of(new ModelWeight("IE00A", new BigDecimal("1.00"))));
   }
 
   @Test

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionInputServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionInputServiceTest.java
@@ -1003,6 +1003,42 @@ class TransactionInputServiceTest {
   }
 
   @Test
+  void gatherInput_r16BufferedPhase_rejectsZeroRoundingStep() {
+    stubEmptyBaseline(TUV100);
+    var flow = r16Flow(TUV100, new BigDecimal("10500"));
+    given(r16FlowCalculationService.calculateFlows(TUV100, AS_OF_DATE))
+        .willReturn(Optional.of(flow));
+    given(r16PhaseCalculator.phaseFor(flow, AS_OF_DATE)).willReturn(R16Phase.BUFFERED);
+    given(investmentParameterRepository.findLatestValue(R16_BUFFER_PERCENT, AS_OF_DATE))
+        .willReturn(new BigDecimal("0.02"));
+    given(investmentParameterRepository.findLatestValue(R16_ROUNDING_STEP, AS_OF_DATE))
+        .willReturn(ZERO);
+
+    assertThatThrownBy(() -> service.gatherInput(TUV100, AS_OF_DATE, Map.of()))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("R16_ROUNDING_STEP")
+        .hasMessageContaining("value=0");
+  }
+
+  @Test
+  void gatherInput_r16BufferedPhase_rejectsNegativeRoundingStep() {
+    stubEmptyBaseline(TUV100);
+    var flow = r16Flow(TUV100, new BigDecimal("10500"));
+    given(r16FlowCalculationService.calculateFlows(TUV100, AS_OF_DATE))
+        .willReturn(Optional.of(flow));
+    given(r16PhaseCalculator.phaseFor(flow, AS_OF_DATE)).willReturn(R16Phase.BUFFERED);
+    given(investmentParameterRepository.findLatestValue(R16_BUFFER_PERCENT, AS_OF_DATE))
+        .willReturn(new BigDecimal("0.02"));
+    given(investmentParameterRepository.findLatestValue(R16_ROUNDING_STEP, AS_OF_DATE))
+        .willReturn(new BigDecimal("-1000"));
+
+    assertThatThrownBy(() -> service.gatherInput(TUV100, AS_OF_DATE, Map.of()))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("R16_ROUNDING_STEP")
+        .hasMessageContaining("value=-1000");
+  }
+
+  @Test
   void gatherInput_r16VisiblePhase_addsNothing() {
     stubEmptyBaseline(TUV100);
     var flow = r16Flow(TUV100, new BigDecimal("10500"));

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionPreparationServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionPreparationServiceTest.java
@@ -14,6 +14,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
 import ee.tuleva.onboarding.comparisons.fundvalue.PositionPriceResolver;
+import ee.tuleva.onboarding.comparisons.fundvalue.PriceSource;
 import ee.tuleva.onboarding.comparisons.fundvalue.ResolvedPrice;
 import ee.tuleva.onboarding.investment.portfolio.ModelPortfolioAllocation;
 import ee.tuleva.onboarding.investment.portfolio.ModelPortfolioAllocationRepository;
@@ -651,6 +652,11 @@ class TransactionPreparationServiceTest {
   }
 
   private TransactionCommand givenSingleEtfBuyCommandPricedAt(BigDecimal price) {
+    return givenSingleEtfBuyCommandPricedAt(price, LocalDate.of(2026, 1, 15), null);
+  }
+
+  private TransactionCommand givenSingleEtfBuyCommandPricedAt(
+      BigDecimal price, LocalDate priceDate, PriceSource priceSource) {
     var command =
         TransactionCommand.builder()
             .id(9L)
@@ -690,8 +696,38 @@ class TransactionPreparationServiceTest {
               return batch;
             });
     given(positionPriceResolver.resolve("IE00ETF", LocalDate.of(2026, 1, 15)))
-        .willReturn(Optional.of(ResolvedPrice.builder().usedPrice(price).build()));
+        .willReturn(
+            Optional.of(
+                ResolvedPrice.builder()
+                    .usedPrice(price)
+                    .priceDate(priceDate)
+                    .priceSource(priceSource)
+                    .build()));
     return command;
+  }
+
+  @Test
+  void processCommand_flagsOrderCommentWhenResolvedPriceIsStale() {
+    var command =
+        givenSingleEtfBuyCommandPricedAt(
+            new BigDecimal("3"), LocalDate.of(2026, 1, 10), PriceSource.EODHD);
+
+    var result = service.processCommand(command);
+
+    var order = orderByIsin(result, "IE00ETF");
+    assertThat(order.getComment()).contains("2026-01-10", "5", "EODHD");
+  }
+
+  @Test
+  void processCommand_doesNotFlagOrderCommentWhenResolvedPriceIsWithinStalenessThreshold() {
+    var command =
+        givenSingleEtfBuyCommandPricedAt(
+            new BigDecimal("3"), LocalDate.of(2026, 1, 12), PriceSource.EODHD);
+
+    var result = service.processCommand(command);
+
+    var order = orderByIsin(result, "IE00ETF");
+    assertThat(order.getComment()).isNull();
   }
 
   @Test

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/calculation/TradeCalculationEngineTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/calculation/TradeCalculationEngineTest.java
@@ -627,6 +627,49 @@ class TradeCalculationEngineTest {
   }
 
   @Test
+  void sell_capsOverSoftReliefAtModelAndSpillsExcessToOtherOverweightFunds() {
+    var input =
+        FundTransactionInput.builder()
+            .fund(TUV100)
+            .positions(
+                List.of(
+                    new PositionSnapshot("IE00A", new BigDecimal("550000")),
+                    new PositionSnapshot("IE00B", new BigDecimal("350000")),
+                    new PositionSnapshot("IE00C", new BigDecimal("100000"))))
+            .modelWeights(
+                List.of(
+                    new ModelWeight("IE00A", new BigDecimal("0.40")),
+                    new ModelWeight("IE00B", new BigDecimal("0.30")),
+                    new ModelWeight("IE00C", new BigDecimal("0.30"))))
+            .grossPortfolioValue(new BigDecimal("1000000"))
+            .cashBuffer(ZERO)
+            .liabilities(ZERO)
+            .freeCash(new BigDecimal("-200000"))
+            .minTransactionThreshold(new BigDecimal("5000"))
+            .positionLimits(
+                Map.of(
+                    "IE00A",
+                        new PositionLimitSnapshot(new BigDecimal("0.50"), new BigDecimal("0.60")),
+                    "IE00B",
+                        new PositionLimitSnapshot(new BigDecimal("0.40"), new BigDecimal("0.50"))))
+            .fastSellIsins(Set.of())
+            .build();
+
+    var result = engine.calculate(input, SELL);
+
+    assertThat(result.trades())
+        .usingRecursiveComparison()
+        .withComparatorForType(BigDecimal::compareTo, BigDecimal.class)
+        .isEqualTo(
+            List.of(
+                new TradeCalculation(
+                    "IE00A", new BigDecimal("-150000"), new BigDecimal("0.400000"), OK),
+                new TradeCalculation(
+                    "IE00B", new BigDecimal("-50000"), new BigDecimal("0.300000"), OK),
+                new TradeCalculation("IE00C", ZERO, new BigDecimal("0.100000"), OK)));
+  }
+
+  @Test
   void sellFast_sellsFastTaggedInstrumentsFirst() {
     var input =
         FundTransactionInput.builder()
@@ -881,6 +924,100 @@ class TradeCalculationEngineTest {
 
     assertThat(tradeA.tradeAmount()).isEqualByComparingTo(new BigDecimal("-100000"));
     assertThat(tradeB.tradeAmount()).isEqualByComparingTo(ZERO);
+  }
+
+  @Test
+  void rebalance_neverSellsAnyPositionBeyondItsMarketValue() {
+    var input =
+        FundTransactionInput.builder()
+            .fund(TUV100)
+            .positions(List.of(new PositionSnapshot("IE00A", new BigDecimal("100000"))))
+            .modelWeights(List.of(new ModelWeight("IE00A", new BigDecimal("1.00"))))
+            .grossPortfolioValue(new BigDecimal("100000"))
+            .cashBuffer(ZERO)
+            .liabilities(new BigDecimal("150000"))
+            .freeCash(ZERO)
+            .minTransactionThreshold(new BigDecimal("5000"))
+            .positionLimits(Map.of())
+            .fastSellIsins(Set.of())
+            .build();
+
+    var result = engine.calculate(input, REBALANCE);
+
+    var tradeA =
+        result.trades().stream().filter(t -> t.isin().equals("IE00A")).findFirst().orElseThrow();
+
+    assertThat(tradeA.tradeAmount()).isGreaterThanOrEqualTo(new BigDecimal("-100000"));
+  }
+
+  @Test
+  void rebalance_neverInflatesSurvivingSellAllocationBeyondMarketValueAfterThresholdElimination() {
+    var input =
+        FundTransactionInput.builder()
+            .fund(TUV100)
+            .positions(
+                List.of(
+                    new PositionSnapshot("IE00A", new BigDecimal("3000")),
+                    new PositionSnapshot("IE00B", new BigDecimal("100000"))))
+            .modelWeights(
+                List.of(
+                    new ModelWeight("IE00A", new BigDecimal("0.50")),
+                    new ModelWeight("IE00B", new BigDecimal("0.50"))))
+            .grossPortfolioValue(new BigDecimal("103000"))
+            .cashBuffer(ZERO)
+            .liabilities(new BigDecimal("203000"))
+            .freeCash(ZERO)
+            .minTransactionThreshold(new BigDecimal("5000"))
+            .positionLimits(Map.of())
+            .fastSellIsins(Set.of())
+            .build();
+
+    var result = engine.calculate(input, REBALANCE);
+
+    var tradeB =
+        result.trades().stream().filter(t -> t.isin().equals("IE00B")).findFirst().orElseThrow();
+
+    assertThat(tradeB.tradeAmount()).isGreaterThanOrEqualTo(new BigDecimal("-100000"));
+  }
+
+  @Test
+  void rebalance_waterFillsHardLimitBuyExcessAcrossRunnersInsteadOfStrandingCash() {
+    var input =
+        FundTransactionInput.builder()
+            .fund(TUV100)
+            .positions(
+                List.of(
+                    new PositionSnapshot("IE00A", new BigDecimal("100000")),
+                    new PositionSnapshot("IE00B", new BigDecimal("100000")),
+                    new PositionSnapshot("IE00C", new BigDecimal("300000"))))
+            .modelWeights(
+                List.of(
+                    new ModelWeight("IE00A", new BigDecimal("0.50")),
+                    new ModelWeight("IE00B", new BigDecimal("0.30")),
+                    new ModelWeight("IE00C", new BigDecimal("0.20"))))
+            .grossPortfolioValue(new BigDecimal("1000000"))
+            .cashBuffer(ZERO)
+            .liabilities(ZERO)
+            .freeCash(ZERO)
+            .minTransactionThreshold(new BigDecimal("5000"))
+            .positionLimits(
+                Map.of(
+                    "IE00A",
+                    new PositionLimitSnapshot(new BigDecimal("0.32"), new BigDecimal("0.32"))))
+            .fastSellIsins(Set.of())
+            .build();
+
+    var result = engine.calculate(input, REBALANCE);
+
+    BigDecimal totalBought =
+        result.trades().stream()
+            .map(TradeCalculation::tradeAmount)
+            .filter(amount -> amount.compareTo(ZERO) > 0)
+            .reduce(ZERO, BigDecimal::add);
+
+    assertThat(totalBought).isEqualByComparingTo(new BigDecimal("600000"));
+    assertThat(result.trades())
+        .allSatisfy(trade -> assertThat(trade.limitStatus()).isNotEqualTo(HARD_LIMIT_EXCEEDED));
   }
 
   @Test
@@ -1204,7 +1341,8 @@ class TradeCalculationEngineTest {
   }
 
   @Test
-  void sell_neverSellsAnyPositionBeyondItsMarketValue() {
+  void
+      sell_respectsMinTradeFloorAndLeavesSubThresholdResidualToReserveRatherThanDumpingOnAtModelPosition() {
     var input =
         FundTransactionInput.builder()
             .fund(TUV100)
@@ -1227,13 +1365,14 @@ class TradeCalculationEngineTest {
 
     var result = engine.calculate(input, SELL);
 
-    var overTrade =
-        result.trades().stream().filter(t -> t.isin().equals("IE00OVER")).findFirst().orElseThrow();
-    assertThat(overTrade.tradeAmount()).isGreaterThanOrEqualTo(new BigDecimal("-40000"));
-
-    BigDecimal totalSold =
-        result.trades().stream().map(TradeCalculation::tradeAmount).reduce(ZERO, BigDecimal::add);
-    assertThat(totalSold).isEqualByComparingTo(new BigDecimal("-44000"));
+    assertThat(result.trades())
+        .usingRecursiveComparison()
+        .withComparatorForType(BigDecimal::compareTo, BigDecimal.class)
+        .isEqualTo(
+            List.of(
+                new TradeCalculation(
+                    "IE00OVER", new BigDecimal("-40000"), new BigDecimal("0.000000"), OK),
+                new TradeCalculation("IE00ATTARGET", ZERO, new BigDecimal("0.100000"), OK)));
   }
 
   @Test
@@ -1261,6 +1400,247 @@ class TradeCalculationEngineTest {
     assertThatThrownBy(() -> engine.calculate(input, SELL))
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("Insufficient liquidity");
+  }
+
+  @Test
+  void buy_concentratesFreeCashIntoSingleAboveThresholdTradeInsteadOfSubThresholdSplits() {
+    var input =
+        FundTransactionInput.builder()
+            .fund(TUV100)
+            .positions(
+                List.of(
+                    new PositionSnapshot("IE00A", new BigDecimal("315900")),
+                    new PositionSnapshot("IE00B", new BigDecimal("316100")),
+                    new PositionSnapshot("IE00C", new BigDecimal("368000"))))
+            .modelWeights(
+                List.of(
+                    new ModelWeight("IE00A", new BigDecimal("0.32")),
+                    new ModelWeight("IE00B", new BigDecimal("0.32")),
+                    new ModelWeight("IE00C", new BigDecimal("0.36"))))
+            .grossPortfolioValue(new BigDecimal("1050000"))
+            .cashBuffer(ZERO)
+            .liabilities(ZERO)
+            .freeCash(new BigDecimal("50000"))
+            .minTransactionThreshold(new BigDecimal("50000"))
+            .positionLimits(Map.of())
+            .fastSellIsins(Set.of())
+            .build();
+
+    var result = engine.calculate(input, BUY);
+
+    assertThat(result.trades())
+        .usingRecursiveComparison()
+        .withComparatorForType(BigDecimal::compareTo, BigDecimal.class)
+        .isEqualTo(
+            List.of(
+                new TradeCalculation(
+                    "IE00A", new BigDecimal("50000.00"), new BigDecimal("0.348476"), OK),
+                new TradeCalculation("IE00B", ZERO, new BigDecimal("0.301048"), OK),
+                new TradeCalculation("IE00C", ZERO, new BigDecimal("0.350476"), OK)));
+  }
+
+  @Test
+  void sellFast_weightsFastBucketSellsByOverweightBeforeTouchingSlowBucket() {
+    var input =
+        FundTransactionInput.builder()
+            .fund(TUV100)
+            .positions(
+                List.of(
+                    new PositionSnapshot("IE00F1", new BigDecimal("250000")),
+                    new PositionSnapshot("IE00F2", new BigDecimal("210000")),
+                    new PositionSnapshot("IE00SLOW", new BigDecimal("240000"))))
+            .modelWeights(
+                List.of(
+                    new ModelWeight("IE00F1", new BigDecimal("0.30")),
+                    new ModelWeight("IE00F2", new BigDecimal("0.30")),
+                    new ModelWeight("IE00SLOW", new BigDecimal("0.40"))))
+            .grossPortfolioValue(new BigDecimal("640000"))
+            .cashBuffer(ZERO)
+            .liabilities(ZERO)
+            .freeCash(new BigDecimal("-60000"))
+            .minTransactionThreshold(new BigDecimal("5000"))
+            .positionLimits(Map.of())
+            .fastSellIsins(Set.of("IE00F1", "IE00F2"))
+            .build();
+
+    var result = engine.calculate(input, SELL_FAST);
+
+    assertThat(result.trades())
+        .usingRecursiveComparison()
+        .withComparatorForType(BigDecimal::compareTo, BigDecimal.class)
+        .isEqualTo(
+            List.of(
+                new TradeCalculation(
+                    "IE00F1", new BigDecimal("-45789.47"), new BigDecimal("0.319079"), OK),
+                new TradeCalculation(
+                    "IE00F2", new BigDecimal("-14210.53"), new BigDecimal("0.305921"), OK),
+                new TradeCalculation("IE00SLOW", ZERO, new BigDecimal("0.375000"), OK)));
+  }
+
+  @Test
+  void sellFast_liquidatesFastBucketFullyBeforeSpillingRemainderToSlowBucket() {
+    var input =
+        FundTransactionInput.builder()
+            .fund(TUV100)
+            .positions(
+                List.of(
+                    new PositionSnapshot("IE00F1", new BigDecimal("250000")),
+                    new PositionSnapshot("IE00F2", new BigDecimal("210000")),
+                    new PositionSnapshot("IE00SLOW", new BigDecimal("240000"))))
+            .modelWeights(
+                List.of(
+                    new ModelWeight("IE00F1", new BigDecimal("0.30")),
+                    new ModelWeight("IE00F2", new BigDecimal("0.30")),
+                    new ModelWeight("IE00SLOW", new BigDecimal("0.40"))))
+            .grossPortfolioValue(new BigDecimal("200000"))
+            .cashBuffer(ZERO)
+            .liabilities(ZERO)
+            .freeCash(new BigDecimal("-500000"))
+            .minTransactionThreshold(new BigDecimal("5000"))
+            .positionLimits(Map.of())
+            .fastSellIsins(Set.of("IE00F1", "IE00F2"))
+            .build();
+
+    var result = engine.calculate(input, SELL_FAST);
+
+    assertThat(result.trades())
+        .usingRecursiveComparison()
+        .withComparatorForType(BigDecimal::compareTo, BigDecimal.class)
+        .isEqualTo(
+            List.of(
+                new TradeCalculation(
+                    "IE00F1", new BigDecimal("-250000"), new BigDecimal("0.000000"), OK),
+                new TradeCalculation(
+                    "IE00F2", new BigDecimal("-210000"), new BigDecimal("0.000000"), OK),
+                new TradeCalculation(
+                    "IE00SLOW", new BigDecimal("-40000"), new BigDecimal("1.000000"), OK)));
+  }
+
+  @Test
+  void sell_lastResortFullyLiquidatesTrappedSubThresholdOddLotsMostOverweightFirst() {
+    var input =
+        FundTransactionInput.builder()
+            .fund(TUV100)
+            .positions(
+                List.of(
+                    new PositionSnapshot("IE00BIG1", new BigDecimal("300000")),
+                    new PositionSnapshot("IE00BIG2", new BigDecimal("300000")),
+                    new PositionSnapshot("IE00ODD1", new BigDecimal("40000")),
+                    new PositionSnapshot("IE00ODD2", new BigDecimal("40000"))))
+            .modelWeights(
+                List.of(
+                    new ModelWeight("IE00BIG1", new BigDecimal("0.30")),
+                    new ModelWeight("IE00BIG2", new BigDecimal("0.30")),
+                    new ModelWeight("IE00ODD1", new BigDecimal("0.20")),
+                    new ModelWeight("IE00ODD2", new BigDecimal("0.20"))))
+            .grossPortfolioValue(new BigDecimal("680000"))
+            .cashBuffer(ZERO)
+            .liabilities(ZERO)
+            .freeCash(new BigDecimal("-660000"))
+            .minTransactionThreshold(new BigDecimal("50000"))
+            .positionLimits(Map.of())
+            .fastSellIsins(Set.of())
+            .build();
+
+    var result = engine.calculate(input, SELL);
+
+    assertThat(result.trades())
+        .usingRecursiveComparison()
+        .withComparatorForType(BigDecimal::compareTo, BigDecimal.class)
+        .isEqualTo(
+            List.of(
+                new TradeCalculation(
+                    "IE00BIG1", new BigDecimal("-300000"), new BigDecimal("0.000000"), OK),
+                new TradeCalculation(
+                    "IE00BIG2", new BigDecimal("-300000"), new BigDecimal("0.000000"), OK),
+                new TradeCalculation(
+                    "IE00ODD1", new BigDecimal("-40000"), new BigDecimal("0.000000"), OK),
+                new TradeCalculation(
+                    "IE00ODD2", new BigDecimal("-40000"), new BigDecimal("0.000000"), OK)));
+  }
+
+  @Test
+  void sellFast_safetySpillFulfilsRedemptionTheBucketsStrandBelowMinTrade() {
+    var input =
+        FundTransactionInput.builder()
+            .fund(TUV100)
+            .positions(
+                List.of(
+                    new PositionSnapshot("IE00FASTBIG", new BigDecimal("86000")),
+                    new PositionSnapshot("IE00FASTODD1", new BigDecimal("4000")),
+                    new PositionSnapshot("IE00FASTODD2", new BigDecimal("3000")),
+                    new PositionSnapshot("IE00SLOWODD", new BigDecimal("2000"))))
+            .modelWeights(
+                List.of(
+                    new ModelWeight("IE00FASTBIG", new BigDecimal("3")),
+                    new ModelWeight("IE00FASTODD1", new BigDecimal("5")),
+                    new ModelWeight("IE00FASTODD2", new BigDecimal("4")),
+                    new ModelWeight("IE00SLOWODD", new BigDecimal("4"))))
+            .grossPortfolioValue(new BigDecimal("95000"))
+            .cashBuffer(ZERO)
+            .liabilities(ZERO)
+            .freeCash(new BigDecimal("-4816"))
+            .minTransactionThreshold(new BigDecimal("5000"))
+            .positionLimits(Map.of())
+            .fastSellIsins(Set.of("IE00FASTBIG", "IE00FASTODD1", "IE00FASTODD2"))
+            .build();
+
+    var result = engine.calculate(input, SELL_FAST);
+
+    assertThat(result.trades())
+        .usingRecursiveComparison()
+        .withComparatorForType(BigDecimal::compareTo, BigDecimal.class)
+        .isEqualTo(
+            List.of(
+                new TradeCalculation("IE00FASTBIG", ZERO, new BigDecimal("0.905263"), OK),
+                new TradeCalculation(
+                    "IE00FASTODD1", new BigDecimal("-4000"), new BigDecimal("0.000000"), OK),
+                new TradeCalculation("IE00FASTODD2", ZERO, new BigDecimal("0.031579"), OK),
+                new TradeCalculation(
+                    "IE00SLOWODD", new BigDecimal("-2000"), new BigDecimal("0.000000"), OK)));
+  }
+
+  @Test
+  void sell_withoutSoftLimitsSpreadsSellsAcrossOverweightFundsTowardModelRatherThanConcentrating() {
+    var input =
+        FundTransactionInput.builder()
+            .fund(TUV100)
+            .positions(
+                List.of(
+                    new PositionSnapshot("IE00A", new BigDecimal("86151")),
+                    new PositionSnapshot("IE00B", new BigDecimal("262989")),
+                    new PositionSnapshot("IE00C", new BigDecimal("93572"))))
+            .modelWeights(
+                List.of(
+                    new ModelWeight("IE00A", ZERO),
+                    new ModelWeight("IE00B", new BigDecimal("0.50")),
+                    new ModelWeight("IE00C", new BigDecimal("0.50"))))
+            .grossPortfolioValue(new BigDecimal("442712"))
+            .cashBuffer(ZERO)
+            .liabilities(ZERO)
+            .freeCash(new BigDecimal("-354775"))
+            .minTransactionThreshold(new BigDecimal("5000"))
+            .positionLimits(Map.of())
+            .fastSellIsins(Set.of())
+            .build();
+
+    var result = engine.calculate(input, SELL);
+
+    assertThat(result.trades())
+        .usingRecursiveComparison()
+        .withComparatorForType(BigDecimal::compareTo, BigDecimal.class)
+        .isEqualTo(
+            List.of(
+                new TradeCalculation(
+                    "IE00A", new BigDecimal("-86151"), new BigDecimal("0.000000"), OK),
+                new TradeCalculation(
+                    "IE00B", new BigDecimal("-201180.01"), new BigDecimal("0.139614"), OK),
+                new TradeCalculation(
+                    "IE00C", new BigDecimal("-67443.99"), new BigDecimal("0.059018"), OK)));
+
+    BigDecimal totalSold =
+        result.trades().stream().map(TradeCalculation::tradeAmount).reduce(ZERO, BigDecimal::add);
+    assertThat(totalSold).isEqualByComparingTo(new BigDecimal("-354775"));
   }
 
   @Test


### PR DESCRIPTION
Ports the remaining **GAS ↔ Java trade-calculation parity** gaps into `TradeCalculationEngine` so the Java engine matches the operator-trusted GAS `tehingud.gs` logic (§4.12 of the transaction-registry gap analysis). The GAS side is fully shipped + fuzz-verified; this brings Java to parity. **No Critical; all changes fail-safe.**

## What changed

**Sell safety-spill (shared Phase A/B/C)** — new `applySellSafetySpill` + capacity-aware `distributeCapped`, wired into both `calculateSell` and `calculateSellFast`, replacing the ad-hoc `remainingMarketValueScores` fallback:
- Phase A opens new ≥min-trade sells from remaining headroom
- Phase B tops up already-selling positions within their headroom
- Phase C liquidates trapped sub-min-trade odd-lots to zero as a last resort
- `SELL_FAST` now sums the *actually filled* fast-bucket amount before routing the remainder to the slow bucket (previously a hardcoded value could strand a small redemption entirely)

**Over-soft relief (SELL)** — cap over-soft relief at the model target and spill the excess to other overweight funds (GAS tier-1/tier-2) instead of selling one fund past model.

**REBALANCE sell** — cap each sell at holdings (score cap **+** final-allocation clamp) so a negative `netInvestable` can no longer oversell a position beyond what the fund holds.

**REBALANCE buy** — route the buy bucket through the hard-limit water-fill used by BUY, so limit-blocked excess cascades to funds with headroom instead of being clipped and stranded.

**Weight-sum guard** — `TransactionInputService.gatherInput` now fails fast when a fund's model weights don't sum to 1.0 (tolerance 0.0001), rather than silently feeding mismatched weights into the raw-vs-normalised engine paths.

## Two deliberate behaviour changes (match GAS)

Both are **total-neutral** (same amount raised, zero oversell) and keep the portfolio closer to model:
1. A sell no longer dumps a sub-min-trade trade on a healthy at-model fund — the residual (< one min-trade) goes to the cash reserve.
2. A no-soft-limit sell **spreads** across overweight funds toward model rather than fully liquidating the most-overweight one first.

## Verification
- **Test-first**: every fix reproduced by a failing test before the change; 47 `TradeCalculationEngineTest` + 38 `TransactionInputServiceTest`, full suite green.
- **Fuzz** (~375k sell / sell-fast cases): **0 oversell**, any under-raise and overshoot bounded **below one min-trade**.
- Clean-code reviewed (no comments; behaviour explained through method extraction and naming).

## Note on the gap-doc framing
Adversarial analysis during this work found the gap doc's "> min-trade payout shortfall" (R1) is **not reproducible in the Java engine** — Java's under-raise is always < min-trade. The safety-spill's real value here is fulfilling *small* redemptions the buckets currently strand entirely, plus the Phase C odd-lot policy. The online gap doc §4.12 will be corrected to match.

## Deferred (documented, out of scope)
- **P5** REBALANCE operator cash warnings — needs a consumer/surface; folds into the §4.5(c) decision-surface / §4.9 audit work.
- **R7** input finiteness — GAS's NaN case is moot for `BigDecimal`; the negative-value case overlaps the weight-sum guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GAMpqZVd8kzkhootmTSA7x