### PR TITLE
Read EPIS report numbers with each report's decimal convention

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/investment/epis/parser/DecimalConvention.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/epis/parser/DecimalConvention.java
@@ -1,0 +1,16 @@
+package ee.tuleva.onboarding.investment.epis.parser;
+
+public enum DecimalConvention {
+  COMMA_DECIMAL(','),
+  PERIOD_DECIMAL('.');
+
+  private final char decimalSeparator;
+
+  DecimalConvention(char decimalSeparator) {
+    this.decimalSeparator = decimalSeparator;
+  }
+
+  char decimalSeparator() {
+    return decimalSeparator;
+  }
+}

--- a/src/main/java/ee/tuleva/onboarding/investment/epis/parser/EpisCsvParser.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/epis/parser/EpisCsvParser.java
@@ -16,8 +16,9 @@ import org.springframework.stereotype.Component;
 public class EpisCsvParser {
 
   private static final int HEADER_SCAN_ROWS = 10;
-  private static final Pattern ESTONIAN_DECIMAL = Pattern.compile("^-?\\d+,\\d+$");
   private static final Pattern DATE = Pattern.compile("(\\d{1,2})\\.(\\d{1,2})\\.(\\d{4})");
+  private static final Pattern COMMA_GROUPED = Pattern.compile("^-?\\d{1,3}(,\\d{3})+$");
+  private static final Pattern PERIOD_GROUPED = Pattern.compile("^-?\\d{1,3}(\\.\\d{3})+$");
 
   public EpisCsv parse(String content, String headerMarker) {
     List<String> lines = content.lines().toList();
@@ -48,7 +49,8 @@ public class EpisCsvParser {
     return null;
   }
 
-  public static @Nullable BigDecimal parseNumber(@Nullable String value) {
+  public static @Nullable BigDecimal parseNumber(
+      @Nullable String value, DecimalConvention convention) {
     if (value == null) {
       return null;
     }
@@ -56,16 +58,33 @@ public class EpisCsvParser {
     if (cleaned.isEmpty()) {
       return null;
     }
-    if (ESTONIAN_DECIMAL.matcher(cleaned).matches() && !cleaned.contains(".")) {
-      cleaned = cleaned.replace(',', '.');
-    } else {
-      cleaned = cleaned.replace(",", "");
+    boolean hasComma = cleaned.indexOf(',') >= 0;
+    boolean hasPeriod = cleaned.indexOf('.') >= 0;
+    if (hasComma && hasPeriod) {
+      cleaned =
+          cleaned.lastIndexOf(',') > cleaned.lastIndexOf('.')
+              ? cleaned.replace(".", "").replace(',', '.')
+              : cleaned.replace(",", "");
+    } else if (hasComma || hasPeriod) {
+      cleaned = resolveSingleSeparator(cleaned, hasComma ? ',' : '.', convention);
     }
     try {
       return new BigDecimal(cleaned);
     } catch (NumberFormatException e) {
       return null;
     }
+  }
+
+  private static String resolveSingleSeparator(
+      String cleaned, char separator, DecimalConvention convention) {
+    Pattern grouping = separator == ',' ? COMMA_GROUPED : PERIOD_GROUPED;
+    boolean isGrouping = grouping.matcher(cleaned).matches();
+    boolean isConventionDecimal = separator == convention.decimalSeparator();
+    long occurrences = cleaned.chars().filter(character -> character == separator).count();
+    if (isGrouping && !(isConventionDecimal && occurrences == 1)) {
+      return cleaned.replace(String.valueOf(separator), "");
+    }
+    return cleaned.replace(separator, '.');
   }
 
   public static @Nullable LocalDate findDate(String line) {

--- a/src/main/java/ee/tuleva/onboarding/investment/epis/parser/R16ReportParser.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/epis/parser/R16ReportParser.java
@@ -20,6 +20,7 @@ import org.springframework.stereotype.Component;
 public class R16ReportParser {
 
   private static final String HEADER_MARKER = "Väärtpaber";
+  private static final DecimalConvention DECIMAL_CONVENTION = DecimalConvention.COMMA_DECIMAL;
   private static final BigDecimal MAX_REASONABLE_UNITS = new BigDecimal("100000000");
   private static final Pattern KUU = Pattern.compile("[Kk]uu[:\\s]*(\\d{4})\\s*(\\d{2})");
 
@@ -83,7 +84,7 @@ public class R16ReportParser {
   }
 
   private static BigDecimal unitsOrZero(Map<String, String> row, String... keywords) {
-    BigDecimal units = parseNumber(findValue(row, keywords));
+    BigDecimal units = parseNumber(findValue(row, keywords), DECIMAL_CONVENTION);
     return units == null ? BigDecimal.ZERO : units.abs();
   }
 

--- a/src/main/java/ee/tuleva/onboarding/investment/epis/parser/R17ReportParser.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/epis/parser/R17ReportParser.java
@@ -22,6 +22,7 @@ import org.springframework.stereotype.Component;
 public class R17ReportParser {
 
   private static final String HEADER_MARKER = "Väärtpaber";
+  private static final DecimalConvention DECIMAL_CONVENTION = DecimalConvention.PERIOD_DECIMAL;
   private static final BigDecimal MAX_REASONABLE_UNITS = new BigDecimal("100000000");
 
   private final EpisCsvParser csvParser;
@@ -101,7 +102,8 @@ public class R17ReportParser {
   }
 
   private static BigDecimal unitsOrZero(Map<String, String> row) {
-    BigDecimal units = parseNumber(findValue(row, "osakud (teenustasuga)", "osakuid"));
+    BigDecimal units =
+        parseNumber(findValue(row, "osakud (teenustasuga)", "osakuid"), DECIMAL_CONVENTION);
     return units == null ? BigDecimal.ZERO : units;
   }
 

--- a/src/main/java/ee/tuleva/onboarding/investment/epis/parser/R21ReportParser.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/epis/parser/R21ReportParser.java
@@ -23,6 +23,7 @@ import org.springframework.stereotype.Component;
 public class R21ReportParser {
 
   private static final String HEADER_MARKER = "Väärtpaber";
+  private static final DecimalConvention DECIMAL_CONVENTION = DecimalConvention.COMMA_DECIMAL;
   private static final BigDecimal MAX_REASONABLE_UNITS = new BigDecimal("100000000");
   private static final Pattern MAKSETE_KUU = Pattern.compile("[Mm]aksete\\s*kuu[:\\s]*(\\d{6})");
   private static final DateTimeFormatter YEAR_MONTH = DateTimeFormatter.ofPattern("yyyyMM");
@@ -36,7 +37,7 @@ public class R21ReportParser {
     Map<String, BigDecimal> unitsByFund = new LinkedHashMap<>();
     for (Map<String, String> row : parsed.rows()) {
       String fundRaw = findValue(row, "väärtpaber", "vaartpaber");
-      BigDecimal parsedUnits = parseNumber(findValue(row, "osakud"));
+      BigDecimal parsedUnits = parseNumber(findValue(row, "osakud"), DECIMAL_CONVENTION);
       BigDecimal units = parsedUnits == null ? BigDecimal.ZERO : parsedUnits.abs();
 
       if (fundRaw == null || fundRaw.isBlank() || units.signum() == 0) {

--- a/src/main/java/ee/tuleva/onboarding/investment/epis/parser/R45ReportParser.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/epis/parser/R45ReportParser.java
@@ -28,6 +28,7 @@ import org.springframework.stereotype.Component;
 public class R45ReportParser {
 
   private static final String HEADER_MARKER = "Tehingu liik";
+  private static final DecimalConvention DECIMAL_CONVENTION = DecimalConvention.PERIOD_DECIMAL;
   private static final BigDecimal MAX_REASONABLE_VALUE = new BigDecimal("100000000");
 
   private final EpisCsvParser csvParser;
@@ -158,7 +159,7 @@ public class R45ReportParser {
   }
 
   private static BigDecimal numberOrZero(Map<String, String> row, String keyword) {
-    BigDecimal value = parseNumber(findValue(row, keyword));
+    BigDecimal value = parseNumber(findValue(row, keyword), DECIMAL_CONVENTION);
     return value == null ? BigDecimal.ZERO : value;
   }
 

--- a/src/test/groovy/ee/tuleva/onboarding/investment/epis/EpisReportIngestionServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/epis/EpisReportIngestionServiceTest.java
@@ -81,9 +81,9 @@ class EpisReportIngestionServiceTest {
       Seisuga: 01.08.2026;;;;;;;
       ;;;;;;;
       Väärtpaber;NAV;Toiming;PF valitseja/PIK;Hind;Osakud (teenustasuta);Osakud (teenustasuga);Summa
-      Tuleva Maailma Aktsiate Pensionifond;0,80;Tagasivõtt;PIK;0,80;100,000;100,000;80,00
-      Tuleva Maailma Aktsiate Pensionifond;0,80;Väljalase;Teine PF valitseja;0,80;200,000;200,000;160,00
-      Tuleva Maailma Võlakirjade Pensionifond;0,70;Tagasivõtt;Teine PF valitseja;0,70;50,000;50,000;35,00
+      Tuleva Maailma Aktsiate Pensionifond;0.80;Tagasivõtt;PIK;0.80;100.000;100.000;80.00
+      Tuleva Maailma Aktsiate Pensionifond;0.80;Väljalase;Teine PF valitseja;0.80;200.000;200.000;160.00
+      Tuleva Maailma Võlakirjade Pensionifond;0.70;Tagasivõtt;Teine PF valitseja;0.70;50.000;50.000;35.00
       """;
 
   @Test
@@ -171,8 +171,8 @@ class EpisReportIngestionServiceTest {
         Tehtud: 14.08.2026;;;;;
         ;;;;;
         Tehingu liik;ISIN;NAV;Osakuid;Summa;Täitmise kuupäev
-        SUB;EE3600109435;0,80000;0;1500,00;17.08.2026
-        RED;EE3600001707;0,90000;0;300,00;18.08.2026
+        SUB;EE3600109435;0.80000;0;1500.00;17.08.2026
+        RED;EE3600001707;0.90000;0;300.00;18.08.2026
         """;
 
     EpisReportIngestionResult result = service.ingestReport(R45, r45Csv);

--- a/src/test/groovy/ee/tuleva/onboarding/investment/epis/R45ReportServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/epis/R45ReportServiceTest.java
@@ -59,10 +59,10 @@ class R45ReportServiceTest {
         Tehtud: 14.08.2026;;;;;
         ;;;;;
         Tehingu liik;ISIN;NAV;Osakuid;Summa;Täitmise kuupäev
-        SUB;EE3600109435;0,80000;0;1500,00;17.08.2026
-        RED;EE3600109435;0,80000;0;500,00;18.08.2026
-        RED;EE3600001707;0,90000;0;300,00;18.08.2026
-        RED;EE3600001707;0,90000;0;100,00;25.08.2026
+        SUB;EE3600109435;0.80000;0;1500.00;17.08.2026
+        RED;EE3600109435;0.80000;0;500.00;18.08.2026
+        RED;EE3600001707;0.90000;0;300.00;18.08.2026
+        RED;EE3600001707;0.90000;0;100.00;25.08.2026
         """;
     givenStoredReport(csv);
 
@@ -113,7 +113,7 @@ class R45ReportServiceTest {
         """
         Tehtud: 14.08.2026;;;;;
         Tehingu liik;ISIN;NAV;Osakuid;Summa;Täitmise kuupäev
-        RED;EE3600109435;0;1000,000;0;18.08.2026
+        RED;EE3600109435;0;1000.000;0;18.08.2026
         """;
     givenStoredReport(csv);
 
@@ -142,7 +142,7 @@ class R45ReportServiceTest {
         """
         Tehtud: 14.08.2026;;;;;
         Tehingu liik;ISIN;NAV;Osakuid;Summa;Täitmise kuupäev
-        XXX;EE3600109435;0,80000;0;1500,00;18.08.2026
+        XXX;EE3600109435;0.80000;0;1500.00;18.08.2026
         """;
     givenStoredReport(csv);
 
@@ -171,8 +171,8 @@ class R45ReportServiceTest {
         """
         Tehtud: 14.08.2026;;;;;
         Tehingu liik;ISIN;NAV;Osakuid;Summa;Täitmise kuupäev
-        SUB;XX0000000000;0,80000;0;1500,00;18.08.2026
-        SUB;EE3600109435;0,80000;0;2000,00;18.08.2026
+        SUB;XX0000000000;0.80000;0;1500.00;18.08.2026
+        SUB;EE3600109435;0.80000;0;2000.00;18.08.2026
         """;
     givenStoredReport(csv);
 
@@ -201,7 +201,7 @@ class R45ReportServiceTest {
         """
         Tehtud: 14.08.2026;;;;;
         Tehingu liik;ISIN;NAV;Osakuid;Summa;Täitmise kuupäev
-        RED;EE3600109443;0;1000,000;0;18.08.2026
+        RED;EE3600109443;0;1000.000;0;18.08.2026
         """;
     givenStoredReport(csv);
     given(fundNavQueryService.findLatestNavDateOnOrBefore(TUK00.getCode(), TODAY))

--- a/src/test/groovy/ee/tuleva/onboarding/investment/epis/parser/EpisCsvParserTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/epis/parser/EpisCsvParserTest.java
@@ -122,18 +122,28 @@ class EpisCsvParserTest {
   @CsvSource(
       nullValues = "NULL",
       value = {
-        "'1,5', 1.5",
-        "'1234.56', 1234.56",
-        "'1,234.56', 1234.56",
-        "'-123,45', -123.45",
-        "'10 000,50', 10000.50",
-        "'5%', 5",
-        "'0', 0",
-        "'', NULL",
-        "'abc', NULL"
+        "'1.234,56', COMMA_DECIMAL, 1234.56",
+        "'12.345', COMMA_DECIMAL, 12345",
+        "'12.345', PERIOD_DECIMAL, 12.345",
+        "'1,234.56', PERIOD_DECIMAL, 1234.56",
+        "'100,000', COMMA_DECIMAL, 100.000",
+        "'100,000', PERIOD_DECIMAL, 100000",
+        "'150000000,000', COMMA_DECIMAL, 150000000.000",
+        "'0.80000', COMMA_DECIMAL, 0.80000",
+        "'1500,00', COMMA_DECIMAL, 1500.00",
+        "'1,5', COMMA_DECIMAL, 1.5",
+        "'10 000,50', COMMA_DECIMAL, 10000.50",
+        "'1.234.567', COMMA_DECIMAL, 1234567",
+        "'1,234,567', PERIOD_DECIMAL, 1234567",
+        "'1234.56', PERIOD_DECIMAL, 1234.56",
+        "'5%', COMMA_DECIMAL, 5",
+        "'0', COMMA_DECIMAL, 0",
+        "'', COMMA_DECIMAL, NULL",
+        "'abc', COMMA_DECIMAL, NULL"
       })
-  void parseNumberHandlesEstonianAndEnglishFormats(String input, String expected) {
-    BigDecimal result = EpisCsvParser.parseNumber(input);
+  void parseNumberHandlesEstonianAndEnglishFormats(
+      String input, DecimalConvention convention, String expected) {
+    BigDecimal result = EpisCsvParser.parseNumber(input, convention);
 
     if (expected == null) {
       assertThat(result).isNull();
@@ -144,6 +154,6 @@ class EpisCsvParserTest {
 
   @Test
   void parseNumberHandlesNull() {
-    assertThat(EpisCsvParser.parseNumber(null)).isNull();
+    assertThat(EpisCsvParser.parseNumber(null, DecimalConvention.COMMA_DECIMAL)).isNull();
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/investment/epis/parser/R16ReportParserTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/epis/parser/R16ReportParserTest.java
@@ -117,6 +117,21 @@ class R16ReportParserTest {
   }
 
   @Test
+  void doesNotMisinterpretCommaDecimalUnitsWithFourLeadingDigitsAsThousandsGrouping() {
+    String csv =
+        """
+        Fondivalitseja: Tuleva Fondid AS;;;;;;
+        Kuu: 2026 06;;;;;;
+        Väärtpaber;Jooksev NAV;Fondimaksed Osakud;Fondimaksed Summa;Ühekordsed maksed Osakud;Ühekordsed maksed Summa;Valuuta
+        EE3600109435;0,80;196,938;800,00;0;0;EUR
+        """;
+
+    Map<String, R16ParsedFlow> result = parser.parse(csv);
+
+    assertThat(result.get("TUK75").fondimaksedUnits()).isEqualByComparingTo("196.938");
+  }
+
+  @Test
   void throwsWhenUnitsExceedHundredMillion() {
     String csv =
         """

--- a/src/test/groovy/ee/tuleva/onboarding/investment/epis/parser/R17ReportParserTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/epis/parser/R17ReportParserTest.java
@@ -22,10 +22,10 @@ class R17ReportParserTest {
         Seisuga: 15.04.2026;;;;;;;
         ;;;;;;;
         Väärtpaber;NAV;Toiming;PF valitseja/PIK;Hind;Osakud (teenustasuta);Osakud (teenustasuga);Summa
-        Tuleva Maailma Aktsiate Pensionifond;0,80;Tagasivõtt;PIK;0,80;100,000;100,000;80,00
-        Tuleva Maailma Aktsiate Pensionifond;0,80;Väljalase;Teine PF valitseja;0,80;200,000;200,000;160,00
-        Tuleva Maailma Aktsiate Pensionifond;0,80;Tagasivõtt;Teine PF valitseja;0,80;50,000;50,000;40,00
-        Tuleva Maailma Võlakirjade Pensionifond;0,70;Väljalase;Oma;0,70;300,000;300,000;210,00
+        Tuleva Maailma Aktsiate Pensionifond;0.80;Tagasivõtt;PIK;0.80;100.000;100.000;80.00
+        Tuleva Maailma Aktsiate Pensionifond;0.80;Väljalase;Teine PF valitseja;0.80;200.000;200.000;160.00
+        Tuleva Maailma Aktsiate Pensionifond;0.80;Tagasivõtt;Teine PF valitseja;0.80;50.000;50.000;40.00
+        Tuleva Maailma Võlakirjade Pensionifond;0.70;Väljalase;Oma;0.70;300.000;300.000;210.00
         """;
 
     Map<String, R17Result> result = parser.parse(csv, LOCK_DATE, EXEC_DATE);
@@ -43,7 +43,7 @@ class R17ReportParserTest {
         """
         Seisuga: 15.03.2026;;;
         Väärtpaber;Toiming;PF valitseja/PIK;Osakud (teenustasuga)
-        Tuleva Maailma Aktsiate Pensionifond;Tagasivõtt;PIK;100,000
+        Tuleva Maailma Aktsiate Pensionifond;Tagasivõtt;PIK;100.000
         """;
 
     assertThatThrownBy(() -> parser.parse(csv, LOCK_DATE, EXEC_DATE))
@@ -56,7 +56,7 @@ class R17ReportParserTest {
         """
         Seisuga: 31.03.2026;;;
         Väärtpaber;Toiming;PF valitseja/PIK;Osakud (teenustasuga)
-        Tuleva Maailma Aktsiate Pensionifond;Tagasivõtt;PIK;100,000
+        Tuleva Maailma Aktsiate Pensionifond;Tagasivõtt;PIK;100.000
         """;
 
     Map<String, R17Result> result = parser.parse(csv, LOCK_DATE, EXEC_DATE);
@@ -70,7 +70,7 @@ class R17ReportParserTest {
         """
         Seisuga: 15.05.2026;;;
         Väärtpaber;Toiming;PF valitseja/PIK;Osakud (teenustasuga)
-        Tuleva Maailma Aktsiate Pensionifond;Tagasivõtt;PIK;100,000
+        Tuleva Maailma Aktsiate Pensionifond;Tagasivõtt;PIK;100.000
         """;
 
     assertThatThrownBy(() -> parser.parse(csv, LOCK_DATE, EXEC_DATE))
@@ -83,7 +83,7 @@ class R17ReportParserTest {
         """
         Seisuga: teadmata;;;
         Väärtpaber;Toiming;PF valitseja/PIK;Osakud (teenustasuga)
-        Tuleva Maailma Aktsiate Pensionifond;Tagasivõtt;PIK;100,000
+        Tuleva Maailma Aktsiate Pensionifond;Tagasivõtt;PIK;100.000
         """;
 
     assertThatThrownBy(() -> parser.parse(csv, LOCK_DATE, EXEC_DATE))
@@ -97,7 +97,7 @@ class R17ReportParserTest {
         Fondi aruanne;;;
         Seisuga: 15.04.2026;;;
         Väärtpaber;Toiming;PF valitseja/PIK;Osakud (teenustasuga)
-        Tuleva Maailma Aktsiate Pensionifond;Tagasivõtt;PIK;100,000
+        Tuleva Maailma Aktsiate Pensionifond;Tagasivõtt;PIK;100.000
         """;
 
     Map<String, R17Result> result = parser.parse(csv, LOCK_DATE, EXEC_DATE);
@@ -110,7 +110,7 @@ class R17ReportParserTest {
     String csv =
         """
         Väärtpaber;Toiming;PF valitseja/PIK;Osakud (teenustasuga)
-        Tuleva Maailma Aktsiate Pensionifond;Tagasivõtt;PIK;100,000
+        Tuleva Maailma Aktsiate Pensionifond;Tagasivõtt;PIK;100.000
         """;
 
     assertThatThrownBy(() -> parser.parse(csv, LOCK_DATE, EXEC_DATE))
@@ -123,7 +123,7 @@ class R17ReportParserTest {
         """
         Seisuga: 15.04.2026;;;
         Väärtpaber;Toiming;PF valitseja/PIK;Osakud (teenustasuga)
-        Tuleva Maailma Aktsiate Pensionifond;Tagasivõtt;Teine PF valitseja;-50,000
+        Tuleva Maailma Aktsiate Pensionifond;Tagasivõtt;Teine PF valitseja;-50.000
         """;
 
     Map<String, R17Result> result = parser.parse(csv, LOCK_DATE, EXEC_DATE);
@@ -137,7 +137,7 @@ class R17ReportParserTest {
         """
         Seisuga: 15.04.2026;;;
         Väärtpaber;Toiming;PF valitseja/PIK;Osakuid
-        Tuleva Maailma Aktsiate Pensionifond;Väljalase;Oma;200,000
+        Tuleva Maailma Aktsiate Pensionifond;Väljalase;Oma;200.000
         """;
 
     Map<String, R17Result> result = parser.parse(csv, LOCK_DATE, EXEC_DATE);
@@ -152,7 +152,7 @@ class R17ReportParserTest {
         Seisuga: 15.04.2026;;;
         Väärtpaber;Toiming;PF valitseja/PIK;Osakud (teenustasuga)
         Tuleva Maailma Aktsiate Pensionifond;Väljalase;Oma;0
-        Mingi Muu Fond;Väljalase;Oma;100,000
+        Mingi Muu Fond;Väljalase;Oma;100.000
         """;
 
     Map<String, R17Result> result = parser.parse(csv, LOCK_DATE, EXEC_DATE);
@@ -161,12 +161,26 @@ class R17ReportParserTest {
   }
 
   @Test
+  void doesNotMisinterpretPeriodDecimalUnitsAsThousandsGrouping() {
+    String csv =
+        """
+        Seisuga: 15.04.2026;;;
+        Väärtpaber;Toiming;PF valitseja/PIK;Osakud (teenustasuga)
+        Tuleva Maailma Aktsiate Pensionifond;Väljalase;Oma;100.500
+        """;
+
+    Map<String, R17Result> result = parser.parse(csv, LOCK_DATE, EXEC_DATE);
+
+    assertThat(result.get("TUK75").switchingNetUnits()).isEqualByComparingTo("100.500");
+  }
+
+  @Test
   void throwsWhenUnitsExceedHundredMillion() {
     String csv =
         """
         Seisuga: 15.04.2026;;;
         Väärtpaber;Toiming;PF valitseja/PIK;Osakud (teenustasuga)
-        Tuleva Maailma Aktsiate Pensionifond;Väljalase;Oma;150000000,000
+        Tuleva Maailma Aktsiate Pensionifond;Väljalase;Oma;150000000.000
         """;
 
     assertThatThrownBy(() -> parser.parse(csv, LOCK_DATE, EXEC_DATE))

--- a/src/test/groovy/ee/tuleva/onboarding/investment/epis/parser/R45ReportParserTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/epis/parser/R45ReportParserTest.java
@@ -28,9 +28,9 @@ class R45ReportParserTest {
         Tehtud: 12.06.2026;;;;;
         ;;;;;
         Tehingu liik;ISIN;NAV;Osakuid;Summa;Täitmise kuupäev
-        SUB;EE3600109435;0,80000;0;1500,00;15.06.2026
-        RED;EE3600109435;0,80000;0;500,00;15.06.2026
-        SUB;EE3600109443;0,70000;0;200,00;15.06.2026
+        SUB;EE3600109435;0.80000;0;1500.00;15.06.2026
+        RED;EE3600109435;0.80000;0;500.00;15.06.2026
+        SUB;EE3600109443;0.70000;0;200.00;15.06.2026
         """;
 
     R45ParseResult result = parser.parse(csv, TODAY, Map.of());
@@ -47,7 +47,7 @@ class R45ReportParserTest {
         """
         Tehtud: 12.06.2026;;;;;
         Tehingu liik;ISIN;NAV;Osakuid;Summa;Täitmise kuupäev
-        RED;EE3600109443;0,70000;-1000,000;0;15.06.2026
+        RED;EE3600109443;0.70000;-1000.000;0;15.06.2026
         """;
 
     R45ParseResult result = parser.parse(csv, TODAY, Map.of());
@@ -61,7 +61,7 @@ class R45ReportParserTest {
         """
         Tehtud: 12.06.2026;;;;;
         Tehingu liik;ISIN;NAV;Osakuid;Summa;Täitmise kuupäev
-        RED;EE3600109443;0;1000,000;0;15.06.2026
+        RED;EE3600109443;0;1000.000;0;15.06.2026
         """;
 
     R45ParseResult result =
@@ -76,8 +76,8 @@ class R45ReportParserTest {
         """
         Tehtud: 12.06.2026;;;;;
         Tehingu liik;ISIN;NAV;Osakuid;Summa;Täitmise kuupäev
-        SUB;EE3600109443;0,70000;0;200,00;15.06.2026
-        RED;EE3600109443;0;1000,000;0;15.06.2026
+        SUB;EE3600109443;0.70000;0;200.00;15.06.2026
+        RED;EE3600109443;0;1000.000;0;15.06.2026
         """;
 
     R45ParseResult result = parser.parse(csv, TODAY, Map.of());
@@ -91,7 +91,7 @@ class R45ReportParserTest {
         """
         Tehtud: 12.06.2026;;;;;
         Tehingu liik;ISIN;NAV;Osakuid;Summa;Täitmise kuupäev
-        RED;EE3600109435;0;1000,000;0;15.06.2026
+        RED;EE3600109435;0;1000.000;0;15.06.2026
         """;
 
     R45ParseResult result = parser.parse(csv, TODAY, Map.of());
@@ -110,7 +110,7 @@ class R45ReportParserTest {
         """
         Tehtud: 12.06.2026;;;;;
         Tehingu liik;ISIN;NAV;Osakuid;Summa;Täitmise kuupäev
-        SWS;EE3600109435;0,80000;0;0;15.06.2026
+        SWS;EE3600109435;0.80000;0;0;15.06.2026
         """;
 
     R45ParseResult result = parser.parse(csv, TODAY, Map.of());
@@ -125,7 +125,7 @@ class R45ReportParserTest {
         """
         Tehtud: 12.06.2026;;;;;
         Tehingu liik;ISIN;NAV;Osakuid;Summa;Täitmise kuupäev
-        SUB;EE3600109435;0,80000;0;1500,00;11.06.2026
+        SUB;EE3600109435;0.80000;0;1500.00;11.06.2026
         """;
 
     R45ParseResult result = parser.parse(csv, TODAY, Map.of());
@@ -139,7 +139,7 @@ class R45ReportParserTest {
         """
         Tehtud: 12.06.2026;;;;;
         Tehingu liik;ISIN;NAV;Osakuid;Summa;Täitmise kuupäev
-        SUB;EE3600109435;0,80000;0;1500,00;12.06.2026
+        SUB;EE3600109435;0.80000;0;1500.00;12.06.2026
         """;
 
     R45ParseResult result = parser.parse(csv, TODAY, Map.of());
@@ -153,7 +153,7 @@ class R45ReportParserTest {
         """
         Tehtud: 12.06.2026;;;;;
         Tehingu liik;ISIN;NAV;Osakuid;Summa;Täitmise kuupäev
-        SUB;;0,80000;0;1500,00;15.06.2026
+        SUB;;0.80000;0;1500.00;15.06.2026
         """;
 
     var logAppender = new ListAppender<ILoggingEvent>();
@@ -178,8 +178,8 @@ class R45ReportParserTest {
         """
         Tehtud: 12.06.2026;;;;;
         Tehingu liik;ISIN;NAV;Osakuid;Summa;Täitmise kuupäev
-        SUB;XX0000000000;0,80000;0;1500,00;15.06.2026
-        XXX;EE3600109435;0,80000;0;1500,00;15.06.2026
+        SUB;XX0000000000;0.80000;0;1500.00;15.06.2026
+        XXX;EE3600109435;0.80000;0;1500.00;15.06.2026
         """;
 
     R45ParseResult result = parser.parse(csv, TODAY, Map.of());
@@ -197,7 +197,7 @@ class R45ReportParserTest {
         """
         Tehtud: 12.06.2026;;;;;
         Tehingu liik;ISIN;NAV;Osakuid;Summa;Täitmise kuupäev
-        SUB;EE3600109435;0,80000;0;150000000,00;15.06.2026
+        SUB;EE3600109435;0.80000;0;150000000.00;15.06.2026
         """;
 
     assertThatThrownBy(() -> parser.parse(csv, TODAY, Map.of()))
@@ -210,7 +210,7 @@ class R45ReportParserTest {
         """
         Tehtud: 12.06.2026;;;;;
         Tehingu liik;ISIN;NAV;Osakuid;Summa;Täitmise kuupäev
-        SUB;EE3600109435;0,80000;150000000,000;0;15.06.2026
+        SUB;EE3600109435;0.80000;150000000.000;0;15.06.2026
         """;
 
     assertThatThrownBy(() -> parser.parse(csv, TODAY, Map.of()))
@@ -223,7 +223,7 @@ class R45ReportParserTest {
         """
         Tehtud: 11.06.2026;;;;;
         Tehingu liik;ISIN;NAV;Osakuid;Summa;Täitmise kuupäev
-        SUB;EE3600109435;0,80000;0;1500,00;15.06.2026
+        SUB;EE3600109435;0.80000;0;1500.00;15.06.2026
         """;
 
     assertThatThrownBy(() -> parser.parse(csv, TODAY, Map.of()))
@@ -237,7 +237,7 @@ class R45ReportParserTest {
         Fondi aruanne;;;;;
         Tehtud: 12.06.2026;;;;;
         Tehingu liik;ISIN;NAV;Osakuid;Summa;Täitmise kuupäev
-        SUB;EE3600109435;0,80000;0;1500,00;15.06.2026
+        SUB;EE3600109435;0.80000;0;1500.00;15.06.2026
         """;
 
     R45ParseResult result = parser.parse(csv, TODAY, Map.of());
@@ -250,7 +250,7 @@ class R45ReportParserTest {
     String csv =
         """
         Tehingu liik;ISIN;NAV;Osakuid;Summa;Täitmise kuupäev
-        SUB;EE3600109435;0,80000;0;1500,00;15.06.2026
+        SUB;EE3600109435;0.80000;0;1500.00;15.06.2026
         """;
 
     assertThatThrownBy(() -> parser.parse(csv, TODAY, Map.of()))


### PR DESCRIPTION
## Problem

`EpisCsvParser.parseNumber` mangles period-as-thousands values. Verified empirically against the pre-fix code:

```
1.234,56    ->  1.23456     (1000x under)
12.345      ->  12.345      (1000x under)
1.234.567   ->  null        (dropped entirely)
```

Any value containing a `.` failed the `ESTONIAN_DECIMAL` regex and fell into an else-branch that blindly stripped commas. The `null` case is the worst: `unitsOrZero`/`numberOrZero` coalesce it to `BigDecimal.ZERO`, so the row silently becomes **0 units** rather than failing.

**Not currently reachable in production** — `investment_report` holds zero `provider = 'EPIS'` rows (only SEB and SWEDBANK), and EPIS reports arrive solely via admin upload (`TransactionRegistryController:145`/`:157`), never S3. Defense-in-depth: the next operator to upload an R-report would have hit it.

## Approach

A naive fix is dangerous, because `12.345` is genuinely ambiguous — period-thousands (12345) or period-decimal (12.345) — and cannot be auto-detected from the value alone. **Nor can it be inferred from the file**: per the internal Trade & EPIS File Formats reference, every EPIS report is semicolon-delimited, yet **R17/R45 use period decimals while R16/R21 use comma decimals**. The delimiter therefore carries no information.

So each parser declares the convention its report is documented to use. Two properties keep this safe:

- **Mixed separators need no convention** — if both `.` and `,` appear, the last-occurring one is necessarily the decimal. This alone fixes the reported bug. (Same last-index approach as the existing `HistoricalRegistryImportService.parseDecimal`.)
- **A lone separator counts as thousands only when it forms an anchored 3-digit grouping** (`^-?\d{1,3}(<sep>\d{3})+$`) **and is not the report's own decimal separator occurring once.** So real period-decimal unit values and real comma-decimal unit values both read correctly, and nothing that parses today stops parsing.

## Fixtures rewritten

The R17/R45 fixtures were comma-decimal, which **misdescribes the real reports** — R17 and R45 are period-decimal. They're rewritten against the documented format (pure literal conversion; business outcomes unchanged). Two regression tests lock in the motivating case: a period-decimal value with <=3 leading digits and exactly 3 decimals must stay a decimal rather than being multiplied by 1000, and the comma-decimal equivalent likewise.

## Notes

- `findValue` substring matching deliberately untouched: an audit of all 18 call sites found zero ambiguous lookups and one guaranteed regression (`R17ReportParser:37` passes `"pf valitseja"` against real header `PF valitseja/PIK`). R16's headers are also space-padded and must match by substring.
- No migration.

## Follow-up (not in this PR)

`unitsOrZero`/`numberOrZero` still coalesce an unparseable number to `BigDecimal.ZERO`, contradicting the "never substitute sentinels for missing data" rule. This PR removes one trigger; the substitution itself is a separate shipped-behavior decision. (Addressed in #1784.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011SDg3ZgueukmG99FYUpHNg