### PR TITLE
Accept multiple investment goals in a KYC survey

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/kyc/survey/KycSurveyResponseItem.java
+++ b/src/main/java/ee/tuleva/onboarding/kyc/survey/KycSurveyResponseItem.java
@@ -1,5 +1,6 @@
 package ee.tuleva.onboarding.kyc.survey;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import ee.tuleva.onboarding.country.ValidIso2CountryCode;
@@ -44,7 +45,12 @@ public sealed interface KycSurveyResponseItem extends Serializable {
   record PepSelfDeclaration(@NotNull OptionValue<PepStatus> value)
       implements KycSurveyResponseItem {}
 
-  record InvestmentGoals(@NotNull InvestmentGoalsValue value) implements KycSurveyResponseItem {}
+  // A list so a saver can pick several goals (e.g. education and a first home). Accepts a single
+  // value too, so existing single-goal payloads and already-stored surveys still deserialize.
+  record InvestmentGoals(
+      @NotNull @JsonFormat(with = JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
+          List<@Valid InvestmentGoalsValue> value)
+      implements KycSurveyResponseItem {}
 
   record InvestableAssets(@NotNull OptionValue<AssetRange> value)
       implements KycSurveyResponseItem {}

--- a/src/test/groovy/ee/tuleva/onboarding/kyc/survey/KycSurveyResponseTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyc/survey/KycSurveyResponseTest.java
@@ -167,11 +167,55 @@ class KycSurveyResponseTest {
                         new FundingSourceValueItem.Option(PARENT_INCOME_AND_SAVINGS),
                         new FundingSourceValueItem.Text("lottery win"))),
                 new PlannedContribution(new OptionValue<>("OPTION", FROM_200_TO_600)),
-                new InvestmentGoals(new InvestmentGoalsValue.Option(EDUCATION)),
-                new InvestmentGoals(new InvestmentGoalsValue.Option(FIRST_HOME))));
+                new InvestmentGoals(List.of(new InvestmentGoalsValue.Option(EDUCATION))),
+                new InvestmentGoals(List.of(new InvestmentGoalsValue.Option(FIRST_HOME)))));
 
     var roundTripped =
         objectMapper.readValue(objectMapper.writeValueAsString(response), KycSurveyResponse.class);
     assertThat(roundTripped).isEqualTo(response);
+  }
+
+  @Test
+  void investmentGoalsAcceptsMultipleGoalsInOneItem() throws Exception {
+    var json =
+        """
+        {
+          "answers": [
+            {
+              "type": "INVESTMENT_GOALS",
+              "value": [
+                { "type": "OPTION", "value": "EDUCATION" },
+                { "type": "OPTION", "value": "FIRST_HOME" }
+              ]
+            }
+          ]
+        }
+        """;
+
+    var response = objectMapper.readValue(json, KycSurveyResponse.class);
+
+    assertThat(response.answers())
+        .containsExactly(
+            new InvestmentGoals(
+                List.of(
+                    new InvestmentGoalsValue.Option(EDUCATION),
+                    new InvestmentGoalsValue.Option(FIRST_HOME))));
+  }
+
+  @Test
+  void investmentGoalsStillAcceptsASingleGoalForBackwardCompatibility() throws Exception {
+    var json =
+        """
+        {
+          "answers": [
+            { "type": "INVESTMENT_GOALS", "value": { "type": "OPTION", "value": "EDUCATION" } }
+          ]
+        }
+        """;
+
+    var response = objectMapper.readValue(json, KycSurveyResponse.class);
+
+    assertThat(response.answers())
+        .containsExactly(new InvestmentGoals(List.of(new InvestmentGoalsValue.Option(EDUCATION))));
   }
 }


### PR DESCRIPTION
## What

The KYC survey's `INVESTMENT_GOALS` item held a **single** value. This makes it a **list**, so a saver can pick more than one goal (e.g. education *and* a first home).

## Backward compatible

`@JsonFormat(with = ACCEPT_SINGLE_VALUE_AS_ARRAY)` on the list means a single value still deserializes into a one-element list. So:
- Live **person / company** flows keep sending a single value — untouched, no coordinated deploy needed.
- **Already-stored** surveys (single value in jsonb) still read back.
- Only the **child** flow sends a real array (separate onboarding-client PR, stacked on #1595).

Nothing in the KYC code reads the investment goal as a single value (it's stored as jsonb and only ever deserialized), so no consumer breaks.

## Tests

- New: multiple goals in one item deserialize to a 2-element list; a single value still deserializes (backward compat).
- Existing JSON-payload survey tests pass unchanged (the annotation absorbs the single-value shape).
- `KycSurveyResponseTest` 10 green; spotless clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)