### PR TITLE
Parse the R16 and R17 reports EPIS actually sends

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/investment/epis/parser/EpisCsvParser.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/epis/parser/EpisCsvParser.java
@@ -21,13 +21,17 @@ public class EpisCsvParser {
   private static final Pattern PERIOD_GROUPED = Pattern.compile("^-?\\d{1,3}(\\.\\d{3})+$");
 
   public EpisCsv parse(String content, String headerMarker) {
+    return parse(content, headerMarker, 1);
+  }
+
+  public EpisCsv parse(String content, String headerMarker, int headerRowCount) {
     List<String> lines = content.lines().toList();
     char delimiter = detectDelimiter(lines);
     int headerLineIndex = findHeaderLineIndex(lines, delimiter, headerMarker);
+    List<String> headers = readHeaders(lines, delimiter, headerLineIndex, headerRowCount);
 
-    List<String> headers = splitLine(lines.get(headerLineIndex), delimiter);
     List<Map<String, String>> rows = new ArrayList<>();
-    for (int i = headerLineIndex + 1; i < lines.size(); i++) {
+    for (int i = headerLineIndex + headerRowCount; i < lines.size(); i++) {
       List<String> cells = splitLine(lines.get(i), delimiter);
       if (cells.stream().allMatch(String::isBlank)) {
         continue;
@@ -35,6 +39,44 @@ public class EpisCsvParser {
       rows.add(toRow(headers, cells));
     }
     return new EpisCsv(lines.subList(0, headerLineIndex), rows);
+  }
+
+  private static List<String> readHeaders(
+      List<String> lines, char delimiter, int headerLineIndex, int headerRowCount) {
+    return switch (headerRowCount) {
+      case 1 -> splitLine(lines.get(headerLineIndex), delimiter);
+      case 2 ->
+          combineHeaderRows(lines.get(headerLineIndex), lines.get(headerLineIndex + 1), delimiter);
+      default ->
+          throw new IllegalArgumentException(
+              "Unsupported EPIS header row count: headerRowCount=" + headerRowCount);
+    };
+  }
+
+  private static List<String> combineHeaderRows(String groupLine, String subLine, char delimiter) {
+    List<String> groupCells = splitLine(groupLine, delimiter);
+    List<String> subCells = splitLine(subLine, delimiter);
+    int columnCount = Math.max(groupCells.size(), subCells.size());
+    List<String> combined = new ArrayList<>();
+    String lastGroup = "";
+    for (int i = 0; i < columnCount; i++) {
+      String rawGroup = i < groupCells.size() ? groupCells.get(i).trim() : "";
+      String sub = i < subCells.size() ? subCells.get(i).trim() : "";
+      String group = rawGroup.isEmpty() ? lastGroup : rawGroup;
+      lastGroup = group;
+      combined.add(joinHeaderParts(group, sub));
+    }
+    return combined;
+  }
+
+  private static String joinHeaderParts(String group, String sub) {
+    if (sub.isEmpty()) {
+      return group;
+    }
+    if (group.isEmpty()) {
+      return sub;
+    }
+    return group + " " + sub;
   }
 
   public static @Nullable String findValue(Map<String, String> row, String... keywords) {

--- a/src/main/java/ee/tuleva/onboarding/investment/epis/parser/R16ReportParser.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/epis/parser/R16ReportParser.java
@@ -27,7 +27,7 @@ public class R16ReportParser {
   private final EpisCsvParser csvParser;
 
   public Map<String, R16ParsedFlow> parse(String csv) {
-    EpisCsv parsed = csvParser.parse(csv, HEADER_MARKER);
+    EpisCsv parsed = csvParser.parse(csv, HEADER_MARKER, 2);
     YearMonth paymentMonth = findPaymentMonth(parsed.preHeaderLines());
 
     Map<String, UnitAccumulator> accumulators = new LinkedHashMap<>();

--- a/src/main/java/ee/tuleva/onboarding/investment/epis/parser/R17ReportParser.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/epis/parser/R17ReportParser.java
@@ -93,9 +93,14 @@ public class R17ReportParser {
 
   @Nullable
   private static LocalDate findSeisugaDate(List<String> preHeaderLines) {
-    for (String line : preHeaderLines) {
+    for (int i = 0; i < preHeaderLines.size(); i++) {
+      String line = preHeaderLines.get(i);
       if (line.toLowerCase(Locale.ROOT).contains("seisuga")) {
-        return findDate(line);
+        LocalDate sameLineDate = findDate(line);
+        if (sameLineDate != null) {
+          return sameLineDate;
+        }
+        return i + 1 < preHeaderLines.size() ? findDate(preHeaderLines.get(i + 1)) : null;
       }
     }
     return null;

--- a/src/test/groovy/ee/tuleva/onboarding/investment/epis/EpisReportIngestionServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/epis/EpisReportIngestionServiceTest.java
@@ -78,12 +78,12 @@ class EpisReportIngestionServiceTest {
 
   private static final String R17_CSV =
       """
-      Seisuga: 01.08.2026;;;;;;;
-      ;;;;;;;
-      Väärtpaber;NAV;Toiming;PF valitseja/PIK;Hind;Osakud (teenustasuta);Osakud (teenustasuga);Summa
-      Tuleva Maailma Aktsiate Pensionifond;0.80;Tagasivõtt;PIK;0.80;100.000;100.000;80.00
-      Tuleva Maailma Aktsiate Pensionifond;0.80;Väljalase;Teine PF valitseja;0.80;200.000;200.000;160.00
-      Tuleva Maailma Võlakirjade Pensionifond;0.70;Tagasivõtt;Teine PF valitseja;0.70;50.000;50.000;35.00
+      Staatus;;;;Seisuga;;Valuuta;;
+      Netitud;;;;01.08.2026;;EUR;;
+      Väärtpaber;NAV;Toiming;PF valitseja/PIK;Hind;Osakud (teenustasuta);Osakud (teenustasuga);Summa;Summa (PF valitseja)
+      Tuleva Maailma Aktsiate Pensionifond;0.80;Tagasivõtt;PIK;0.80;100.000;100.000;80.00;0.00
+      Tuleva Maailma Aktsiate Pensionifond;0.80;Väljalase;Teine PF valitseja;0.80;200.000;200.000;160.00;0.00
+      Tuleva Maailma Võlakirjade Pensionifond;0.70;Tagasivõtt;Teine PF valitseja;0.70;50.000;50.000;35.00;0.00
       """;
 
   @Test
@@ -194,7 +194,8 @@ class EpisReportIngestionServiceTest {
     return """
         Fondivalitseja: Tuleva Fondid AS;;;;;;
         Kuu: 2026 08;;;;;;
-        Väärtpaber;Jooksev NAV;Fondimaksed Osakud;Fondimaksed Summa;Ühekordsed maksed Osakud;Ühekordsed maksed Summa;Valuuta
+        Väärtpaber;Jooksev NAV;                       Fondimaksed;;                       Ühekordsed maksed;;Valuuta
+        ;;Osakud;Summa;Osakud;Summa;
         EE3600109435;0,80;%s;800,00;0;0;EUR
         """
         .formatted(fondimaksedUnits);

--- a/src/test/groovy/ee/tuleva/onboarding/investment/epis/parser/EpisCsvParserTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/epis/parser/EpisCsvParserTest.java
@@ -107,6 +107,62 @@ class EpisCsvParserTest {
   }
 
   @Test
+  void combinesGroupedTwoRowHeaderWhenHeaderRowCountIsTwo() {
+    String csv =
+        """
+        Fondivalitseja: Tuleva Fondid AS;;;;;;
+        Kuu: 2026 07;;;;;;
+        Väärtpaber;Jooksev NAV;                       Fondimaksed;;                       Ühekordsed maksed;;Valuuta
+        ;;Osakud;Summa;Osakud;Summa;
+        Tuleva III Samba Pensionifond;1,4153;7892,021;11169,58;123,456;278,73;EUR
+        """;
+
+    EpisCsv result = parser.parse(csv, "Väärtpaber", 2);
+
+    assertThat(result.rows()).hasSize(1);
+    Map<String, String> row = result.rows().getFirst();
+    assertThat(EpisCsvParser.findValue(row, "väärtpaber"))
+        .isEqualTo("Tuleva III Samba Pensionifond");
+    assertThat(EpisCsvParser.findValue(row, "jooksev nav")).isEqualTo("1,4153");
+    assertThat(EpisCsvParser.findValue(row, "fondimaksed osakud")).isEqualTo("7892,021");
+    assertThat(EpisCsvParser.findValue(row, "fondimaksed summa")).isEqualTo("11169,58");
+    assertThat(EpisCsvParser.findValue(row, "ühekordsed maksed osakud")).isEqualTo("123,456");
+    assertThat(EpisCsvParser.findValue(row, "ühekordsed maksed summa")).isEqualTo("278,73");
+    assertThat(EpisCsvParser.findValue(row, "valuuta")).isEqualTo("EUR");
+  }
+
+  @Test
+  void twoRowHeaderModeKeepsPreHeaderLines() {
+    String csv =
+        """
+        Fondivalitseja: Tuleva Fondid AS;;;;;;
+        Kuu: 2026 07;;;;;;
+        Väärtpaber;Jooksev NAV;                       Fondimaksed;;                       Ühekordsed maksed;;Valuuta
+        ;;Osakud;Summa;Osakud;Summa;
+        Tuleva III Samba Pensionifond;1,4153;7892,021;11169,58;123,456;278,73;EUR
+        """;
+
+    EpisCsv result = parser.parse(csv, "Väärtpaber", 2);
+
+    assertThat(result.preHeaderLines())
+        .containsExactly("Fondivalitseja: Tuleva Fondid AS;;;;;;", "Kuu: 2026 07;;;;;;");
+  }
+
+  @Test
+  void singleHeaderRowModeIsUnaffectedByThreeArgOverload() {
+    String csv =
+        """
+        Tehingu liik;ISIN;Osakuid;Summa
+        SUB;EE3600109435;100,500;1500,00
+        """;
+
+    EpisCsv result = parser.parse(csv, "Tehingu liik", 1);
+
+    assertThat(result.rows()).hasSize(1);
+    assertThat(EpisCsvParser.findValue(result.rows().getFirst(), "osakuid")).isEqualTo("100,500");
+  }
+
+  @Test
   void throwsWhenHeaderMarkerNotFoundInFirstTenRows() {
     String csv =
         """

--- a/src/test/groovy/ee/tuleva/onboarding/investment/epis/parser/EpisCsvParserTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/epis/parser/EpisCsvParserTest.java
@@ -163,6 +163,72 @@ class EpisCsvParserTest {
   }
 
   @Test
+  void throwsWhenHeaderRowCountIsUnsupported() {
+    String csv =
+        """
+        Tehingu liik;ISIN
+        SUB;EE3600109435
+        """;
+
+    assertThatThrownBy(() -> parser.parse(csv, "Tehingu liik", 3))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("headerRowCount=3");
+  }
+
+  @Test
+  void combinedHeaderFallsBackToGroupLabelWhenSubRowHasFewerColumnsThanGroupRow() {
+    String csv =
+        """
+        Väärtpaber;Jooksev NAV;Fondimaksed;Valuuta
+        ;;Osakud
+        Tuleva III Samba Pensionifond;1,4153;100,000;EUR
+        """;
+
+    EpisCsv result = parser.parse(csv, "Väärtpaber", 2);
+
+    Map<String, String> row = result.rows().getFirst();
+    assertThat(EpisCsvParser.findValue(row, "väärtpaber"))
+        .isEqualTo("Tuleva III Samba Pensionifond");
+    assertThat(EpisCsvParser.findValue(row, "fondimaksed osakud")).isEqualTo("100,000");
+    assertThat(EpisCsvParser.findValue(row, "valuuta")).isEqualTo("EUR");
+  }
+
+  @Test
+  void combinedHeaderCarriesLastGroupIntoTrailingColumnWhenGroupRowHasFewerColumnsThanSubRow() {
+    String csv =
+        """
+        Väärtpaber;Jooksev NAV;Valuuta
+        ;;;
+        Tuleva III Samba Pensionifond;1,4153;EUR;
+        """;
+
+    EpisCsv result = parser.parse(csv, "Väärtpaber", 2);
+
+    Map<String, String> row = result.rows().getFirst();
+    assertThat(EpisCsvParser.findValue(row, "väärtpaber"))
+        .isEqualTo("Tuleva III Samba Pensionifond");
+    assertThat(EpisCsvParser.findValue(row, "jooksev nav")).isEqualTo("1,4153");
+    assertThat(EpisCsvParser.findValue(row, "valuuta")).isEqualTo("EUR");
+  }
+
+  @Test
+  void combinedHeaderUsesSubLabelAloneWhenFirstColumnHasNoGroupLabelAtAll() {
+    String csv =
+        """
+        ;Väärtpaber
+        Positsioon;Osakud
+        Tuleva III Samba Pensionifond;100,000
+        """;
+
+    EpisCsv result = parser.parse(csv, "Väärtpaber", 2);
+
+    Map<String, String> row = result.rows().getFirst();
+    assertThat(EpisCsvParser.findValue(row, "positsioon"))
+        .isEqualTo("Tuleva III Samba Pensionifond");
+    assertThat(EpisCsvParser.findValue(row, "väärtpaber osakud")).isEqualTo("100,000");
+  }
+
+  @Test
   void throwsWhenHeaderMarkerNotFoundInFirstTenRows() {
     String csv =
         """
@@ -222,7 +288,8 @@ class EpisCsvParserTest {
     "abc, COMMA_DECIMAL",
     "1.2.3, COMMA_DECIMAL",
     "-, COMMA_DECIMAL",
-    "N/A, COMMA_DECIMAL"
+    "N/A, COMMA_DECIMAL",
+    "'1,2,3', COMMA_DECIMAL"
   })
   void parseNumberThrowsOnUnparseableValue(String input, DecimalConvention convention) {
     assertThatThrownBy(() -> EpisCsvParser.parseNumber(input, convention))

--- a/src/test/groovy/ee/tuleva/onboarding/investment/epis/parser/R16ReportParserTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/epis/parser/R16ReportParserTest.java
@@ -20,7 +20,8 @@ class R16ReportParserTest {
         """
         Fondivalitseja: Tuleva Fondid AS;;;;;;
         Kuu: 2026 06;;;;;;
-        Väärtpaber;Jooksev NAV;Fondimaksed Osakud;Fondimaksed Summa;Ühekordsed maksed Osakud;Ühekordsed maksed Summa;Valuuta
+        Väärtpaber;Jooksev NAV;                       Fondimaksed;;                       Ühekordsed maksed;;Valuuta
+        ;;Osakud;Summa;Osakud;Summa;
         EE3600109435;0,80;1000,000;800,00;5000,000;4000,00;EUR
         EE3600109443;0,70;200,000;140,00;0;0;EUR
         """;
@@ -46,7 +47,8 @@ class R16ReportParserTest {
         """
         Fondivalitseja: Tuleva Fondid AS;;;;;;
         Kuu: 2026 06;;;;;;
-        Väärtpaber;Jooksev NAV;Fondimaksed Osakud;Fondimaksed Summa;Ühekordsed maksed Osakud;Ühekordsed maksed Summa;Valuuta
+        Väärtpaber;Jooksev NAV;Fondimaksed;;Ühekordsed maksed;;Valuuta
+        ;;Osakud;Summa;Osakud;Summa;
         Tuleva III Samba Pensionifond;0,90;300,000;270,00;100,000;90,00;EUR
         """;
 
@@ -62,7 +64,8 @@ class R16ReportParserTest {
     String csv =
         """
         Fondivalitseja: Tuleva Fondid AS;;;;;;
-        Väärtpaber;Jooksev NAV;Fondimaksed Osakud;Fondimaksed Summa;Ühekordsed maksed Osakud;Ühekordsed maksed Summa;Valuuta
+        Väärtpaber;Jooksev NAV;Fondimaksed;;Ühekordsed maksed;;Valuuta
+        ;;Osakud;Summa;Osakud;Summa;
         EE3600109435;0,80;1000,000;800,00;5000,000;4000,00;EUR
         """;
 
@@ -75,7 +78,8 @@ class R16ReportParserTest {
         """
         Fondivalitseja: Tuleva Fondid AS;;;;;;
         Kuu: 2026 06;;;;;;
-        Väärtpaber;Jooksev NAV;Fondimaksed Osakud;Fondimaksed Summa;Ühekordsed maksed Osakud;Ühekordsed maksed Summa;Valuuta
+        Väärtpaber;Jooksev NAV;Fondimaksed;;Ühekordsed maksed;;Valuuta
+        ;;Osakud;Summa;Osakud;Summa;
         XX0000000000;0,80;1000,000;800,00;5000,000;4000,00;EUR
         """;
 
@@ -90,7 +94,8 @@ class R16ReportParserTest {
         """
         Fondivalitseja: Tuleva Fondid AS;;;;;;
         Kuu: 2026 06;;;;;;
-        Väärtpaber;Jooksev NAV;Fondimaksed Osakud;Fondimaksed Summa;Ühekordsed maksed Osakud;Ühekordsed maksed Summa;Valuuta
+        Väärtpaber;Jooksev NAV;Fondimaksed;;Ühekordsed maksed;;Valuuta
+        ;;Osakud;Summa;Osakud;Summa;
         EE3600109435;0,80;0;0;0;0;EUR
         """;
 
@@ -106,7 +111,8 @@ class R16ReportParserTest {
         """
         Fondivalitseja: Tuleva Fondid AS;;;;;;
         Kuu: 2026 06;;;;;;
-        Väärtpaber;Jooksev NAV;Fondimaksed Osakud;Fondimaksed Summa;Ühekordsed maksed Osakud;Ühekordsed maksed Summa;Valuuta
+        Väärtpaber;Jooksev NAV;Fondimaksed;;Ühekordsed maksed;;Valuuta
+        ;;Osakud;Summa;Osakud;Summa;
         EE3600109435;0,80;100,000;80,00;0;0;EUR
         EE3600109435;0,80;50,000;40,00;0;0;EUR
         """;
@@ -122,13 +128,14 @@ class R16ReportParserTest {
         """
         Fondivalitseja: Tuleva Fondid AS;;;;;;
         Kuu: 2026 06;;;;;;
-        Väärtpaber;Jooksev NAV;Fondimaksed Osakud;Fondimaksed Summa;Ühekordsed maksed Osakud;Ühekordsed maksed Summa;Valuuta
-        EE3600109435;0,80;196,938;800,00;0;0;EUR
+        Väärtpaber;Jooksev NAV;Fondimaksed;;Ühekordsed maksed;;Valuuta
+        ;;Osakud;Summa;Osakud;Summa;
+        EE3600109435;0,80;123,456;800,00;0;0;EUR
         """;
 
     Map<String, R16ParsedFlow> result = parser.parse(csv);
 
-    assertThat(result.get("TUK75").fondimaksedUnits()).isEqualByComparingTo("196.938");
+    assertThat(result.get("TUK75").fondimaksedUnits()).isEqualByComparingTo("123.456");
   }
 
   @Test
@@ -137,10 +144,31 @@ class R16ReportParserTest {
         """
         Fondivalitseja: Tuleva Fondid AS;;;;;;
         Kuu: 2026 06;;;;;;
-        Väärtpaber;Jooksev NAV;Fondimaksed Osakud;Fondimaksed Summa;Ühekordsed maksed Osakud;Ühekordsed maksed Summa;Valuuta
+        Väärtpaber;Jooksev NAV;Fondimaksed;;Ühekordsed maksed;;Valuuta
+        ;;Osakud;Summa;Osakud;Summa;
         EE3600109435;0,80;150000000,000;800,00;0;0;EUR
         """;
 
     assertThatThrownBy(() -> parser.parse(csv)).isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void parsesRealTwoRowGroupedHeaderWithSpacePaddedGroupCells() {
+    String csv =
+        """
+        Fondivalitseja: Tuleva Fondid AS;;;;;;
+        Kuu: 2026 07;;;;;;
+        Väärtpaber;Jooksev NAV;                       Fondimaksed;;                       Ühekordsed maksed;;Valuuta
+        ;;Osakud;Summa;Osakud;Summa;
+        Tuleva III Samba Pensionifond;1,4153;7892,021;11169,58;123,456;278,73;EUR
+        """;
+
+    Map<String, R16ParsedFlow> result = parser.parse(csv);
+
+    assertThat(result).containsOnlyKeys("TUV100");
+    R16ParsedFlow tuv100 = result.get("TUV100");
+    assertThat(tuv100.fondimaksedUnits()).isEqualByComparingTo("7892.021");
+    assertThat(tuv100.uhekordsedUnits()).isEqualByComparingTo("123.456");
+    assertThat(tuv100.paymentMonth()).isEqualTo(YearMonth.of(2026, 7));
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/investment/epis/parser/R17ReportParserTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/epis/parser/R17ReportParserTest.java
@@ -12,6 +12,8 @@ class R17ReportParserTest {
 
   private static final LocalDate LOCK_DATE = LocalDate.of(2026, 3, 31);
   private static final LocalDate EXEC_DATE = LocalDate.of(2026, 5, 1);
+  private static final String HEADER_ROW =
+      "Väärtpaber;NAV;Toiming;PF valitseja/PIK;Hind;Osakud (teenustasuta);Osakud (teenustasuga);Summa;Summa (PF valitseja)";
 
   private final R17ReportParser parser = new R17ReportParser(new EpisCsvParser());
 
@@ -19,14 +21,15 @@ class R17ReportParserTest {
   void aggregatesPikAndSwitchingNetUnitsPerFund() {
     String csv =
         """
-        Seisuga: 15.04.2026;;;;;;;
-        ;;;;;;;
-        Väärtpaber;NAV;Toiming;PF valitseja/PIK;Hind;Osakud (teenustasuta);Osakud (teenustasuga);Summa
-        Tuleva Maailma Aktsiate Pensionifond;0.80;Tagasivõtt;PIK;0.80;100.000;100.000;80.00
-        Tuleva Maailma Aktsiate Pensionifond;0.80;Väljalase;Teine PF valitseja;0.80;200.000;200.000;160.00
-        Tuleva Maailma Aktsiate Pensionifond;0.80;Tagasivõtt;Teine PF valitseja;0.80;50.000;50.000;40.00
-        Tuleva Maailma Võlakirjade Pensionifond;0.70;Väljalase;Oma;0.70;300.000;300.000;210.00
-        """;
+        Staatus;;;;Seisuga;;Valuuta;;
+        Netitud;;;;15.04.2026;;EUR;;
+        %s
+        Tuleva Maailma Aktsiate Pensionifond;0.80;Tagasivõtt;PIK;0.80;100.000;100.000;80.00;0.00
+        Tuleva Maailma Aktsiate Pensionifond;0.80;Väljalase;Teine PF valitseja;0.80;200.000;200.000;160.00;0.00
+        Tuleva Maailma Aktsiate Pensionifond;0.80;Tagasivõtt;Teine PF valitseja;0.80;50.000;50.000;40.00;0.00
+        Tuleva Maailma Võlakirjade Pensionifond;0.70;Väljalase;Oma;0.70;300.000;300.000;210.00;0.00
+        """
+            .formatted(HEADER_ROW);
 
     Map<String, R17Result> result = parser.parse(csv, LOCK_DATE, EXEC_DATE);
 
@@ -41,10 +44,12 @@ class R17ReportParserTest {
   void throwsWhenSeisugaDateOutsideCycleWindow() {
     String csv =
         """
-        Seisuga: 15.03.2026;;;
-        Väärtpaber;Toiming;PF valitseja/PIK;Osakud (teenustasuga)
-        Tuleva Maailma Aktsiate Pensionifond;Tagasivõtt;PIK;100.000
-        """;
+        Staatus;;;;Seisuga;;Valuuta;;
+        Netitud;;;;15.03.2026;;EUR;;
+        %s
+        Tuleva Maailma Aktsiate Pensionifond;0.80;Tagasivõtt;PIK;0.80;100.000;100.000;80.00;0.00
+        """
+            .formatted(HEADER_ROW);
 
     assertThatThrownBy(() -> parser.parse(csv, LOCK_DATE, EXEC_DATE))
         .isInstanceOf(IllegalArgumentException.class);
@@ -54,10 +59,12 @@ class R17ReportParserTest {
   void acceptsSeisugaDateOnCycleBoundaries() {
     String csv =
         """
-        Seisuga: 31.03.2026;;;
-        Väärtpaber;Toiming;PF valitseja/PIK;Osakud (teenustasuga)
-        Tuleva Maailma Aktsiate Pensionifond;Tagasivõtt;PIK;100.000
-        """;
+        Staatus;;;;Seisuga;;Valuuta;;
+        Netitud;;;;31.03.2026;;EUR;;
+        %s
+        Tuleva Maailma Aktsiate Pensionifond;0.80;Tagasivõtt;PIK;0.80;100.000;100.000;80.00;0.00
+        """
+            .formatted(HEADER_ROW);
 
     Map<String, R17Result> result = parser.parse(csv, LOCK_DATE, EXEC_DATE);
 
@@ -68,23 +75,27 @@ class R17ReportParserTest {
   void throwsWhenSeisugaDateAfterExecutionDate() {
     String csv =
         """
-        Seisuga: 15.05.2026;;;
-        Väärtpaber;Toiming;PF valitseja/PIK;Osakud (teenustasuga)
-        Tuleva Maailma Aktsiate Pensionifond;Tagasivõtt;PIK;100.000
-        """;
+        Staatus;;;;Seisuga;;Valuuta;;
+        Netitud;;;;15.05.2026;;EUR;;
+        %s
+        Tuleva Maailma Aktsiate Pensionifond;0.80;Tagasivõtt;PIK;0.80;100.000;100.000;80.00;0.00
+        """
+            .formatted(HEADER_ROW);
 
     assertThatThrownBy(() -> parser.parse(csv, LOCK_DATE, EXEC_DATE))
         .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
-  void throwsWhenSeisugaLinePresentButHasNoDate() {
+  void throwsWhenSeisugaLinePresentButHasNoDateOnEitherLine() {
     String csv =
         """
-        Seisuga: teadmata;;;
-        Väärtpaber;Toiming;PF valitseja/PIK;Osakud (teenustasuga)
-        Tuleva Maailma Aktsiate Pensionifond;Tagasivõtt;PIK;100.000
-        """;
+        Staatus;;;;Seisuga;;Valuuta;;
+        Netitud;;;;teadmata;;EUR;;
+        %s
+        Tuleva Maailma Aktsiate Pensionifond;0.80;Tagasivõtt;PIK;0.80;100.000;100.000;80.00;0.00
+        """
+            .formatted(HEADER_ROW);
 
     assertThatThrownBy(() -> parser.parse(csv, LOCK_DATE, EXEC_DATE))
         .isInstanceOf(IllegalArgumentException.class);
@@ -94,11 +105,13 @@ class R17ReportParserTest {
   void skipsNonSeisugaPreHeaderLinesBeforeSeisugaLine() {
     String csv =
         """
-        Fondi aruanne;;;
-        Seisuga: 15.04.2026;;;
-        Väärtpaber;Toiming;PF valitseja/PIK;Osakud (teenustasuga)
-        Tuleva Maailma Aktsiate Pensionifond;Tagasivõtt;PIK;100.000
-        """;
+        Fondi aruanne;;;;;;;;
+        Staatus;;;;Seisuga;;Valuuta;;
+        Netitud;;;;15.04.2026;;EUR;;
+        %s
+        Tuleva Maailma Aktsiate Pensionifond;0.80;Tagasivõtt;PIK;0.80;100.000;100.000;80.00;0.00
+        """
+            .formatted(HEADER_ROW);
 
     Map<String, R17Result> result = parser.parse(csv, LOCK_DATE, EXEC_DATE);
 
@@ -109,22 +122,40 @@ class R17ReportParserTest {
   void throwsWhenSeisugaMarkerMissing() {
     String csv =
         """
-        Väärtpaber;Toiming;PF valitseja/PIK;Osakud (teenustasuga)
-        Tuleva Maailma Aktsiate Pensionifond;Tagasivõtt;PIK;100.000
-        """;
+        %s
+        Tuleva Maailma Aktsiate Pensionifond;0.80;Tagasivõtt;PIK;0.80;100.000;100.000;80.00;0.00
+        """
+            .formatted(HEADER_ROW);
 
     assertThatThrownBy(() -> parser.parse(csv, LOCK_DATE, EXEC_DATE))
         .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
+  void acceptsSeisugaDateWhenLabelAndValueAreOnTheSameLine() {
+    String csv =
+        """
+        Seisuga: 15.04.2026;;;;;;;;
+        %s
+        Tuleva Maailma Aktsiate Pensionifond;0.80;Tagasivõtt;PIK;0.80;100.000;100.000;80.00;0.00
+        """
+            .formatted(HEADER_ROW);
+
+    Map<String, R17Result> result = parser.parse(csv, LOCK_DATE, EXEC_DATE);
+
+    assertThat(result.get("TUK75").pikUnits()).isEqualByComparingTo("100.000");
+  }
+
+  @Test
   void usesAbsoluteUnits() {
     String csv =
         """
-        Seisuga: 15.04.2026;;;
-        Väärtpaber;Toiming;PF valitseja/PIK;Osakud (teenustasuga)
-        Tuleva Maailma Aktsiate Pensionifond;Tagasivõtt;Teine PF valitseja;-50.000
-        """;
+        Staatus;;;;Seisuga;;Valuuta;;
+        Netitud;;;;15.04.2026;;EUR;;
+        %s
+        Tuleva Maailma Aktsiate Pensionifond;0.80;Tagasivõtt;Teine PF valitseja;0.80;-50.000;-50.000;-40.00;0.00
+        """
+            .formatted(HEADER_ROW);
 
     Map<String, R17Result> result = parser.parse(csv, LOCK_DATE, EXEC_DATE);
 
@@ -135,7 +166,8 @@ class R17ReportParserTest {
   void fallsBackToOsakuidColumnWhenTeenustasugaColumnMissing() {
     String csv =
         """
-        Seisuga: 15.04.2026;;;
+        Staatus;;;;Seisuga;;Valuuta;;
+        Netitud;;;;15.04.2026;;EUR;;
         Väärtpaber;Toiming;PF valitseja/PIK;Osakuid
         Tuleva Maailma Aktsiate Pensionifond;Väljalase;Oma;200.000
         """;
@@ -149,11 +181,13 @@ class R17ReportParserTest {
   void skipsRowsWithZeroUnitsOrUnknownFund() {
     String csv =
         """
-        Seisuga: 15.04.2026;;;
-        Väärtpaber;Toiming;PF valitseja/PIK;Osakud (teenustasuga)
-        Tuleva Maailma Aktsiate Pensionifond;Väljalase;Oma;0
-        Mingi Muu Fond;Väljalase;Oma;100.000
-        """;
+        Staatus;;;;Seisuga;;Valuuta;;
+        Netitud;;;;15.04.2026;;EUR;;
+        %s
+        Tuleva Maailma Aktsiate Pensionifond;0.80;Väljalase;Oma;0.80;0;0;0.00;0.00
+        Mingi Muu Fond;0.80;Väljalase;Oma;0.80;100.000;100.000;80.00;0.00
+        """
+            .formatted(HEADER_ROW);
 
     Map<String, R17Result> result = parser.parse(csv, LOCK_DATE, EXEC_DATE);
 
@@ -164,10 +198,12 @@ class R17ReportParserTest {
   void doesNotMisinterpretPeriodDecimalUnitsAsThousandsGrouping() {
     String csv =
         """
-        Seisuga: 15.04.2026;;;
-        Väärtpaber;Toiming;PF valitseja/PIK;Osakud (teenustasuga)
-        Tuleva Maailma Aktsiate Pensionifond;Väljalase;Oma;100.500
-        """;
+        Staatus;;;;Seisuga;;Valuuta;;
+        Netitud;;;;15.04.2026;;EUR;;
+        %s
+        Tuleva Maailma Aktsiate Pensionifond;0.80;Väljalase;Oma;0.80;100.500;100.500;80.00;0.00
+        """
+            .formatted(HEADER_ROW);
 
     Map<String, R17Result> result = parser.parse(csv, LOCK_DATE, EXEC_DATE);
 
@@ -178,12 +214,48 @@ class R17ReportParserTest {
   void throwsWhenUnitsExceedHundredMillion() {
     String csv =
         """
-        Seisuga: 15.04.2026;;;
-        Väärtpaber;Toiming;PF valitseja/PIK;Osakud (teenustasuga)
-        Tuleva Maailma Aktsiate Pensionifond;Väljalase;Oma;150000000.000
-        """;
+        Staatus;;;;Seisuga;;Valuuta;;
+        Netitud;;;;15.04.2026;;EUR;;
+        %s
+        Tuleva Maailma Aktsiate Pensionifond;0.80;Väljalase;Oma;0.80;150000000.000;150000000.000;80.00;0.00
+        """
+            .formatted(HEADER_ROW);
 
     assertThatThrownBy(() -> parser.parse(csv, LOCK_DATE, EXEC_DATE))
         .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void pfValitsejaColumnTakesPrecedenceOverSummaPfValitsejaColumnDueToHeaderOrder() {
+    String csv =
+        """
+        Staatus;;;;Seisuga;;Valuuta;;
+        Netitud;;;;15.04.2026;;EUR;;
+        %s
+        Tuleva Maailma Aktsiate Pensionifond;0.80;Tagasivõtt;PIK;0.80;100.000;100.000;80.00;999.00
+        """
+            .formatted(HEADER_ROW);
+
+    Map<String, R17Result> result = parser.parse(csv, LOCK_DATE, EXEC_DATE);
+
+    assertThat(result.get("TUK75").pikUnits()).isEqualByComparingTo("100.000");
+    assertThat(result.get("TUK75").switchingNetUnits()).isEqualByComparingTo("0");
+  }
+
+  @Test
+  void parsesWhenFileStartsWithUtf8Bom() {
+    String csv =
+        "﻿"
+            + """
+        Staatus;;;;Seisuga;;Valuuta;;
+        Netitud;;;;15.04.2026;;EUR;;
+        %s
+        Tuleva Maailma Aktsiate Pensionifond;0.80;Tagasivõtt;PIK;0.80;100.000;100.000;80.00;0.00
+        """
+                .formatted(HEADER_ROW);
+
+    Map<String, R17Result> result = parser.parse(csv, LOCK_DATE, EXEC_DATE);
+
+    assertThat(result.get("TUK75").pikUnits()).isEqualByComparingTo("100.000");
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/investment/epis/parser/R17ReportParserTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/epis/parser/R17ReportParserTest.java
@@ -119,6 +119,20 @@ class R17ReportParserTest {
   }
 
   @Test
+  void throwsWhenSeisugaLabelIsOnTheLastPreHeaderLineWithNoFollowingLine() {
+    String csv =
+        """
+        Seisuga teadmata;;;;;;;;
+        %s
+        Tuleva Maailma Aktsiate Pensionifond;0.80;Tagasivõtt;PIK;0.80;100.000;100.000;80.00;0.00
+        """
+            .formatted(HEADER_ROW);
+
+    assertThatThrownBy(() -> parser.parse(csv, LOCK_DATE, EXEC_DATE))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
   void throwsWhenSeisugaMarkerMissing() {
     String csv =
         """


### PR DESCRIPTION
**Stacked on #1784** (same files) — base will retarget to `master` once that merges.

I ran real Pensionikeskus sample reports through the parsers. **R16 and R17 have never been able to read a real EPIS file.** R21 and R45 are correct and untouched. (Real figures omitted — samples are confidential; values below are illustrative.)

## R16 returned zero units for every fund — silently

Real R16 has a **two-row grouped header**: `Fondimaksed` / `Ühekordsed maksed` sit on the marker row, each spanning an `Osakud`+`Summa` pair on the row below (group cells are space-padded).

```
Väärtpaber;Jooksev NAV;          Fondimaksed;;          Ühekordsed maksed;;Valuuta
;;Osakud;Summa;Osakud;Summa;
<fund name>;<nav>;<units>;<amount>;<units>;<amount>;EUR
```

`EpisCsvParser` read only the marker row, so keys became `fondimaksed`/`ühekordsedmaksed` (the blank-headered `Summa` columns dropped entirely). The lookup for `"fondimaksed osakud"` matched nothing -> `findValue` null -> `unitsOrZero` -> **`BigDecimal.ZERO`**. Verified against a real file: **every fund reported 0 units, silently, before the fix.**

R16 feeds forecasted payments -> liquidity, so at cutover liquidity would have been computed from zero flows, with nothing to grep. `EpisCsvParser` gains a `parse(content, marker, headerRowCount)` overload that combines the two rows, forward-filling a group name across the blank cell it spans. **No R16 keyword changes were needed** — the combined names normalize to exactly what the parser already asked for. After the fix, the same real file parses every fund's units correctly.

## R17 threw on every real file

Real R17 puts the label `Seisuga` on row 1 and its date value on row 2; every other report keeps label and value on one line, which is why only R17 trips. `findSeisugaDate` searched for the date on the label's own line -> null -> `IllegalArgumentException: R17 Seisuga date marker missing or unparseable`. It now falls back to the following pre-header line, keeping the same-line form working (pinned by a test). After the fix the real file parses, and the netting arithmetic was verified by hand against the source rows.

## Fixtures rebuilt

Both bugs had the same cause: **fixtures describing files that don't exist** (R16: one combined header row; R17: `Seisuga: <date>` on one line, 8 columns). Rebuilt to the real structure with **synthetic values** — the sample reports are confidential and stay out of the repo. R17 fixtures now include the real 9th column `Summa (PF valitseja)`.

Also **removed a real Tuleva figure** that #1782 had merged into an R16 fixture, replacing it with a synthetic value of identical shape.

## New tests

- R16 two-row grouped header (incl. space-padded group cells) — the RED test, returned 0 before
- R17 split label/value marker — the RED test, threw before
- **R17 column-ambiguity pin**: the real 9-column header means `"pf valitseja"` substring-matches **both** `PF valitseja/PIK` and `Summa (PF valitseja)`. Today it reads the right one *only* because `LinkedHashMap` order puts the real column first. Test pins that behavior. `findValue` deliberately untouched — but this is a standing fragility: reorder those columns and the pik/switching classification silently flips. (It also confirms the earlier decision to drop exact-header matching: `equals` would break this lookup outright.)
- UTF-8 BOM tolerance — every real EPIS file starts with one

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011SDg3ZgueukmG99FYUpHNg