### PR TITLE
Guard batch confirmation with an optimistic lock against double-send (§4.7)

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionAdminService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionAdminService.java
@@ -18,6 +18,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
@@ -98,6 +99,11 @@ class TransactionAdminService {
     batch.setStatus(BatchStatus.CONFIRMED);
     batch.setConfirmedBy(actor);
     batch.setConfirmedAt(Instant.now(clock));
+    try {
+      batchRepository.saveAndFlush(batch);
+    } catch (ObjectOptimisticLockingFailureException e) {
+      throw new ResponseStatusException(CONFLICT, "Batch was modified concurrently: id=" + id);
+    }
     preparationService.finalizeConfirmedBatch(batch);
     return TransactionBatchResponse.from(batch, orderRepository.findByBatchId(batch.getId()));
   }

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionBatch.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionBatch.java
@@ -13,6 +13,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
+import jakarta.persistence.Version;
 import jakarta.validation.constraints.NotNull;
 import java.time.Instant;
 import java.util.Map;
@@ -62,6 +63,8 @@ public class TransactionBatch {
   private String cancelledBy;
 
   private Instant cancelledAt;
+
+  @Version private Long version;
 
   @PrePersist
   protected void onCreate() {

--- a/src/main/resources/db/migration/V1_229__transaction_batch_optimistic_lock.sql
+++ b/src/main/resources/db/migration/V1_229__transaction_batch_optimistic_lock.sql
@@ -1,0 +1,1 @@
+ALTER TABLE investment_transaction_batch ADD COLUMN version bigint NOT NULL DEFAULT 0;

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionAdminServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionAdminServiceTest.java
@@ -16,6 +16,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.never;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.BDDMockito.willAnswer;
+import static org.mockito.BDDMockito.willThrow;
 
 import ee.tuleva.onboarding.fund.TulevaFund;
 import java.math.BigDecimal;
@@ -33,6 +34,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.web.server.ResponseStatusException;
 
 @ExtendWith(MockitoExtension.class)
@@ -283,6 +285,21 @@ class TransactionAdminServiceTest {
         .isInstanceOf(ResponseStatusException.class)
         .extracting(e -> ((ResponseStatusException) e).getStatusCode().value())
         .isEqualTo(404);
+  }
+
+  @Test
+  void confirmAndFinalize_concurrentlyModifiedBatch_throwsConflictAndNeverFinalizes() {
+    TransactionBatch batch = batch(10L, AWAITING_CONFIRMATION);
+    given(batchRepository.findById(10L)).willReturn(Optional.of(batch));
+    willThrow(new ObjectOptimisticLockingFailureException(TransactionBatch.class, 10L))
+        .given(batchRepository)
+        .saveAndFlush(batch);
+
+    assertThatThrownBy(() -> service.confirmAndFinalize(10L, "admin"))
+        .isInstanceOf(ResponseStatusException.class)
+        .extracting(e -> ((ResponseStatusException) e).getStatusCode().value())
+        .isEqualTo(409);
+    then(preparationService).should(never()).finalizeConfirmedBatch(any());
   }
 
   @Test

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionBatchRepositoryIT.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionBatchRepositoryIT.java
@@ -4,18 +4,26 @@ import static ee.tuleva.onboarding.fund.TulevaFund.TUK00;
 import static ee.tuleva.onboarding.fund.TulevaFund.TUK75;
 import static ee.tuleva.onboarding.investment.transaction.BatchStatus.AWAITING_CONFIRMATION;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import ee.tuleva.onboarding.fund.TulevaFund;
+import jakarta.persistence.EntityManager;
 import java.time.Instant;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
 
 @DataJpaTest
 class TransactionBatchRepositoryIT {
 
   @Autowired private TransactionBatchRepository batchRepository;
+
+  @Autowired private EntityManager entityManager;
+
+  @Autowired private JdbcTemplate jdbcTemplate;
 
   @Test
   void findFirstByFundOrderByCreatedAtDesc_returnsLatestBatchOfTheGivenFund() {
@@ -66,6 +74,23 @@ class TransactionBatchRepositoryIT {
               assertThat(persisted.getCancelledAt())
                   .isEqualTo(Instant.parse("2026-06-11T09:10:00Z"));
             });
+  }
+
+  @Test
+  void saveAndFlush_withStaleVersion_throwsOptimisticLockingFailure() {
+    TransactionBatch batch = persistBatch(TUK75, Instant.parse("2026-06-11T09:00:00Z"));
+    entityManager.clear();
+    TransactionBatch staleCopy = batchRepository.findById(batch.getId()).orElseThrow();
+
+    jdbcTemplate.update(
+        "UPDATE investment_transaction_batch SET version = version + 1, confirmed_by = ? WHERE id = ?",
+        "operator-first",
+        batch.getId());
+
+    staleCopy.setStatus(BatchStatus.CANCELLED);
+    staleCopy.setCancelledBy("operator-stale");
+    assertThatThrownBy(() -> batchRepository.saveAndFlush(staleCopy))
+        .isInstanceOf(ObjectOptimisticLockingFailureException.class);
   }
 
   private TransactionBatch persistBatch(TulevaFund fund, Instant createdAt) {


### PR DESCRIPTION
`TransactionAdminService.confirmAndFinalize` checked the batch status but held no optimistic lock, so two concurrent confirmations could both read `AWAITING_CONFIRMATION`, both pass the status guard, and both commit (last-write-wins). `finalizeConfirmedBatch` defers its external side effects to after commit, so **both would fire** — a double custodian email, double Google Drive upload, and double `BATCH_FINALIZED` audit event. This closes the residual concurrency gap left open when the status guard landed in PR #1764.

## Change
- Add a `@Version` column to `TransactionBatch` (migration `V1_229`, `investment_transaction_batch`).
- Flush the confirmed batch (`saveAndFlush`) before finalizing; map `ObjectOptimisticLockingFailureException` to a 409 CONFLICT. The losing transaction now fails **before** any after-commit side effect can register.

## Verification (test-first)
- Repository IT: a stale-version `saveAndFlush` throws `ObjectOptimisticLockingFailureException` (proven via a genuine external raw-JDBC version bump against a still-attached entity — a same-session `merge` dance does not reproduce a lost update).
- Service unit: an optimistic-lock failure maps to 409 and `finalizeConfirmedBatch` is never called (the loser never sends).
- Full `./gradlew test` green; the new NOT NULL `version` column defaults to 0, no fixture regressions.

Migration `V1_229` is above the current master max (`V1_228`); re-check ordering before merge if other migrations land first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GAMpqZVd8kzkhootmTSA7x