### PR TITLE
Reject unparseable EPIS numbers instead of reading them as zero

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/investment/epis/parser/DecimalConvention.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/epis/parser/DecimalConvention.java
@@ -1,6 +1,6 @@
 package ee.tuleva.onboarding.investment.epis.parser;
 
-public enum DecimalConvention {
+enum DecimalConvention {
   COMMA_DECIMAL(','),
   PERIOD_DECIMAL('.');
 

--- a/src/main/java/ee/tuleva/onboarding/investment/epis/parser/EpisCsvParser.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/epis/parser/EpisCsvParser.java
@@ -71,7 +71,8 @@ public class EpisCsvParser {
     try {
       return new BigDecimal(cleaned);
     } catch (NumberFormatException e) {
-      return null;
+      throw new IllegalArgumentException(
+          "Unparseable EPIS number: value=" + value + ", convention=" + convention, e);
     }
   }
 
@@ -80,8 +81,9 @@ public class EpisCsvParser {
     Pattern grouping = separator == ',' ? COMMA_GROUPED : PERIOD_GROUPED;
     boolean isGrouping = grouping.matcher(cleaned).matches();
     boolean isConventionDecimal = separator == convention.decimalSeparator();
-    long occurrences = cleaned.chars().filter(character -> character == separator).count();
-    if (isGrouping && !(isConventionDecimal && occurrences == 1)) {
+    boolean singleOccurrence = cleaned.indexOf(separator) == cleaned.lastIndexOf(separator);
+    boolean isDecimalUsage = isConventionDecimal && singleOccurrence;
+    if (isGrouping && !isDecimalUsage) {
       return cleaned.replace(String.valueOf(separator), "");
     }
     return cleaned.replace(separator, '.');

--- a/src/test/groovy/ee/tuleva/onboarding/investment/epis/parser/EpisCsvParserTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/epis/parser/EpisCsvParserTest.java
@@ -137,9 +137,7 @@ class EpisCsvParserTest {
         "'1,234,567', PERIOD_DECIMAL, 1234567",
         "'1234.56', PERIOD_DECIMAL, 1234.56",
         "'5%', COMMA_DECIMAL, 5",
-        "'0', COMMA_DECIMAL, 0",
-        "'', COMMA_DECIMAL, NULL",
-        "'abc', COMMA_DECIMAL, NULL"
+        "'0', COMMA_DECIMAL, 0"
       })
   void parseNumberHandlesEstonianAndEnglishFormats(
       String input, DecimalConvention convention, String expected) {
@@ -155,5 +153,23 @@ class EpisCsvParserTest {
   @Test
   void parseNumberHandlesNull() {
     assertThat(EpisCsvParser.parseNumber(null, DecimalConvention.COMMA_DECIMAL)).isNull();
+  }
+
+  @Test
+  void parseNumberHandlesBlank() {
+    assertThat(EpisCsvParser.parseNumber("", DecimalConvention.COMMA_DECIMAL)).isNull();
+    assertThat(EpisCsvParser.parseNumber("   ", DecimalConvention.COMMA_DECIMAL)).isNull();
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "abc, COMMA_DECIMAL",
+    "1.2.3, COMMA_DECIMAL",
+    "-, COMMA_DECIMAL",
+    "N/A, COMMA_DECIMAL"
+  })
+  void parseNumberThrowsOnUnparseableValue(String input, DecimalConvention convention) {
+    assertThatThrownBy(() -> EpisCsvParser.parseNumber(input, convention))
+        .isInstanceOf(IllegalArgumentException.class);
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/investment/epis/parser/R16ReportParserTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/epis/parser/R16ReportParserTest.java
@@ -117,7 +117,7 @@ class R16ReportParserTest {
   }
 
   @Test
-  void doesNotMisinterpretCommaDecimalUnitsWithFourLeadingDigitsAsThousandsGrouping() {
+  void doesNotMisinterpretCommaDecimalUnitsThatMatchThousandsGroupingShape() {
     String csv =
         """
         Fondivalitseja: Tuleva Fondid AS;;;;;;


### PR DESCRIPTION
Follow-ups to #1782, from an independent Clean Code review. Two commits: refactor first, then the behavior change.

## 1. Refactor (no behavior change)

- `DecimalConvention` was `public` but nothing outside `epis.parser` references it -> package-private, per the Modulith "sub-packages are internal" rule.
- `R16ReportParserTest.doesNotMisinterpretCommaDecimalUnitsWithFourLeadingDigitsAsThousandsGrouping` used `196,938` — **three** leading digits. The name asserted a falsehood about its own fixture and pointed at the wrong boundary; the value matters because it looks exactly like comma-grouped thousands. Renamed, fixture untouched.

## 2. Fail loudly on unparseable numbers

`parseNumber` returned `null` for **two different things**: an absent/blank cell, and a value it couldn't parse. `unitsOrZero`/`numberOrZero` coalesce `null` to `BigDecimal.ZERO`, so garbage silently became **0 units / 0 EUR** and flowed into liquidity and trade sizing as though EPIS had reported no activity — no exception, no log, nothing to grep.

Decided on expected value: the two outcomes share the same (low) probability, so it turns purely on payoff. A silent zero costs up to the full row value — an R45 `Summa` of €419,379 becomes €0, so the trade simply isn't placed — discovered late via NAV/reconciliation drift, likely after trades are placed, with inaccurate Art 14/16 records. A loud failure costs one operator retry, immediately, with a human already present (it's a manual admin upload).

So:
- `null` / blank / whitespace -> **still `null` -> 0** (blank legitimately means zero)
- present but unparseable -> **throws `IllegalArgumentException`** with the value and convention

This is consistent with how these parsers already behave: `validateMagnitude` throws on absurd unit counts, the R17/R21/R45 date markers throw when missing, and the sibling `HistoricalRegistryImportService.parseDecimal` throws on garbage. Silent-zero was the odd one out.

**Legitimate paths verified untouched** — R45's blank `NAV` is *normal* (unvalued row -> `R45UnvaluedRow`/`complete=false`) and still returns null->0 rather than throwing; every R45 unvalued/fallback-NAV test passes unchanged. Only one expectation flipped, and it's the intended one: `abc` -> `null` becomes `abc` -> throws.

Also aligns the occurrence check with the historical importer's `indexOf == lastIndexOf` idiom and names the decimal case instead of negating it (`isDecimalUsage`), since the same algorithm existed in two idioms.

## Not done (deliberately)

An independent review flagged that `requiresExecutedQuantity()`/`isFundSubscription()` (#1783) are a **third** encoding of one business rule — `TransactionPreparationService.isAmountBasedOrder` (`:327`) and `QuantityAmountValidator.kind()` (`:205`) already encode it. That's real, but consolidating spans `transaction` and `transaction.ingest`, the right shared home isn't obvious (`MismatchKind` is close but lives in an event class), and CLAUDE.md warns duplication beats a wrong abstraction. Recorded as a follow-up rather than rushed. Same for pushing `EXECUTED || SETTLED` onto `OrderStatus` (duplicates `TransactionAdminService.isInMarket:154`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011SDg3ZgueukmG99FYUpHNg