### PR TITLE
§4.7 low-severity hardening: constant-time tokens, EPIS parser fixes, FT ambiguity, bounded settlement scan

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/admin/AdminController.java
+++ b/src/main/java/ee/tuleva/onboarding/admin/AdminController.java
@@ -1,5 +1,6 @@
 package ee.tuleva.onboarding.admin;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.springframework.format.annotation.DateTimeFormat.ISO.DATE;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.SERVICE_UNAVAILABLE;
@@ -38,6 +39,7 @@ import jakarta.transaction.Transactional;
 import jakarta.validation.Valid;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.security.MessageDigest;
 import java.time.Clock;
 import java.time.DateTimeException;
 import java.time.LocalDate;
@@ -563,8 +565,12 @@ public class AdminController {
   }
 
   private void validateTokenWithOpsAccess(String token) {
-    boolean matchesAdmin = !adminApiToken.isBlank() && adminApiToken.equals(token);
-    boolean matchesOps = !opsToken.isBlank() && opsToken.equals(token);
+    boolean matchesAdmin =
+        !adminApiToken.isBlank()
+            && MessageDigest.isEqual(adminApiToken.getBytes(UTF_8), token.getBytes(UTF_8));
+    boolean matchesOps =
+        !opsToken.isBlank()
+            && MessageDigest.isEqual(opsToken.getBytes(UTF_8), token.getBytes(UTF_8));
     if (!matchesAdmin && !matchesOps) {
       throw new ResponseStatusException(UNAUTHORIZED, "Invalid admin token");
     }
@@ -574,7 +580,7 @@ public class AdminController {
     if (adminApiToken.isBlank()) {
       throw new ResponseStatusException(SERVICE_UNAVAILABLE, "Admin API not configured");
     }
-    if (!adminApiToken.equals(token)) {
+    if (!MessageDigest.isEqual(adminApiToken.getBytes(UTF_8), token.getBytes(UTF_8))) {
       throw new ResponseStatusException(UNAUTHORIZED, "Invalid admin token");
     }
   }

--- a/src/main/java/ee/tuleva/onboarding/investment/epis/parser/R16ReportParser.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/epis/parser/R16ReportParser.java
@@ -29,7 +29,7 @@ public class R16ReportParser {
     EpisCsv parsed = csvParser.parse(csv, HEADER_MARKER);
     YearMonth paymentMonth = findPaymentMonth(parsed.preHeaderLines());
 
-    Map<String, R16ParsedFlow> results = new LinkedHashMap<>();
+    Map<String, UnitAccumulator> accumulators = new LinkedHashMap<>();
     for (Map<String, String> row : parsed.rows()) {
       Optional<TulevaFund> fund = FundResolver.resolve(findValue(row, "väärtpaber", "vaartpaber"));
       if (fund.isEmpty()) {
@@ -41,10 +41,23 @@ public class R16ReportParser {
           unitsOrZero(row, "ühekordsed maksed osakud", "uhekordsed maksed osakud");
       validateMagnitude(fondimaksedUnits, uhekordsedUnits);
 
-      results.put(
-          fund.get().getCode(),
-          new R16ParsedFlow(fund.get(), fondimaksedUnits, uhekordsedUnits, paymentMonth));
+      UnitAccumulator accumulator =
+          accumulators.computeIfAbsent(
+              fund.get().getCode(), code -> new UnitAccumulator(fund.get()));
+      accumulator.fondimaksedUnits = accumulator.fondimaksedUnits.add(fondimaksedUnits);
+      accumulator.uhekordsedUnits = accumulator.uhekordsedUnits.add(uhekordsedUnits);
     }
+
+    Map<String, R16ParsedFlow> results = new LinkedHashMap<>();
+    accumulators.forEach(
+        (fundCode, accumulator) ->
+            results.put(
+                fundCode,
+                new R16ParsedFlow(
+                    accumulator.fund,
+                    accumulator.fondimaksedUnits,
+                    accumulator.uhekordsedUnits,
+                    paymentMonth)));
     return results;
   }
 
@@ -72,5 +85,15 @@ public class R16ReportParser {
   private static BigDecimal unitsOrZero(Map<String, String> row, String... keywords) {
     BigDecimal units = parseNumber(findValue(row, keywords));
     return units == null ? BigDecimal.ZERO : units.abs();
+  }
+
+  private static final class UnitAccumulator {
+    private final TulevaFund fund;
+    private BigDecimal fondimaksedUnits = BigDecimal.ZERO;
+    private BigDecimal uhekordsedUnits = BigDecimal.ZERO;
+
+    private UnitAccumulator(TulevaFund fund) {
+      this.fund = fund;
+    }
   }
 }

--- a/src/main/java/ee/tuleva/onboarding/investment/epis/parser/R45ReportParser.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/epis/parser/R45ReportParser.java
@@ -18,9 +18,11 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.Nullable;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class R45ReportParser {
@@ -44,6 +46,9 @@ public class R45ReportParser {
       String typeCode = trimmedUpperCase(findValue(row, "tehingu liik"));
       String isin = normalizeIsin(findValue(row, "isin"));
       if (typeCode.isEmpty() || isin.isEmpty()) {
+        if (!typeCode.isEmpty()) {
+          log.warn("R45 row dropped: reason=missingIsin, typeCode={}", typeCode);
+        }
         continue;
       }
 

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionCommandController.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionCommandController.java
@@ -1,10 +1,12 @@
 package ee.tuleva.onboarding.investment.transaction;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 import static org.springframework.http.HttpStatus.SERVICE_UNAVAILABLE;
 import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 
 import jakarta.validation.Valid;
+import java.security.MessageDigest;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -159,7 +161,7 @@ public class TransactionCommandController {
     if (adminApiToken.isBlank()) {
       throw new ResponseStatusException(SERVICE_UNAVAILABLE, "Admin API not configured");
     }
-    if (!adminApiToken.equals(token)) {
+    if (!MessageDigest.isEqual(adminApiToken.getBytes(UTF_8), token.getBytes(UTF_8))) {
       throw new ResponseStatusException(UNAUTHORIZED, "Invalid admin token");
     }
   }

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionRegistryController.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionRegistryController.java
@@ -26,6 +26,7 @@ import ee.tuleva.onboarding.investment.transaction.ingest.FtConfirmationVerifica
 import ee.tuleva.onboarding.investment.transaction.ingest.HistoricalRegistryImportService;
 import jakarta.validation.Valid;
 import java.io.IOException;
+import java.security.MessageDigest;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
@@ -232,7 +233,7 @@ public class TransactionRegistryController {
     if (adminApiToken.isBlank()) {
       throw new ResponseStatusException(SERVICE_UNAVAILABLE, "Admin API not configured");
     }
-    if (!adminApiToken.equals(token)) {
+    if (!MessageDigest.isEqual(adminApiToken.getBytes(UTF_8), token.getBytes(UTF_8))) {
       throw new ResponseStatusException(UNAUTHORIZED, "Invalid admin token");
     }
   }

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationVerificationService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationVerificationService.java
@@ -227,7 +227,7 @@ public class FtConfirmationVerificationService {
     if (quantityMatches.size() > 1) {
       return new OrderSelection(oldest(quantityMatches), true, quantityMatches.size());
     }
-    return new OrderSelection(oldest(candidates), false, candidates.size());
+    return new OrderSelection(oldest(candidates), true, candidates.size());
   }
 
   private static TransactionOrder oldest(List<TransactionOrder> orders) {

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/SebPendingTransactionReconciliationService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/SebPendingTransactionReconciliationService.java
@@ -31,6 +31,7 @@ import java.util.Optional;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -57,6 +58,9 @@ public class SebPendingTransactionReconciliationService {
   private final TransactionSettlementRepository settlementRepository;
   private final TransactionSettlementService settlementService;
   private final InvestmentReportService reportService;
+
+  @Value("${transaction-registry.settlement-check.scan-lookback-days:60}")
+  private int scanLookbackDays = 60;
 
   @Transactional
   public void reconcile(InvestmentReport report) {
@@ -335,7 +339,10 @@ public class SebPendingTransactionReconciliationService {
     if (isPossibleTruncation(reportDate, rowCount)) {
       return;
     }
-    orderRepository.findByOrderStatusIn(List.of(OrderStatus.EXECUTED)).stream()
+    Instant since = reportDate.minusDays(scanLookbackDays).atStartOfDay(ZoneOffset.UTC).toInstant();
+    orderRepository
+        .findByOrderStatusInAndOrderTimestampSince(List.of(OrderStatus.EXECUTED), since)
+        .stream()
         .filter(order -> order.getOrderVenue() == OrderVenue.SEB)
         .filter(order -> !presentOrderIds.contains(order.getId()))
         .filter(order -> !settlementRepository.existsByOrderId(order.getId()))

--- a/src/test/groovy/ee/tuleva/onboarding/admin/AdminControllerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/admin/AdminControllerTest.java
@@ -164,6 +164,23 @@ class AdminControllerTest {
   }
 
   @Test
+  void attributeUnattributedPayment_withOpsTokenDifferingInLastCharacter_returnsUnauthorized()
+      throws Exception {
+    var paymentId = UUID.randomUUID();
+
+    mockMvc
+        .perform(
+            post("/admin/savings-fund/payments/{paymentId}/attribute", paymentId)
+                .with(csrf())
+                .header("X-Admin-Token", "ops-tokeX")
+                .param("partyType", "PERSON")
+                .param("partyCode", "48806046007"))
+        .andExpect(status().isUnauthorized());
+
+    verifyNoInteractions(unattributedPaymentAttributionService);
+  }
+
+  @Test
   void fetchSebHistory_withValidToken_returnsOk() throws Exception {
     mockMvc
         .perform(
@@ -200,6 +217,18 @@ class AdminControllerTest {
             post("/admin/fetch-seb-history")
                 .with(csrf())
                 .header("X-Admin-Token", "wrong-token")
+                .param("from", "2026-01-01")
+                .param("to", "2026-01-31"))
+        .andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  void fetchSebHistory_withTokenDifferingInLastCharacter_returnsUnauthorized() throws Exception {
+    mockMvc
+        .perform(
+            post("/admin/fetch-seb-history")
+                .with(csrf())
+                .header("X-Admin-Token", "valid-tokeX")
                 .param("from", "2026-01-01")
                 .param("to", "2026-01-31"))
         .andExpect(status().isUnauthorized());

--- a/src/test/groovy/ee/tuleva/onboarding/investment/epis/parser/R16ReportParserTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/epis/parser/R16ReportParserTest.java
@@ -101,6 +101,22 @@ class R16ReportParserTest {
   }
 
   @Test
+  void accumulatesUnitsAcrossMultipleRowsForSameFund() {
+    String csv =
+        """
+        Fondivalitseja: Tuleva Fondid AS;;;;;;
+        Kuu: 2026 06;;;;;;
+        Väärtpaber;Jooksev NAV;Fondimaksed Osakud;Fondimaksed Summa;Ühekordsed maksed Osakud;Ühekordsed maksed Summa;Valuuta
+        EE3600109435;0,80;100,000;80,00;0;0;EUR
+        EE3600109435;0,80;50,000;40,00;0;0;EUR
+        """;
+
+    Map<String, R16ParsedFlow> result = parser.parse(csv);
+
+    assertThat(result.get("TUK75").fondimaksedUnits()).isEqualByComparingTo("150.000");
+  }
+
+  @Test
   void throwsWhenUnitsExceedHundredMillion() {
     String csv =
         """

--- a/src/test/groovy/ee/tuleva/onboarding/investment/epis/parser/R45ReportParserTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/epis/parser/R45ReportParserTest.java
@@ -3,12 +3,17 @@ package ee.tuleva.onboarding.investment.epis.parser;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import ee.tuleva.onboarding.investment.epis.R45Result;
 import ee.tuleva.onboarding.investment.epis.R45TransactionType;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
 
 class R45ReportParserTest {
 
@@ -140,6 +145,31 @@ class R45ReportParserTest {
     R45ParseResult result = parser.parse(csv, TODAY, Map.of());
 
     assertResult(result.fundResults().get("TUK75"), "1500.00", "0", "1500.00");
+  }
+
+  @Test
+  void warnsWhenRowHasResolvableTypeCodeButBlankIsin() {
+    String csv =
+        """
+        Tehtud: 12.06.2026;;;;;
+        Tehingu liik;ISIN;NAV;Osakuid;Summa;Täitmise kuupäev
+        SUB;;0,80000;0;1500,00;15.06.2026
+        """;
+
+    var logAppender = new ListAppender<ILoggingEvent>();
+    var logger = (Logger) LoggerFactory.getLogger(R45ReportParser.class);
+    logAppender.start();
+    logger.addAppender(logAppender);
+
+    R45ParseResult result = parser.parse(csv, TODAY, Map.of());
+
+    logger.detachAppender(logAppender);
+
+    assertThat(result.fundResults()).isEmpty();
+    assertThat(logAppender.list)
+        .filteredOn(event -> event.getLevel() == Level.WARN)
+        .anyMatch(event -> event.getFormattedMessage().contains("reason=missingIsin"))
+        .anyMatch(event -> event.getFormattedMessage().contains("typeCode=SUB"));
   }
 
   @Test

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionCommandControllerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionCommandControllerTest.java
@@ -128,6 +128,21 @@ class TransactionCommandControllerTest {
   }
 
   @Test
+  void createCommand_withTokenDifferingInLastCharacter_returnsUnauthorized() throws Exception {
+    mockMvc
+        .perform(
+            post("/admin/transaction-commands")
+                .with(csrf())
+                .header("X-Admin-Token", "valid-tokeX")
+                .contentType(APPLICATION_JSON)
+                .content(
+                    """
+                    {"fund": "TUK75", "mode": "REBALANCE", "asOfDate": "2026-06-10"}
+                    """))
+        .andExpect(status().isUnauthorized());
+  }
+
+  @Test
   void createCommand_withMissingFund_returnsBadRequest() throws Exception {
     mockMvc
         .perform(

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionRegistryControllerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionRegistryControllerTest.java
@@ -108,6 +108,19 @@ class TransactionRegistryControllerTest {
   }
 
   @Test
+  void triggerMatch_withTokenDifferingInLastCharacter_returnsUnauthorized() throws Exception {
+    mockMvc
+        .perform(
+            post("/admin/transaction-registry/match")
+                .with(csrf())
+                .header("X-Admin-Token", "valid-tokeX"))
+        .andExpect(status().isUnauthorized());
+
+    assertThat(applicationEvents.stream(RunSebPendingTransactionReconciliationRequested.class))
+        .isEmpty();
+  }
+
+  @Test
   void dailySummary_returnsPerFundSummary() throws Exception {
     given(adminService.dailySummary())
         .willReturn(

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationVerificationServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationVerificationServiceTest.java
@@ -406,6 +406,19 @@ class FtConfirmationVerificationServiceTest {
   }
 
   @Test
+  void normalConfirmation_noOrderMatchesQuantity_returnsAmbiguousNotOldest() {
+    TransactionOrder first = order(10L, new BigDecimal("99999"));
+    TransactionOrder second = order(42L, new BigDecimal("88888"));
+    given(orderRepository.findByInstrumentIsin(ISIN)).willReturn(List.of(first, second));
+
+    FtConfirmationResult result = service(DAY_AFTER_TRADE).verify(confirmation());
+
+    assertThat(result.quantityStatus()).isEqualTo(AMBIGUOUS);
+    assertThat(result.priceStatus()).isEqualTo(AMBIGUOUS);
+    assertThat(result.details()).containsEntry("ambiguousOrderCount", "2");
+  }
+
+  @Test
   void weekendTradeDate_returnsIgnored_noMismatch() {
     LocalDate saturday = LocalDate.of(2026, 6, 6); // Saturday
     FtConfirmation weekendConfirmation =

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/SebPendingTransactionReconciliationIT.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/SebPendingTransactionReconciliationIT.java
@@ -433,6 +433,7 @@ class SebPendingTransactionReconciliationIT {
                 .orderVenue(OrderVenue.SEB)
                 .orderUuid(UUID.randomUUID())
                 .orderStatus(EXECUTED)
+                .orderTimestamp(Instant.parse("2026-02-10T10:00:00Z"))
                 .build());
     executionRepository.save(
         TransactionExecution.builder()

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/SebPendingTransactionReconciliationServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/SebPendingTransactionReconciliationServiceTest.java
@@ -749,7 +749,8 @@ class SebPendingTransactionReconciliationServiceTest {
     // Absent EXECUTED order (target 100) executed before the report date, but only 60 filled so
     // far — a split order momentarily absent must not be settled while still short.
     TransactionOrder absentOrder = executedOrder(456L);
-    given(orderRepository.findByOrderStatusIn(anyCollection())).willReturn(List.of(absentOrder));
+    given(orderRepository.findByOrderStatusInAndOrderTimestampSince(anyCollection(), any()))
+        .willReturn(List.of(absentOrder));
     given(executionRepository.findAllByOrderId(456L))
         .willReturn(
             List.of(
@@ -777,7 +778,8 @@ class SebPendingTransactionReconciliationServiceTest {
     given(executionRepository.findAllByOrderId(123L)).willReturn(List.of());
 
     TransactionOrder absentOrder = executedOrder(456L);
-    given(orderRepository.findByOrderStatusIn(anyCollection())).willReturn(List.of(absentOrder));
+    given(orderRepository.findByOrderStatusInAndOrderTimestampSince(anyCollection(), any()))
+        .willReturn(List.of(absentOrder));
     given(executionRepository.findAllByOrderId(456L))
         .willReturn(List.of(executionWithTradeInstant(456L, "2026-05-11T10:00:00Z")));
     given(settlementRepository.save(any()))
@@ -802,6 +804,30 @@ class SebPendingTransactionReconciliationServiceTest {
   }
 
   @Test
+  void reconcile_absentExecutedOrder_usesBoundedLookbackFinder_notUnboundedScan() {
+    service = newService();
+    UUID clientRef = UUID.fromString("bd83f551-8c79-4193-b92b-18e1dfd0bd29");
+    TransactionOrder matchedOrder = sampleOrder(clientRef);
+    given(orderRepository.findByOrderUuid(clientRef)).willReturn(Optional.of(matchedOrder));
+    given(executionRepository.findAllByOrderId(123L)).willReturn(List.of());
+
+    TransactionOrder absentOrder = executedOrder(456L);
+    given(orderRepository.findByOrderStatusInAndOrderTimestampSince(anyCollection(), any()))
+        .willReturn(List.of(absentOrder));
+    given(executionRepository.findAllByOrderId(456L))
+        .willReturn(List.of(executionWithTradeInstant(456L, "2026-05-11T10:00:00Z")));
+    given(settlementRepository.save(any()))
+        .willAnswer(invocation -> invocation.getArgument(0, TransactionSettlement.class));
+
+    service.reconcile(reportWithSingleRow(clientRef));
+
+    verify(settlementRepository)
+        .save(argThat((TransactionSettlement settlement) -> settlement.getOrderId().equals(456L)));
+    assertThat(absentOrder.getOrderStatus()).isEqualTo(SETTLED);
+    verify(orderRepository, never()).findByOrderStatusIn(anyCollection());
+  }
+
+  @Test
   void reconcile_zeroMatchesOnNonEmptyReport_skipsSettlementDetection() {
     service = newService();
     UUID clientRef = UUID.fromString("00000000-0000-0000-0000-000000000099");
@@ -810,7 +836,8 @@ class SebPendingTransactionReconciliationServiceTest {
 
     service.reconcile(reportWithSingleRow(clientRef));
 
-    verify(orderRepository, never()).findByOrderStatusIn(anyCollection());
+    verify(orderRepository, never())
+        .findByOrderStatusInAndOrderTimestampSince(anyCollection(), any());
     verify(settlementRepository, never()).save(any());
   }
 
@@ -827,7 +854,8 @@ class SebPendingTransactionReconciliationServiceTest {
 
     service.reconcile(report);
 
-    verify(orderRepository, never()).findByOrderStatusIn(anyCollection());
+    verify(orderRepository, never())
+        .findByOrderStatusInAndOrderTimestampSince(anyCollection(), any());
     verify(settlementRepository, never()).save(any());
   }
 
@@ -882,7 +910,8 @@ class SebPendingTransactionReconciliationServiceTest {
     given(executionRepository.findAllByOrderId(123L)).willReturn(List.of());
 
     TransactionOrder absentOrder = executedOrder(456L);
-    given(orderRepository.findByOrderStatusIn(anyCollection())).willReturn(List.of(absentOrder));
+    given(orderRepository.findByOrderStatusInAndOrderTimestampSince(anyCollection(), any()))
+        .willReturn(List.of(absentOrder));
     given(executionRepository.findAllByOrderId(456L)).willReturn(List.of());
 
     service.reconcile(reportWithSingleRow(clientRef));
@@ -900,7 +929,8 @@ class SebPendingTransactionReconciliationServiceTest {
     given(executionRepository.findAllByOrderId(123L)).willReturn(List.of());
 
     TransactionOrder absentOrder = executedOrder(456L);
-    given(orderRepository.findByOrderStatusIn(anyCollection())).willReturn(List.of(absentOrder));
+    given(orderRepository.findByOrderStatusInAndOrderTimestampSince(anyCollection(), any()))
+        .willReturn(List.of(absentOrder));
     given(executionRepository.findAllByOrderId(456L))
         .willReturn(List.of(executionWithTradeInstant(456L, "2026-05-13T10:00:00Z")));
 
@@ -926,7 +956,7 @@ class SebPendingTransactionReconciliationServiceTest {
         .willReturn(List.of(executionWithTradeInstant(456L, "2026-05-11T10:00:00Z")));
 
     TransactionOrder presentByOurRef = executedOrder(456L);
-    given(orderRepository.findByOrderStatusIn(anyCollection()))
+    given(orderRepository.findByOrderStatusInAndOrderTimestampSince(anyCollection(), any()))
         .willReturn(List.of(presentByOurRef));
 
     Map<String, Object> secondRow = validRawRow(secondClientRef);
@@ -962,7 +992,8 @@ class SebPendingTransactionReconciliationServiceTest {
     service.reconcile(reportWithSingleRow(clientRef));
 
     // Truncation guard trips before candidate orders are even looked up.
-    verify(orderRepository, never()).findByOrderStatusIn(anyCollection());
+    verify(orderRepository, never())
+        .findByOrderStatusInAndOrderTimestampSince(anyCollection(), any());
     verify(settlementRepository, never()).save(any());
     verify(eventPublisher)
         .publishEvent(
@@ -995,7 +1026,8 @@ class SebPendingTransactionReconciliationServiceTest {
     given(orderRepository.findByInstrumentIsin(any())).willReturn(List.of());
 
     TransactionOrder absentOrder = executedOrder(456L);
-    given(orderRepository.findByOrderStatusIn(anyCollection())).willReturn(List.of(absentOrder));
+    given(orderRepository.findByOrderStatusInAndOrderTimestampSince(anyCollection(), any()))
+        .willReturn(List.of(absentOrder));
     given(executionRepository.findAllByOrderId(456L))
         .willReturn(List.of(executionWithTradeInstant(456L, "2026-05-11T10:00:00Z")));
     given(settlementRepository.save(any()))
@@ -1022,7 +1054,8 @@ class SebPendingTransactionReconciliationServiceTest {
     given(executionRepository.findAllByOrderId(123L)).willReturn(List.of());
 
     TransactionOrder absentOrder = executedOrder(456L);
-    given(orderRepository.findByOrderStatusIn(anyCollection())).willReturn(List.of(absentOrder));
+    given(orderRepository.findByOrderStatusInAndOrderTimestampSince(anyCollection(), any()))
+        .willReturn(List.of(absentOrder));
     given(executionRepository.findAllByOrderId(456L))
         .willReturn(List.of(executionWithTradeInstant(456L, "2026-05-11T10:00:00Z")));
     given(settlementRepository.save(any()))
@@ -1056,7 +1089,8 @@ class SebPendingTransactionReconciliationServiceTest {
 
     service.reconcile(reportWithSingleRow(clientRef)); // reportDate 2026-05-13
 
-    verify(orderRepository, never()).findByOrderStatusIn(anyCollection());
+    verify(orderRepository, never())
+        .findByOrderStatusInAndOrderTimestampSince(anyCollection(), any());
     verify(settlementRepository, never()).save(any());
   }
 
@@ -1084,7 +1118,8 @@ class SebPendingTransactionReconciliationServiceTest {
 
     service.reconcile(report);
 
-    verify(orderRepository, never()).findByOrderStatusIn(anyCollection());
+    verify(orderRepository, never())
+        .findByOrderStatusInAndOrderTimestampSince(anyCollection(), any());
     verify(settlementRepository, never()).save(any());
   }
 


### PR DESCRIPTION
Five low-severity hardening fixes from the §4.7 code-review batch. No Flyway migration; each is test-first, committed as its own logical unit.

## Fixes
1. **Constant-time admin token compare** (`1c1f51173`) — the admin/ops token checks used `String.equals` (short-circuits on the first differing byte → timing side-channel). Now `MessageDigest.isEqual`, across all three admin token checks (`AdminController`, `TransactionCommandController`, `TransactionRegistryController`).
2. **R16 accumulate + R45 dropped-row logging** (`111f56609`) — `R16ReportParser` overwrote a fund's flow when the same fund appeared twice (silently discarding one row); now accumulates like R17/R21. `R45ReportParser` dropped blank-ISIN rows silently; now logs them.
3. **FT `selectOrder` ambiguity** (`288695f77`) — when several orders shared instrument/fund/trade-date and none matched the confirmation's quantity, it silently picked the oldest and reported an unambiguous match. Now flags 2+ candidates with no quantity match as **ambiguous** for manual review.
4. **Bounded settlement-by-absence scan** (`197a01658`) — `detectSettlementsByAbsence` scanned every EXECUTED order. Now bounds to orders within the settlement lookback window (reusing the finder the overdue check already uses), **anchored on the report's own date, not wall-clock** — so replaying a historical report still settles the orders that belong to it.

## Notes
- Fix 4's report-date anchor matters: `reconcile()` processes arbitrary historical reports (unlike `SettlementCheckJob`, which is always near-live). Bounding on `now` would drop a historical report's orders. One IT fixture was made realistic (a real EXECUTED order carries an `orderTimestamp`, set at finalize).

## Deferred (real, but need proper design — tracked separately)
- `EpisCsvParser` `parseNumber` period-thousands bug (a genuine ~1000× error) — a naive fix would break R17/R45, which legitimately use `.` as the **decimal** separator, so it needs per-report decimal-convention handling.
- `EpisCsvParser` `contains`→`equals` header match (needs a keyword audit).
- `v_transaction_registry` settlement-SUM caveat — not a live bug (no consuming code); optional `COMMENT ON VIEW`, doc-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GAMpqZVd8kzkhootmTSA7x