### PR TITLE
Harden SEB reconciliation: NPE isolation, inconsistent-row visibility, truncation guard, split fills (§4.4/§4.8)

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/investment/report/InvestmentReportRepository.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/report/InvestmentReportRepository.java
@@ -18,4 +18,8 @@ public interface InvestmentReportRepository extends JpaRepository<InvestmentRepo
 
   Optional<InvestmentReport> findTopByProviderAndReportTypeOrderByReportDateDesc(
       ReportProvider provider, ReportType reportType);
+
+  Optional<InvestmentReport>
+      findTopByProviderAndReportTypeAndReportDateLessThanOrderByReportDateDesc(
+          ReportProvider provider, ReportType reportType, LocalDate reportDate);
 }

--- a/src/main/java/ee/tuleva/onboarding/investment/report/InvestmentReportService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/report/InvestmentReportService.java
@@ -82,6 +82,12 @@ public class InvestmentReportService {
     return repository.findTopByProviderAndReportTypeOrderByReportDateDesc(provider, reportType);
   }
 
+  public Optional<InvestmentReport> getPriorReport(
+      ReportProvider provider, ReportType reportType, LocalDate reportDate) {
+    return repository.findTopByProviderAndReportTypeAndReportDateLessThanOrderByReportDateDesc(
+        provider, reportType, reportDate);
+  }
+
   private byte[] readAllBytes(InputStream stream) {
     try {
       return stream.readAllBytes();

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/PossibleReportTruncationAlertListener.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/PossibleReportTruncationAlertListener.java
@@ -1,0 +1,81 @@
+package ee.tuleva.onboarding.investment.transaction.ingest;
+
+import static ee.tuleva.onboarding.notification.OperationsNotificationService.Channel.INVESTMENT;
+
+import ee.tuleva.onboarding.notification.OperationsNotificationService;
+import ee.tuleva.onboarding.notification.email.EmailService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+class PossibleReportTruncationAlertListener {
+
+  private final AlertMandrillMessageFactory messageFactory;
+  private final EmailService emailService;
+  private final OperationsNotificationService notificationService;
+
+  // Fire after the reconcile transaction commits so a Slack/email failure can never roll back
+  // persisted reconciliation state; fallbackExecution lets it still run outside a transaction.
+  @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
+  public void onPossibleReportTruncation(PossibleReportTruncationEvent event) {
+    try {
+      notificationService.sendMessage(buildSlackMessage(event), INVESTMENT);
+    } catch (RuntimeException e) {
+      log.error(
+          "Failed to send possible report truncation Slack alert: reportDate={}",
+          event.reportDate(),
+          e);
+    }
+
+    var subject =
+        "[HOIATUS] SEB pending transactions raport võib olla poolik – " + event.reportDate();
+    var body = buildBody(event);
+
+    boolean sent = emailService.sendSystemEmail(messageFactory.create(subject, body));
+    if (sent) {
+      log.info(
+          "Sent possible report truncation alert: reportDate={}, rowCount={}, priorReportDate={},"
+              + " priorRowCount={}",
+          event.reportDate(),
+          event.rowCount(),
+          event.priorReportDate(),
+          event.priorRowCount());
+    } else {
+      log.error(
+          "Failed to send possible report truncation alert: reportDate={}, rowCount={}",
+          event.reportDate(),
+          event.rowCount());
+    }
+  }
+
+  private static String buildSlackMessage(PossibleReportTruncationEvent event) {
+    return """
+        ⚠️ SEB pending transactions raport võib olla poolik – %s
+        Ridu: %s (eelmine raport %s: %s rida)
+        Kadumise põhjal tuvastamist ei tehtud, oodatakse käsitsi kontrolli."""
+        .formatted(
+            event.reportDate(), event.rowCount(), event.priorReportDate(), event.priorRowCount());
+  }
+
+  private static String buildBody(PossibleReportTruncationEvent event) {
+    return """
+        SEB pending transactions raporti ridade arv langes eelmise raportiga võrreldes järsult.
+        See võib viidata poolikult üleslaetud failile. Kadumise põhjal tehingute sulgemine
+        (settlement-by-absence) selle raporti jaoks jäeti vahele, et vältida tellimuste
+        valesti sulgemist. Vajab käsitsi uurimist.
+
+        Raporti kuupäev: %s
+        Ridu: %s
+
+        Eelmise raporti kuupäev: %s
+        Eelmise raporti ridu: %s
+        """
+        .formatted(
+            event.reportDate(), event.rowCount(), event.priorReportDate(), event.priorRowCount());
+  }
+}

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/PossibleReportTruncationAlertListener.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/PossibleReportTruncationAlertListener.java
@@ -19,8 +19,6 @@ class PossibleReportTruncationAlertListener {
   private final EmailService emailService;
   private final OperationsNotificationService notificationService;
 
-  // Fire after the reconcile transaction commits so a Slack/email failure can never roll back
-  // persisted reconciliation state; fallbackExecution lets it still run outside a transaction.
   @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
   public void onPossibleReportTruncation(PossibleReportTruncationEvent event) {
     try {

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/PossibleReportTruncationEvent.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/PossibleReportTruncationEvent.java
@@ -1,0 +1,6 @@
+package ee.tuleva.onboarding.investment.transaction.ingest;
+
+import java.time.LocalDate;
+
+record PossibleReportTruncationEvent(
+    LocalDate reportDate, int rowCount, LocalDate priorReportDate, int priorRowCount) {}

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/QuantityAmountValidator.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/QuantityAmountValidator.java
@@ -42,6 +42,23 @@ class QuantityAmountValidator {
     return withinTolerance(order, row, properties, properties.nearMissMultiplier());
   }
 
+  boolean withinResidualTolerance(
+      TransactionOrder order,
+      SebPendingTransactionRow row,
+      List<TransactionExecution> existingExecutions,
+      TransactionMatchingProperties properties) {
+    return withinResidualTolerance(order, row, existingExecutions, properties, BigDecimal.ONE);
+  }
+
+  boolean withinResidualNearMiss(
+      TransactionOrder order,
+      SebPendingTransactionRow row,
+      List<TransactionExecution> existingExecutions,
+      TransactionMatchingProperties properties) {
+    return withinResidualTolerance(
+        order, row, existingExecutions, properties, properties.nearMissMultiplier());
+  }
+
   QuantityAmountMismatchEvent buildMismatchEvent(
       TransactionOrder order,
       SebPendingTransactionRow row,
@@ -145,12 +162,36 @@ class QuantityAmountValidator {
       SebPendingTransactionRow row,
       TransactionMatchingProperties properties,
       BigDecimal multiplier) {
+    return withinToleranceOf(expected(order), order, row, properties, multiplier);
+  }
+
+  private boolean withinResidualTolerance(
+      TransactionOrder order,
+      SebPendingTransactionRow row,
+      List<TransactionExecution> existingExecutions,
+      TransactionMatchingProperties properties,
+      BigDecimal multiplier) {
+    BigDecimal target = expected(order);
+    if (target == null) {
+      return false;
+    }
+    BigDecimal residual =
+        target.subtract(sumExecutedValue(order, existingExecutions, row.ourRef()));
+    return withinToleranceOf(residual, order, row, properties, multiplier);
+  }
+
+  private static boolean withinToleranceOf(
+      BigDecimal expectedValue,
+      TransactionOrder order,
+      SebPendingTransactionRow row,
+      TransactionMatchingProperties properties,
+      BigDecimal multiplier) {
     MismatchKind kind = kind(order);
     BigDecimal tolerance = tolerance(kind, properties).multiply(multiplier);
     if (kind == MismatchKind.FUND_BUY_AMOUNT) {
-      return amountWithinRelativeTolerance(expected(order), actual(order, row), tolerance);
+      return amountWithinRelativeTolerance(expectedValue, actual(order, row), tolerance);
     }
-    return quantityWithinTolerance(expected(order), actual(order, row), tolerance);
+    return quantityWithinTolerance(expectedValue, actual(order, row), tolerance);
   }
 
   private static BigDecimal tolerance(MismatchKind kind, TransactionMatchingProperties properties) {

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/ReconciliationAuditRecorder.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/ReconciliationAuditRecorder.java
@@ -23,6 +23,7 @@ class ReconciliationAuditRecorder {
   static final String SETTLEMENT_DETECTED = "SETTLEMENT_DETECTED";
   static final String SETTLEMENT_REAPPEARED = "SETTLEMENT_REAPPEARED";
   static final String INCONSISTENT_MATCHED_ROW = "INCONSISTENT_MATCHED_ROW";
+  static final String POSSIBLE_REPORT_TRUNCATION = "POSSIBLE_REPORT_TRUNCATION";
 
   static final String REASON_MISSING_OUR_REF = "MISSING_OUR_REF";
   static final String REASON_MISSING_ISIN = "MISSING_ISIN";
@@ -109,6 +110,24 @@ class ReconciliationAuditRecorder {
     Map<String, Object> payload = rowPayload(row, reportDate);
     payload.put("settlementReportDate", settlement.getReportDate().toString());
     save(SETTLEMENT_REAPPEARED, order, payload);
+  }
+
+  void recordPossibleReportTruncation(
+      LocalDate reportDate, int rowCount, LocalDate priorReportDate, int priorRowCount) {
+    String dedupKey = reportDate.toString();
+    boolean alreadyRecorded =
+        !auditEventRepository
+            .findByEventTypeAndDedupKey(POSSIBLE_REPORT_TRUNCATION, dedupKey)
+            .isEmpty();
+    if (alreadyRecorded) {
+      return;
+    }
+    Map<String, Object> payload = new LinkedHashMap<>();
+    payload.put("reportDate", reportDate.toString());
+    payload.put("rowCount", rowCount);
+    payload.put("priorReportDate", priorReportDate.toString());
+    payload.put("priorRowCount", priorRowCount);
+    save(POSSIBLE_REPORT_TRUNCATION, null, payload, dedupKey);
   }
 
   private boolean alreadyRecordedForReportDate(

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/ReconciliationAuditRecorder.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/ReconciliationAuditRecorder.java
@@ -54,11 +54,7 @@ class ReconciliationAuditRecorder {
 
   void recordUnmatched(SebPendingTransactionRow row, LocalDate reportDate) {
     String dedupKey = unmatchedDedupKey(row, reportDate);
-    boolean alreadyRecorded =
-        !auditEventRepository
-            .findByEventTypeAndDedupKey(UNMATCHED_SEB_TRANSACTION, dedupKey)
-            .isEmpty();
-    if (alreadyRecorded) {
+    if (alreadyRecordedForDedupKey(UNMATCHED_SEB_TRANSACTION, dedupKey)) {
       return;
     }
     save(UNMATCHED_SEB_TRANSACTION, null, rowPayload(row, reportDate), dedupKey);
@@ -67,11 +63,7 @@ class ReconciliationAuditRecorder {
   void recordInconsistentMatchedRow(
       TransactionOrder order, SebPendingTransactionRow row, String reason, LocalDate reportDate) {
     String dedupKey = inconsistentMatchedRowDedupKey(order, reportDate, reason);
-    boolean alreadyRecorded =
-        !auditEventRepository
-            .findByEventTypeAndDedupKey(INCONSISTENT_MATCHED_ROW, dedupKey)
-            .isEmpty();
-    if (alreadyRecorded) {
+    if (alreadyRecordedForDedupKey(INCONSISTENT_MATCHED_ROW, dedupKey)) {
       return;
     }
     Map<String, Object> payload = rowPayload(row, reportDate);
@@ -115,11 +107,7 @@ class ReconciliationAuditRecorder {
   void recordPossibleReportTruncation(
       LocalDate reportDate, int rowCount, LocalDate priorReportDate, int priorRowCount) {
     String dedupKey = reportDate.toString();
-    boolean alreadyRecorded =
-        !auditEventRepository
-            .findByEventTypeAndDedupKey(POSSIBLE_REPORT_TRUNCATION, dedupKey)
-            .isEmpty();
-    if (alreadyRecorded) {
+    if (alreadyRecordedForDedupKey(POSSIBLE_REPORT_TRUNCATION, dedupKey)) {
       return;
     }
     Map<String, Object> payload = new LinkedHashMap<>();
@@ -134,6 +122,10 @@ class ReconciliationAuditRecorder {
       Long orderId, String eventType, LocalDate reportDate) {
     return auditEventRepository.findByOrderIdAndEventType(orderId, eventType).stream()
         .anyMatch(event -> reportDate.toString().equals(event.getPayload().get("reportDate")));
+  }
+
+  private boolean alreadyRecordedForDedupKey(String eventType, String dedupKey) {
+    return !auditEventRepository.findByEventTypeAndDedupKey(eventType, dedupKey).isEmpty();
   }
 
   private void save(String eventType, TransactionOrder order, Map<String, Object> payload) {

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/ReconciliationAuditRecorder.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/ReconciliationAuditRecorder.java
@@ -22,6 +22,12 @@ class ReconciliationAuditRecorder {
   static final String QUANTITY_AMOUNT_MISMATCH = "QUANTITY_AMOUNT_MISMATCH";
   static final String SETTLEMENT_DETECTED = "SETTLEMENT_DETECTED";
   static final String SETTLEMENT_REAPPEARED = "SETTLEMENT_REAPPEARED";
+  static final String INCONSISTENT_MATCHED_ROW = "INCONSISTENT_MATCHED_ROW";
+
+  static final String REASON_MISSING_OUR_REF = "MISSING_OUR_REF";
+  static final String REASON_MISSING_ISIN = "MISSING_ISIN";
+  static final String REASON_ISIN_SIDE_MISMATCH = "ISIN_SIDE_MISMATCH";
+  static final String REASON_FUND_MISMATCH = "FUND_MISMATCH";
 
   private static final String SYSTEM_ACTOR = "system";
 
@@ -55,6 +61,21 @@ class ReconciliationAuditRecorder {
       return;
     }
     save(UNMATCHED_SEB_TRANSACTION, null, rowPayload(row, reportDate), dedupKey);
+  }
+
+  void recordInconsistentMatchedRow(
+      TransactionOrder order, SebPendingTransactionRow row, String reason, LocalDate reportDate) {
+    String dedupKey = inconsistentMatchedRowDedupKey(order, reportDate, reason);
+    boolean alreadyRecorded =
+        !auditEventRepository
+            .findByEventTypeAndDedupKey(INCONSISTENT_MATCHED_ROW, dedupKey)
+            .isEmpty();
+    if (alreadyRecorded) {
+      return;
+    }
+    Map<String, Object> payload = rowPayload(row, reportDate);
+    payload.put("reason", reason);
+    save(INCONSISTENT_MATCHED_ROW, order, payload, dedupKey);
   }
 
   void recordQuantityAmountMismatch(QuantityAmountMismatchEvent mismatch) {
@@ -121,6 +142,11 @@ class ReconciliationAuditRecorder {
         Objects.toString(row.ourRef(), ""),
         Objects.toString(row.clientRef(), ""),
         Objects.toString(row.isin(), ""));
+  }
+
+  private static String inconsistentMatchedRowDedupKey(
+      TransactionOrder order, LocalDate reportDate, String reason) {
+    return String.join("|", reportDate.toString(), Objects.toString(order.getId(), ""), reason);
   }
 
   private static Map<String, Object> rowPayload(

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/SebPendingTransactionComplexMatcher.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/SebPendingTransactionComplexMatcher.java
@@ -29,7 +29,7 @@ class SebPendingTransactionComplexMatcher {
       return Optional.empty();
     }
     List<TransactionOrder> inTolerance =
-        candidates.stream().filter(o -> withinTolerance(o, row, properties)).toList();
+        candidates.stream().filter(o -> withinResidualAwareTolerance(o, row, properties)).toList();
 
     if (inTolerance.isEmpty()) {
       return Optional.empty();
@@ -56,7 +56,8 @@ class SebPendingTransactionComplexMatcher {
     if (candidates == null) {
       return false;
     }
-    return candidates.stream().anyMatch(candidate -> withinNearMiss(candidate, row, properties));
+    return candidates.stream()
+        .anyMatch(candidate -> withinResidualAwareNearMiss(candidate, row, properties));
   }
 
   Optional<QuantityAmountMismatchEvent> findNearMiss(
@@ -69,8 +70,8 @@ class SebPendingTransactionComplexMatcher {
     // a clean match would have been picked up by match() and is not a near miss.
     List<TransactionOrder> nearMissCandidates =
         candidates.stream()
-            .filter(o -> !withinTolerance(o, row, properties))
-            .filter(o -> withinNearMiss(o, row, properties))
+            .filter(o -> !withinResidualAwareTolerance(o, row, properties))
+            .filter(o -> withinResidualAwareNearMiss(o, row, properties))
             .toList();
 
     if (nearMissCandidates.size() != 1) {
@@ -100,10 +101,7 @@ class SebPendingTransactionComplexMatcher {
         .toList();
   }
 
-  // Orders with no prior execution are matched against the full order target. Orders that
-  // already have one or more executions (a split fill) are matched against the residual —
-  // the target minus what's already been executed — so a later piece can still attach.
-  private boolean withinTolerance(
+  private boolean withinResidualAwareTolerance(
       TransactionOrder order,
       SebPendingTransactionRow row,
       TransactionMatchingProperties properties) {
@@ -113,7 +111,7 @@ class SebPendingTransactionComplexMatcher {
         : quantityAmountValidator.withinResidualTolerance(order, row, executions, properties);
   }
 
-  private boolean withinNearMiss(
+  private boolean withinResidualAwareNearMiss(
       TransactionOrder order,
       SebPendingTransactionRow row,
       TransactionMatchingProperties properties) {

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/SebPendingTransactionComplexMatcher.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/SebPendingTransactionComplexMatcher.java
@@ -2,6 +2,7 @@ package ee.tuleva.onboarding.investment.transaction.ingest;
 
 import ee.tuleva.onboarding.fund.TulevaFund;
 import ee.tuleva.onboarding.investment.transaction.OrderStatus;
+import ee.tuleva.onboarding.investment.transaction.TransactionExecution;
 import ee.tuleva.onboarding.investment.transaction.TransactionExecutionRepository;
 import ee.tuleva.onboarding.investment.transaction.TransactionOrder;
 import ee.tuleva.onboarding.investment.transaction.TransactionOrderRepository;
@@ -28,9 +29,7 @@ class SebPendingTransactionComplexMatcher {
       return Optional.empty();
     }
     List<TransactionOrder> inTolerance =
-        candidates.stream()
-            .filter(o -> quantityAmountValidator.withinTolerance(o, row, properties))
-            .toList();
+        candidates.stream().filter(o -> withinTolerance(o, row, properties)).toList();
 
     if (inTolerance.isEmpty()) {
       return Optional.empty();
@@ -57,8 +56,7 @@ class SebPendingTransactionComplexMatcher {
     if (candidates == null) {
       return false;
     }
-    return candidates.stream()
-        .anyMatch(candidate -> quantityAmountValidator.withinNearMiss(candidate, row, properties));
+    return candidates.stream().anyMatch(candidate -> withinNearMiss(candidate, row, properties));
   }
 
   Optional<QuantityAmountMismatchEvent> findNearMiss(
@@ -71,8 +69,8 @@ class SebPendingTransactionComplexMatcher {
     // a clean match would have been picked up by match() and is not a near miss.
     List<TransactionOrder> nearMissCandidates =
         candidates.stream()
-            .filter(o -> !quantityAmountValidator.withinTolerance(o, row, properties))
-            .filter(o -> quantityAmountValidator.withinNearMiss(o, row, properties))
+            .filter(o -> !withinTolerance(o, row, properties))
+            .filter(o -> withinNearMiss(o, row, properties))
             .toList();
 
     if (nearMissCandidates.size() != 1) {
@@ -99,11 +97,29 @@ class SebPendingTransactionComplexMatcher {
         .filter(o -> o.getFund() == fund)
         .filter(o -> o.getTransactionType() == row.side())
         .filter(o -> o.getOrderStatus() != OrderStatus.CANCELLED)
-        .filter(this::isNotAlreadyLinkedToExecution)
         .toList();
   }
 
-  private boolean isNotAlreadyLinkedToExecution(TransactionOrder order) {
-    return executionRepository.findAllByOrderId(order.getId()).isEmpty();
+  // Orders with no prior execution are matched against the full order target. Orders that
+  // already have one or more executions (a split fill) are matched against the residual —
+  // the target minus what's already been executed — so a later piece can still attach.
+  private boolean withinTolerance(
+      TransactionOrder order,
+      SebPendingTransactionRow row,
+      TransactionMatchingProperties properties) {
+    List<TransactionExecution> executions = executionRepository.findAllByOrderId(order.getId());
+    return executions.isEmpty()
+        ? quantityAmountValidator.withinTolerance(order, row, properties)
+        : quantityAmountValidator.withinResidualTolerance(order, row, executions, properties);
+  }
+
+  private boolean withinNearMiss(
+      TransactionOrder order,
+      SebPendingTransactionRow row,
+      TransactionMatchingProperties properties) {
+    List<TransactionExecution> executions = executionRepository.findAllByOrderId(order.getId());
+    return executions.isEmpty()
+        ? quantityAmountValidator.withinNearMiss(order, row, properties)
+        : quantityAmountValidator.withinResidualNearMiss(order, row, executions, properties);
   }
 }

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/SebPendingTransactionReconciliationService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/SebPendingTransactionReconciliationService.java
@@ -209,6 +209,16 @@ public class SebPendingTransactionReconciliationService {
           reportDate);
       return false;
     }
+    if (row.isin() == null || row.isin().isBlank()) {
+      log.error(
+          "Matched SEB row is missing ISIN, cannot verify instrument: orderId={}, clientRef={},"
+              + " ourRef={}, reportDate={}",
+          order.getId(),
+          row.clientRef(),
+          row.ourRef(),
+          reportDate);
+      return false;
+    }
     if (!row.isin().equals(order.getInstrumentIsin()) || row.side() != order.getTransactionType()) {
       log.error(
           "Matched SEB row instrument/side does not match order: orderId={}, orderIsin={},"

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/SebPendingTransactionReconciliationService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/SebPendingTransactionReconciliationService.java
@@ -207,6 +207,8 @@ public class SebPendingTransactionReconciliationService {
           row.clientRef(),
           row.isin(),
           reportDate);
+      auditRecorder.recordInconsistentMatchedRow(
+          order, row, ReconciliationAuditRecorder.REASON_MISSING_OUR_REF, reportDate);
       return false;
     }
     if (row.isin() == null || row.isin().isBlank()) {
@@ -217,6 +219,8 @@ public class SebPendingTransactionReconciliationService {
           row.clientRef(),
           row.ourRef(),
           reportDate);
+      auditRecorder.recordInconsistentMatchedRow(
+          order, row, ReconciliationAuditRecorder.REASON_MISSING_ISIN, reportDate);
       return false;
     }
     if (!row.isin().equals(order.getInstrumentIsin()) || row.side() != order.getTransactionType()) {
@@ -230,6 +234,8 @@ public class SebPendingTransactionReconciliationService {
           row.side(),
           row.ourRef(),
           reportDate);
+      auditRecorder.recordInconsistentMatchedRow(
+          order, row, ReconciliationAuditRecorder.REASON_ISIN_SIDE_MISMATCH, reportDate);
       return false;
     }
     Optional<TulevaFund> rowFund = fundResolver.resolve(row.clientName());
@@ -243,6 +249,8 @@ public class SebPendingTransactionReconciliationService {
           row.clientName(),
           row.ourRef(),
           reportDate);
+      auditRecorder.recordInconsistentMatchedRow(
+          order, row, ReconciliationAuditRecorder.REASON_FUND_MISMATCH, reportDate);
       return false;
     }
     return true;

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/SebPendingTransactionReconciliationService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/SebPendingTransactionReconciliationService.java
@@ -2,6 +2,10 @@ package ee.tuleva.onboarding.investment.transaction.ingest;
 
 import static ee.tuleva.onboarding.investment.report.ReportProvider.SEB;
 import static ee.tuleva.onboarding.investment.report.ReportType.PENDING_TRANSACTIONS;
+import static ee.tuleva.onboarding.investment.transaction.ingest.ReconciliationAuditRecorder.REASON_FUND_MISMATCH;
+import static ee.tuleva.onboarding.investment.transaction.ingest.ReconciliationAuditRecorder.REASON_ISIN_SIDE_MISMATCH;
+import static ee.tuleva.onboarding.investment.transaction.ingest.ReconciliationAuditRecorder.REASON_MISSING_ISIN;
+import static ee.tuleva.onboarding.investment.transaction.ingest.ReconciliationAuditRecorder.REASON_MISSING_OUR_REF;
 
 import ee.tuleva.onboarding.fund.TulevaFund;
 import ee.tuleva.onboarding.investment.report.InvestmentReport;
@@ -36,9 +40,6 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class SebPendingTransactionReconciliationService {
 
-  // A latest report whose row count drops by more than this fraction relative to the prior
-  // available report is treated as a possibly truncated upload: settlement-by-absence is skipped
-  // for it (present rows still reconcile normally) rather than risk mass over-settlement.
   private static final double TRUNCATION_ROW_DROP_RATIO = 0.5;
 
   private final SebPendingTransactionExtractor extractor;
@@ -212,9 +213,7 @@ public class SebPendingTransactionReconciliationService {
           row.clientRef(),
           row.isin(),
           reportDate);
-      auditRecorder.recordInconsistentMatchedRow(
-          order, row, ReconciliationAuditRecorder.REASON_MISSING_OUR_REF, reportDate);
-      return false;
+      return rejectInconsistentRow(order, row, REASON_MISSING_OUR_REF, reportDate);
     }
     if (row.isin() == null || row.isin().isBlank()) {
       log.error(
@@ -224,9 +223,7 @@ public class SebPendingTransactionReconciliationService {
           row.clientRef(),
           row.ourRef(),
           reportDate);
-      auditRecorder.recordInconsistentMatchedRow(
-          order, row, ReconciliationAuditRecorder.REASON_MISSING_ISIN, reportDate);
-      return false;
+      return rejectInconsistentRow(order, row, REASON_MISSING_ISIN, reportDate);
     }
     if (!row.isin().equals(order.getInstrumentIsin()) || row.side() != order.getTransactionType()) {
       log.error(
@@ -239,9 +236,7 @@ public class SebPendingTransactionReconciliationService {
           row.side(),
           row.ourRef(),
           reportDate);
-      auditRecorder.recordInconsistentMatchedRow(
-          order, row, ReconciliationAuditRecorder.REASON_ISIN_SIDE_MISMATCH, reportDate);
-      return false;
+      return rejectInconsistentRow(order, row, REASON_ISIN_SIDE_MISMATCH, reportDate);
     }
     Optional<TulevaFund> rowFund = fundResolver.resolve(row.clientName());
     if (rowFund.isPresent() && rowFund.get() != order.getFund()) {
@@ -254,11 +249,15 @@ public class SebPendingTransactionReconciliationService {
           row.clientName(),
           row.ourRef(),
           reportDate);
-      auditRecorder.recordInconsistentMatchedRow(
-          order, row, ReconciliationAuditRecorder.REASON_FUND_MISMATCH, reportDate);
-      return false;
+      return rejectInconsistentRow(order, row, REASON_FUND_MISMATCH, reportDate);
     }
     return true;
+  }
+
+  private boolean rejectInconsistentRow(
+      TransactionOrder order, SebPendingTransactionRow row, String reason, LocalDate reportDate) {
+    auditRecorder.recordInconsistentMatchedRow(order, row, reason, reportDate);
+    return false;
   }
 
   private boolean upsert(

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/SebPendingTransactionReconciliationService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/SebPendingTransactionReconciliationService.java
@@ -36,6 +36,11 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class SebPendingTransactionReconciliationService {
 
+  // A latest report whose row count drops by more than this fraction relative to the prior
+  // available report is treated as a possibly truncated upload: settlement-by-absence is skipped
+  // for it (present rows still reconcile normally) rather than risk mass over-settlement.
+  private static final double TRUNCATION_ROW_DROP_RATIO = 0.5;
+
   private final SebPendingTransactionExtractor extractor;
   private final SebPendingTransactionMatcher matcher;
   private final SebPendingTransactionComplexMatcher complexMatcher;
@@ -328,6 +333,9 @@ public class SebPendingTransactionReconciliationService {
       log.info("Skipping settlement detection on non-latest report: reportDate={}", reportDate);
       return;
     }
+    if (isPossibleTruncation(reportDate, rowCount)) {
+      return;
+    }
     orderRepository.findByOrderStatusIn(List.of(OrderStatus.EXECUTED)).stream()
         .filter(order -> order.getOrderVenue() == OrderVenue.SEB)
         .filter(order -> !presentOrderIds.contains(order.getId()))
@@ -342,6 +350,35 @@ public class SebPendingTransactionReconciliationService {
         .map(InvestmentReport::getReportDate)
         .map(latest -> !reportDate.isBefore(latest))
         .orElse(true);
+  }
+
+  private boolean isPossibleTruncation(LocalDate reportDate, int rowCount) {
+    Optional<InvestmentReport> priorReport =
+        reportService.getPriorReport(SEB, PENDING_TRANSACTIONS, reportDate);
+    if (priorReport.isEmpty()) {
+      log.info(
+          "Skipping truncation comparison, no prior SEB pending report found: reportDate={}",
+          reportDate);
+      return false;
+    }
+    int priorRowCount = extractor.extractWithDiagnostics(priorReport.get()).rows().size();
+    boolean truncated = rowCount < priorRowCount * (1 - TRUNCATION_ROW_DROP_RATIO);
+    if (!truncated) {
+      return false;
+    }
+    LocalDate priorReportDate = priorReport.get().getReportDate();
+    log.warn(
+        "Possible SEB pending report truncation, skipping settlement by absence: reportDate={},"
+            + " rowCount={}, priorReportDate={}, priorRowCount={}",
+        reportDate,
+        rowCount,
+        priorReportDate,
+        priorRowCount);
+    auditRecorder.recordPossibleReportTruncation(
+        reportDate, rowCount, priorReportDate, priorRowCount);
+    eventPublisher.publishEvent(
+        new PossibleReportTruncationEvent(reportDate, rowCount, priorReportDate, priorRowCount));
+    return true;
   }
 
   private boolean executedBefore(TransactionOrder order, LocalDate reportDate) {

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/SettlementCheckJob.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/SettlementCheckJob.java
@@ -19,6 +19,7 @@ import ee.tuleva.onboarding.investment.transaction.TransactionExecution;
 import ee.tuleva.onboarding.investment.transaction.TransactionExecutionRepository;
 import ee.tuleva.onboarding.investment.transaction.TransactionOrder;
 import ee.tuleva.onboarding.investment.transaction.TransactionOrderRepository;
+import ee.tuleva.onboarding.investment.transaction.ingest.UnmatchedPendingTransactionFinder.InconsistentMatchedRow;
 import ee.tuleva.onboarding.notification.OperationsNotificationService;
 import java.time.Clock;
 import java.time.Instant;
@@ -103,12 +104,17 @@ class SettlementCheckJob {
         collectOverdue(referenceDate, fresh, reportClientRefs, reportOurRefs, registryOrders);
     List<SebPendingTransactionRow> unmatched =
         fresh ? unmatchedFinder.collectUnmatched(latestReport.get()) : List.of();
+    List<InconsistentMatchedRow> inconsistent =
+        fresh ? unmatchedFinder.collectInconsistent(latestReport.get()) : List.of();
 
     boolean emptyRegistryBootstrap = registryOrders.isEmpty();
     // TODO: drop emptyRegistryBootstrap once the registry holds real orders — it silences the
     // stale-report warning during bootstrap but would also mask a broken pipeline on an empty
     // table.
-    if (overdue.isEmpty() && unmatched.isEmpty() && (fresh || emptyRegistryBootstrap)) {
+    if (overdue.isEmpty()
+        && unmatched.isEmpty()
+        && inconsistent.isEmpty()
+        && (fresh || emptyRegistryBootstrap)) {
       log.info(
           "Settlement check clean: today={}, fresh={}, registryEmpty={}",
           today,
@@ -117,13 +123,15 @@ class SettlementCheckJob {
       return;
     }
 
-    String message = buildMessage(today, fresh, overdue, unmatched);
+    String message = buildMessage(today, fresh, overdue, unmatched, inconsistent);
     notificationService.sendMessage(message, INVESTMENT);
     log.info(
-        "Sent settlement check digest: today={}, overdue={}, unmatched={}, fresh={}",
+        "Sent settlement check digest: today={}, overdue={}, unmatched={}, inconsistent={},"
+            + " fresh={}",
         today,
         overdue.size(),
         unmatched.size(),
+        inconsistent.size(),
         fresh);
   }
 
@@ -231,7 +239,8 @@ class SettlementCheckJob {
       LocalDate today,
       boolean fresh,
       List<OverdueLine> overdue,
-      List<SebPendingTransactionRow> unmatched) {
+      List<SebPendingTransactionRow> unmatched,
+      List<InconsistentMatchedRow> inconsistent) {
     Map<TulevaFund, List<OverdueLine>> overdueByFund =
         overdue.stream().collect(Collectors.groupingBy(line -> line.order().getFund()));
     Map<TulevaFund, List<SebPendingTransactionRow>> unmatchedByFund = new LinkedHashMap<>();
@@ -243,6 +252,8 @@ class SettlementCheckJob {
               fund -> unmatchedByFund.computeIfAbsent(fund, k -> new ArrayList<>()).add(row),
               () -> unresolved.add(row));
     }
+    Map<TulevaFund, List<InconsistentMatchedRow>> inconsistentByFund =
+        inconsistent.stream().collect(Collectors.groupingBy(entry -> entry.order().getFund()));
 
     StringBuilder message = new StringBuilder();
     message.append("⚠️ SEB arveldus- ja tehingukontroll – ").append(today);
@@ -256,14 +267,16 @@ class SettlementCheckJob {
     Set<TulevaFund> fundsToReport = new LinkedHashSet<>(FUND_ORDER);
     fundsToReport.addAll(overdueByFund.keySet());
     fundsToReport.addAll(unmatchedByFund.keySet());
+    fundsToReport.addAll(inconsistentByFund.keySet());
     for (TulevaFund fund : fundsToReport) {
       appendFundBlock(
           message,
           fund.getCode(),
           unmatchedByFund.getOrDefault(fund, List.of()),
-          overdueByFund.getOrDefault(fund, List.of()));
+          overdueByFund.getOrDefault(fund, List.of()),
+          inconsistentByFund.getOrDefault(fund, List.of()));
     }
-    appendFundBlock(message, "Tundmatu fond / lahendamata", unresolved, List.of());
+    appendFundBlock(message, "Tundmatu fond / lahendamata", unresolved, List.of(), List.of());
 
     return message.toString();
   }
@@ -272,8 +285,9 @@ class SettlementCheckJob {
       StringBuilder message,
       String fundLabel,
       List<SebPendingTransactionRow> unmatched,
-      List<OverdueLine> overdue) {
-    if (unmatched.isEmpty() && overdue.isEmpty()) {
+      List<OverdueLine> overdue,
+      List<InconsistentMatchedRow> inconsistent) {
+    if (unmatched.isEmpty() && overdue.isEmpty() && inconsistent.isEmpty()) {
       return;
     }
     message.append("\n\n").append(fundLabel);
@@ -310,6 +324,22 @@ class SettlementCheckJob {
             .append(order.getOrderTimestamp() == null ? "?" : orderDate(order))
             .append(", tähtaeg: ")
             .append(line.deadline());
+      }
+    }
+    if (!inconsistent.isEmpty()) {
+      message.append("\n  Ebakõlalised vastavused (").append(inconsistent.size()).append("):");
+      for (InconsistentMatchedRow entry : inconsistent) {
+        message
+            .append("\n    - Order ")
+            .append(entry.order().getId())
+            .append(", põhjus: ")
+            .append(entry.reason())
+            .append(", ISIN: ")
+            .append(entry.row().isin())
+            .append(", Our ref: ")
+            .append(entry.row().ourRef())
+            .append(", Client ref: ")
+            .append(entry.row().clientRef());
       }
     }
   }

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/UnmatchedPendingTransactionFinder.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/UnmatchedPendingTransactionFinder.java
@@ -1,11 +1,14 @@
 package ee.tuleva.onboarding.investment.transaction.ingest;
 
-import ee.tuleva.onboarding.fund.TulevaFund;
+import static ee.tuleva.onboarding.investment.transaction.ingest.ReconciliationAuditRecorder.REASON_FUND_MISMATCH;
+import static ee.tuleva.onboarding.investment.transaction.ingest.ReconciliationAuditRecorder.REASON_ISIN_SIDE_MISMATCH;
+import static ee.tuleva.onboarding.investment.transaction.ingest.ReconciliationAuditRecorder.REASON_MISSING_ISIN;
+import static ee.tuleva.onboarding.investment.transaction.ingest.ReconciliationAuditRecorder.REASON_MISSING_OUR_REF;
+
 import ee.tuleva.onboarding.investment.report.InvestmentReport;
 import ee.tuleva.onboarding.investment.transaction.TransactionExecutionRepository;
 import ee.tuleva.onboarding.investment.transaction.TransactionOrder;
 import ee.tuleva.onboarding.investment.transaction.TransactionOrderRepository;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -37,38 +40,39 @@ class UnmatchedPendingTransactionFinder {
   }
 
   List<InconsistentMatchedRow> collectInconsistent(InvestmentReport report) {
-    List<InconsistentMatchedRow> inconsistent = new ArrayList<>();
-    for (SebPendingTransactionRow row : extractor.extract(report)) {
-      if (row.clientRef() == null) {
-        continue;
-      }
-      orderRepository
-          .findByOrderUuid(row.clientRef())
-          .ifPresent(
-              order ->
-                  inconsistencyReason(order, row)
-                      .ifPresent(
-                          reason ->
-                              inconsistent.add(new InconsistentMatchedRow(row, order, reason))));
+    return extractor.extract(report).stream()
+        .map(this::toInconsistentMatchedRow)
+        .flatMap(Optional::stream)
+        .toList();
+  }
+
+  private Optional<InconsistentMatchedRow> toInconsistentMatchedRow(SebPendingTransactionRow row) {
+    if (row.clientRef() == null) {
+      return Optional.empty();
     }
-    return inconsistent;
+    return orderRepository
+        .findByOrderUuid(row.clientRef())
+        .flatMap(
+            order ->
+                inconsistencyReason(order, row)
+                    .map(reason -> new InconsistentMatchedRow(row, order, reason)));
   }
 
   private Optional<String> inconsistencyReason(
       TransactionOrder order, SebPendingTransactionRow row) {
     if (row.ourRef() == null) {
-      return Optional.of(ReconciliationAuditRecorder.REASON_MISSING_OUR_REF);
+      return Optional.of(REASON_MISSING_OUR_REF);
     }
     if (row.isin() == null || row.isin().isBlank()) {
-      return Optional.of(ReconciliationAuditRecorder.REASON_MISSING_ISIN);
+      return Optional.of(REASON_MISSING_ISIN);
     }
     if (!row.isin().equals(order.getInstrumentIsin()) || row.side() != order.getTransactionType()) {
-      return Optional.of(ReconciliationAuditRecorder.REASON_ISIN_SIDE_MISMATCH);
+      return Optional.of(REASON_ISIN_SIDE_MISMATCH);
     }
     return fundResolver
         .resolve(row.clientName())
-        .filter((TulevaFund rowFund) -> rowFund != order.getFund())
-        .map(rowFund -> ReconciliationAuditRecorder.REASON_FUND_MISMATCH);
+        .filter(rowFund -> rowFund != order.getFund())
+        .map(rowFund -> REASON_FUND_MISMATCH);
   }
 
   private boolean isAlreadyLinkedToExecution(SebPendingTransactionRow row) {

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/UnmatchedPendingTransactionFinder.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/UnmatchedPendingTransactionFinder.java
@@ -1,9 +1,13 @@
 package ee.tuleva.onboarding.investment.transaction.ingest;
 
+import ee.tuleva.onboarding.fund.TulevaFund;
 import ee.tuleva.onboarding.investment.report.InvestmentReport;
 import ee.tuleva.onboarding.investment.transaction.TransactionExecutionRepository;
+import ee.tuleva.onboarding.investment.transaction.TransactionOrder;
 import ee.tuleva.onboarding.investment.transaction.TransactionOrderRepository;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -17,6 +21,10 @@ class UnmatchedPendingTransactionFinder {
   private final TransactionMatchingPolicy matchingPolicy;
   private final TransactionOrderRepository orderRepository;
   private final TransactionExecutionRepository executionRepository;
+  private final SebClientNameToFundResolver fundResolver;
+
+  record InconsistentMatchedRow(
+      SebPendingTransactionRow row, TransactionOrder order, String reason) {}
 
   List<SebPendingTransactionRow> collectUnmatched(InvestmentReport report) {
     TransactionMatchingProperties matchingProperties = matchingPolicy.current();
@@ -26,6 +34,41 @@ class UnmatchedPendingTransactionFinder {
         .filter(row -> complexMatcher.match(row, matchingProperties).isEmpty())
         .filter(row -> !complexMatcher.hasNearMissCandidate(row, matchingProperties))
         .toList();
+  }
+
+  List<InconsistentMatchedRow> collectInconsistent(InvestmentReport report) {
+    List<InconsistentMatchedRow> inconsistent = new ArrayList<>();
+    for (SebPendingTransactionRow row : extractor.extract(report)) {
+      if (row.clientRef() == null) {
+        continue;
+      }
+      orderRepository
+          .findByOrderUuid(row.clientRef())
+          .ifPresent(
+              order ->
+                  inconsistencyReason(order, row)
+                      .ifPresent(
+                          reason ->
+                              inconsistent.add(new InconsistentMatchedRow(row, order, reason))));
+    }
+    return inconsistent;
+  }
+
+  private Optional<String> inconsistencyReason(
+      TransactionOrder order, SebPendingTransactionRow row) {
+    if (row.ourRef() == null) {
+      return Optional.of(ReconciliationAuditRecorder.REASON_MISSING_OUR_REF);
+    }
+    if (row.isin() == null || row.isin().isBlank()) {
+      return Optional.of(ReconciliationAuditRecorder.REASON_MISSING_ISIN);
+    }
+    if (!row.isin().equals(order.getInstrumentIsin()) || row.side() != order.getTransactionType()) {
+      return Optional.of(ReconciliationAuditRecorder.REASON_ISIN_SIDE_MISMATCH);
+    }
+    return fundResolver
+        .resolve(row.clientName())
+        .filter((TulevaFund rowFund) -> rowFund != order.getFund())
+        .map(rowFund -> ReconciliationAuditRecorder.REASON_FUND_MISMATCH);
   }
 
   private boolean isAlreadyLinkedToExecution(SebPendingTransactionRow row) {

--- a/src/test/groovy/ee/tuleva/onboarding/investment/report/InvestmentReportRepositoryTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/report/InvestmentReportRepositoryTest.java
@@ -100,4 +100,58 @@ class InvestmentReportRepositoryTest {
 
     assertThat(result).isEmpty();
   }
+
+  @Test
+  void
+      findTopByProviderAndReportTypeAndReportDateLessThanOrderByReportDateDesc_returnsMostRecentPriorReport() {
+    repository.save(
+        InvestmentReport.builder()
+            .provider(SWEDBANK)
+            .reportType(POSITIONS)
+            .reportDate(LocalDate.of(2026, 1, 10))
+            .rawData(List.of(Map.of("test", "old")))
+            .createdAt(Instant.now())
+            .build());
+    repository.save(
+        InvestmentReport.builder()
+            .provider(SWEDBANK)
+            .reportType(POSITIONS)
+            .reportDate(LocalDate.of(2026, 1, 14))
+            .rawData(List.of(Map.of("test", "closest")))
+            .createdAt(Instant.now())
+            .build());
+    repository.save(
+        InvestmentReport.builder()
+            .provider(SWEDBANK)
+            .reportType(POSITIONS)
+            .reportDate(LocalDate.of(2026, 1, 15))
+            .rawData(List.of(Map.of("test", "sameDayExcluded")))
+            .createdAt(Instant.now())
+            .build());
+
+    Optional<InvestmentReport> result =
+        repository.findTopByProviderAndReportTypeAndReportDateLessThanOrderByReportDateDesc(
+            SWEDBANK, POSITIONS, LocalDate.of(2026, 1, 15));
+
+    assertThat(result).isPresent();
+    assertThat(result.get().getReportDate()).isEqualTo(LocalDate.of(2026, 1, 14));
+  }
+
+  @Test
+  void
+      findTopByProviderAndReportTypeAndReportDateLessThanOrderByReportDateDesc_returnsEmptyWhenNoPriorReport() {
+    repository.save(
+        InvestmentReport.builder()
+            .provider(SWEDBANK)
+            .reportType(POSITIONS)
+            .reportDate(LocalDate.of(2026, 1, 15))
+            .createdAt(Instant.now())
+            .build());
+
+    Optional<InvestmentReport> result =
+        repository.findTopByProviderAndReportTypeAndReportDateLessThanOrderByReportDateDesc(
+            SWEDBANK, POSITIONS, LocalDate.of(2026, 1, 15));
+
+    assertThat(result).isEmpty();
+  }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/investment/report/InvestmentReportServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/report/InvestmentReportServiceTest.java
@@ -118,4 +118,22 @@ class InvestmentReportServiceTest {
 
     assertThat(service.getLatestReport(SEB, PENDING_TRANSACTIONS)).contains(latest);
   }
+
+  @Test
+  void getPriorReport_returnsMostRecentReportBeforeGivenDate() {
+    InvestmentReport prior =
+        InvestmentReport.builder()
+            .id(8L)
+            .provider(SEB)
+            .reportType(PENDING_TRANSACTIONS)
+            .reportDate(LocalDate.of(2026, 5, 17))
+            .build();
+    given(
+            repository.findTopByProviderAndReportTypeAndReportDateLessThanOrderByReportDateDesc(
+                SEB, PENDING_TRANSACTIONS, LocalDate.of(2026, 5, 18)))
+        .willReturn(Optional.of(prior));
+
+    assertThat(service.getPriorReport(SEB, PENDING_TRANSACTIONS, LocalDate.of(2026, 5, 18)))
+        .contains(prior);
+  }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/PossibleReportTruncationAlertListenerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/PossibleReportTruncationAlertListenerTest.java
@@ -1,0 +1,70 @@
+package ee.tuleva.onboarding.investment.transaction.ingest;
+
+import static ee.tuleva.onboarding.notification.OperationsNotificationService.Channel.INVESTMENT;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import com.microtripit.mandrillapp.lutung.view.MandrillMessage;
+import ee.tuleva.onboarding.notification.OperationsNotificationService;
+import ee.tuleva.onboarding.notification.email.EmailService;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PossibleReportTruncationAlertListenerTest {
+
+  @Mock private EmailService emailService;
+  @Mock private OperationsNotificationService notificationService;
+
+  private final AlertProperties alertProperties =
+      new AlertProperties(List.of("funds@tuleva.ee"), List.of("taavi.pertman@tuleva.ee"));
+
+  private PossibleReportTruncationAlertListener listener() {
+    return new PossibleReportTruncationAlertListener(
+        new AlertMandrillMessageFactory(alertProperties), emailService, notificationService);
+  }
+
+  private static PossibleReportTruncationEvent sampleEvent() {
+    return new PossibleReportTruncationEvent(
+        LocalDate.parse("2026-05-13"), 5, LocalDate.parse("2026-05-12"), 50);
+  }
+
+  @Test
+  void sendsSlackNotificationWithKeyDetails() {
+    given(emailService.sendSystemEmail(any(MandrillMessage.class))).willReturn(true);
+
+    listener().onPossibleReportTruncation(sampleEvent());
+
+    verify(notificationService)
+        .sendMessage(
+            """
+            ⚠️ SEB pending transactions raport võib olla poolik – 2026-05-13
+            Ridu: 5 (eelmine raport 2026-05-12: 50 rida)
+            Kadumise põhjal tuvastamist ei tehtud, oodatakse käsitsi kontrolli.""",
+            INVESTMENT);
+  }
+
+  @Test
+  void sendsEmailContainingRowCounts() {
+    given(emailService.sendSystemEmail(any(MandrillMessage.class))).willReturn(true);
+
+    listener().onPossibleReportTruncation(sampleEvent());
+
+    ArgumentCaptor<MandrillMessage> captor = ArgumentCaptor.forClass(MandrillMessage.class);
+    verify(emailService).sendSystemEmail(captor.capture());
+    MandrillMessage message = captor.getValue();
+    assertThat(message.getSubject())
+        .isEqualTo("[HOIATUS] SEB pending transactions raport võib olla poolik – 2026-05-13");
+    assertThat(message.getText()).contains("Raporti kuupäev: 2026-05-13");
+    assertThat(message.getText()).contains("Ridu: 5");
+    assertThat(message.getText()).contains("Eelmise raporti kuupäev: 2026-05-12");
+    assertThat(message.getText()).contains("Eelmise raporti ridu: 50");
+  }
+}

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/QuantityAmountValidatorTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/QuantityAmountValidatorTest.java
@@ -74,6 +74,41 @@ class QuantityAmountValidatorTest {
   }
 
   @Test
+  void withinResidualTolerance_etfSecondPieceMatchesResidualExactly_returnsTrue() {
+    TransactionOrder order = etfBuyOrder(new BigDecimal("13288"));
+    var existing = List.of(execQuantity("REF1", new BigDecimal("10000")));
+    SebPendingTransactionRow row = etfRowWithRef("REF2", new BigDecimal("3288"));
+
+    assertThat(validator.withinResidualTolerance(order, row, existing, PROPERTIES)).isTrue();
+  }
+
+  @Test
+  void withinResidualTolerance_fundBuyAmountSecondPieceMatchesResidual_returnsTrue() {
+    TransactionOrder order = fundBuyOrder(new BigDecimal("100000.00"));
+    var existing = List.of(execAmount("REF1", new BigDecimal("70000.00")));
+    SebPendingTransactionRow row = fundBuyRowWithRef("REF2", new BigDecimal("30000.00"));
+
+    assertThat(validator.withinResidualTolerance(order, row, existing, PROPERTIES)).isTrue();
+  }
+
+  @Test
+  void withinResidualTolerance_fullyExecutedOrder_returnsFalse() {
+    TransactionOrder order = etfBuyOrder(new BigDecimal("13288"));
+    var existing = List.of(execQuantity("REF1", new BigDecimal("13288")));
+    SebPendingTransactionRow row = etfRowWithRef("REF2", new BigDecimal("100"));
+
+    assertThat(validator.withinResidualTolerance(order, row, existing, PROPERTIES)).isFalse();
+  }
+
+  @Test
+  void withinResidualTolerance_nullOrderTarget_returnsFalse() {
+    TransactionOrder order = fundBuyOrder(null);
+    SebPendingTransactionRow row = fundBuyRowWithRef("REF2", new BigDecimal("30000.00"));
+
+    assertThat(validator.withinResidualTolerance(order, row, List.of(), PROPERTIES)).isFalse();
+  }
+
+  @Test
   void validate_fundBuyWithNullOrderAmount_returnsEmpty() {
     TransactionOrder order = fundBuyOrder(null);
     SebPendingTransactionRow row = fundBuyRow(new BigDecimal("102000.00"));

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/ReconciliationAuditRecorderTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/ReconciliationAuditRecorderTest.java
@@ -227,6 +227,38 @@ class ReconciliationAuditRecorderTest {
     verify(auditEventRepository, never()).save(any());
   }
 
+  @Test
+  void recordPossibleReportTruncation_savesEventWithoutOrderAndRowCounts() {
+    newRecorder().recordPossibleReportTruncation(REPORT_DATE, 5, LocalDate.of(2026, 5, 12), 50);
+
+    verify(auditEventRepository)
+        .save(
+            argThat(
+                (TransactionAuditEvent event) ->
+                    "POSSIBLE_REPORT_TRUNCATION".equals(event.getEventType())
+                        && event.getOrderId() == null
+                        && event.getBatch() == null
+                        && "2026-05-13".equals(event.getDedupKey())
+                        && REPORT_DATE.toString().equals(event.getPayload().get("reportDate"))
+                        && Integer.valueOf(5).equals(event.getPayload().get("rowCount"))
+                        && "2026-05-12".equals(event.getPayload().get("priorReportDate"))
+                        && Integer.valueOf(50).equals(event.getPayload().get("priorRowCount"))));
+  }
+
+  @Test
+  void recordPossibleReportTruncation_skipsDuplicateForSameReportDate() {
+    given(
+            auditEventRepository.findByEventTypeAndDedupKey(
+                "POSSIBLE_REPORT_TRUNCATION", "2026-05-13"))
+        .willReturn(
+            List.of(
+                TransactionAuditEvent.builder().eventType("POSSIBLE_REPORT_TRUNCATION").build()));
+
+    newRecorder().recordPossibleReportTruncation(REPORT_DATE, 5, LocalDate.of(2026, 5, 12), 50);
+
+    verify(auditEventRepository, never()).save(any());
+  }
+
   private static TransactionOrder sampleOrder() {
     return TransactionOrder.builder()
         .id(123L)

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/ReconciliationAuditRecorderTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/ReconciliationAuditRecorderTest.java
@@ -91,6 +91,63 @@ class ReconciliationAuditRecorderTest {
   }
 
   @Test
+  void recordInconsistentMatchedRow_savesEventWithOrderIdReasonAndRowPayload() {
+    newRecorder()
+        .recordInconsistentMatchedRow(
+            sampleOrder(), sampleRow(), "ISIN_SIDE_MISMATCH", REPORT_DATE);
+
+    verify(auditEventRepository)
+        .save(
+            argThat(
+                (TransactionAuditEvent event) ->
+                    "INCONSISTENT_MATCHED_ROW".equals(event.getEventType())
+                        && event.getOrderId().equals(123L)
+                        && "ISIN_SIDE_MISMATCH".equals(event.getPayload().get("reason"))
+                        && "DLA0799512".equals(event.getPayload().get("ourRef"))
+                        && "2026-05-13|123|ISIN_SIDE_MISMATCH".equals(event.getDedupKey())
+                        && REPORT_DATE.toString().equals(event.getPayload().get("reportDate"))));
+  }
+
+  @Test
+  void recordInconsistentMatchedRow_twoDifferentOrdersMissingOurRef_bothRecordedWithDistinctKeys() {
+    ReconciliationAuditRecorder recorder = newRecorder();
+    TransactionOrder orderA = sampleOrder();
+    TransactionOrder orderB = TransactionOrder.builder().id(456L).build();
+    SebPendingTransactionRow rowMissingOurRef = rowWithoutOurRef();
+
+    recorder.recordInconsistentMatchedRow(orderA, rowMissingOurRef, "MISSING_OUR_REF", REPORT_DATE);
+    recorder.recordInconsistentMatchedRow(orderB, rowMissingOurRef, "MISSING_OUR_REF", REPORT_DATE);
+
+    verify(auditEventRepository)
+        .save(
+            argThat(
+                (TransactionAuditEvent event) ->
+                    "INCONSISTENT_MATCHED_ROW".equals(event.getEventType())
+                        && "2026-05-13|123|MISSING_OUR_REF".equals(event.getDedupKey())));
+    verify(auditEventRepository)
+        .save(
+            argThat(
+                (TransactionAuditEvent event) ->
+                    "INCONSISTENT_MATCHED_ROW".equals(event.getEventType())
+                        && "2026-05-13|456|MISSING_OUR_REF".equals(event.getDedupKey())));
+  }
+
+  @Test
+  void recordInconsistentMatchedRow_skipsDuplicateForSameRowReportDateAndReason() {
+    given(
+            auditEventRepository.findByEventTypeAndDedupKey(
+                "INCONSISTENT_MATCHED_ROW", "2026-05-13|123|ISIN_SIDE_MISMATCH"))
+        .willReturn(
+            List.of(TransactionAuditEvent.builder().eventType("INCONSISTENT_MATCHED_ROW").build()));
+
+    newRecorder()
+        .recordInconsistentMatchedRow(
+            sampleOrder(), sampleRow(), "ISIN_SIDE_MISMATCH", REPORT_DATE);
+
+    verify(auditEventRepository, never()).save(any());
+  }
+
+  @Test
   void recordQuantityAmountMismatch_savesEventWithOrderIdAndMismatchPayload() {
     newRecorder().recordQuantityAmountMismatch(sampleMismatch());
 
@@ -197,6 +254,24 @@ class ReconciliationAuditRecorderTest {
     return new SebPendingTransactionRow(
         CLIENT_REF,
         "DLA0799512",
+        "IE000F60HVH9",
+        new BigDecimal("15007"),
+        new BigDecimal("4.7255"),
+        new BigDecimal("70915.58"),
+        new BigDecimal("0.00"),
+        new BigDecimal("70915.58"),
+        BUY,
+        Instant.parse("2026-05-11T10:26:04Z"),
+        LocalDate.of(2026, 5, 13),
+        "Tuleva Täiendav Kogumisfond",
+        "VP68168",
+        "ICAV Amundi MSCI USA Screened UCITS ETF");
+  }
+
+  private static SebPendingTransactionRow rowWithoutOurRef() {
+    return new SebPendingTransactionRow(
+        CLIENT_REF,
+        null,
         "IE000F60HVH9",
         new BigDecimal("15007"),
         new BigDecimal("4.7255"),

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/SebPendingTransactionComplexMatchIT.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/SebPendingTransactionComplexMatchIT.java
@@ -94,19 +94,62 @@ class SebPendingTransactionComplexMatchIT {
     assertThat(reloaded.getOrderStatus()).isEqualTo(EXECUTED);
   }
 
+  @Test
+  void reconcile_secondPartialFillMissingClientRef_complexMatchesResidualAndAddsExecution() {
+    executionRepository.save(
+        TransactionExecution.builder()
+            .orderId(order.getId())
+            .brokerTransactionId("DLA0001111")
+            .executedQuantity(new BigDecimal("10000"))
+            .totalConsideration(new BigDecimal("345000.00"))
+            .source("SEB_OOTEL")
+            .build());
+    order.setOrderStatus(EXECUTED);
+    orderRepository.save(order);
+
+    InvestmentReport secondPieceReport =
+        reportRepository.save(
+            InvestmentReport.builder()
+                .provider(SEB)
+                .reportType(PENDING_TRANSACTIONS)
+                .reportDate(LocalDate.of(2026, 5, 14))
+                .rawData(List.of(rawRowWithoutClientRef("DLA0002222", "3288")))
+                .metadata(Map.of("source", "fixture"))
+                .createdAt(Instant.now())
+                .build());
+
+    reconciliationService.reconcile(secondPieceReport);
+    entityManager.flush();
+    entityManager.clear();
+
+    List<TransactionExecution> executions = executionRepository.findAllByOrderId(order.getId());
+    assertThat(executions).hasSize(2);
+    assertThat(executions)
+        .extracting(TransactionExecution::getExecutedQuantity)
+        .usingElementComparator(BigDecimal::compareTo)
+        .containsExactlyInAnyOrder(new BigDecimal("10000"), new BigDecimal("3288"));
+
+    TransactionOrder reloaded = orderRepository.findById(order.getId()).orElseThrow();
+    assertThat(reloaded.getOrderStatus()).isEqualTo(EXECUTED);
+  }
+
   private static Map<String, Object> rawRowWithoutClientRef() {
+    return rawRowWithoutClientRef("DLA0001234", "13288");
+  }
+
+  private static Map<String, Object> rawRowWithoutClientRef(String ourRef, String quantity) {
     Map<String, Object> raw = new HashMap<>();
     raw.put("Client name", "Tuleva Maailma Aktsiate Pensionifond");
     raw.put("Account", "VP68958");
-    raw.put("Our ref", "DLA0001234");
+    raw.put("Our ref", ourRef);
     raw.put("ISIN", ETF_ISIN);
     raw.put("Instrument name", "iShares Edge MSCI USA Quality Factor UCITS ETF");
     raw.put("Currency", "EUR");
-    raw.put("Quantity", new BigDecimal("13288"));
+    raw.put("Quantity", new BigDecimal(quantity));
     raw.put("Price", new BigDecimal("34.50"));
-    raw.put("Settlement amount", new BigDecimal("458436.00"));
+    raw.put("Settlement amount", new BigDecimal(quantity).multiply(new BigDecimal("34.50")));
     raw.put("Broker fee", new BigDecimal("0.00"));
-    raw.put("Total", new BigDecimal("458436.00"));
+    raw.put("Total", new BigDecimal(quantity).multiply(new BigDecimal("34.50")));
     raw.put("Buy/Sell", "Buy");
     raw.put("Trade date", "2026-05-11T10:26:04Z");
     raw.put("Settlement date", "2026-05-13");

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/SebPendingTransactionComplexMatcherTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/SebPendingTransactionComplexMatcherTest.java
@@ -149,15 +149,41 @@ class SebPendingTransactionComplexMatcherTest {
   }
 
   @Test
-  void match_skipsOrdersAlreadyLinkedToExecution() {
+  void match_alreadyLinkedOrderResidualFitsTolerance_returnsOrder() {
     TransactionOrder order = orderOf(41L, TUK75, "IE00BFNM3G45", BUY, ETF, 13288L, null, SENT);
     givenCandidates("IE00BFNM3G45", List.of(order));
     given(executionRepository.findAllByOrderId(41L))
         .willReturn(
-            List.of(TransactionExecution.builder().id(99L).orderId(41L).source("X").build()));
+            List.of(
+                TransactionExecution.builder()
+                    .id(99L)
+                    .orderId(41L)
+                    .executedQuantity(new BigDecimal("10000"))
+                    .source("X")
+                    .build()));
 
     SebPendingTransactionRow row =
-        row("Tuleva Maailma Aktsiate Pensionifond", "IE00BFNM3G45", "Buy", "13288", null);
+        row("Tuleva Maailma Aktsiate Pensionifond", "IE00BFNM3G45", "Buy", "3288", null);
+
+    assertThat(matcher().match(row, PROPERTIES)).contains(order);
+  }
+
+  @Test
+  void match_fullyExecutedOrderResidualOutsideTolerance_returnsEmpty() {
+    TransactionOrder order = orderOf(42L, TUK75, "IE00BFNM3G45", BUY, ETF, 13288L, null, SENT);
+    givenCandidates("IE00BFNM3G45", List.of(order));
+    given(executionRepository.findAllByOrderId(42L))
+        .willReturn(
+            List.of(
+                TransactionExecution.builder()
+                    .id(100L)
+                    .orderId(42L)
+                    .executedQuantity(new BigDecimal("13288"))
+                    .source("X")
+                    .build()));
+
+    SebPendingTransactionRow row =
+        row("Tuleva Maailma Aktsiate Pensionifond", "IE00BFNM3G45", "Buy", "100", null);
 
     assertThat(matcher().match(row, PROPERTIES)).isEmpty();
   }
@@ -364,17 +390,47 @@ class SebPendingTransactionComplexMatcherTest {
   }
 
   @Test
-  void findNearMiss_excludesOrdersAlreadyLinkedToExecution() {
+  void findNearMiss_fullyExecutedOrderResidualOutsideNearMiss_returnsEmpty() {
     TransactionOrder order = orderOf(89L, TUK75, "IE00BFNM3G45", BUY, ETF, 13288L, null, SENT);
     givenCandidates("IE00BFNM3G45", List.of(order));
     given(executionRepository.findAllByOrderId(89L))
         .willReturn(
-            List.of(TransactionExecution.builder().id(99L).orderId(89L).source("X").build()));
+            List.of(
+                TransactionExecution.builder()
+                    .id(99L)
+                    .orderId(89L)
+                    .executedQuantity(new BigDecimal("13288"))
+                    .source("X")
+                    .build()));
 
     SebPendingTransactionRow row =
         row("Tuleva Maailma Aktsiate Pensionifond", "IE00BFNM3G45", "Buy", "13288.0003", null);
 
     assertThat(matcher().findNearMiss(row, PROPERTIES)).isEmpty();
+  }
+
+  @Test
+  void findNearMiss_alreadyLinkedOrderResidualOutsideToleranceButWithinFiveX_returnsNearMiss() {
+    TransactionOrder order = orderOf(90L, TUK75, "IE00BFNM3G45", BUY, ETF, 13288L, null, SENT);
+    givenCandidates("IE00BFNM3G45", List.of(order));
+    given(executionRepository.findAllByOrderId(90L))
+        .willReturn(
+            List.of(
+                TransactionExecution.builder()
+                    .id(101L)
+                    .orderId(90L)
+                    .executedQuantity(new BigDecimal("10000"))
+                    .source("X")
+                    .build()));
+
+    // Residual = 3288. Tolerance = 0.0001, 5x = 0.0005. Diff 0.0003 is outside tolerance but
+    // inside 5x.
+    SebPendingTransactionRow row =
+        row("Tuleva Maailma Aktsiate Pensionifond", "IE00BFNM3G45", "Buy", "3288.0003", null);
+
+    Optional<QuantityAmountMismatchEvent> nearMiss = matcher().findNearMiss(row, PROPERTIES);
+    assertThat(nearMiss).isPresent();
+    assertThat(nearMiss.get().order()).isEqualTo(order);
   }
 
   @Test

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/SebPendingTransactionReconciliationServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/SebPendingTransactionReconciliationServiceTest.java
@@ -644,6 +644,48 @@ class SebPendingTransactionReconciliationServiceTest {
   }
 
   @Test
+  void reconcile_matchedRowWithMissingIsin_isQuarantinedAndRunContinues() {
+    service = newService();
+    UUID clientRefA = UUID.fromString("bd83f551-8c79-4193-b92b-18e1dfd0bd29");
+    TransactionOrder orderA = sampleOrder(clientRefA);
+    given(orderRepository.findByOrderUuid(clientRefA)).willReturn(Optional.of(orderA));
+    given(executionRepository.findAllByOrderId(123L)).willReturn(List.of());
+
+    UUID clientRefB = UUID.fromString("00000000-0000-0000-0000-000000000042");
+    TransactionOrder orderB =
+        TransactionOrder.builder()
+            .id(124L)
+            .fund(TKF100)
+            .instrumentIsin("IE000F60HVH9")
+            .transactionType(BUY)
+            .instrumentType(ETF)
+            .orderVenue(OrderVenue.SEB)
+            .orderUuid(clientRefB)
+            .orderStatus(SENT)
+            .build();
+    given(orderRepository.findByOrderUuid(clientRefB)).willReturn(Optional.of(orderB));
+
+    Map<String, Object> rowB = validRawRow(clientRefB);
+    rowB.put("Our ref", "DLA0888888");
+    rowB.remove("ISIN");
+
+    InvestmentReport report =
+        InvestmentReport.builder()
+            .provider(SEB)
+            .reportType(PENDING_TRANSACTIONS)
+            .reportDate(LocalDate.of(2026, 5, 13))
+            .rawData(List.of(validRawRow(clientRefA), rowB))
+            .build();
+
+    service.reconcile(report);
+
+    assertThat(orderA.getOrderStatus()).isEqualTo(EXECUTED);
+    verify(executionRepository)
+        .save(argThat((TransactionExecution e) -> e.getOrderId().equals(123L)));
+    assertThat(orderB.getOrderStatus()).isEqualTo(SENT);
+  }
+
+  @Test
   void reconcile_matchedRowWithoutOurRef_isQuarantinedNotExecuted() {
     service = newService();
     UUID clientRef = UUID.fromString("bd83f551-8c79-4193-b92b-18e1dfd0bd29");

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/SebPendingTransactionReconciliationServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/SebPendingTransactionReconciliationServiceTest.java
@@ -624,6 +624,35 @@ class SebPendingTransactionReconciliationServiceTest {
 
     verify(executionRepository, never()).save(any());
     assertThat(order.getOrderStatus()).isEqualTo(SENT);
+    verify(auditEventRepository)
+        .save(
+            argThat(
+                (TransactionAuditEvent event) ->
+                    "INCONSISTENT_MATCHED_ROW".equals(event.getEventType())
+                        && event.getOrderId().equals(123L)
+                        && "ISIN_SIDE_MISMATCH".equals(event.getPayload().get("reason"))));
+  }
+
+  @Test
+  void reconcile_matchedRowWithMismatchedSide_secondReconcileDoesNotDuplicateAuditEvent() {
+    service = newService();
+    UUID clientRef = UUID.fromString("bd83f551-8c79-4193-b92b-18e1dfd0bd29");
+    TransactionOrder order = orderWith(clientRef, ETF, SELL, new BigDecimal("15007"), null);
+    given(orderRepository.findByOrderUuid(clientRef)).willReturn(Optional.of(order));
+    String dedupKey = "2026-05-13|123|ISIN_SIDE_MISMATCH";
+    given(auditEventRepository.findByEventTypeAndDedupKey("INCONSISTENT_MATCHED_ROW", dedupKey))
+        .willReturn(
+            List.of(),
+            List.of(TransactionAuditEvent.builder().eventType("INCONSISTENT_MATCHED_ROW").build()));
+
+    service.reconcile(reportWithSingleRow(clientRef));
+    service.reconcile(reportWithSingleRow(clientRef));
+
+    verify(auditEventRepository, org.mockito.Mockito.times(1))
+        .save(
+            argThat(
+                (TransactionAuditEvent event) ->
+                    "INCONSISTENT_MATCHED_ROW".equals(event.getEventType())));
   }
 
   @Test
@@ -683,6 +712,13 @@ class SebPendingTransactionReconciliationServiceTest {
     verify(executionRepository)
         .save(argThat((TransactionExecution e) -> e.getOrderId().equals(123L)));
     assertThat(orderB.getOrderStatus()).isEqualTo(SENT);
+    verify(auditEventRepository)
+        .save(
+            argThat(
+                (TransactionAuditEvent event) ->
+                    "INCONSISTENT_MATCHED_ROW".equals(event.getEventType())
+                        && event.getOrderId().equals(124L)
+                        && "MISSING_ISIN".equals(event.getPayload().get("reason"))));
   }
 
   @Test

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/SebPendingTransactionReconciliationServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/SebPendingTransactionReconciliationServiceTest.java
@@ -946,6 +946,96 @@ class SebPendingTransactionReconciliationServiceTest {
   }
 
   @Test
+  void reconcile_reportRowCountDroppedSharplyFromPriorReport_skipsSettlementByAbsence() {
+    service = newService();
+    UUID clientRef = UUID.fromString("bd83f551-8c79-4193-b92b-18e1dfd0bd29");
+    TransactionOrder matchedOrder = sampleOrder(clientRef);
+    given(orderRepository.findByOrderUuid(clientRef)).willReturn(Optional.of(matchedOrder));
+    given(executionRepository.findAllByOrderId(123L)).willReturn(List.of());
+
+    // Prior report had ~50 well-formed rows; today's report has just 1 — a >50% row-count cliff
+    // that looks like a truncated upload rather than genuine settlement activity.
+    InvestmentReport priorReport = reportWithRows(LocalDate.of(2026, 5, 12), 50);
+    given(reportService.getPriorReport(SEB, PENDING_TRANSACTIONS, LocalDate.of(2026, 5, 13)))
+        .willReturn(Optional.of(priorReport));
+
+    service.reconcile(reportWithSingleRow(clientRef));
+
+    // Truncation guard trips before candidate orders are even looked up.
+    verify(orderRepository, never()).findByOrderStatusIn(anyCollection());
+    verify(settlementRepository, never()).save(any());
+    verify(eventPublisher)
+        .publishEvent(
+            argThat(
+                (Object e) ->
+                    e instanceof PossibleReportTruncationEvent event
+                        && event.reportDate().equals(LocalDate.of(2026, 5, 13))
+                        && event.rowCount() == 1
+                        && event.priorReportDate().equals(LocalDate.of(2026, 5, 12))
+                        && event.priorRowCount() == 50));
+    verify(auditEventRepository)
+        .save(
+            argThat(
+                (TransactionAuditEvent event) ->
+                    "POSSIBLE_REPORT_TRUNCATION".equals(event.getEventType())
+                        && event.getOrderId() == null
+                        && "2026-05-13".equals(event.getPayload().get("reportDate"))
+                        && Integer.valueOf(1).equals(event.getPayload().get("rowCount"))
+                        && "2026-05-12".equals(event.getPayload().get("priorReportDate"))
+                        && Integer.valueOf(50).equals(event.getPayload().get("priorRowCount"))));
+  }
+
+  @Test
+  void reconcile_reportRowCountShrinksNormallyFromPriorReport_stillSettlesByAbsence() {
+    service = newService();
+    UUID clientRef = UUID.fromString("bd83f551-8c79-4193-b92b-18e1dfd0bd29");
+    TransactionOrder matchedOrder = sampleOrder(clientRef);
+    given(orderRepository.findByOrderUuid(clientRef)).willReturn(Optional.of(matchedOrder));
+    given(executionRepository.findAllByOrderId(123L)).willReturn(List.of());
+    given(orderRepository.findByInstrumentIsin(any())).willReturn(List.of());
+
+    TransactionOrder absentOrder = executedOrder(456L);
+    given(orderRepository.findByOrderStatusIn(anyCollection())).willReturn(List.of(absentOrder));
+    given(executionRepository.findAllByOrderId(456L))
+        .willReturn(List.of(executionWithTradeInstant(456L, "2026-05-11T10:00:00Z")));
+    given(settlementRepository.save(any()))
+        .willAnswer(invocation -> invocation.getArgument(0, TransactionSettlement.class));
+
+    // Prior report had 10 rows; today's report has 6 — a 40% drop, below the truncation threshold.
+    InvestmentReport priorReport = reportWithRows(LocalDate.of(2026, 5, 12), 10);
+    given(reportService.getPriorReport(SEB, PENDING_TRANSACTIONS, LocalDate.of(2026, 5, 13)))
+        .willReturn(Optional.of(priorReport));
+
+    service.reconcile(reportWithRowsAndMatch(LocalDate.of(2026, 5, 13), clientRef, 6));
+
+    verify(settlementRepository)
+        .save(argThat((TransactionSettlement settlement) -> settlement.getOrderId().equals(456L)));
+    assertThat(absentOrder.getOrderStatus()).isEqualTo(SETTLED);
+  }
+
+  @Test
+  void reconcile_absentExecutedOrderNoPriorReportAvailable_stillSettlesByAbsence() {
+    service = newService();
+    UUID clientRef = UUID.fromString("bd83f551-8c79-4193-b92b-18e1dfd0bd29");
+    TransactionOrder matchedOrder = sampleOrder(clientRef);
+    given(orderRepository.findByOrderUuid(clientRef)).willReturn(Optional.of(matchedOrder));
+    given(executionRepository.findAllByOrderId(123L)).willReturn(List.of());
+
+    TransactionOrder absentOrder = executedOrder(456L);
+    given(orderRepository.findByOrderStatusIn(anyCollection())).willReturn(List.of(absentOrder));
+    given(executionRepository.findAllByOrderId(456L))
+        .willReturn(List.of(executionWithTradeInstant(456L, "2026-05-11T10:00:00Z")));
+    given(settlementRepository.save(any()))
+        .willAnswer(invocation -> invocation.getArgument(0, TransactionSettlement.class));
+
+    service.reconcile(reportWithSingleRow(clientRef));
+
+    verify(settlementRepository)
+        .save(argThat((TransactionSettlement settlement) -> settlement.getOrderId().equals(456L)));
+    assertThat(absentOrder.getOrderStatus()).isEqualTo(SETTLED);
+  }
+
+  @Test
   void reconcile_nonLatestReplayedReport_skipsSettlementByAbsence() {
     service = newService();
     UUID clientRef = UUID.fromString("bd83f551-8c79-4193-b92b-18e1dfd0bd29");
@@ -1174,6 +1264,31 @@ class SebPendingTransactionReconciliationServiceTest {
 
   private static InvestmentReport reportWithSingleRow(UUID clientRef) {
     return reportOf(validRawRow(clientRef));
+  }
+
+  private static InvestmentReport reportWithRows(LocalDate reportDate, int rowCount) {
+    return reportWithRowsAndMatch(reportDate, null, rowCount);
+  }
+
+  // Builds a report with one row matching clientRef (if given) plus enough noise rows —
+  // referencing no known order — to reach rowCount, so only row count is exercised.
+  private static InvestmentReport reportWithRowsAndMatch(
+      LocalDate reportDate, UUID clientRef, int rowCount) {
+    List<Map<String, Object>> rows = new java.util.ArrayList<>();
+    if (clientRef != null) {
+      rows.add(validRawRow(clientRef));
+    }
+    while (rows.size() < rowCount) {
+      Map<String, Object> raw = validRawRow(UUID.randomUUID());
+      raw.put("Our ref", "DLA9" + (100000 + rows.size()));
+      rows.add(raw);
+    }
+    return InvestmentReport.builder()
+        .provider(SEB)
+        .reportType(PENDING_TRANSACTIONS)
+        .reportDate(reportDate)
+        .rawData(rows)
+        .build();
   }
 
   private static InvestmentReport reportOf(Map<String, Object> raw) {

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/SettlementCheckJobTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/SettlementCheckJobTest.java
@@ -36,6 +36,7 @@ import ee.tuleva.onboarding.investment.transaction.TransactionExecution;
 import ee.tuleva.onboarding.investment.transaction.TransactionExecutionRepository;
 import ee.tuleva.onboarding.investment.transaction.TransactionOrder;
 import ee.tuleva.onboarding.investment.transaction.TransactionOrderRepository;
+import ee.tuleva.onboarding.investment.transaction.ingest.UnmatchedPendingTransactionFinder.InconsistentMatchedRow;
 import ee.tuleva.onboarding.notification.OperationsNotificationService;
 import java.math.BigDecimal;
 import java.time.Clock;
@@ -613,6 +614,51 @@ class SettlementCheckJobTest {
     assertThat(captor.getValue())
         .contains("[TÄIDETUD, arveldus hilinenud] Order 2")
         .contains("saadetud: ?");
+  }
+
+  @Test
+  void run_inconsistentMatchedRow_appearsInDedicatedDigestSection() {
+    given(publicHolidays.previousWorkingDay(TODAY)).willReturn(LAST_WORKING_DAY);
+    InvestmentReport report = report(TODAY);
+    given(reportService.getLatestReport(SEB, PENDING_TRANSACTIONS)).willReturn(Optional.of(report));
+    given(extractor.extract(report)).willReturn(List.of());
+    given(orderRepository.findByOrderStatusInAndOrderTimestampSince(any(), any()))
+        .willReturn(List.of());
+    given(executionRepository.findByOrderIdIn(any())).willReturn(List.of());
+    given(unmatchedFinder.collectUnmatched(report)).willReturn(List.of());
+
+    TransactionOrder order =
+        order(5L, ETF, EXECUTED, dateOnly(2026, 5, 4), TUV100, "IE000F60HVH9", PRESENT_UUID);
+    InconsistentMatchedRow inconsistentRow =
+        new InconsistentMatchedRow(rowWithClientRef(PRESENT_UUID), order, "ISIN_SIDE_MISMATCH");
+    given(unmatchedFinder.collectInconsistent(report)).willReturn(List.of(inconsistentRow));
+
+    job().run();
+
+    ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+    verify(notificationService).sendMessage(captor.capture(), eq(INVESTMENT));
+    assertThat(captor.getValue())
+        .contains("TUV100")
+        .contains("Ebakõlalised vastavused (1)")
+        .contains("ISIN_SIDE_MISMATCH")
+        .contains("Order 5");
+  }
+
+  @Test
+  void run_consistentReport_noInconsistentSection_sendsNothing() {
+    given(publicHolidays.previousWorkingDay(TODAY)).willReturn(LAST_WORKING_DAY);
+    InvestmentReport report = report(TODAY);
+    given(reportService.getLatestReport(SEB, PENDING_TRANSACTIONS)).willReturn(Optional.of(report));
+    given(extractor.extract(report)).willReturn(List.of());
+    given(orderRepository.findByOrderStatusInAndOrderTimestampSince(any(), any()))
+        .willReturn(List.of());
+    given(executionRepository.findByOrderIdIn(any())).willReturn(List.of());
+    given(unmatchedFinder.collectUnmatched(report)).willReturn(List.of());
+    given(unmatchedFinder.collectInconsistent(report)).willReturn(List.of());
+
+    job().run();
+
+    verifyNoInteractions(notificationService);
   }
 
   private static SebPendingTransactionRow rowWithOurRefOnly(String ourRef) {

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/UnmatchedPendingTransactionFinderTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/UnmatchedPendingTransactionFinderTest.java
@@ -1,11 +1,17 @@
 package ee.tuleva.onboarding.investment.transaction.ingest;
 
+import static ee.tuleva.onboarding.fund.TulevaFund.TKF100;
+import static ee.tuleva.onboarding.fund.TulevaFund.TUK75;
+import static ee.tuleva.onboarding.investment.transaction.InstrumentType.ETF;
+import static ee.tuleva.onboarding.investment.transaction.OrderStatus.SENT;
 import static ee.tuleva.onboarding.investment.transaction.TransactionType.BUY;
+import static ee.tuleva.onboarding.investment.transaction.TransactionType.SELL;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
 import ee.tuleva.onboarding.investment.report.InvestmentReport;
+import ee.tuleva.onboarding.investment.transaction.OrderVenue;
 import ee.tuleva.onboarding.investment.transaction.TransactionExecution;
 import ee.tuleva.onboarding.investment.transaction.TransactionExecutionRepository;
 import ee.tuleva.onboarding.investment.transaction.TransactionOrder;
@@ -30,15 +36,22 @@ class UnmatchedPendingTransactionFinderTest {
   @Mock private TransactionMatchingPolicy matchingPolicy;
   @Mock private TransactionOrderRepository orderRepository;
   @Mock private TransactionExecutionRepository executionRepository;
+  @Mock private SebClientNameToFundResolver fundResolver;
 
   private final InvestmentReport report = InvestmentReport.builder().build();
   private final TransactionMatchingProperties properties =
       new TransactionMatchingProperties(null, null, null, null, null);
 
   private UnmatchedPendingTransactionFinder finder() {
-    given(matchingPolicy.current()).willReturn(properties);
+    org.mockito.Mockito.lenient().when(matchingPolicy.current()).thenReturn(properties);
     return new UnmatchedPendingTransactionFinder(
-        extractor, matcher, complexMatcher, matchingPolicy, orderRepository, executionRepository);
+        extractor,
+        matcher,
+        complexMatcher,
+        matchingPolicy,
+        orderRepository,
+        executionRepository,
+        fundResolver);
   }
 
   @Test
@@ -123,6 +136,80 @@ class UnmatchedPendingTransactionFinderTest {
     given(complexMatcher.hasNearMissCandidate(row, properties)).willReturn(false);
 
     assertThat(finder().collectUnmatched(report)).containsExactly(row);
+  }
+
+  @Test
+  void collectInconsistent_clientRefMatchedRowWithMismatchedSide_isReturnedWithReason() {
+    UUID clientRef = UUID.randomUUID();
+    SebPendingTransactionRow row = rowWithClientRef(clientRef);
+    TransactionOrder order = orderWithClientRef(clientRef, SELL);
+    given(extractor.extract(report)).willReturn(List.of(row));
+    given(orderRepository.findByOrderUuid(clientRef)).willReturn(Optional.of(order));
+
+    assertThat(finder().collectInconsistent(report))
+        .containsExactly(
+            new UnmatchedPendingTransactionFinder.InconsistentMatchedRow(
+                row, order, "ISIN_SIDE_MISMATCH"));
+  }
+
+  @Test
+  void
+      collectInconsistent_clientRefMatchedRowWhoseClientNameResolvesToADifferentFund_isReturnedWithReason() {
+    UUID clientRef = UUID.randomUUID();
+    SebPendingTransactionRow row = rowWithClientRef(clientRef);
+    TransactionOrder order = orderWithClientRef(clientRef, BUY);
+    given(extractor.extract(report)).willReturn(List.of(row));
+    given(orderRepository.findByOrderUuid(clientRef)).willReturn(Optional.of(order));
+    given(fundResolver.resolve(row.clientName())).willReturn(Optional.of(TUK75));
+
+    assertThat(finder().collectInconsistent(report))
+        .containsExactly(
+            new UnmatchedPendingTransactionFinder.InconsistentMatchedRow(
+                row, order, "FUND_MISMATCH"));
+  }
+
+  @Test
+  void collectInconsistent_consistentClientRefMatchedRow_isNotReturned() {
+    UUID clientRef = UUID.randomUUID();
+    SebPendingTransactionRow row = rowWithClientRef(clientRef);
+    TransactionOrder order = orderWithClientRef(clientRef, BUY);
+    given(extractor.extract(report)).willReturn(List.of(row));
+    given(orderRepository.findByOrderUuid(clientRef)).willReturn(Optional.of(order));
+    given(fundResolver.resolve(row.clientName())).willReturn(Optional.of(TKF100));
+
+    assertThat(finder().collectInconsistent(report)).isEmpty();
+  }
+
+  @Test
+  void collectInconsistent_rowWithoutClientRef_isSkipped() {
+    SebPendingTransactionRow row = row("R1");
+    given(extractor.extract(report)).willReturn(List.of(row));
+
+    assertThat(finder().collectInconsistent(report)).isEmpty();
+  }
+
+  @Test
+  void collectInconsistent_unknownClientRef_isSkipped() {
+    UUID clientRef = UUID.randomUUID();
+    SebPendingTransactionRow row = rowWithClientRef(clientRef);
+    given(extractor.extract(report)).willReturn(List.of(row));
+    given(orderRepository.findByOrderUuid(clientRef)).willReturn(Optional.empty());
+
+    assertThat(finder().collectInconsistent(report)).isEmpty();
+  }
+
+  private static TransactionOrder orderWithClientRef(
+      UUID clientRef, ee.tuleva.onboarding.investment.transaction.TransactionType side) {
+    return TransactionOrder.builder()
+        .id(7L)
+        .fund(TKF100)
+        .instrumentIsin("IE000F60HVH9")
+        .transactionType(side)
+        .instrumentType(ETF)
+        .orderVenue(OrderVenue.SEB)
+        .orderUuid(clientRef)
+        .orderStatus(SENT)
+        .build();
   }
 
   private static SebPendingTransactionRow rowWithClientRef(UUID clientRef) {


### PR DESCRIPTION
Four correctness/observability fixes to the post-send SEB reconciliation pipeline (Wave 4 of the transaction-registry remediation; §4.7/§4.8 of the gap analysis). **No Critical; no migrations** (`event_type`/`dedup_key` are unconstrained `text`). Each item is test-first, one commit; a final clean-code commit removes explanatory comments in favour of expressive names.

## Fixes

**1. Missing-ISIN NPE no longer aborts the run** (`8dde3f9c3`)
A row matched by Client ref but with a blank ISIN hit `row.isin().equals(...)` and threw. Because `reconcile()` is transactional with no per-row isolation, that rolled back the *entire* report date's reconciliation — one bad row stopped every other order. Now a missing/blank ISIN is quarantined and the run continues.

**2. Inconsistent matched rows are surfaced to ops** (`b70ec1205`)
When a row matched an order by Client ref but failed a consistency guard (missing Our ref, missing ISIN, ISIN/side mismatch, fund mismatch — a likely wrong/reused Client ref), it was quarantined but only logged, and hidden from the digest. Now each records a durable `INCONSISTENT_MATCHED_ROW` audit event (deduped per report-date/order/reason) and appears in a dedicated settlement-digest section with its diagnosis.

**3. Truncation guard on settlement-by-absence** (`60ae447a0`)
Settlement-by-absence was guarded only by "no malformed rows," so a cleanly-truncated report (cut short mid-transfer, no trailer) could over-settle every order in the missing tail. Now, before settling by absence, the report's well-formed row count is compared against the most recent prior report; a drop of more than half is treated as possible truncation — settlement-by-absence is skipped (present rows still reconcile), a `POSSIBLE_REPORT_TRUNCATION` audit event is recorded, and ops is alerted over Slack + email. (The SEB feed has no trailer/count line to check directly, so a relative drop is the available signal.)

**4. Split fills' later piece complex-matches the residual** (`b9cb3b3a8`)
The complex matcher excluded any order that already had an execution, so a second partial-fill row that lost its Client ref orphaned — the exact split case partial settlement was built for. Removing the exclusion alone is insufficient (the tolerance check compares against the *full* target, which a residual piece can't satisfy), so this adds a residual-aware tolerance: for an order with executions, the row is compared against `target − already-executed`. Single-fill matching is unchanged; a fully-executed order has no residual, so a further row cannot over-attach.

## Maintainer decisions baked in
- **Item 2**: dedicated new event + digest section (not lumped into "unmatched"), so ops can distinguish a wrong/reused Client ref from a row that never matched.
- **Item 3**: relative row-count-drop guard now (threshold 50%, tunable) rather than deferring for a real truncated-file sample / SEB trailer spec.

## Verification
- Test-first throughout; full `./gradlew test` green on every commit (pre-commit hook).
- No comments in production (repo convention); clean-code reviewed.

## Known follow-ups (non-blocking)
- The `v_unmatched_seb_entries` Metabase view is hardcoded to `UNMATCHED_SEB_TRANSACTION`; the new `INCONSISTENT_MATCHED_ROW` event needs its own view/filter to show there too.
- The live inconsistent-row digest recomputes the Client-ref tier only (the durable audit covers all match tiers); broker-ref/complex-tier inconsistencies are audited but not double-reported in that digest section.
- Near-miss alert content for split orders still shows the full-target delta rather than the residual delta (matching logic is correct; only the displayed number).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GAMpqZVd8kzkhootmTSA7x