### PR TITLE
Mark eligible children who have already been onboarded

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/party/ChildOnboardingService.java
+++ b/src/main/java/ee/tuleva/onboarding/party/ChildOnboardingService.java
@@ -1,5 +1,7 @@
 package ee.tuleva.onboarding.party;
 
+import static ee.tuleva.onboarding.party.PartyId.Type.PERSON;
+
 import ee.tuleva.onboarding.aml.AmlService;
 import ee.tuleva.onboarding.auth.principal.AuthenticatedPerson;
 import ee.tuleva.onboarding.event.TrackableEvent;
@@ -39,8 +41,17 @@ public class ChildOnboardingService {
         .filter(right -> PersonalCode.isMinor(right.childPersonalCode(), today))
         .map(
             right ->
-                new EligibleChild(right.childPersonalCode(), right.firstName(), right.lastName()))
+                new EligibleChild(
+                    right.childPersonalCode(),
+                    right.firstName(),
+                    right.lastName(),
+                    hasBeenOnboarded(right.childPersonalCode())))
         .toList();
+  }
+
+  private boolean hasBeenOnboarded(String childPersonalCode) {
+    return savingsFundOnboardingService.getOnboardingStatus(new PartyId(PERSON, childPersonalCode))
+        != null;
   }
 
   @Transactional

--- a/src/main/java/ee/tuleva/onboarding/party/EligibleChild.java
+++ b/src/main/java/ee/tuleva/onboarding/party/EligibleChild.java
@@ -4,4 +4,8 @@ import org.jspecify.annotations.Nullable;
 
 // A child the authenticated parent may open a savings fund account for. The name comes from the
 // population register's custody response and may be absent, so it is nullable.
-record EligibleChild(String personalCode, @Nullable String firstName, @Nullable String lastName) {}
+record EligibleChild(
+    String personalCode,
+    @Nullable String firstName,
+    @Nullable String lastName,
+    boolean hasBeenOnboarded) {}

--- a/src/main/java/ee/tuleva/onboarding/party/EligibleChildResponse.java
+++ b/src/main/java/ee/tuleva/onboarding/party/EligibleChildResponse.java
@@ -3,9 +3,12 @@ package ee.tuleva.onboarding.party;
 import org.jspecify.annotations.Nullable;
 
 public record EligibleChildResponse(
-    String personalCode, @Nullable String firstName, @Nullable String lastName) {
+    String personalCode,
+    @Nullable String firstName,
+    @Nullable String lastName,
+    boolean hasBeenOnboarded) {
 
   EligibleChildResponse(EligibleChild child) {
-    this(child.personalCode(), child.firstName(), child.lastName());
+    this(child.personalCode(), child.firstName(), child.lastName(), child.hasBeenOnboarded());
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/party/ChildControllerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/party/ChildControllerTest.java
@@ -48,8 +48,8 @@ class ChildControllerTest {
     given(childOnboardingService.findEligibleChildren(parent))
         .willReturn(
             List.of(
-                new EligibleChild(CHILD, "Mari", "Maasikas"),
-                new EligibleChild("61001010000", "Jüri", "Tamm")));
+                new EligibleChild(CHILD, "Mari", "Maasikas", true),
+                new EligibleChild("61001010000", "Jüri", "Tamm", false)));
 
     mvc.perform(get("/v1/me/children").with(authentication(authentication)))
         .andExpect(status().isOk())
@@ -57,8 +57,10 @@ class ChildControllerTest {
         .andExpect(jsonPath("$[0].personalCode").value(CHILD))
         .andExpect(jsonPath("$[0].firstName").value("Mari"))
         .andExpect(jsonPath("$[0].lastName").value("Maasikas"))
+        .andExpect(jsonPath("$[0].hasBeenOnboarded").value(true))
         .andExpect(jsonPath("$[1].personalCode").value("61001010000"))
-        .andExpect(jsonPath("$[1].firstName").value("Jüri"));
+        .andExpect(jsonPath("$[1].firstName").value("Jüri"))
+        .andExpect(jsonPath("$[1].hasBeenOnboarded").value(false));
   }
 
   @Test

--- a/src/test/groovy/ee/tuleva/onboarding/party/ChildOnboardingServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/party/ChildOnboardingServiceTest.java
@@ -4,8 +4,10 @@ import static ee.tuleva.onboarding.auth.AuthenticatedPersonFixture.sampleAuthent
 import static ee.tuleva.onboarding.party.ChildOnboardingService.CUSTODY_MAX_AGE;
 import static ee.tuleva.onboarding.party.CustodyVerification.Outcome.NO_CUSTODY;
 import static ee.tuleva.onboarding.party.CustodyVerification.Outcome.OK;
+import static ee.tuleva.onboarding.party.PartyId.Type.PERSON;
 import static ee.tuleva.onboarding.populationregister.CustodyRight.Type.PROPERTY;
 import static ee.tuleva.onboarding.populationregister.PopulationRegisterPerson.Status.ALIVE;
+import static ee.tuleva.onboarding.savings.fund.SavingsFundOnboardingStatus.PENDING;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -77,7 +79,7 @@ class ChildOnboardingServiceTest {
         .willReturn(List.of(new CustodyRight(CHILD, PROPERTY, true, true, "Mari", "Maasikas")));
 
     assertThat(service.findEligibleChildren(parent))
-        .containsExactly(new EligibleChild(CHILD, "Mari", "Maasikas"));
+        .containsExactly(new EligibleChild(CHILD, "Mari", "Maasikas", false));
   }
 
   @Test
@@ -91,7 +93,26 @@ class ChildOnboardingServiceTest {
                 new CustodyRight(ADULT, PROPERTY, true, true, "Jüri", "Tamm")));
 
     assertThat(service.findEligibleChildren(parent))
-        .containsExactly(new EligibleChild(CHILD, "Mari", "Maasikas"));
+        .containsExactly(new EligibleChild(CHILD, "Mari", "Maasikas", false));
+  }
+
+  @Test
+  void findEligibleChildren_marksChildrenWhoHaveAlreadyBeenOnboarded() {
+    var secondChild = "61001010000";
+    given(
+            custodyVerificationService.findChildrenWithAssetManagementCustody(
+                PARENT, CUSTODY_MAX_AGE))
+        .willReturn(
+            List.of(
+                new CustodyRight(CHILD, PROPERTY, true, true, "Mari", "Maasikas"),
+                new CustodyRight(secondChild, PROPERTY, true, true, "Jüri", "Tamm")));
+    given(savingsFundOnboardingService.getOnboardingStatus(new PartyId(PERSON, CHILD)))
+        .willReturn(PENDING);
+
+    assertThat(service.findEligibleChildren(parent))
+        .containsExactly(
+            new EligibleChild(CHILD, "Mari", "Maasikas", true),
+            new EligibleChild(secondChild, "Jüri", "Tamm", false));
   }
 
   @Test


### PR DESCRIPTION
GET /v1/me/children now returns hasBeenOnboarded per child, so the frontend can stop offering onboarding for a child whose savings fund onboarding record already exists. The record is seeded the moment a child is onboarded and can still be PENDING, so existence, not COMPLETED status, is the marker.