### PR TITLE
Wave 8: make the broker order files match what SEB and FT actually read

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionBatchNotifier.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionBatchNotifier.java
@@ -19,7 +19,8 @@ class TransactionBatchNotifier {
       Map.of(
           "sebFundXlsx", "SEB indeksfondid",
           "sebEtfXlsx", "SEB ETF",
-          "ftEtfXlsx", "FT ETF");
+          "ftEtfXlsx", "FT ETF",
+          "uuidWorkbookXlsx", "UUID workbook");
 
   private final OperationsNotificationService notificationService;
 

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionBatchResponse.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionBatchResponse.java
@@ -20,7 +20,7 @@ public record TransactionBatchResponse(
     List<TransactionOrderResponse> orders) {
 
   static final Set<String> EXPORT_TYPES =
-      Set.of("xlsxExport", "sebFundXlsx", "sebEtfXlsx", "ftEtfXlsx");
+      Set.of("xlsxExport", "sebFundXlsx", "sebEtfXlsx", "ftEtfXlsx", "uuidWorkbookXlsx");
 
   static TransactionBatchResponse from(TransactionBatch batch, List<TransactionOrder> orders) {
     Map<String, Object> metadata = batch.getMetadata();

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionPreparationService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionPreparationService.java
@@ -164,13 +164,16 @@ public class TransactionPreparationService {
     byte[] xlsxExport = exportService.generateOrdersExport(orders);
     byte[] sebFundXlsx = exportService.generateSebFundExport(orders, labelsByIsin);
     byte[] sebEtfXlsx = exportService.generateSebEtfExport(orders, ricByIsin);
-    byte[] ftEtfXlsx = exportService.generateFtEtfExport(orders, labelsByIsin, bbgByIsin);
+    byte[] ftEtfXlsx =
+        exportService.generateFtEtfExport(orders, labelsByIsin, bbgByIsin, tradeDate);
+    byte[] uuidWorkbookXlsx = exportService.generateUuidWorkbook(orders);
 
     Map<String, Object> updatedMetadata = new HashMap<>(batch.getMetadata());
     updatedMetadata.put("xlsxExport", encodeExport(xlsxExport));
     updatedMetadata.put("sebFundXlsx", encodeExport(sebFundXlsx));
     updatedMetadata.put("sebEtfXlsx", encodeExport(sebEtfXlsx));
     updatedMetadata.put("ftEtfXlsx", encodeExport(ftEtfXlsx));
+    updatedMetadata.put("uuidWorkbookXlsx", encodeExport(uuidWorkbookXlsx));
     batch.setMetadata(updatedMetadata);
 
     batch.setStatus(BatchStatus.SENT);
@@ -188,7 +191,14 @@ public class TransactionPreparationService {
     runAfterCommit(
         () ->
             publishExportsToDrive(
-                batch, now, tradeDate, orders.size(), sebFundXlsx, sebEtfXlsx, ftEtfXlsx));
+                batch,
+                now,
+                tradeDate,
+                orders.size(),
+                sebFundXlsx,
+                sebEtfXlsx,
+                ftEtfXlsx,
+                uuidWorkbookXlsx));
 
     log.info("Batch finalized: id={}, orderCount={}", batch.getId(), orders.size());
   }
@@ -200,9 +210,14 @@ public class TransactionPreparationService {
       int orderCount,
       byte[] sebFundXlsx,
       byte[] sebEtfXlsx,
-      byte[] ftEtfXlsx) {
+      byte[] ftEtfXlsx,
+      byte[] uuidWorkbookXlsx) {
     var exports =
-        Map.of("sebFundXlsx", sebFundXlsx, "sebEtfXlsx", sebEtfXlsx, "ftEtfXlsx", ftEtfXlsx);
+        Map.of(
+            "sebFundXlsx", sebFundXlsx,
+            "sebEtfXlsx", sebEtfXlsx,
+            "ftEtfXlsx", ftEtfXlsx,
+            "uuidWorkbookXlsx", uuidWorkbookXlsx);
     Map<String, String> driveFileUrls = uploadExportsToDrive(batch, timestamp, exports);
     if (!driveFileUrls.isEmpty()) {
       persistDriveFileUrls(batch, driveFileUrls);

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/export/CustodianOrderMessageFactory.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/export/CustodianOrderMessageFactory.java
@@ -23,6 +23,7 @@ class CustodianOrderMessageFactory {
 
   private static final String XLSX_MIME_TYPE =
       "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+  private static final String CSV_MIME_TYPE = "text/csv";
 
   private static final DateTimeFormatter TIMESTAMP =
       DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH_mm_ss").withZone(ZoneOffset.UTC);
@@ -31,9 +32,15 @@ class CustodianOrderMessageFactory {
 
   private static final Map<String, String> FILE_NAME_PATTERNS =
       Map.of(
-          "sebFundXlsx", "SEB_%s_indeksfondid_%s.xlsx",
+          "sebFundXlsx", "SEB_%s_indeksfondid_%s.csv",
           "sebEtfXlsx", "SEB_%s_ETF_tehingud_%s.xlsx",
           "ftEtfXlsx", "FT_%s_ETF_orders_%s.xlsx");
+
+  private static final Map<String, String> MIME_TYPES =
+      Map.of(
+          "sebFundXlsx", CSV_MIME_TYPE,
+          "sebEtfXlsx", XLSX_MIME_TYPE,
+          "ftEtfXlsx", XLSX_MIME_TYPE);
 
   private final CustodianOrderEmailProperties properties;
 
@@ -84,7 +91,7 @@ class CustodianOrderMessageFactory {
           if (content != null && content.length > 0) {
             var attachment = new MessageContent();
             attachment.setName(namePattern.formatted(fund.getCode(), fileTimestamp));
-            attachment.setType(XLSX_MIME_TYPE);
+            attachment.setType(MIME_TYPES.get(exportKey));
             attachment.setContent(Base64.getEncoder().encodeToString(content));
             attachments.add(attachment);
           }

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/export/CustodianOrderMessageFactory.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/export/CustodianOrderMessageFactory.java
@@ -14,6 +14,7 @@ import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
+import java.util.function.BiFunction;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -27,20 +28,34 @@ class CustodianOrderMessageFactory {
 
   private static final DateTimeFormatter TIMESTAMP =
       DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH_mm_ss").withZone(ZoneOffset.UTC);
+  private static final DateTimeFormatter UUID_WORKBOOK_TIMESTAMP =
+      DateTimeFormatter.ofPattern("yyyyMMdd_HHmm").withZone(ZoneOffset.UTC);
   private static final DateTimeFormatter SUBJECT_DATE =
       DateTimeFormatter.ofPattern("dd.MM.yyyy").withZone(ZoneOffset.UTC);
 
-  private static final Map<String, String> FILE_NAME_PATTERNS =
+  private static final Map<String, BiFunction<TulevaFund, Instant, String>> FILE_NAME_GENERATORS =
       Map.of(
-          "sebFundXlsx", "SEB_%s_indeksfondid_%s.csv",
-          "sebEtfXlsx", "SEB_%s_ETF_tehingud_%s.xlsx",
-          "ftEtfXlsx", "FT_%s_ETF_orders_%s.xlsx");
+          "sebFundXlsx",
+              (fund, timestamp) ->
+                  "SEB_%s_indeksfondid_%s.csv"
+                      .formatted(fund.getCode(), TIMESTAMP.format(timestamp)),
+          "sebEtfXlsx",
+              (fund, timestamp) ->
+                  "SEB_%s_ETF_tehingud_%s.xlsx"
+                      .formatted(fund.getCode(), TIMESTAMP.format(timestamp)),
+          "ftEtfXlsx",
+              (fund, timestamp) ->
+                  "FT_%s_ETF_orders_%s.xlsx".formatted(fund.getCode(), TIMESTAMP.format(timestamp)),
+          "uuidWorkbookXlsx",
+              (fund, timestamp) ->
+                  "Tehingud_UUID_%s.xlsx".formatted(UUID_WORKBOOK_TIMESTAMP.format(timestamp)));
 
   private static final Map<String, String> MIME_TYPES =
       Map.of(
           "sebFundXlsx", CSV_MIME_TYPE,
           "sebEtfXlsx", XLSX_MIME_TYPE,
-          "ftEtfXlsx", XLSX_MIME_TYPE);
+          "ftEtfXlsx", XLSX_MIME_TYPE,
+          "uuidWorkbookXlsx", XLSX_MIME_TYPE);
 
   private final CustodianOrderEmailProperties properties;
 
@@ -83,14 +98,13 @@ class CustodianOrderMessageFactory {
 
   private List<MessageContent> buildAttachments(
       TulevaFund fund, Instant timestamp, Map<String, byte[]> exports) {
-    var fileTimestamp = TIMESTAMP.format(timestamp);
     List<MessageContent> attachments = new ArrayList<>();
-    FILE_NAME_PATTERNS.forEach(
-        (exportKey, namePattern) -> {
+    FILE_NAME_GENERATORS.forEach(
+        (exportKey, fileNameGenerator) -> {
           var content = exports.get(exportKey);
           if (content != null && content.length > 0) {
             var attachment = new MessageContent();
-            attachment.setName(namePattern.formatted(fund.getCode(), fileTimestamp));
+            attachment.setName(fileNameGenerator.apply(fund, timestamp));
             attachment.setType(MIME_TYPES.get(exportKey));
             attachment.setContent(Base64.getEncoder().encodeToString(content));
             attachments.add(attachment);

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/export/GoogleDriveClient.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/export/GoogleDriveClient.java
@@ -14,6 +14,9 @@ import tools.jackson.databind.json.JsonMapper;
 class GoogleDriveClient {
 
   private static final String FOLDER_MIME_TYPE = "application/vnd.google-apps.folder";
+  private static final String CSV_CONTENT_TYPE = "text/csv";
+  private static final String SPREADSHEET_CONTENT_TYPE =
+      "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
   private static final ParameterizedTypeReference<Map<String, Object>> MAP_TYPE =
       new ParameterizedTypeReference<>() {};
 
@@ -69,7 +72,8 @@ class GoogleDriveClient {
     var metadata = Map.of("name", fileName, "parents", List.of(folderId));
 
     var metadataJson = toJson(metadata);
-    var multipartBody = buildMultipartBody(boundary, metadataJson, content);
+    var multipartBody =
+        buildMultipartBody(boundary, metadataJson, content, contentTypeFor(fileName));
 
     Map<String, Object> response =
         restClient
@@ -85,14 +89,16 @@ class GoogleDriveClient {
     return (String) response.get("webViewLink");
   }
 
+  static String contentTypeFor(String fileName) {
+    return fileName.endsWith(".csv") ? CSV_CONTENT_TYPE : SPREADSHEET_CONTENT_TYPE;
+  }
+
   private static byte[] buildMultipartBody(
-      String boundary, String metadataJson, byte[] fileContent) {
+      String boundary, String metadataJson, byte[] fileContent, String contentType) {
     var metadataPart =
         ("--%s\r\nContent-Type: application/json; charset=UTF-8\r\n\r\n%s\r\n"
             .formatted(boundary, metadataJson));
-    var filePart =
-        ("--%s\r\nContent-Type: application/vnd.openxmlformats-officedocument.spreadsheetml.sheet\r\n\r\n"
-            .formatted(boundary));
+    var filePart = ("--%s\r\nContent-Type: %s\r\n\r\n".formatted(boundary, contentType));
     var closing = "\r\n--%s--".formatted(boundary);
 
     var metadataBytes = metadataPart.getBytes();

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/export/TransactionExportService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/export/TransactionExportService.java
@@ -6,6 +6,7 @@ import static ee.tuleva.onboarding.investment.transaction.InstrumentType.FUND;
 import static ee.tuleva.onboarding.investment.transaction.OrderVenue.SEB;
 import static ee.tuleva.onboarding.investment.transaction.TransactionType.BUY;
 import static java.math.BigDecimal.ZERO;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 import ee.tuleva.onboarding.fund.TulevaFund;
 import ee.tuleva.onboarding.investment.transaction.OrderVenue;
@@ -14,6 +15,8 @@ import ee.tuleva.onboarding.investment.transaction.TransactionType;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -31,15 +34,11 @@ public class TransactionExportService {
   };
 
   private static final String[] SEB_FUND_HEADERS = {
-    "Portfelli t\u00e4his",
-    "Issuer Of Order",
-    "Korralduse andja CIF",
-    "Securities Acc",
+    "Original reference",
+    "Client name",
+    "Securities Acc ",
     "Cash Acc",
     "Currency",
-    "Counterparties name",
-    "Counterparties Securities No",
-    "Counterparties Account Manager",
     "Transaction Type",
     "Trade Date",
     "Settlement Date",
@@ -48,9 +47,11 @@ public class TransactionExportService {
     "Quantity",
     "Price",
     "Transaction Sum",
-    "Commission",
+    "Transaction fee",
     "Total Sum"
   };
+
+  private static final String CSV_DELIMITER = ";";
 
   private static final String[] SEB_ETF_HEADERS = {
     "Client Name",
@@ -97,39 +98,46 @@ public class TransactionExportService {
     List<TransactionOrder> fundOrders =
         orders.stream().filter(order -> order.getInstrumentType() == FUND).toList();
 
-    try (Workbook workbook = new XSSFWorkbook()) {
-      Sheet sheet = workbook.createSheet("Indeksfondid SEB");
-
-      createCellAt(sheet, 0, 1, "ORDER");
-      createCellAt(sheet, 1, 1, "Fund units");
-      createRow(sheet, 2, SEB_FUND_HEADERS);
-
-      int rowIndex = 3;
-      for (var order : fundOrders) {
-        Row row = sheet.createRow(rowIndex++);
-        row.createCell(1).setCellValue(order.getFund().getDisplayName());
-        row.createCell(3).setCellValue(order.getFund().getSecuritiesAccount());
-        row.createCell(4).setCellValue(order.getFund().getCashAccount());
-        row.createCell(5).setCellValue("EUR");
-        row.createCell(9).setCellValue(order.getTransactionType() == BUY ? "SUBS" : "REDP");
-        row.createCell(12).setCellValue(labelsByIsin.getOrDefault(order.getInstrumentIsin(), ""));
-        row.createCell(13).setCellValue(order.getInstrumentIsin());
-        if (order.getTransactionType() == BUY) {
-          if (order.getOrderAmount() != null) {
-            row.createCell(16).setCellValue(order.getOrderAmount().doubleValue());
-          }
-        } else {
-          if (order.getOrderQuantity() != null) {
-            row.createCell(14).setCellValue(order.getOrderQuantity().doubleValue());
-          }
-        }
-      }
-
-      autoSizeColumns(sheet, SEB_FUND_HEADERS.length);
-      return toByteArray(workbook);
-    } catch (IOException e) {
-      throw new IllegalStateException("Failed to generate SEB Fund export", e);
+    List<String> lines = new ArrayList<>();
+    lines.add(sebFundPreambleRow("ORDER"));
+    lines.add(sebFundPreambleRow("Fund units"));
+    lines.add(String.join(CSV_DELIMITER, SEB_FUND_HEADERS));
+    for (var order : fundOrders) {
+      lines.add(sebFundDataRow(order, labelsByIsin));
     }
+
+    return String.join("\n", lines).getBytes(UTF_8);
+  }
+
+  private String sebFundPreambleRow(String label) {
+    String[] cells = new String[SEB_FUND_HEADERS.length];
+    Arrays.fill(cells, "");
+    cells[1] = label;
+    return String.join(CSV_DELIMITER, cells);
+  }
+
+  private String sebFundDataRow(TransactionOrder order, Map<String, String> labelsByIsin) {
+    boolean isSell = order.getTransactionType() != BUY;
+    String[] cells = new String[SEB_FUND_HEADERS.length];
+    Arrays.fill(cells, "");
+    cells[0] = order.getOrderUuid().toString();
+    cells[1] = order.getFund().getDisplayName();
+    cells[2] = order.getFund().getSecuritiesAccount();
+    cells[3] = order.getFund().getCashAccount();
+    cells[4] = "EUR";
+    cells[5] = isSell ? "REDM" : "SUBS";
+    cells[8] = labelsByIsin.getOrDefault(order.getInstrumentIsin(), "");
+    cells[9] = order.getInstrumentIsin();
+    if (isSell) {
+      if (order.getOrderQuantity() != null) {
+        cells[10] = order.getOrderQuantity().toPlainString();
+      }
+    } else {
+      if (order.getOrderAmount() != null) {
+        cells[12] = order.getOrderAmount().toPlainString();
+      }
+    }
+    return String.join(CSV_DELIMITER, cells);
   }
 
   public byte[] generateSebEtfExport(List<TransactionOrder> orders, Map<String, String> ricByIsin) {
@@ -141,10 +149,9 @@ public class TransactionExportService {
     try (Workbook workbook = new XSSFWorkbook()) {
       Sheet sheet = workbook.createSheet("SEB ETF");
 
-      createRow(sheet, 0, "SEB");
-      createRow(sheet, 1, SEB_ETF_HEADERS);
+      createRow(sheet, 0, SEB_ETF_HEADERS);
 
-      int rowIndex = 2;
+      int rowIndex = 1;
       for (var order : sebEtfOrders) {
         Row row = sheet.createRow(rowIndex++);
         row.createCell(0).setCellValue(order.getFund().getDisplayName());
@@ -155,7 +162,7 @@ public class TransactionExportService {
         if (order.getOrderQuantity() != null) {
           row.createCell(6).setCellValue(order.getOrderQuantity().doubleValue());
         }
-        row.createCell(7).setCellValue(order.getTransactionType().name());
+        row.createCell(7).setCellValue(titleCase(order.getTransactionType()));
       }
 
       autoSizeColumns(sheet, SEB_ETF_HEADERS.length);
@@ -248,16 +255,15 @@ public class TransactionExportService {
     }
   }
 
+  private String titleCase(TransactionType transactionType) {
+    return transactionType == BUY ? "Buy" : "Sell";
+  }
+
   private void createRow(Sheet sheet, int rowIndex, String... values) {
     Row row = sheet.createRow(rowIndex);
     for (int i = 0; i < values.length; i++) {
       row.createCell(i).setCellValue(values[i]);
     }
-  }
-
-  private void createCellAt(Sheet sheet, int rowIndex, int cellIndex, String value) {
-    Row row = sheet.createRow(rowIndex);
-    row.createCell(cellIndex).setCellValue(value);
   }
 
   private void autoSizeColumns(Sheet sheet, int columnCount) {

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/export/TransactionExportService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/export/TransactionExportService.java
@@ -15,11 +15,13 @@ import ee.tuleva.onboarding.investment.transaction.TransactionType;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import org.apache.poi.ss.usermodel.DateUtil;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
@@ -64,12 +66,24 @@ public class TransactionExportService {
     "Type"
   };
 
+  private static final String[] UUID_WORKBOOK_HEADERS = {
+    "Client name",
+    "instrument_isin",
+    "transaction_type",
+    "order_quantity",
+    "order_amount",
+    "order_id",
+    "order_venue"
+  };
+
   private static final String[] FT_ETF_HEADERS = {
-    "ETF Name",
-    "BBG",
-    "ISIN",
-    "Type",
+    "Symbol",
+    "Side",
     "QTY",
+    "TD",
+    "SD",
+    "ETF Name",
+    "ISIN",
     "Approximate total size in EUR (for control purposes)",
     "TULEVA ADDITIONAL INVESTMENT FUND",
     "TULEVA MAAILMA AKTSIATE PENSIONIFOND",
@@ -175,42 +189,47 @@ public class TransactionExportService {
   public byte[] generateFtEtfExport(
       List<TransactionOrder> orders,
       Map<String, String> labelsByIsin,
-      Map<String, String> bbgByIsin) {
+      Map<String, String> bbgByIsin,
+      LocalDate tradeDate) {
     List<TransactionOrder> ftOrders =
         orders.stream().filter(order -> order.getOrderVenue() == OrderVenue.FT).toList();
 
     Map<String, AggregatedFtOrder> aggregated = aggregateFtOrders(ftOrders);
+    double tradeDateSerial = DateUtil.getExcelDate(tradeDate);
 
     try (Workbook workbook = new XSSFWorkbook()) {
       Sheet sheet = workbook.createSheet("FT ETF");
 
-      createRow(sheet, 0, "FT");
-      createRow(sheet, 1, FT_ETF_HEADERS);
+      createRow(sheet, 0, FT_ETF_HEADERS);
 
-      int rowIndex = 2;
+      int rowIndex = 1;
       BigDecimal grandTotal = ZERO;
 
       for (var entry : aggregated.entrySet()) {
         var aggregation = entry.getValue();
         Row row = sheet.createRow(rowIndex++);
-        row.createCell(0).setCellValue(labelsByIsin.getOrDefault(aggregation.isin, ""));
-        row.createCell(1).setCellValue(bbgByIsin.getOrDefault(aggregation.isin, ""));
-        row.createCell(2).setCellValue(aggregation.isin);
-        row.createCell(3).setCellValue(aggregation.transactionType.name());
-        row.createCell(4).setCellValue(aggregation.totalQuantity.doubleValue());
-        row.createCell(5).setCellValue(aggregation.totalAmount.doubleValue());
-        row.createCell(6)
-            .setCellValue(aggregation.quantityByFund.getOrDefault(TKF100, ZERO).doubleValue());
-        row.createCell(7)
-            .setCellValue(aggregation.quantityByFund.getOrDefault(TUK75, ZERO).doubleValue());
+        row.createCell(0).setCellValue(bbgByIsin.getOrDefault(aggregation.isin, ""));
+        row.createCell(1).setCellValue(aggregation.transactionType.name());
+        row.createCell(2).setCellValue(aggregation.totalQuantity.doubleValue());
+        row.createCell(3).setCellValue(tradeDateSerial);
+        if (aggregation.settlementDate != null) {
+          row.createCell(4).setCellValue(DateUtil.getExcelDate(aggregation.settlementDate));
+        }
+        row.createCell(5).setCellValue(labelsByIsin.getOrDefault(aggregation.isin, ""));
+        row.createCell(6).setCellValue(aggregation.isin);
+        row.createCell(7).setCellValue(aggregation.totalAmount.doubleValue());
         row.createCell(8)
+            .setCellValue(aggregation.quantityByFund.getOrDefault(TKF100, ZERO).doubleValue());
+        row.createCell(9)
+            .setCellValue(aggregation.quantityByFund.getOrDefault(TUK75, ZERO).doubleValue());
+        row.createCell(10)
             .setCellValue(aggregation.quantityByFund.getOrDefault(TUV100, ZERO).doubleValue());
         grandTotal = grandTotal.add(aggregation.totalAmount);
       }
 
       Row totalRow = sheet.createRow(rowIndex);
       totalRow.createCell(0).setCellValue("Approximate total order size:");
-      totalRow.createCell(5).setCellValue(grandTotal.doubleValue());
+      totalRow.createCell(7).setCellValue(grandTotal.doubleValue());
 
       autoSizeColumns(sheet, FT_ETF_HEADERS.length);
       return toByteArray(workbook);
@@ -232,6 +251,43 @@ public class TransactionExportService {
     }
 
     return aggregated;
+  }
+
+  public byte[] generateUuidWorkbook(List<TransactionOrder> orders) {
+    List<TransactionOrder> uuidWorkbookOrders =
+        orders.stream()
+            .filter(
+                order ->
+                    order.getOrderVenue() == OrderVenue.FT
+                        || (order.getOrderVenue() == SEB && order.getInstrumentType() == ETF))
+            .toList();
+
+    try (Workbook workbook = new XSSFWorkbook()) {
+      Sheet sheet = workbook.createSheet("UUID");
+
+      createRow(sheet, 0, UUID_WORKBOOK_HEADERS);
+
+      int rowIndex = 1;
+      for (var order : uuidWorkbookOrders) {
+        Row row = sheet.createRow(rowIndex++);
+        row.createCell(0).setCellValue(order.getFund().getDisplayName());
+        row.createCell(1).setCellValue(order.getInstrumentIsin());
+        row.createCell(2).setCellValue(order.getTransactionType().name());
+        if (order.getOrderQuantity() != null) {
+          row.createCell(3).setCellValue(order.getOrderQuantity().doubleValue());
+        }
+        if (order.getOrderAmount() != null) {
+          row.createCell(4).setCellValue(order.getOrderAmount().doubleValue());
+        }
+        row.createCell(5).setCellValue(order.getOrderUuid().toString());
+        row.createCell(6).setCellValue(order.getOrderVenue().name());
+      }
+
+      autoSizeColumns(sheet, UUID_WORKBOOK_HEADERS.length);
+      return toByteArray(workbook);
+    } catch (IOException e) {
+      throw new IllegalStateException("Failed to generate UUID workbook export", e);
+    }
   }
 
   private void createGenericOrderRow(Sheet sheet, int rowIndex, TransactionOrder order) {
@@ -284,6 +340,7 @@ public class TransactionExportService {
     final TransactionType transactionType;
     BigDecimal totalQuantity = ZERO;
     BigDecimal totalAmount = ZERO;
+    LocalDate settlementDate;
     final Map<TulevaFund, BigDecimal> quantityByFund = new LinkedHashMap<>();
 
     AggregatedFtOrder(String isin, TransactionType transactionType) {
@@ -298,6 +355,9 @@ public class TransactionExportService {
       }
       if (order.getOrderAmount() != null) {
         totalAmount = totalAmount.add(order.getOrderAmount());
+      }
+      if (settlementDate == null) {
+        settlementDate = order.getExpectedSettlementDate();
       }
     }
   }

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/export/TransactionExportUploader.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/export/TransactionExportUploader.java
@@ -6,6 +6,7 @@ import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.BiFunction;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -15,14 +16,27 @@ public class TransactionExportUploader {
 
   private static final DateTimeFormatter TIMESTAMP =
       DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH_mm_ss").withZone(ZoneOffset.UTC);
+  private static final DateTimeFormatter UUID_WORKBOOK_TIMESTAMP =
+      DateTimeFormatter.ofPattern("yyyyMMdd_HHmm").withZone(ZoneOffset.UTC);
   private static final DateTimeFormatter MONTH =
       DateTimeFormatter.ofPattern("MM").withZone(ZoneOffset.UTC);
 
-  private static final Map<String, String> FILE_NAME_PATTERNS =
+  private static final Map<String, BiFunction<TulevaFund, Instant, String>> FILE_NAME_GENERATORS =
       Map.of(
-          "sebFundXlsx", "SEB_%s_indeksfondid_%s.csv",
-          "sebEtfXlsx", "SEB_%s_ETF_tehingud_%s.xlsx",
-          "ftEtfXlsx", "FT_%s_ETF_orders_%s.xlsx");
+          "sebFundXlsx",
+              (fund, timestamp) ->
+                  "SEB_%s_indeksfondid_%s.csv"
+                      .formatted(fund.getCode(), TIMESTAMP.format(timestamp)),
+          "sebEtfXlsx",
+              (fund, timestamp) ->
+                  "SEB_%s_ETF_tehingud_%s.xlsx"
+                      .formatted(fund.getCode(), TIMESTAMP.format(timestamp)),
+          "ftEtfXlsx",
+              (fund, timestamp) ->
+                  "FT_%s_ETF_orders_%s.xlsx".formatted(fund.getCode(), TIMESTAMP.format(timestamp)),
+          "uuidWorkbookXlsx",
+              (fund, timestamp) ->
+                  "Tehingud_UUID_%s.xlsx".formatted(UUID_WORKBOOK_TIMESTAMP.format(timestamp)));
 
   private final GoogleDriveClient driveClient;
 
@@ -36,14 +50,13 @@ public class TransactionExportUploader {
     var yearFolder = driveClient.getOrCreateFolder(rootFolderId, String.valueOf(year));
     var monthFolder = driveClient.getOrCreateFolder(yearFolder, MONTH.format(timestamp));
 
-    var fileTimestamp = TIMESTAMP.format(timestamp);
     Map<String, String> urls = new HashMap<>();
 
-    FILE_NAME_PATTERNS.forEach(
-        (exportKey, namePattern) -> {
+    FILE_NAME_GENERATORS.forEach(
+        (exportKey, fileNameGenerator) -> {
           var content = exports.get(exportKey);
           if (content != null && content.length > 0) {
-            var fileName = namePattern.formatted(fund.getCode(), fileTimestamp);
+            var fileName = fileNameGenerator.apply(fund, timestamp);
             var url = driveClient.uploadFile(monthFolder, fileName, content);
             urls.put(exportKey, url);
           }

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/export/TransactionExportUploader.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/export/TransactionExportUploader.java
@@ -20,7 +20,7 @@ public class TransactionExportUploader {
 
   private static final Map<String, String> FILE_NAME_PATTERNS =
       Map.of(
-          "sebFundXlsx", "SEB_%s_indeksfondid_%s.xlsx",
+          "sebFundXlsx", "SEB_%s_indeksfondid_%s.csv",
           "sebEtfXlsx", "SEB_%s_ETF_tehingud_%s.xlsx",
           "ftEtfXlsx", "FT_%s_ETF_orders_%s.xlsx");
 

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionAdminServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionAdminServiceTest.java
@@ -391,6 +391,16 @@ class TransactionAdminServiceTest {
   }
 
   @Test
+  void exportFile_decodesStoredUuidWorkbookExport() {
+    byte[] xlsx = {4, 5, 6};
+    TransactionBatch batch = batch(10L, BatchStatus.SENT);
+    batch.setMetadata(Map.of("uuidWorkbookXlsx", Base64.getEncoder().encodeToString(xlsx)));
+    given(batchRepository.findById(10L)).willReturn(Optional.of(batch));
+
+    assertThat(service.exportFile(10L, "uuidWorkbookXlsx")).contains(xlsx);
+  }
+
+  @Test
   void exportFile_missingExport_returnsEmpty() {
     given(batchRepository.findById(10L)).willReturn(Optional.of(batch(10L, BatchStatus.SENT)));
 

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionBatchNotifierTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionBatchNotifierTest.java
@@ -51,6 +51,20 @@ class TransactionBatchNotifierTest {
   }
 
   @Test
+  void onBatchFinalized_includesUuidWorkbookDriveUrlInMessage() {
+    var urls = Map.of("uuidWorkbookXlsx", "https://drive.google.com/uuid-workbook");
+    var event = new BatchFinalizedEvent(1L, 5, "2026-01-15", urls);
+
+    notifier.onBatchFinalized(event);
+
+    var messageCaptor = org.mockito.ArgumentCaptor.forClass(String.class);
+    verify(notificationService).sendMessage(messageCaptor.capture(), eq(INVESTMENT));
+
+    assertThat(messageCaptor.getValue())
+        .contains("UUID workbook: https://drive.google.com/uuid-workbook");
+  }
+
+  @Test
   void onBatchFinalized_whenNotificationFails_doesNotPropagate() {
     var event = new BatchFinalizedEvent(1L, 3, "2026-01-20", Map.of());
     doThrow(new RuntimeException("Slack unavailable"))

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionPipelineIntegrationTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionPipelineIntegrationTest.java
@@ -12,6 +12,7 @@ import static ee.tuleva.onboarding.investment.transaction.TransactionMode.BUY;
 import static ee.tuleva.onboarding.investment.transaction.TransactionMode.REBALANCE;
 import static ee.tuleva.onboarding.investment.transaction.TransactionType.SELL;
 import static java.math.BigDecimal.ZERO;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.stream.Collectors.toMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.within;
@@ -177,17 +178,16 @@ class TransactionPipelineIntegrationTest {
   void finalizeConfirmedBatch_sebFundExportContainsCorrectData() throws Exception {
     var batch = runFullPipeline();
 
-    byte[] sebFundXlsx = decodeExport(batch.getMetadata(), "sebFundXlsx");
-    try (var workbook = WorkbookFactory.create(new ByteArrayInputStream(sebFundXlsx))) {
-      Sheet sheet = workbook.getSheetAt(0);
+    byte[] sebFundCsv = decodeExport(batch.getMetadata(), "sebFundXlsx");
+    List<String> lines = List.of(new String(sebFundCsv, UTF_8).split("\n", -1));
 
-      Row dataRow = sheet.getRow(3);
-      assertThat(dataRow).isNotNull();
-      assertThat(dataRow.getCell(9).getStringCellValue()).isEqualTo("SUBS");
-      assertThat(dataRow.getCell(13).getStringCellValue()).isEqualTo("IE00BFG1TM61");
-      assertThat(new BigDecimal(String.valueOf(dataRow.getCell(16).getNumericCellValue())))
-          .isCloseTo(new BigDecimal("53487"), within(BigDecimal.ONE));
-    }
+    String dataLine =
+        lines.stream().filter(line -> line.contains("IE00BFG1TM61")).findFirst().orElseThrow();
+    List<String> cells = List.of(dataLine.split(";", -1));
+    assertThat(cells.get(5)).isEqualTo("SUBS");
+    assertThat(cells.get(9)).isEqualTo("IE00BFG1TM61");
+    assertThat(new BigDecimal(cells.get(12)))
+        .isCloseTo(new BigDecimal("53487"), within(BigDecimal.ONE));
   }
 
   @Test
@@ -199,7 +199,7 @@ class TransactionPipelineIntegrationTest {
       Sheet sheet = workbook.getSheetAt(0);
 
       Map<String, Row> rowsByIsin = new java.util.HashMap<>();
-      for (int i = 2; i <= sheet.getLastRowNum(); i++) {
+      for (int i = 1; i <= sheet.getLastRowNum(); i++) {
         Row row = sheet.getRow(i);
         if (row != null && row.getCell(2) != null) {
           rowsByIsin.put(row.getCell(2).getStringCellValue(), row);
@@ -209,13 +209,13 @@ class TransactionPipelineIntegrationTest {
       assertThat(rowsByIsin).containsKey("IE00BMDBMY19");
       assertThat(rowsByIsin.get("IE00BMDBMY19").getCell(3).getStringCellValue())
           .isEqualTo("ESGM.DE");
-      assertThat(rowsByIsin.get("IE00BMDBMY19").getCell(7).getStringCellValue()).isEqualTo("BUY");
+      assertThat(rowsByIsin.get("IE00BMDBMY19").getCell(7).getStringCellValue()).isEqualTo("Buy");
 
       assertThat(rowsByIsin).containsKey("LU1291106356");
-      assertThat(rowsByIsin.get("LU1291106356").getCell(7).getStringCellValue()).isEqualTo("BUY");
+      assertThat(rowsByIsin.get("LU1291106356").getCell(7).getStringCellValue()).isEqualTo("Buy");
 
       assertThat(rowsByIsin).containsKey("LU1291102447");
-      assertThat(rowsByIsin.get("LU1291102447").getCell(7).getStringCellValue()).isEqualTo("SELL");
+      assertThat(rowsByIsin.get("LU1291102447").getCell(7).getStringCellValue()).isEqualTo("Sell");
     }
   }
 

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionPreparationServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionPreparationServiceTest.java
@@ -329,7 +329,9 @@ class TransactionPreparationServiceTest {
     when(exportService.generateOrdersExport(any())).thenReturn(new byte[] {1, 2, 3});
     when(exportService.generateSebFundExport(any(), any())).thenReturn(new byte[] {4, 5});
     when(exportService.generateSebEtfExport(any(), any())).thenReturn(new byte[] {6, 7});
-    when(exportService.generateFtEtfExport(any(), any(), any())).thenReturn(new byte[] {8, 9});
+    when(exportService.generateFtEtfExport(any(), any(), any(), any()))
+        .thenReturn(new byte[] {8, 9});
+    when(exportService.generateUuidWorkbook(any())).thenReturn(new byte[] {10, 11});
 
     service.finalizeConfirmedBatch(batch);
 
@@ -341,10 +343,12 @@ class TransactionPreparationServiceTest {
     assertThat(batch.getMetadata()).containsKey("sebFundXlsx");
     assertThat(batch.getMetadata()).containsKey("sebEtfXlsx");
     assertThat(batch.getMetadata()).containsKey("ftEtfXlsx");
+    assertThat(batch.getMetadata()).containsKey("uuidWorkbookXlsx");
 
     verify(exportService).generateSebFundExport(eq(List.of(order)), any());
     verify(exportService).generateSebEtfExport(eq(List.of(order)), any());
-    verify(exportService).generateFtEtfExport(eq(List.of(order)), any(), any());
+    verify(exportService).generateFtEtfExport(eq(List.of(order)), any(), any(), any());
+    verify(exportService).generateUuidWorkbook(eq(List.of(order)));
     verify(orderRepository).saveAll(List.of(order));
     verify(batchRepository).save(batch);
     verify(auditEventRepository).save(any(TransactionAuditEvent.class));
@@ -948,7 +952,8 @@ class TransactionPreparationServiceTest {
     when(exportService.generateOrdersExport(any())).thenReturn(new byte[] {1});
     when(exportService.generateSebFundExport(any(), any())).thenReturn(new byte[] {2});
     when(exportService.generateSebEtfExport(any(), any())).thenReturn(new byte[] {3});
-    when(exportService.generateFtEtfExport(any(), any(), any())).thenReturn(new byte[] {4});
+    when(exportService.generateFtEtfExport(any(), any(), any(), any())).thenReturn(new byte[] {4});
+    when(exportService.generateUuidWorkbook(any())).thenReturn(new byte[] {5});
     when(driveProperties.enabled()).thenReturn(true);
     when(driveProperties.rootFolderId()).thenReturn("root-folder-id");
     when(exportUploader.uploadExports(any(), any(), any(), any()))
@@ -997,7 +1002,8 @@ class TransactionPreparationServiceTest {
     given(exportService.generateOrdersExport(any())).willReturn(new byte[] {1});
     given(exportService.generateSebFundExport(any(), any())).willReturn(new byte[] {2});
     given(exportService.generateSebEtfExport(any(), any())).willReturn(new byte[] {3});
-    given(exportService.generateFtEtfExport(any(), any(), any())).willReturn(new byte[] {4});
+    given(exportService.generateFtEtfExport(any(), any(), any(), any())).willReturn(new byte[] {4});
+    given(exportService.generateUuidWorkbook(any())).willReturn(new byte[] {5});
     given(driveProperties.enabled()).willReturn(true);
     given(driveProperties.rootFolderId()).willReturn("root-folder-id");
     given(exportUploader.uploadExports(any(), any(), any(), any()))

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/export/CustodianOrderMessageFactoryTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/export/CustodianOrderMessageFactoryTest.java
@@ -43,15 +43,17 @@ class CustodianOrderMessageFactoryTest {
             Map.of(
                 "sebFundXlsx", new byte[] {1, 2},
                 "sebEtfXlsx", new byte[] {3, 4},
-                "ftEtfXlsx", new byte[] {5, 6}));
+                "ftEtfXlsx", new byte[] {5, 6},
+                "uuidWorkbookXlsx", new byte[] {7, 8}));
 
     assertThat(message.getAttachments())
-        .hasSize(3)
+        .hasSize(4)
         .extracting(MessageContent::getName)
         .anySatisfy(
             name -> assertThat(name).contains("SEB").contains("indeksfondid").endsWith(".csv"))
         .anySatisfy(name -> assertThat(name).contains("SEB").contains("ETF").endsWith(".xlsx"))
-        .anySatisfy(name -> assertThat(name).contains("FT").contains("TUV100").endsWith(".xlsx"));
+        .anySatisfy(name -> assertThat(name).contains("FT").contains("TUV100").endsWith(".xlsx"))
+        .anySatisfy(name -> assertThat(name).isEqualTo("Tehingud_UUID_20260115_1000.xlsx"));
   }
 
   @Test
@@ -79,6 +81,16 @@ class CustodianOrderMessageFactoryTest {
                 assertThat(attachment.getType())
                     .isEqualTo(
                         "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"));
+  }
+
+  @Test
+  void create_uuidWorkbookAttachmentHasXlsxMimeTypeAndFundlessFilename() {
+    var message = factory.create(TUV100, TIMESTAMP, Map.of("uuidWorkbookXlsx", new byte[] {9, 10}));
+
+    var attachment = message.getAttachments().getFirst();
+    assertThat(attachment.getName()).isEqualTo("Tehingud_UUID_20260115_1000.xlsx");
+    assertThat(attachment.getType())
+        .isEqualTo("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
   }
 
   @Test

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/export/CustodianOrderMessageFactoryTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/export/CustodianOrderMessageFactoryTest.java
@@ -48,8 +48,31 @@ class CustodianOrderMessageFactoryTest {
     assertThat(message.getAttachments())
         .hasSize(3)
         .extracting(MessageContent::getName)
-        .anySatisfy(name -> assertThat(name).contains("SEB").contains("TUV100").endsWith(".xlsx"))
+        .anySatisfy(
+            name -> assertThat(name).contains("SEB").contains("indeksfondid").endsWith(".csv"))
+        .anySatisfy(name -> assertThat(name).contains("SEB").contains("ETF").endsWith(".xlsx"))
         .anySatisfy(name -> assertThat(name).contains("FT").contains("TUV100").endsWith(".xlsx"));
+  }
+
+  @Test
+  void create_sebFundAttachmentHasCsvMimeTypeAndFilename() {
+    var message = factory.create(TUV100, TIMESTAMP, Map.of("sebFundXlsx", new byte[] {1, 2}));
+
+    var attachment = message.getAttachments().getFirst();
+    assertThat(attachment.getName()).isEqualTo("SEB_TUV100_indeksfondid_2026-01-15T10_00_00.csv");
+    assertThat(attachment.getType()).isEqualTo("text/csv");
+  }
+
+  @Test
+  void create_sebEtfAndFtEtfAttachmentsKeepXlsxMimeType() {
+    var message =
+        factory.create(
+            TUV100,
+            TIMESTAMP,
+            Map.of(
+                "sebEtfXlsx", new byte[] {3, 4},
+                "ftEtfXlsx", new byte[] {5, 6}));
+
     assertThat(message.getAttachments())
         .allSatisfy(
             attachment ->

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/export/GoogleDriveClientTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/export/GoogleDriveClientTest.java
@@ -89,6 +89,18 @@ class GoogleDriveClientTest {
         .uri(contains("https://www.googleapis.com/upload/drive/v3/files"), any(Object[].class));
   }
 
+  @Test
+  void uploadFile_sendsSpreadsheetContentTypeForXlsxFile() {
+    assertThat(GoogleDriveClient.contentTypeFor("SEB_TKF100_ETF_tehingud_16022026.xlsx"))
+        .isEqualTo("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
+  }
+
+  @Test
+  void uploadFile_sendsCsvContentTypeForCsvFile() {
+    assertThat(GoogleDriveClient.contentTypeFor("SEB_TKF100_indeksfondid_16022026.csv"))
+        .isEqualTo("text/csv");
+  }
+
   @SuppressWarnings("unchecked")
   private static RestClient.RequestHeadersUriSpec<?> stubGet(
       RestClient restClient, Map<String, Object> response) {

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/export/TransactionExportServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/export/TransactionExportServiceTest.java
@@ -8,6 +8,7 @@ import static ee.tuleva.onboarding.investment.transaction.OrderVenue.SEB;
 import static ee.tuleva.onboarding.investment.transaction.TransactionType.BUY;
 import static ee.tuleva.onboarding.investment.transaction.TransactionType.SELL;
 import static ee.tuleva.onboarding.time.TestClockHolder.now;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import ee.tuleva.onboarding.fund.TulevaFund;
@@ -74,7 +75,23 @@ class TransactionExportServiceTest {
   }
 
   @Test
-  void generateSebFundExport_filtersOnlyFundOrdersAndFormatsCorrectly() throws Exception {
+  void generateSebFundExport_writesPreambleAndHeaderRows() {
+    byte[] csv = service.generateSebFundExport(List.of(), Map.of());
+
+    List<String> lines = csvLines(csv);
+
+    assertThat(lines.get(0)).isEqualTo(";ORDER;;;;;;;;;;;;;");
+    assertThat(lines.get(1)).isEqualTo(";Fund units;;;;;;;;;;;;;");
+    assertThat(lines.get(2))
+        .isEqualTo(
+            "Original reference;Client name;Securities Acc ;Cash Acc;Currency;Transaction Type;"
+                + "Trade Date;Settlement Date;Security Name;ISIN;Quantity;Price;"
+                + "Transaction Sum;Transaction fee;Total Sum");
+    assertThat(lines).hasSize(3);
+  }
+
+  @Test
+  void generateSebFundExport_filtersOnlyFundOrdersAndWritesBuyRow() {
     var batch = buildBatch();
 
     var fundOrder =
@@ -84,69 +101,38 @@ class TransactionExportServiceTest {
 
     var labelsByIsin = Map.of("LU00FUND", "SEB Fund X");
 
-    byte[] xlsx = service.generateSebFundExport(List.of(fundOrder, etfOrder), labelsByIsin);
+    byte[] csv = service.generateSebFundExport(List.of(fundOrder, etfOrder), labelsByIsin);
 
-    assertThat(xlsx).isNotEmpty();
+    List<String> lines = csvLines(csv);
 
-    try (var workbook = WorkbookFactory.create(new ByteArrayInputStream(xlsx))) {
-      var sheet = workbook.getSheetAt(0);
-      assertThat(sheet.getSheetName()).isEqualTo("Indeksfondid SEB");
-
-      assertThat(sheet.getRow(0).getCell(1).getStringCellValue()).isEqualTo("ORDER");
-      assertThat(sheet.getRow(1).getCell(1).getStringCellValue()).isEqualTo("Fund units");
-
-      var headerRow = sheet.getRow(2);
-      assertThat(headerRow.getCell(0).getStringCellValue()).isEqualTo("Portfelli tähis");
-      assertThat(headerRow.getCell(1).getStringCellValue()).isEqualTo("Issuer Of Order");
-      assertThat(headerRow.getCell(9).getStringCellValue()).isEqualTo("Transaction Type");
-      assertThat(headerRow.getCell(12).getStringCellValue()).isEqualTo("Security Name");
-      assertThat(headerRow.getCell(13).getStringCellValue()).isEqualTo("ISIN");
-      assertThat(headerRow.getCell(16).getStringCellValue()).isEqualTo("Transaction Sum");
-
-      var dataRow = sheet.getRow(3);
-      assertThat(dataRow.getCell(1).getStringCellValue()).isEqualTo("Tuleva Täiendav Kogumisfond");
-      assertThat(dataRow.getCell(3).getStringCellValue()).isEqualTo("VP68168");
-      assertThat(dataRow.getCell(4).getStringCellValue()).isEqualTo("EE861010220306591229");
-      assertThat(dataRow.getCell(5).getStringCellValue()).isEqualTo("EUR");
-      assertThat(dataRow.getCell(9).getStringCellValue()).isEqualTo("SUBS");
-      assertThat(dataRow.getCell(12).getStringCellValue()).isEqualTo("SEB Fund X");
-      assertThat(dataRow.getCell(13).getStringCellValue()).isEqualTo("LU00FUND");
-      assertThat(dataRow.getCell(16).getNumericCellValue()).isEqualTo(75000.0);
-
-      assertThat(sheet.getPhysicalNumberOfRows()).isEqualTo(4);
-    }
+    assertThat(lines).hasSize(4);
+    assertThat(lines.get(3))
+        .isEqualTo(
+            fundOrder.getOrderUuid()
+                + ";Tuleva Täiendav Kogumisfond;VP68168;EE861010220306591229;EUR;SUBS;;;"
+                + "SEB Fund X;LU00FUND;;;75000;;");
   }
 
   @Test
-  void generateSebFundExport_usesSellTransactionType() throws Exception {
-    var batch = buildBatch();
-    var sellOrder =
-        buildOrder(batch, TUV100, "LU00FUND", SELL, FUND, SEB, new BigDecimal("30000"), null);
-
-    byte[] xlsx =
-        service.generateSebFundExport(List.of(sellOrder), Map.of("LU00FUND", "SEB Fund X"));
-
-    try (var workbook = WorkbookFactory.create(new ByteArrayInputStream(xlsx))) {
-      var dataRow = workbook.getSheetAt(0).getRow(3);
-      assertThat(dataRow.getCell(9).getStringCellValue()).isEqualTo("REDP");
-    }
-  }
-
-  @Test
-  void generateSebFundExport_redpRowCarriesQuantityNotTransactionSum() throws Exception {
+  void generateSebFundExport_writesReDMAndQuantityForSellOrder() {
     var batch = buildBatch();
     var sellOrder =
         buildOrder(batch, TUV100, "LU00FUND", SELL, FUND, SEB, new BigDecimal("30000"), 2400L);
 
-    byte[] xlsx =
+    byte[] csv =
         service.generateSebFundExport(List.of(sellOrder), Map.of("LU00FUND", "SEB Fund X"));
 
-    try (var workbook = WorkbookFactory.create(new ByteArrayInputStream(xlsx))) {
-      var dataRow = workbook.getSheetAt(0).getRow(3);
-      assertThat(dataRow.getCell(9).getStringCellValue()).isEqualTo("REDP");
-      assertThat(dataRow.getCell(14).getNumericCellValue()).isEqualTo(2400.0);
-      assertThat(dataRow.getCell(16)).isNull();
-    }
+    List<String> lines = csvLines(csv);
+
+    assertThat(lines.get(3))
+        .isEqualTo(
+            sellOrder.getOrderUuid()
+                + ";Tuleva III Samba Pensionifond;VP68959;EE691010220306737229;EUR;REDM;;;"
+                + "SEB Fund X;LU00FUND;2400;;;;");
+  }
+
+  private List<String> csvLines(byte[] csv) {
+    return List.of(new String(csv, UTF_8).split("\n", -1));
   }
 
   @Test
@@ -171,10 +157,7 @@ class TransactionExportServiceTest {
       var sheet = workbook.getSheetAt(0);
       assertThat(sheet.getSheetName()).isEqualTo("SEB ETF");
 
-      var titleRow = sheet.getRow(0);
-      assertThat(titleRow.getCell(0).getStringCellValue()).isEqualTo("SEB");
-
-      var headerRow = sheet.getRow(1);
+      var headerRow = sheet.getRow(0);
       assertThat(headerRow.getCell(0).getStringCellValue()).isEqualTo("Client Name");
       assertThat(headerRow.getCell(1).getStringCellValue()).isEqualTo("Account external no.");
       assertThat(headerRow.getCell(2).getStringCellValue()).isEqualTo("Instruction ISIN");
@@ -184,16 +167,16 @@ class TransactionExportServiceTest {
       assertThat(headerRow.getCell(6).getStringCellValue()).isEqualTo("Quantity");
       assertThat(headerRow.getCell(7).getStringCellValue()).isEqualTo("Type");
 
-      var dataRow = sheet.getRow(2);
+      var dataRow = sheet.getRow(1);
       assertThat(dataRow.getCell(0).getStringCellValue()).isEqualTo("Tuleva Täiendav Kogumisfond");
       assertThat(dataRow.getCell(1).getStringCellValue()).isEqualTo("VP68168");
       assertThat(dataRow.getCell(2).getStringCellValue()).isEqualTo("IE00ETF");
       assertThat(dataRow.getCell(3).getStringCellValue()).isEqualTo("ESGM.DE");
       assertThat(dataRow.getCell(4).getStringCellValue()).isEqualTo("MOC");
       assertThat((long) dataRow.getCell(6).getNumericCellValue()).isEqualTo(500L);
-      assertThat(dataRow.getCell(7).getStringCellValue()).isEqualTo("BUY");
+      assertThat(dataRow.getCell(7).getStringCellValue()).isEqualTo("Buy");
 
-      assertThat(sheet.getPhysicalNumberOfRows()).isEqualTo(3);
+      assertThat(sheet.getPhysicalNumberOfRows()).isEqualTo(2);
     }
   }
 

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/export/TransactionExportServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/export/TransactionExportServiceTest.java
@@ -18,6 +18,7 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
+import org.apache.poi.ss.usermodel.DateUtil;
 import org.apache.poi.ss.usermodel.WorkbookFactory;
 import org.junit.jupiter.api.Test;
 
@@ -183,6 +184,8 @@ class TransactionExportServiceTest {
   @Test
   void generateFtEtfExport_aggregatesAcrossFundsAndFormatsCorrectly() throws Exception {
     var batch = buildBatch();
+    var tradeDate = LocalDate.of(2026, 1, 15);
+    var settlementDate = LocalDate.of(2026, 1, 20);
 
     var tkfOrder =
         buildOrder(batch, TKF100, "IE00FT", BUY, ETF, FT, new BigDecimal("100000"), 400L);
@@ -197,7 +200,7 @@ class TransactionExportServiceTest {
 
     byte[] xlsx =
         service.generateFtEtfExport(
-            List.of(tkfOrder, tukOrder, tuvOrder, sebOrder), labelsByIsin, bbgByIsin);
+            List.of(tkfOrder, tukOrder, tuvOrder, sebOrder), labelsByIsin, bbgByIsin, tradeDate);
 
     assertThat(xlsx).isNotEmpty();
 
@@ -205,51 +208,116 @@ class TransactionExportServiceTest {
       var sheet = workbook.getSheetAt(0);
       assertThat(sheet.getSheetName()).isEqualTo("FT ETF");
 
-      var titleRow = sheet.getRow(0);
-      assertThat(titleRow.getCell(0).getStringCellValue()).isEqualTo("FT");
-
-      var headerRow = sheet.getRow(1);
-      assertThat(headerRow.getCell(0).getStringCellValue()).isEqualTo("ETF Name");
-      assertThat(headerRow.getCell(1).getStringCellValue()).isEqualTo("BBG");
-      assertThat(headerRow.getCell(2).getStringCellValue()).isEqualTo("ISIN");
-      assertThat(headerRow.getCell(3).getStringCellValue()).isEqualTo("Type");
-      assertThat(headerRow.getCell(4).getStringCellValue()).isEqualTo("QTY");
-      assertThat(headerRow.getCell(5).getStringCellValue())
-          .isEqualTo("Approximate total size in EUR (for control purposes)");
-      assertThat(headerRow.getCell(6).getStringCellValue())
-          .isEqualTo("TULEVA ADDITIONAL INVESTMENT FUND");
+      var headerRow = sheet.getRow(0);
+      assertThat(headerRow.getCell(0).getStringCellValue()).isEqualTo("Symbol");
+      assertThat(headerRow.getCell(1).getStringCellValue()).isEqualTo("Side");
+      assertThat(headerRow.getCell(2).getStringCellValue()).isEqualTo("QTY");
+      assertThat(headerRow.getCell(3).getStringCellValue()).isEqualTo("TD");
+      assertThat(headerRow.getCell(4).getStringCellValue()).isEqualTo("SD");
+      assertThat(headerRow.getCell(5).getStringCellValue()).isEqualTo("ETF Name");
+      assertThat(headerRow.getCell(6).getStringCellValue()).isEqualTo("ISIN");
       assertThat(headerRow.getCell(7).getStringCellValue())
-          .isEqualTo("TULEVA MAAILMA AKTSIATE PENSIONIFOND");
+          .isEqualTo("Approximate total size in EUR (for control purposes)");
       assertThat(headerRow.getCell(8).getStringCellValue())
+          .isEqualTo("TULEVA ADDITIONAL INVESTMENT FUND");
+      assertThat(headerRow.getCell(9).getStringCellValue())
+          .isEqualTo("TULEVA MAAILMA AKTSIATE PENSIONIFOND");
+      assertThat(headerRow.getCell(10).getStringCellValue())
           .isEqualTo("TULEVA III SAMBA PENSIONIFOND");
 
-      var dataRow = sheet.getRow(2);
-      assertThat(dataRow.getCell(0).getStringCellValue()).isEqualTo("iShares ESG MSCI");
-      assertThat(dataRow.getCell(1).getStringCellValue()).isEqualTo("ESGM GY");
-      assertThat(dataRow.getCell(2).getStringCellValue()).isEqualTo("IE00FT");
-      assertThat(dataRow.getCell(3).getStringCellValue()).isEqualTo("BUY");
-      assertThat((long) dataRow.getCell(4).getNumericCellValue()).isEqualTo(1800L);
-      assertThat(dataRow.getCell(5).getNumericCellValue()).isEqualTo(450000.0);
-      assertThat((long) dataRow.getCell(6).getNumericCellValue()).isEqualTo(400L);
-      assertThat((long) dataRow.getCell(7).getNumericCellValue()).isEqualTo(800L);
-      assertThat((long) dataRow.getCell(8).getNumericCellValue()).isEqualTo(600L);
+      var dataRow = sheet.getRow(1);
+      assertThat(dataRow.getCell(0).getStringCellValue()).isEqualTo("ESGM GY");
+      assertThat(dataRow.getCell(1).getStringCellValue()).isEqualTo("BUY");
+      assertThat((long) dataRow.getCell(2).getNumericCellValue()).isEqualTo(1800L);
+      assertThat(dataRow.getCell(3).getNumericCellValue())
+          .isEqualTo(DateUtil.getExcelDate(tradeDate));
+      assertThat(dataRow.getCell(4).getNumericCellValue())
+          .isEqualTo(DateUtil.getExcelDate(settlementDate));
+      assertThat(dataRow.getCell(5).getStringCellValue()).isEqualTo("iShares ESG MSCI");
+      assertThat(dataRow.getCell(6).getStringCellValue()).isEqualTo("IE00FT");
+      assertThat(dataRow.getCell(7).getNumericCellValue()).isEqualTo(450000.0);
+      assertThat((long) dataRow.getCell(8).getNumericCellValue()).isEqualTo(400L);
+      assertThat((long) dataRow.getCell(9).getNumericCellValue()).isEqualTo(800L);
+      assertThat((long) dataRow.getCell(10).getNumericCellValue()).isEqualTo(600L);
 
-      var totalRow = sheet.getRow(3);
+      var totalRow = sheet.getRow(2);
       assertThat(totalRow.getCell(0).getStringCellValue())
           .isEqualTo("Approximate total order size:");
-      assertThat(totalRow.getCell(5).getNumericCellValue()).isEqualTo(450000.0);
+      assertThat(totalRow.getCell(7).getNumericCellValue()).isEqualTo(450000.0);
 
-      assertThat(sheet.getPhysicalNumberOfRows()).isEqualTo(4);
+      assertThat(sheet.getPhysicalNumberOfRows()).isEqualTo(3);
     }
   }
 
   @Test
   void generateFtEtfExport_withEmptyOrders_returnsEmptySheet() throws Exception {
-    byte[] xlsx = service.generateFtEtfExport(List.of(), Map.of(), Map.of());
+    byte[] xlsx =
+        service.generateFtEtfExport(List.of(), Map.of(), Map.of(), LocalDate.of(2026, 1, 15));
 
     try (var workbook = WorkbookFactory.create(new ByteArrayInputStream(xlsx))) {
       var sheet = workbook.getSheetAt(0);
+      assertThat(sheet.getPhysicalNumberOfRows()).isEqualTo(2);
+    }
+  }
+
+  @Test
+  void generateUuidWorkbook_writesOneRowPerSebEtfAndFtOrder() throws Exception {
+    var batch = buildBatch();
+
+    var sebEtfOrder =
+        buildOrder(batch, TKF100, "IE00ETF", BUY, ETF, SEB, new BigDecimal("100000"), 500L);
+    var ftOrder =
+        buildOrder(batch, TUV100, "IE00FT", SELL, ETF, FT, new BigDecimal("200000"), 800L);
+    var sebFundOrder =
+        buildOrder(batch, TKF100, "LU00FUND", BUY, FUND, SEB, new BigDecimal("75000"), null);
+
+    byte[] xlsx = service.generateUuidWorkbook(List.of(sebEtfOrder, ftOrder, sebFundOrder));
+
+    assertThat(xlsx).isNotEmpty();
+
+    try (var workbook = WorkbookFactory.create(new ByteArrayInputStream(xlsx))) {
+      var sheet = workbook.getSheetAt(0);
+
+      var headerRow = sheet.getRow(0);
+      assertThat(headerRow.getCell(0).getStringCellValue()).isEqualTo("Client name");
+      assertThat(headerRow.getCell(1).getStringCellValue()).isEqualTo("instrument_isin");
+      assertThat(headerRow.getCell(2).getStringCellValue()).isEqualTo("transaction_type");
+      assertThat(headerRow.getCell(3).getStringCellValue()).isEqualTo("order_quantity");
+      assertThat(headerRow.getCell(4).getStringCellValue()).isEqualTo("order_amount");
+      assertThat(headerRow.getCell(5).getStringCellValue()).isEqualTo("order_id");
+      assertThat(headerRow.getCell(6).getStringCellValue()).isEqualTo("order_venue");
+
+      var sebRow = sheet.getRow(1);
+      assertThat(sebRow.getCell(0).getStringCellValue()).isEqualTo("Tuleva Täiendav Kogumisfond");
+      assertThat(sebRow.getCell(1).getStringCellValue()).isEqualTo("IE00ETF");
+      assertThat(sebRow.getCell(2).getStringCellValue()).isEqualTo("BUY");
+      assertThat((long) sebRow.getCell(3).getNumericCellValue()).isEqualTo(500L);
+      assertThat(sebRow.getCell(4).getNumericCellValue()).isEqualTo(100000.0);
+      assertThat(sebRow.getCell(5).getStringCellValue())
+          .isEqualTo(sebEtfOrder.getOrderUuid().toString());
+      assertThat(sebRow.getCell(6).getStringCellValue()).isEqualTo("SEB");
+
+      var ftRow = sheet.getRow(2);
+      assertThat(ftRow.getCell(0).getStringCellValue()).isEqualTo("Tuleva III Samba Pensionifond");
+      assertThat(ftRow.getCell(1).getStringCellValue()).isEqualTo("IE00FT");
+      assertThat(ftRow.getCell(2).getStringCellValue()).isEqualTo("SELL");
+      assertThat((long) ftRow.getCell(3).getNumericCellValue()).isEqualTo(800L);
+      assertThat(ftRow.getCell(4).getNumericCellValue()).isEqualTo(200000.0);
+      assertThat(ftRow.getCell(5).getStringCellValue())
+          .isEqualTo(ftOrder.getOrderUuid().toString());
+      assertThat(ftRow.getCell(6).getStringCellValue()).isEqualTo("FT");
+
       assertThat(sheet.getPhysicalNumberOfRows()).isEqualTo(3);
+    }
+  }
+
+  @Test
+  void generateUuidWorkbook_withEmptyOrders_returnsHeaderOnly() throws Exception {
+    byte[] xlsx = service.generateUuidWorkbook(List.of());
+
+    try (var workbook = WorkbookFactory.create(new ByteArrayInputStream(xlsx))) {
+      var sheet = workbook.getSheetAt(0);
+      assertThat(sheet.getPhysicalNumberOfRows()).isEqualTo(1);
     }
   }
 

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/export/TransactionExportUploaderTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/export/TransactionExportUploaderTest.java
@@ -27,7 +27,8 @@ class TransactionExportUploaderTest {
         Map.of(
             "sebFundXlsx", new byte[] {1, 2},
             "sebEtfXlsx", new byte[] {3, 4},
-            "ftEtfXlsx", new byte[] {5, 6});
+            "ftEtfXlsx", new byte[] {5, 6},
+            "uuidWorkbookXlsx", new byte[] {7, 8});
 
     when(driveClient.getOrCreateFolder("root-id", "2026")).thenReturn("year-folder-id");
     when(driveClient.getOrCreateFolder("year-folder-id", "02")).thenReturn("month-folder-id");
@@ -45,6 +46,9 @@ class TransactionExportUploaderTest {
     when(driveClient.uploadFile(
             "month-folder-id", "FT_TKF100_ETF_orders_2026-02-16T14_30_05.xlsx", new byte[] {5, 6}))
         .thenReturn("https://drive.google.com/ft-etf");
+    when(driveClient.uploadFile(
+            "month-folder-id", "Tehingud_UUID_20260216_1430.xlsx", new byte[] {7, 8}))
+        .thenReturn("https://drive.google.com/uuid-workbook");
 
     var result = uploader.uploadExports(rootFolderId, TKF100, timestamp, exports);
 
@@ -53,7 +57,8 @@ class TransactionExportUploaderTest {
             Map.of(
                 "sebFundXlsx", "https://drive.google.com/seb-fund",
                 "sebEtfXlsx", "https://drive.google.com/seb-etf",
-                "ftEtfXlsx", "https://drive.google.com/ft-etf"));
+                "ftEtfXlsx", "https://drive.google.com/ft-etf",
+                "uuidWorkbookXlsx", "https://drive.google.com/uuid-workbook"));
   }
 
   @Test

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/export/TransactionExportUploaderTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/export/TransactionExportUploaderTest.java
@@ -34,7 +34,7 @@ class TransactionExportUploaderTest {
 
     when(driveClient.uploadFile(
             "month-folder-id",
-            "SEB_TKF100_indeksfondid_2026-02-16T14_30_05.xlsx",
+            "SEB_TKF100_indeksfondid_2026-02-16T14_30_05.csv",
             new byte[] {1, 2}))
         .thenReturn("https://drive.google.com/seb-fund");
     when(driveClient.uploadFile(
@@ -65,7 +65,7 @@ class TransactionExportUploaderTest {
     when(driveClient.getOrCreateFolder("root-id", "2026")).thenReturn("year-id");
     when(driveClient.getOrCreateFolder("year-id", "03")).thenReturn("month-id");
     when(driveClient.uploadFile(
-            "month-id", "SEB_TKF100_indeksfondid_2026-03-05T09_15_00.xlsx", new byte[] {1, 2}))
+            "month-id", "SEB_TKF100_indeksfondid_2026-03-05T09_15_00.csv", new byte[] {1, 2}))
         .thenReturn("https://drive.google.com/fund-only");
 
     var result = uploader.uploadExports(rootFolderId, TKF100, timestamp, exports);


### PR DESCRIPTION
Closes §4.11 format parity + the §4.8 UUID handoff — the last correctness cutover-blocker. Built against the internal Trade & EPIS File Formats reference (Part A), cross-checked against the **production GAS implementation** that generates these files today. No migration.

## Why this matters

Reconciliation has a UUID match tier — `SebPendingTransactionMatcher.match` does `findByOrderUuid(row.clientRef())`, first in the tier order (uuid -> complex -> near-miss). **It has never fired.** The SEB fund export never wrote the order uuid, and the ETF/FT files carry no uuid at all, so SEB had nothing to echo back as `Client ref` and every row silently fell through to matching by fund/ISIN/side/quantity. The consumer side is correct and needed no changes — it was simply starved.

## A1 — SEB fund order file: wrong container, wrong template

The doc says CSV; GAS confirms it — `tehingud.gs:3540` `createSebFundOrdersCsv` joins cells with `;` and ships `Utilities.newBlob(csvContent, 'text/csv', fileName + '.csv')`. **Java emitted XLSX** from a 19-column *counterparty* template, so every value sat under the wrong heading.

- Container: XLSX -> `;`-delimited CSV (preamble `;ORDER;;;;;;;;;;;;;` now matches GAS byte-for-byte)
- 19 -> the real **15** columns, incl. the verbatim trailing space in `Securities Acc `
- **col 0 `Original reference` = `order.getOrderUuid()`** — the handoff itself, never written before
- `Client name`, `Transaction fee` added; the six counterparty/portfolio columns dropped
- **`REDP` -> `REDM`** on sells
- Lockstep so SEB doesn't get an `.xlsx`-named CSV: writer + email MIME (`text/csv`) + filename in **both** `FILE_NAME_*` maps + the Drive upload content type

**Metadata key `sebFundXlsx` deliberately NOT renamed.** It's persisted jsonb read by `TransactionAdminService.exportFile`/`TransactionBatchResponse.EXPORT_TYPES`; renaming would orphan the export on any batch finalized before the deploy. The name is now slightly dishonest (it holds CSV) — the alternative silently breaks history.

## A2 — SEB ETF order file

Headers already matched. Two defects: an extra `SEB` preamble row (the real file's header is row 0), and `Type` emitted `BUY`/`SELL` where SEB writes `Buy`/`Sell`.

## A3 — FT ETF order file: 9 columns where the desk reads 11

`BBG` -> `Symbol`, `Type` -> `Side`, reordered to the real layout; **`TD`/`SD` were missing entirely** and are now written as Excel date serials (`tradeDate` threaded in from `finalizeConfirmedBatch`, where it was a local; `expectedSettlementDate` was already set before the export calls); the `FT` preamble row dropped; the control total moved to sit under the Approx column (col 7) instead of col 5.

`Side` stays UPPER-case per the doc — deliberately *not* title-cased like A2's `Type`. Aggregation by `isin+type` is kept: the doc says "by symbol", and ISIN<->symbol is 1:1 here, so it's equivalent.

## A4 — UUID workbook: did not exist

`Tehingud_UUID_<yyyyMMdd>_<HHmm>.xlsx`, 7 columns, one row per order across the union of SEB-venue ETF and FT orders, generated in `finalizeConfirmedBatch` (which already means "finalized and sent" — no new lifecycle state invented). Threaded through **five** places, not three — an audit turned up two more enumerations that would have silently omitted it: `TransactionBatchResponse.EXPORT_TYPES` (download API) and `TransactionBatchNotifier.DRIVE_URL_LABELS` (Slack links), alongside metadata, Drive upload and the email attachment.

## Risk

Low. **Nothing internally parses our own exports back** — ingest only reads SEB's inbound reports and FT's PDFs, so the only consumer of these formats is the external broker, which is the point.

## Notes for review

- One existing expectation flipped, justified: `generateSebFundExport_usesSellTransactionType` asserted `REDP`, locking in the known-wrong value.
- **Follow-up (not done):** `FILE_NAME_*` maps are duplicated across `TransactionExportUploader` and `CustodianOrderMessageFactory`, and this PR made both more verbose (a map of lambdas, since the UUID workbook uses a different timestamp format and no fund code). One `ExportFile` enum owning key + filename + MIME would consolidate those and likely serve `EXPORT_TYPES`/`DRIVE_URL_LABELS` too.
- **Follow-up:** `TransactionPipelineIntegrationTest` is `@Disabled` and its FT-sheet assertions use the old column indices. Updated where trivially possible, but it isn't exercised by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011SDg3ZgueukmG99FYUpHNg