### PR TITLE
Resolve backfill instrument type from the register, not an ETF guess

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/HistoricalRegistryImportService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/HistoricalRegistryImportService.java
@@ -5,6 +5,8 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.time.ZoneOffset.UTC;
 
 import ee.tuleva.onboarding.fund.TulevaFund;
+import ee.tuleva.onboarding.investment.instrument.InstrumentReference;
+import ee.tuleva.onboarding.investment.instrument.InstrumentReferenceService;
 import ee.tuleva.onboarding.investment.transaction.BatchStatus;
 import ee.tuleva.onboarding.investment.transaction.HistoricalImportFormatException;
 import ee.tuleva.onboarding.investment.transaction.HistoricalImportResult;
@@ -80,6 +82,7 @@ public class HistoricalRegistryImportService {
   private final TransactionOrderRepository orderRepository;
   private final TransactionExecutionRepository executionRepository;
   private final TransactionSettlementService settlementService;
+  private final InstrumentReferenceService instrumentReferenceService;
   private final Clock clock;
 
   @Transactional
@@ -212,6 +215,7 @@ public class HistoricalRegistryImportService {
   private ParsedRow parseRow(int rowNumber, CSVRecord record, char decimalSeparator) {
     String orderId = requireValue(record, "order_id");
     String fundIsin = requireValue(record, "fund_isin");
+    String instrumentIsin = requireValue(record, "instrument_isin");
     OrderStatus orderStatus =
         parseEnum(OrderStatus.class, requireValue(record, "order_status"), "order_status");
     LocalDate expectedSettlementDate =
@@ -231,12 +235,12 @@ public class HistoricalRegistryImportService {
             toOrderUuid(orderId),
             value(record, "transaction_id"),
             resolveFund(fundIsin),
-            requireValue(record, "instrument_isin"),
+            instrumentIsin,
             parseEnum(
                 TransactionType.class,
                 requireValue(record, "transaction_type"),
                 "transaction_type"),
-            parseInstrumentType(value(record, "instrument_type")),
+            resolveInstrumentType(value(record, "instrument_type"), instrumentIsin),
             parseDecimal(value(record, "order_amount"), "order_amount", decimalSeparator),
             parseDecimal(value(record, "order_quantity"), "order_quantity", decimalSeparator),
             parseInstant(value(record, "order_timestamp"), "order_timestamp"),
@@ -357,11 +361,31 @@ public class HistoricalRegistryImportService {
         .orElseThrow(() -> new RowParseException("Unknown fund: fundIsin=" + fundIsin));
   }
 
-  private static InstrumentType parseInstrumentType(@Nullable String value) {
-    if (value == null) {
-      return InstrumentType.ETF;
+  private InstrumentType resolveInstrumentType(
+      @Nullable String instrumentTypeValue, String instrumentIsin) {
+    if (instrumentTypeValue != null) {
+      return parseEnum(InstrumentType.class, instrumentTypeValue, "instrument_type");
     }
-    return parseEnum(InstrumentType.class, value, "instrument_type");
+    InstrumentReference reference =
+        instrumentReferenceService
+            .findByIsin(instrumentIsin)
+            .orElseThrow(
+                () ->
+                    new RowParseException("Unknown instrument: instrumentIsin=" + instrumentIsin));
+    String referenceInstrumentType = reference.getInstrumentType();
+    if (referenceInstrumentType == null) {
+      throw new RowParseException(
+          "Instrument reference missing instrument type: instrumentIsin=" + instrumentIsin);
+    }
+    try {
+      return InstrumentType.valueOf(referenceInstrumentType.strip().toUpperCase());
+    } catch (IllegalArgumentException e) {
+      throw new RowParseException(
+          "Instrument reference has unrecognised instrument type: instrumentIsin="
+              + instrumentIsin
+              + ", instrumentType="
+              + referenceInstrumentType);
+    }
   }
 
   private static <E extends Enum<E>> E parseEnum(Class<E> type, String value, String column) {

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/HistoricalRegistryImportServiceIT.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/HistoricalRegistryImportServiceIT.java
@@ -438,6 +438,73 @@ class HistoricalRegistryImportServiceIT {
     assertThat(result.ordersCreated()).isEqualTo(3);
   }
 
+  @Test
+  void terminalFundBuyWithoutInstrumentTypeColumnResolvesTypeFromInstrumentReference() {
+    String csv =
+        """
+        order_id,fund_isin,instrument_isin,transaction_id,transaction_type,order_amount,order_quantity,order_timestamp,order_status,expected_settlement_date,actual_settlement_date,execution_timestamp,executed_quantity,unit_price,total_consideration,net_settlement_amount,commission_amount,comment
+        GAS-9101,EE3600109443,IE0009FT4LX4,BR-9101,BUY,5000.00,,2025-03-10 09:00:00,EXECUTED,2025-03-12,,2025-03-10 14:30:00,,100.00,5000.00,4995.00,5.00,
+        """;
+
+    HistoricalImportResult result = importService.importCsv(csv);
+
+    assertThat(result.errors()).isEmpty();
+    assertThat(result.ordersCreated()).isEqualTo(1);
+    TransactionOrder order = orderRepository.findByInstrumentIsin("IE0009FT4LX4").getFirst();
+    assertThat(order.getInstrumentType()).isEqualTo(InstrumentType.FUND);
+  }
+
+  @Test
+  void etfBuyWithoutInstrumentTypeColumnStillRequiresExecutedQuantity() {
+    String csv =
+        """
+        order_id,fund_isin,instrument_isin,transaction_id,transaction_type,order_amount,order_quantity,order_timestamp,order_status,expected_settlement_date,actual_settlement_date,execution_timestamp,executed_quantity,unit_price,total_consideration,net_settlement_amount,commission_amount,comment
+        GAS-9102,EE3600109443,IE000I9HGDZ3,BR-9102,BUY,5000.00,,2025-03-10 09:00:00,EXECUTED,2025-03-12,,2025-03-10 14:30:00,,100.00,5000.00,4995.00,5.00,
+        """;
+
+    HistoricalImportResult result = importService.importCsv(csv);
+
+    assertThat(result.errors())
+        .containsExactly(
+            new HistoricalImportResult.RowError(
+                2, "Missing value: column=executed_quantity, orderId=GAS-9102"));
+    assertThat(result.ordersCreated()).isZero();
+  }
+
+  @Test
+  void unknownInstrumentIsinWithoutInstrumentTypeColumnIsRejectedWithoutEtfGuess() {
+    String csv =
+        """
+        order_id,fund_isin,instrument_isin,transaction_id,transaction_type,order_amount,order_quantity,order_timestamp,order_status,expected_settlement_date,actual_settlement_date,execution_timestamp,executed_quantity,unit_price,total_consideration,net_settlement_amount,commission_amount,comment
+        GAS-9103,EE3600109443,XX0000000099,,BUY,5000.00,,2025-03-10 09:00:00,SENT,2025-03-12,,,,,,,,
+        """;
+    long ordersBefore = orderRepository.count();
+
+    HistoricalImportResult result = importService.importCsv(csv);
+
+    assertThat(result.errors())
+        .containsExactly(
+            new HistoricalImportResult.RowError(
+                2, "Unknown instrument: instrumentIsin=XX0000000099"));
+    assertThat(result.ordersCreated()).isZero();
+    assertThat(orderRepository.count()).isEqualTo(ordersBefore);
+  }
+
+  @Test
+  void explicitInstrumentTypeColumnWinsOverInstrumentReference() {
+    String csv =
+        """
+        order_id,fund_isin,instrument_isin,transaction_id,transaction_type,instrument_type,order_amount,order_quantity,order_timestamp,order_status,expected_settlement_date,actual_settlement_date,execution_timestamp,executed_quantity,unit_price,total_consideration,net_settlement_amount,commission_amount,comment
+        GAS-9104,EE3600109443,IE000I9HGDZ3,,BUY,FUND,5000.00,,2025-03-10 09:00:00,SENT,2025-03-12,,,,,,,,
+        """;
+
+    HistoricalImportResult result = importService.importCsv(csv);
+
+    assertThat(result.errors()).isEmpty();
+    TransactionOrder order = orderRepository.findByInstrumentIsin("IE000I9HGDZ3").getFirst();
+    assertThat(order.getInstrumentType()).isEqualTo(InstrumentType.FUND);
+  }
+
   private TransactionOrder findByComment(String brokerTransactionId) {
     TransactionExecution execution =
         executionRepository.findByBrokerTransactionId(brokerTransactionId).orElseThrow();

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/HistoricalRegistryImportServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/HistoricalRegistryImportServiceTest.java
@@ -1,0 +1,100 @@
+package ee.tuleva.onboarding.investment.transaction.ingest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import ee.tuleva.onboarding.investment.instrument.InstrumentReference;
+import ee.tuleva.onboarding.investment.instrument.InstrumentReferenceService;
+import ee.tuleva.onboarding.investment.transaction.HistoricalImportResult;
+import ee.tuleva.onboarding.investment.transaction.HistoricalImportResult.RowError;
+import ee.tuleva.onboarding.investment.transaction.TransactionBatchRepository;
+import ee.tuleva.onboarding.investment.transaction.TransactionExecutionRepository;
+import ee.tuleva.onboarding.investment.transaction.TransactionOrderRepository;
+import ee.tuleva.onboarding.investment.transaction.TransactionSettlementService;
+import java.time.Clock;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.BeanUtils;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class HistoricalRegistryImportServiceTest {
+
+  private static final String FUND_ISIN = "EE3600001707";
+  private static final String INSTRUMENT_ISIN = "US0000000001";
+
+  @Mock private TransactionBatchRepository batchRepository;
+  @Mock private TransactionOrderRepository orderRepository;
+  @Mock private TransactionExecutionRepository executionRepository;
+  @Mock private TransactionSettlementService settlementService;
+  @Mock private InstrumentReferenceService instrumentReferenceService;
+  @Mock private Clock clock;
+
+  private HistoricalRegistryImportService importService;
+
+  @BeforeEach
+  void setUp() {
+    importService =
+        new HistoricalRegistryImportService(
+            batchRepository,
+            orderRepository,
+            executionRepository,
+            settlementService,
+            instrumentReferenceService,
+            clock);
+  }
+
+  @Test
+  void rowIsRejectedWhenInstrumentReferenceHasNoInstrumentType() {
+    InstrumentReference reference = instrumentReference(INSTRUMENT_ISIN, null);
+    given(instrumentReferenceService.findByIsin(INSTRUMENT_ISIN))
+        .willReturn(Optional.of(reference));
+
+    HistoricalImportResult result = importService.importCsv(csvWithoutInstrumentTypeColumn());
+
+    assertThat(result.errors()).extracting(RowError::rowNumber).containsExactly(2);
+    assertThat(result.ordersCreated()).isZero();
+    assertThat(result.executionsCreated()).isZero();
+    assertThat(result.settlementsCreated()).isZero();
+    then(instrumentReferenceService).should().findByIsin(INSTRUMENT_ISIN);
+    then(orderRepository).shouldHaveNoInteractions();
+    then(executionRepository).shouldHaveNoInteractions();
+  }
+
+  @Test
+  void rowIsRejectedWhenInstrumentReferenceHasUnrecognisedInstrumentType() {
+    InstrumentReference reference = instrumentReference(INSTRUMENT_ISIN, "BOND");
+    given(instrumentReferenceService.findByIsin(INSTRUMENT_ISIN))
+        .willReturn(Optional.of(reference));
+
+    HistoricalImportResult result = importService.importCsv(csvWithoutInstrumentTypeColumn());
+
+    assertThat(result.errors()).extracting(RowError::rowNumber).containsExactly(2);
+    assertThat(result.ordersCreated()).isZero();
+    assertThat(result.executionsCreated()).isZero();
+    assertThat(result.settlementsCreated()).isZero();
+    then(instrumentReferenceService).should().findByIsin(INSTRUMENT_ISIN);
+    then(orderRepository).shouldHaveNoInteractions();
+    then(executionRepository).shouldHaveNoInteractions();
+  }
+
+  private static String csvWithoutInstrumentTypeColumn() {
+    return """
+        order_id,fund_isin,instrument_isin,order_timestamp,order_status,expected_settlement_date,comment,transaction_type
+        GAS-9201,%s,%s,,SENT,,,BUY
+        """
+        .formatted(FUND_ISIN, INSTRUMENT_ISIN);
+  }
+
+  private static InstrumentReference instrumentReference(String isin, String instrumentType) {
+    InstrumentReference reference = BeanUtils.instantiateClass(InstrumentReference.class);
+    ReflectionTestUtils.setField(reference, "isin", isin);
+    ReflectionTestUtils.setField(reference, "instrumentType", instrumentType);
+    return reference;
+  }
+}


### PR DESCRIPTION
Closes the last open §4.6 cutover check. No migration. **Format now specified**: [Formats Reference — Part D](https://github.com/TulevaEE/tuleva/blob/main/work/investeerimistegevus/docs/Trade%20%26%20EPIS%20File%20Formats%20%E2%80%94%20Reference.md).

## This was a real cutover blocker, not a hypothetical

`parseInstrumentType` silently defaulted to **`ETF`** when the CSV had no `instrument_type` column. Evidence from the GAS source that produces the backfill sheet:

- `REQUIRED_EXEC_HEADERS` (`transaction_registry.gs:119`) is character-for-character our `REQUIRED_HEADERS` — the importer models the **Exec** tab.
- **The Exec tab has no `instrument_type`.** `:2414` builds an `order_id -> instrument_type` lookup *from the Transactions tab*, precisely because the tab it processes lacks it. Its own comment says so.
- GAS itself defaults to `'ETF'` when absent (`:947`) — Java had faithfully copied that, which is why nobody noticed.

Combined with #1783's terminal-status validation, every fund BUY would have been mis-typed as an ETF, had `executed_quantity` demanded of it — which a subscription legitimately never has, since SEB fills amount instead — and errored. The importer is all-or-nothing, so **one such row aborts the entire backfill**. #1783 turned a silent wrong-type into a hard stop; this stops it stopping the cutover.

## The fix

Precedence, decided by the user:

1. `instrument_type` column present -> use it (unchanged).
2. Absent -> look up `instrument_isin` in `instrument_reference` (V1_225 — seeded with every portfolio instrument, `instrument_type` exactly `FUND`/`ETF`) and use its authoritative type.
3. Unknown ISIN, or a reference row with a missing/unrecognised type -> **clean `RowError`. Never a guess, never a default.**

`InstrumentReferenceService.findByIsin` is an in-memory cache read, not a query, so the per-row lookup costs nothing — no per-import map needed.

**Module boundary checked**: `investment.instrument` and `investment.transaction.ingest` are both internal sub-packages of the single `investment` module; `TransactionModuleBoundaryTest` only forbids *outside* code reaching *into* `investment.transaction.*`, and `InvestmentReportDataService` already injects `InstrumentReferenceService` the same way. No violation.

## Tests

- Terminal fund BUY, no `instrument_type` column, FUND ISIN, blank quantity + populated consideration -> **imports** (the RED test; failed before with `Missing value: column=executed_quantity`)
- Same shape but an ETF ISIN -> quantity still required (not silently permissive)
- Unknown ISIN, no column -> clean `RowError`, nothing persisted, no ETF guess
- Explicit column wins over the reference

All existing tests pass unchanged — their fixtures carry an explicit `instrument_type`, which precedence 1 preserves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011SDg3ZgueukmG99FYUpHNg