### PR TITLE
Harden the historical registry import

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/HistoricalRegistryImportService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/HistoricalRegistryImportService.java
@@ -214,29 +214,59 @@ public class HistoricalRegistryImportService {
       throw new RowParseException(
           "Settled row missing both actual and expected settlement date: orderId=" + orderId);
     }
-    return new ParsedRow(
-        rowNumber,
-        orderId,
-        toOrderUuid(orderId),
-        value(record, "transaction_id"),
-        resolveFund(fundIsin),
-        requireValue(record, "instrument_isin"),
-        parseEnum(
-            TransactionType.class, requireValue(record, "transaction_type"), "transaction_type"),
-        parseInstrumentType(value(record, "instrument_type")),
-        parseDecimal(value(record, "order_amount"), "order_amount"),
-        parseDecimal(value(record, "order_quantity"), "order_quantity"),
-        parseInstant(value(record, "order_timestamp"), "order_timestamp"),
-        orderStatus,
-        expectedSettlementDate,
-        value(record, "comment"),
-        parseInstant(value(record, "execution_timestamp"), "execution_timestamp"),
-        parseDecimal(value(record, "executed_quantity"), "executed_quantity"),
-        parseDecimal(value(record, "unit_price"), "unit_price"),
-        parseDecimal(value(record, "total_consideration"), "total_consideration"),
-        parseDecimal(value(record, "net_settlement_amount"), "net_settlement_amount"),
-        parseDecimal(value(record, "commission_amount"), "commission_amount"),
-        actualSettlementDate);
+    ParsedRow row =
+        new ParsedRow(
+            rowNumber,
+            orderId,
+            toOrderUuid(orderId),
+            value(record, "transaction_id"),
+            resolveFund(fundIsin),
+            requireValue(record, "instrument_isin"),
+            parseEnum(
+                TransactionType.class,
+                requireValue(record, "transaction_type"),
+                "transaction_type"),
+            parseInstrumentType(value(record, "instrument_type")),
+            parseDecimal(value(record, "order_amount"), "order_amount"),
+            parseDecimal(value(record, "order_quantity"), "order_quantity"),
+            parseInstant(value(record, "order_timestamp"), "order_timestamp"),
+            orderStatus,
+            expectedSettlementDate,
+            value(record, "comment"),
+            parseInstant(value(record, "execution_timestamp"), "execution_timestamp"),
+            parseDecimal(value(record, "executed_quantity"), "executed_quantity"),
+            parseDecimal(value(record, "unit_price"), "unit_price"),
+            parseDecimal(value(record, "total_consideration"), "total_consideration"),
+            parseDecimal(value(record, "net_settlement_amount"), "net_settlement_amount"),
+            parseDecimal(value(record, "commission_amount"), "commission_amount"),
+            actualSettlementDate);
+    requireTerminalStatusData(row);
+    return row;
+  }
+
+  private static void requireTerminalStatusData(ParsedRow row) {
+    if (row.orderStatus() != OrderStatus.EXECUTED && row.orderStatus() != OrderStatus.SETTLED) {
+      return;
+    }
+    if (row.orderTimestamp() == null) {
+      throw new RowParseException(
+          "Missing value: column=order_timestamp, orderId=" + row.orderId());
+    }
+    if (!row.hasExecutionData()) {
+      throw new RowParseException(
+          "Terminal order missing execution data: orderId=" + row.orderId());
+    }
+    if (row.unitPrice() == null) {
+      throw new RowParseException("Missing value: column=unit_price, orderId=" + row.orderId());
+    }
+    if (row.requiresExecutedQuantity() && row.executedQuantity() == null) {
+      throw new RowParseException(
+          "Missing value: column=executed_quantity, orderId=" + row.orderId());
+    }
+    if (row.isFundSubscription() && row.totalConsideration() == null) {
+      throw new RowParseException(
+          "Missing value: column=total_consideration, orderId=" + row.orderId());
+    }
   }
 
   private boolean isDuplicateBrokerTransactionId(ParsedRow row) {
@@ -433,6 +463,14 @@ public class HistoricalRegistryImportService {
           || executedQuantity != null
           || unitPrice != null
           || totalConsideration != null;
+    }
+
+    boolean requiresExecutedQuantity() {
+      return instrumentType == InstrumentType.ETF || transactionType == TransactionType.SELL;
+    }
+
+    boolean isFundSubscription() {
+      return instrumentType == InstrumentType.FUND && transactionType == TransactionType.BUY;
     }
 
     LocalDate settlementReportDate() {

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/HistoricalRegistryImportService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/HistoricalRegistryImportService.java
@@ -177,12 +177,19 @@ public class HistoricalRegistryImportService {
   private List<ParsedRow> parseRows(List<CSVRecord> records, List<RowError> errors) {
     List<ParsedRow> parsedRows = new ArrayList<>();
     Set<UUID> seenOrderUuids = new HashSet<>();
+    Set<String> seenBrokerTransactionIds = new HashSet<>();
     for (CSVRecord record : records) {
       int rowNumber = (int) record.getRecordNumber() + 1;
       try {
         ParsedRow row = parseRow(rowNumber, record);
         if (!seenOrderUuids.add(row.orderUuid())) {
           throw new RowParseException("Duplicate order_id in file: orderId=" + row.orderId());
+        }
+        if (row.brokerTransactionId() != null
+            && !seenBrokerTransactionIds.add(row.brokerTransactionId())) {
+          throw new RowParseException(
+              "Duplicate brokerTransactionId in file: brokerTransactionId="
+                  + row.brokerTransactionId());
         }
         parsedRows.add(row);
       } catch (RowParseException e) {

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/HistoricalRegistryImportService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/HistoricalRegistryImportService.java
@@ -38,6 +38,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.csv.CSVFormat;
@@ -71,6 +72,9 @@ public class HistoricalRegistryImportService {
   private static final DateTimeFormatter SHEET_TIMESTAMP =
       DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
   private static final DateTimeFormatter ESTONIAN_DATE = DateTimeFormatter.ofPattern("dd.MM.yyyy");
+  private static final Pattern THOUSANDS_GROUPING_COMMA = Pattern.compile("^-?\\d{1,3}(,\\d{3})+$");
+  private static final Pattern THOUSANDS_GROUPING_PERIOD =
+      Pattern.compile("^-?\\d{1,3}(\\.\\d{3})+$");
 
   private final TransactionBatchRepository batchRepository;
   private final TransactionOrderRepository orderRepository;
@@ -80,9 +84,11 @@ public class HistoricalRegistryImportService {
 
   @Transactional
   public HistoricalImportResult importCsv(String csv) {
-    List<CSVRecord> records = parseRecords(csv);
+    char delimiter = sniffDelimiter(csv);
+    char decimalSeparator = decimalSeparatorFor(delimiter);
+    List<CSVRecord> records = parseRecords(csv, delimiter);
     List<RowError> errors = new ArrayList<>();
-    List<ParsedRow> parsedRows = parseRows(records, errors);
+    List<ParsedRow> parsedRows = parseRows(records, errors, decimalSeparator);
 
     Map<TulevaFund, BigDecimal> totalAmountByFund = totalAmountByFund(parsedRows);
     if (!errors.isEmpty()) {
@@ -142,8 +148,7 @@ public class HistoricalRegistryImportService {
         totalAmountByFund);
   }
 
-  private List<CSVRecord> parseRecords(String csv) {
-    char delimiter = sniffDelimiter(csv);
+  private List<CSVRecord> parseRecords(String csv, char delimiter) {
     try (CSVParser parser =
         CSVFormat.DEFAULT
             .builder()
@@ -170,18 +175,23 @@ public class HistoricalRegistryImportService {
     return headerLine.contains(";") ? ';' : ',';
   }
 
+  private static char decimalSeparatorFor(char delimiter) {
+    return delimiter == ';' ? ',' : '.';
+  }
+
   private String normalize(String header) {
     return header.strip().toLowerCase();
   }
 
-  private List<ParsedRow> parseRows(List<CSVRecord> records, List<RowError> errors) {
+  private List<ParsedRow> parseRows(
+      List<CSVRecord> records, List<RowError> errors, char decimalSeparator) {
     List<ParsedRow> parsedRows = new ArrayList<>();
     Set<UUID> seenOrderUuids = new HashSet<>();
     Set<String> seenBrokerTransactionIds = new HashSet<>();
     for (CSVRecord record : records) {
       int rowNumber = (int) record.getRecordNumber() + 1;
       try {
-        ParsedRow row = parseRow(rowNumber, record);
+        ParsedRow row = parseRow(rowNumber, record, decimalSeparator);
         if (!seenOrderUuids.add(row.orderUuid())) {
           throw new RowParseException("Duplicate order_id in file: orderId=" + row.orderId());
         }
@@ -199,7 +209,7 @@ public class HistoricalRegistryImportService {
     return parsedRows;
   }
 
-  private ParsedRow parseRow(int rowNumber, CSVRecord record) {
+  private ParsedRow parseRow(int rowNumber, CSVRecord record, char decimalSeparator) {
     String orderId = requireValue(record, "order_id");
     String fundIsin = requireValue(record, "fund_isin");
     OrderStatus orderStatus =
@@ -227,18 +237,20 @@ public class HistoricalRegistryImportService {
                 requireValue(record, "transaction_type"),
                 "transaction_type"),
             parseInstrumentType(value(record, "instrument_type")),
-            parseDecimal(value(record, "order_amount"), "order_amount"),
-            parseDecimal(value(record, "order_quantity"), "order_quantity"),
+            parseDecimal(value(record, "order_amount"), "order_amount", decimalSeparator),
+            parseDecimal(value(record, "order_quantity"), "order_quantity", decimalSeparator),
             parseInstant(value(record, "order_timestamp"), "order_timestamp"),
             orderStatus,
             expectedSettlementDate,
             value(record, "comment"),
             parseInstant(value(record, "execution_timestamp"), "execution_timestamp"),
-            parseDecimal(value(record, "executed_quantity"), "executed_quantity"),
-            parseDecimal(value(record, "unit_price"), "unit_price"),
-            parseDecimal(value(record, "total_consideration"), "total_consideration"),
-            parseDecimal(value(record, "net_settlement_amount"), "net_settlement_amount"),
-            parseDecimal(value(record, "commission_amount"), "commission_amount"),
+            parseDecimal(value(record, "executed_quantity"), "executed_quantity", decimalSeparator),
+            parseDecimal(value(record, "unit_price"), "unit_price", decimalSeparator),
+            parseDecimal(
+                value(record, "total_consideration"), "total_consideration", decimalSeparator),
+            parseDecimal(
+                value(record, "net_settlement_amount"), "net_settlement_amount", decimalSeparator),
+            parseDecimal(value(record, "commission_amount"), "commission_amount", decimalSeparator),
             actualSettlementDate);
     requireTerminalStatusData(row);
     return row;
@@ -376,24 +388,41 @@ public class HistoricalRegistryImportService {
     return value;
   }
 
-  private static @Nullable BigDecimal parseDecimal(@Nullable String raw, String column) {
+  private static @Nullable BigDecimal parseDecimal(
+      @Nullable String raw, String column, char decimalSeparator) {
     if (raw == null) {
       return null;
     }
-    String cleaned = raw.replace(" ", "").replace(" ", "");
-    if (cleaned.contains(",") && cleaned.contains(".")) {
+    String cleaned = raw.replace("\u00A0", "").replace(" ", "");
+    boolean hasComma = cleaned.contains(",");
+    boolean hasPeriod = cleaned.contains(".");
+    if (hasComma && hasPeriod) {
       cleaned =
           cleaned.lastIndexOf(',') > cleaned.lastIndexOf('.')
               ? cleaned.replace(".", "").replace(',', '.')
               : cleaned.replace(",", "");
-    } else {
-      cleaned = cleaned.replace(',', '.');
+    } else if (hasComma || hasPeriod) {
+      cleaned = resolveSingleSeparator(cleaned, hasComma ? ',' : '.', decimalSeparator);
     }
     try {
       return new BigDecimal(cleaned);
     } catch (NumberFormatException e) {
       throw new RowParseException("Invalid number: column=" + column + ", value=" + raw);
     }
+  }
+
+  private static String resolveSingleSeparator(
+      String cleaned, char separator, char decimalSeparator) {
+    Pattern groupingPattern =
+        separator == ',' ? THOUSANDS_GROUPING_COMMA : THOUSANDS_GROUPING_PERIOD;
+    if (!groupingPattern.matcher(cleaned).matches()) {
+      return cleaned.replace(separator, '.');
+    }
+    boolean singleOccurrence = cleaned.indexOf(separator) == cleaned.lastIndexOf(separator);
+    boolean isDecimalUsage = separator == decimalSeparator && singleOccurrence;
+    return isDecimalUsage
+        ? cleaned.replace(separator, '.')
+        : cleaned.replace(String.valueOf(separator), "");
   }
 
   private static @Nullable Instant parseInstant(@Nullable String raw, String column) {

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/HistoricalRegistryImportServiceIT.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/HistoricalRegistryImportServiceIT.java
@@ -263,6 +263,126 @@ class HistoricalRegistryImportServiceIT {
             "comment");
   }
 
+  @Test
+  void executedRowWithBlankOrderTimestampIsRejected() {
+    String csv =
+        """
+        order_id,fund_isin,instrument_isin,transaction_id,transaction_type,instrument_type,order_amount,order_quantity,order_timestamp,order_status,expected_settlement_date,actual_settlement_date,execution_timestamp,executed_quantity,unit_price,total_consideration,net_settlement_amount,commission_amount,comment
+        GAS-9001,EE3600109435,IE00BFG1TM61,BR-9001,BUY,ETF,1000.00,10.000000,,EXECUTED,2025-03-12,,2025-03-10 14:30:00,10.000000,100.00,1000.00,995.00,5.00,
+        """;
+
+    HistoricalImportResult result = importService.importCsv(csv);
+
+    assertThat(result.errors())
+        .containsExactly(
+            new HistoricalImportResult.RowError(
+                2, "Missing value: column=order_timestamp, orderId=GAS-9001"));
+    assertThat(result.ordersCreated()).isZero();
+    assertThat(executionRepository.findByBrokerTransactionId("BR-9001")).isEmpty();
+  }
+
+  @Test
+  void executedRowWithNoExecutionDataIsRejected() {
+    String csv =
+        """
+        order_id,fund_isin,instrument_isin,transaction_id,transaction_type,instrument_type,order_amount,order_quantity,order_timestamp,order_status,expected_settlement_date,actual_settlement_date,execution_timestamp,executed_quantity,unit_price,total_consideration,net_settlement_amount,commission_amount,comment
+        GAS-9002,EE3600109435,IE00BFG1TM61,BR-9002,BUY,ETF,1000.00,10.000000,2025-03-10 09:00:00,EXECUTED,2025-03-12,,,,,,,,
+        """;
+
+    HistoricalImportResult result = importService.importCsv(csv);
+
+    assertThat(result.errors())
+        .containsExactly(
+            new HistoricalImportResult.RowError(
+                2, "Terminal order missing execution data: orderId=GAS-9002"));
+    assertThat(result.ordersCreated()).isZero();
+  }
+
+  @Test
+  void executedRowWithBlankUnitPriceIsRejected() {
+    String csv =
+        """
+        order_id,fund_isin,instrument_isin,transaction_id,transaction_type,instrument_type,order_amount,order_quantity,order_timestamp,order_status,expected_settlement_date,actual_settlement_date,execution_timestamp,executed_quantity,unit_price,total_consideration,net_settlement_amount,commission_amount,comment
+        GAS-9003,EE3600109435,IE00BFG1TM61,BR-9003,BUY,ETF,1000.00,10.000000,2025-03-10 09:00:00,EXECUTED,2025-03-12,,2025-03-10 14:30:00,10.000000,,1000.00,995.00,5.00,
+        """;
+
+    HistoricalImportResult result = importService.importCsv(csv);
+
+    assertThat(result.errors())
+        .containsExactly(
+            new HistoricalImportResult.RowError(
+                2, "Missing value: column=unit_price, orderId=GAS-9003"));
+    assertThat(result.ordersCreated()).isZero();
+  }
+
+  @Test
+  void executedEtfBuyWithBlankExecutedQuantityIsRejected() {
+    String csv =
+        """
+        order_id,fund_isin,instrument_isin,transaction_id,transaction_type,instrument_type,order_amount,order_quantity,order_timestamp,order_status,expected_settlement_date,actual_settlement_date,execution_timestamp,executed_quantity,unit_price,total_consideration,net_settlement_amount,commission_amount,comment
+        GAS-9004,EE3600109435,IE00BFG1TM61,BR-9004,BUY,ETF,1000.00,10.000000,2025-03-10 09:00:00,EXECUTED,2025-03-12,,2025-03-10 14:30:00,,100.00,1000.00,995.00,5.00,
+        """;
+
+    HistoricalImportResult result = importService.importCsv(csv);
+
+    assertThat(result.errors())
+        .containsExactly(
+            new HistoricalImportResult.RowError(
+                2, "Missing value: column=executed_quantity, orderId=GAS-9004"));
+    assertThat(result.ordersCreated()).isZero();
+  }
+
+  @Test
+  void executedSellWithBlankExecutedQuantityIsRejected() {
+    String csv =
+        """
+        order_id,fund_isin,instrument_isin,transaction_id,transaction_type,instrument_type,order_amount,order_quantity,order_timestamp,order_status,expected_settlement_date,actual_settlement_date,execution_timestamp,executed_quantity,unit_price,total_consideration,net_settlement_amount,commission_amount,comment
+        GAS-9005,EE3600109443,IE0009FT4LX4,BR-9005,SELL,FUND,1000.00,10.000000,2025-03-10 09:00:00,EXECUTED,2025-03-12,,2025-03-10 14:30:00,,100.00,1000.00,995.00,5.00,
+        """;
+
+    HistoricalImportResult result = importService.importCsv(csv);
+
+    assertThat(result.errors())
+        .containsExactly(
+            new HistoricalImportResult.RowError(
+                2, "Missing value: column=executed_quantity, orderId=GAS-9005"));
+    assertThat(result.ordersCreated()).isZero();
+  }
+
+  @Test
+  void executedFundBuyWithBlankExecutedQuantityButPopulatedTotalConsiderationSucceeds() {
+    String csv =
+        """
+        order_id,fund_isin,instrument_isin,transaction_id,transaction_type,instrument_type,order_amount,order_quantity,order_timestamp,order_status,expected_settlement_date,actual_settlement_date,execution_timestamp,executed_quantity,unit_price,total_consideration,net_settlement_amount,commission_amount,comment
+        GAS-9006,EE3600109443,IE0009FT4LX4,BR-9006,BUY,FUND,5000.00,,2025-03-10 09:00:00,EXECUTED,2025-03-12,,2025-03-10 14:30:00,,100.00,5000.00,4995.00,5.00,
+        """;
+
+    HistoricalImportResult result = importService.importCsv(csv);
+
+    assertThat(result.errors()).isEmpty();
+    assertThat(result.ordersCreated()).isEqualTo(1);
+    TransactionExecution execution =
+        executionRepository.findByBrokerTransactionId("BR-9006").orElseThrow();
+    assertThat(execution.getExecutedQuantity()).isNull();
+    assertThat(execution.getTotalConsideration()).isEqualByComparingTo("5000.00");
+  }
+
+  @Test
+  void nonTerminalRowsWithBlankTimestampAndEconomicsSucceed() {
+    String csv =
+        """
+        order_id,fund_isin,instrument_isin,transaction_id,transaction_type,instrument_type,order_amount,order_quantity,order_timestamp,order_status,expected_settlement_date,actual_settlement_date,execution_timestamp,executed_quantity,unit_price,total_consideration,net_settlement_amount,commission_amount,comment
+        GAS-9007,EE3600109435,IE00BFG1TM61,,BUY,ETF,1000.00,10.000000,,PENDING,2025-03-12,,,,,,,,
+        GAS-9008,EE3600109435,IE00BFG1TM61,,BUY,ETF,1000.00,10.000000,,SENT,2025-03-12,,,,,,,,
+        GAS-9009,EE3600109435,IE00BFG1TM61,,BUY,ETF,1000.00,10.000000,,CANCELLED,2025-03-12,,,,,,,,
+        """;
+
+    HistoricalImportResult result = importService.importCsv(csv);
+
+    assertThat(result.errors()).isEmpty();
+    assertThat(result.ordersCreated()).isEqualTo(3);
+  }
+
   private TransactionOrder findByComment(String brokerTransactionId) {
     TransactionExecution execution =
         executionRepository.findByBrokerTransactionId(brokerTransactionId).orElseThrow();

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/HistoricalRegistryImportServiceIT.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/HistoricalRegistryImportServiceIT.java
@@ -150,6 +150,69 @@ class HistoricalRegistryImportServiceIT {
   }
 
   @Test
+  void importWithInFileDuplicateBrokerTransactionIdPersistsNothing() {
+    long ordersBefore = orderRepository.count();
+    String csv =
+        """
+        order_id,fund_isin,instrument_isin,transaction_id,transaction_type,instrument_type,order_amount,order_quantity,order_timestamp,order_status,expected_settlement_date,actual_settlement_date,execution_timestamp,executed_quantity,unit_price,total_consideration,net_settlement_amount,commission_amount,comment
+        GAS-2024-040,EE3600109435,IE00BFG1TM61,BR-3040,BUY,ETF,1000.00,10.000000,2025-03-10 09:00:00,EXECUTED,2025-03-12,,2025-03-10 14:30:00,10.000000,100.00,1000.00,995.00,5.00,
+        GAS-2024-041,EE3600109435,IE00BFG1TM61,BR-3040,BUY,ETF,2000.00,20.000000,2025-03-11 09:00:00,EXECUTED,2025-03-13,,2025-03-11 14:30:00,20.000000,100.00,2000.00,1995.00,5.00,
+        """;
+
+    HistoricalImportResult result = importService.importCsv(csv);
+
+    assertThat(result.rowCount()).isEqualTo(2);
+    assertThat(result.ordersCreated()).isZero();
+    assertThat(result.executionsCreated()).isZero();
+    assertThat(result.errors())
+        .containsExactly(
+            new HistoricalImportResult.RowError(
+                3, "Duplicate brokerTransactionId in file: brokerTransactionId=BR-3040"));
+    assertThat(orderRepository.count()).isEqualTo(ordersBefore);
+    assertThat(executionRepository.findByBrokerTransactionId("BR-3040")).isEmpty();
+  }
+
+  @Test
+  void importWithMultipleBlankBrokerTransactionIdsSucceeds() {
+    String csv =
+        """
+        order_id,fund_isin,instrument_isin,transaction_id,transaction_type,instrument_type,order_amount,order_quantity,order_timestamp,order_status,expected_settlement_date,actual_settlement_date,execution_timestamp,executed_quantity,unit_price,total_consideration,net_settlement_amount,commission_amount,comment
+        GAS-2024-050,EE3600109435,IE00BFG1TM61,,BUY,ETF,1000.00,,2025-03-10 09:00:00,SENT,2025-03-12,,,,,,,,
+        GAS-2024-051,EE3600109435,IE00BFG1TM61,,BUY,ETF,2000.00,,2025-03-11 09:00:00,SENT,2025-03-13,,,,,,,,
+        """;
+
+    HistoricalImportResult result = importService.importCsv(csv);
+
+    assertThat(result.errors()).isEmpty();
+    assertThat(result.ordersCreated()).isEqualTo(2);
+  }
+
+  @Test
+  void importWithAlreadyPersistedDuplicateBrokerTransactionIdReportsRowError() {
+    importService.importCsv(
+        """
+        order_id,fund_isin,instrument_isin,transaction_id,transaction_type,instrument_type,order_amount,order_quantity,order_timestamp,order_status,expected_settlement_date,actual_settlement_date,execution_timestamp,executed_quantity,unit_price,total_consideration,net_settlement_amount,commission_amount,comment
+        GAS-2024-060,EE3600109435,IE00BFG1TM61,BR-3060,BUY,ETF,1000.00,10.000000,2025-03-10 09:00:00,EXECUTED,2025-03-12,,2025-03-10 14:30:00,10.000000,100.00,1000.00,995.00,5.00,
+        """);
+    long ordersBefore = orderRepository.count();
+    String csv =
+        """
+        order_id,fund_isin,instrument_isin,transaction_id,transaction_type,instrument_type,order_amount,order_quantity,order_timestamp,order_status,expected_settlement_date,actual_settlement_date,execution_timestamp,executed_quantity,unit_price,total_consideration,net_settlement_amount,commission_amount,comment
+        GAS-2024-061,EE3600109435,IE00BFG1TM61,BR-3060,BUY,ETF,2000.00,20.000000,2025-03-11 09:00:00,EXECUTED,2025-03-13,,2025-03-11 14:30:00,20.000000,100.00,2000.00,1995.00,5.00,
+        """;
+
+    HistoricalImportResult result = importService.importCsv(csv);
+
+    assertThat(result.rowCount()).isEqualTo(1);
+    assertThat(result.ordersCreated()).isZero();
+    assertThat(result.errors())
+        .containsExactly(
+            new HistoricalImportResult.RowError(
+                2, "Duplicate brokerTransactionId: brokerTransactionId=BR-3060"));
+    assertThat(orderRepository.count()).isEqualTo(ordersBefore);
+  }
+
+  @Test
   void importParsesSemicolonDelimiterAndEstonianDecimals() {
     String csv =
         """

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/HistoricalRegistryImportServiceIT.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/HistoricalRegistryImportServiceIT.java
@@ -234,6 +234,61 @@ class HistoricalRegistryImportServiceIT {
   }
 
   @Test
+  void importResolvesSingleSeparatorAsThousandsUnderSemicolonDelimiter() {
+    String csv =
+        """
+        order_id;fund_isin;instrument_isin;transaction_id;transaction_type;instrument_type;order_amount;order_quantity;order_timestamp;order_status;expected_settlement_date;actual_settlement_date;execution_timestamp;executed_quantity;unit_price;total_consideration;net_settlement_amount;commission_amount;comment
+        GAS-2024-070;EE3600109435;IE00BFG1TM61;BR-2070;BUY;ETF;12.345;;2025-03-10 09:00:00;SENT;2025-03-12;;;;;;;;
+        """;
+
+    HistoricalImportResult result = importService.importCsv(csv);
+
+    assertThat(result.errors()).isEmpty();
+    TransactionOrder order = orderRepository.findByInstrumentIsin("IE00BFG1TM61").getFirst();
+    assertThat(order.getOrderAmount()).isEqualByComparingTo("12345");
+  }
+
+  @Test
+  void importResolvesCommaDecimalConventionAcrossThousandsAndDecimalForms() {
+    String csv =
+        """
+        order_id;fund_isin;instrument_isin;transaction_id;transaction_type;instrument_type;order_amount;order_quantity;order_timestamp;order_status;expected_settlement_date;actual_settlement_date;execution_timestamp;executed_quantity;unit_price;total_consideration;net_settlement_amount;commission_amount;comment
+        GAS-2024-071;EE3600109435;IE00BFG1TM61;BR-2071;BUY;ETF;1.234.567;0.80000;2025-03-10 09:00:00;SENT;2025-03-12;;;;150000000,000;100,000;;;
+        """;
+
+    HistoricalImportResult result = importService.importCsv(csv);
+
+    assertThat(result.errors()).isEmpty();
+    TransactionOrder order = orderRepository.findByInstrumentIsin("IE00BFG1TM61").getFirst();
+    assertThat(order.getOrderAmount()).isEqualByComparingTo("1234567");
+    assertThat(order.getOrderQuantity()).isEqualByComparingTo("0.80000");
+    TransactionExecution execution =
+        executionRepository.findByBrokerTransactionId("BR-2071").orElseThrow();
+    assertThat(execution.getUnitPrice()).isEqualByComparingTo("150000000.000");
+    assertThat(execution.getTotalConsideration()).isEqualByComparingTo("100.000");
+  }
+
+  @Test
+  void importResolvesPeriodDecimalConventionAcrossThousandsAndDecimalForms() {
+    String csv =
+        """
+        order_id,fund_isin,instrument_isin,transaction_id,transaction_type,instrument_type,order_amount,order_quantity,order_timestamp,order_status,expected_settlement_date,actual_settlement_date,execution_timestamp,executed_quantity,unit_price,total_consideration,net_settlement_amount,commission_amount,comment
+        GAS-2024-072,EE3600109435,IE00BFG1TM61,BR-2072,BUY,ETF,12.345,"1,234.56",2025-03-10 09:00:00,SENT,2025-03-12,,,,"100,000",1234.56,,,
+        """;
+
+    HistoricalImportResult result = importService.importCsv(csv);
+
+    assertThat(result.errors()).isEmpty();
+    TransactionOrder order = orderRepository.findByInstrumentIsin("IE00BFG1TM61").getFirst();
+    assertThat(order.getOrderAmount()).isEqualByComparingTo("12.345");
+    assertThat(order.getOrderQuantity()).isEqualByComparingTo("1234.56");
+    TransactionExecution execution =
+        executionRepository.findByBrokerTransactionId("BR-2072").orElseThrow();
+    assertThat(execution.getUnitPrice()).isEqualByComparingTo("100000");
+    assertThat(execution.getTotalConsideration()).isEqualByComparingTo("1234.56");
+  }
+
+  @Test
   void importWithMissingHeadersThrowsFormatException() {
     String csv =
         """


### PR DESCRIPTION
Three independent gaps in `HistoricalRegistryImportService`, one commit each. No migration. Pre-cutover path — the importer must be trustworthy before it carries the backfill.

## 1. In-file duplicate broker transaction ids returned a 500

`isDuplicateBrokerTransactionId` only queried **already-persisted** executions. Two rows in the *same* CSV sharing a broker transaction id both passed, then the second `save` violated `uk_investment_transaction_execution_broker_tx` (`V1_223:30`). Since `TransactionExecution.id` is `GenerationType.IDENTITY`, the insert flushes immediately, so a `DataIntegrityViolationException` escaped `@Transactional importCsv` as an unhandled 500 (no `@ExceptionHandler` covers it).

Now tracked during parse alongside the existing `seenOrderUuids`, so the row fails as a clean `RowError` and the existing whole-file abort gate keeps the import all-or-nothing. Blank broker transaction ids repeat legitimately and stay untracked (SQL UNIQUE permits multiple NULLs) — covered by a test.

## 2. Terminal rows could import with no economics at all

`order_timestamp` was a required *header* but not a required *value*, and execution persistence was gated purely on `hasExecutionData()` — if every execution field was blank, **no execution row was created, silently**. So this imported as a completed trade:

```
order_id,fund_isin,instrument_isin,transaction_type,order_timestamp,order_status,expected_settlement_date,comment
GAS-9999,EE3600109435,IE00BFG1TM61,BUY,,EXECUTED,,
```

`EXECUTED`/`SETTLED` now require an order timestamp, execution data and a unit price. Quantity is required for ETF trades and all sells; **fund subscriptions require total consideration instead, and may leave quantity blank** — the §4.8 carve-out, since SEB fills amount rather than quantity on a fund buy. A test guards that carve-out against over-strictness, and non-terminal rows are unaffected.

No existing fixture needed changing — every pre-existing terminal row already carried complete economics.

## 3. parseDecimal shrank period-thousands values a thousandfold

A lone separator was unconditionally read as a decimal point, so `12.345` parsed as `12.345` instead of `12345` — silently, no error. (Mixed separators like `1.234,56` were already resolved correctly, and `1.234.567` threw loudly; only the single-separator case was wrong.) Same bug class as #1782 in the sibling EPIS parser.

The sniffed delimiter now settles it: `;` file => comma-decimal, `,` file => period-decimal. A lone separator is only read as thousands when it forms an anchored 3-digit grouping (`^-?\d{1,3}(<sep>\d{3})+$`), so `0.80000`, `100,10` and `25 000,00` parse exactly as before. `1.234.567` now parses as `1234567` rather than throwing — intended.

Implemented **locally** rather than sharing `DecimalConvention` with `epis.parser`: separate Spring Modulith sub-modules with deliberately different failure semantics (EPIS returns `null`; this one throws `RowParseException`). Duplication is cheaper than that coupling.

## Notes for review

- **The plan's "V1_190 duplicate-delete" item is falsified.** V1_190 has nothing to do with the transaction registry — it dedupes `investment_model_portfolio_allocation` and the limit tables. The `broker_transaction_id` constraint came from `V1_223` with no dedup DELETE at all. (V1_190 *does* delete on the grouping key without comparing values, but those rows are long gone — not auditable in the live DB.)
- **`instrument_type` defaults to `ETF` when the column is absent** (pre-existing). Combined with change 2, a fund row that omits it is now *rejected* for a blank quantity rather than silently persisted as an ETF. Worth confirming against a real backfill CSV.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011SDg3ZgueukmG99FYUpHNg