### PR TITLE
Add yellow warning icon to NAV impact alerts

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/savings/fund/nav/NavTransactionImpactAlertJob.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/nav/NavTransactionImpactAlertJob.java
@@ -148,7 +148,7 @@ public class NavTransactionImpactAlertJob {
     if (isPevaRavaExecutionDate(today)) {
       sendOnce(
           "PEVA_RAVA",
-          "NAV IMPACT ALERT — PEVA/RAVA execution date (navDate=%s)\n".formatted(navDate)
+          "⚠️ NAV IMPACT ALERT — PEVA/RAVA execution date (navDate=%s)\n".formatted(navDate)
               + "  All Pillar 2 fund switches and exits will use today's NAV.\n"
               + "  Funds affected: TUK75, TUK00\n"
               + "  Manual NAV verification strongly recommended.");
@@ -159,7 +159,7 @@ public class NavTransactionImpactAlertJob {
     if (isR16BookingDay(today)) {
       sendOnce(
           "R16",
-          "NAV IMPACT ALERT — R16 booking day (navDate=%s)\n".formatted(navDate)
+          "⚠️ NAV IMPACT ALERT — R16 booking day (navDate=%s)\n".formatted(navDate)
               + "  Fondimaksed + ühekordsed väljamaksed: Pensionikeskus will book unit redemptions\n"
               + "  using today's NAV (12:00-16:00).\n"
               + "  Funds affected: TUK75, TUK00, TUV100\n"
@@ -197,7 +197,7 @@ public class NavTransactionImpactAlertJob {
     BigDecimal impactAt10bp = totalVolume.multiply(new BigDecimal("0.001")).setScale(2, HALF_UP);
     BigDecimal impactAt100bp = totalVolume.multiply(new BigDecimal("0.01")).setScale(2, HALF_UP);
 
-    return "NAV IMPACT ALERT — TKF100 (navDate=%s)\n".formatted(navDate)
+    return "⚠️ NAV IMPACT ALERT — TKF100 (navDate=%s)\n".formatted(navDate)
         + String.format(
             Locale.US,
             "  Pending Subscriptions: %,.2f EUR (%d payments)\n",

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/nav/NavTransactionImpactAlertJobTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/nav/NavTransactionImpactAlertJobTest.java
@@ -91,6 +91,20 @@ class NavTransactionImpactAlertJobTest {
   }
 
   @Test
+  void tkf100_alert_showsYellowIcon() {
+    // 2026-03-10 = Tuesday, regular day
+    var job = jobOn("2026-03-10T08:00:00Z");
+    stubThreshold(ONE_MILLION);
+    stubTkf100Subscriptions(new BigDecimal("800000"));
+    stubTkf100Redemptions(List.of(redemption(new BigDecimal("200000"))));
+    stubNav(NAV);
+
+    job.onFundPositionsImported();
+
+    verify(notificationService).sendMessage(contains("⚠️ NAV IMPACT ALERT — TKF100"), eq(SAVINGS));
+  }
+
+  @Test
   void tkf100_redemptionEur_estimatedFromUnitsTimesNav() {
     // 2026-03-10 = Tuesday
     var job = jobOn("2026-03-10T08:00:00Z");
@@ -120,6 +134,21 @@ class NavTransactionImpactAlertJobTest {
     job.onFundPositionsImported();
 
     verify(notificationService).sendMessage(contains("PEVA/RAVA"), eq(SAVINGS));
+  }
+
+  @Test
+  void pevaRava_alert_showsYellowIcon() {
+    // 2026-01-02 = PEVA/RAVA execution date
+    var job = jobOn("2026-01-02T08:00:00Z");
+    stubThresholdLenient(ONE_MILLION);
+    stubTkf100SubscriptionsLenient(ZERO);
+    stubTkf100RedemptionsLenient(List.of());
+    stubNavLenient(NAV);
+
+    job.onFundPositionsImported();
+
+    verify(notificationService)
+        .sendMessage(contains("⚠️ NAV IMPACT ALERT — PEVA/RAVA"), eq(SAVINGS));
   }
 
   @Test
@@ -177,6 +206,20 @@ class NavTransactionImpactAlertJobTest {
     job.onFundPositionsImported();
 
     verify(notificationService).sendMessage(contains("R16"), eq(SAVINGS));
+  }
+
+  @Test
+  void r16_alert_showsYellowIcon() {
+    // 2026-04-15 = Wednesday (business day, 15th is the booking day)
+    var job = jobOn("2026-04-15T08:00:00Z");
+    stubThresholdLenient(ONE_MILLION);
+    stubTkf100SubscriptionsLenient(ZERO);
+    stubTkf100RedemptionsLenient(List.of());
+    stubNavLenient(NAV);
+
+    job.onFundPositionsImported();
+
+    verify(notificationService).sendMessage(contains("⚠️ NAV IMPACT ALERT — R16"), eq(SAVINGS));
   }
 
   @Test


### PR DESCRIPTION
## What

Prefix all three NAV IMPACT ALERT Slack messages with the ⚠️ yellow warning icon so they're easy to spot in the SAVINGS channel:

- **R16 booking day** (Fondimaksed + ühekordsed väljamaksed — TUK75/TUK00/TUV100)
- **PEVA/RAVA execution date** (TUK75/TUK00)
- **TKF100 volume** threshold

## Why

These alerts were plain text that blended into the channel and were easy to overlook — the same problem the TD and limit-breach notifications had before #1773. All three are WARNING severity, so they get ⚠️, mirroring the ⚠️/🛑/✅ convention already used by `NavNotifier`, `HealthCheckNotifier`, and the TD/limit notifiers.

Example after:

```
⚠️ NAV IMPACT ALERT — R16 booking day (navDate=2026-07-14)
  Fondimaksed + ühekordsed väljamaksed: Pensionikeskus will book unit redemptions
  ...
```

## Tests

Added three tests asserting each alert message contains `⚠️ NAV IMPACT ALERT — …`. Full `NavTransactionImpactAlertJobTest` suite + Spotless green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)