### PR TITLE
Restore optional amount for PARTNER and COOP_WEB recurring payment links

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/payment/recurring/RecurringPaymentLinkGenerator.java
+++ b/src/main/java/ee/tuleva/onboarding/payment/recurring/RecurringPaymentLinkGenerator.java
@@ -90,8 +90,12 @@ public class RecurringPaymentLinkGenerator implements PaymentLinkGenerator {
             amount);
       }
       case LUMINOR -> new RedirectLink("https://luminor.ee/auth/#/web/view/autopilot/newpayment");
-      case COOP, COOP_WEB, PARTNER -> {
+      case COOP -> {
         requireAmount(paymentData, channel);
+        yield coopPankPaymentLinkGenerator.getPaymentLink(paymentData, person);
+      }
+      case COOP_WEB, PARTNER -> {
+        validateAmountIfPresent(paymentData);
         yield coopPankPaymentLinkGenerator.getPaymentLink(paymentData, person);
       }
       case TULUNDUSUHISTU ->
@@ -114,11 +118,16 @@ public class RecurringPaymentLinkGenerator implements PaymentLinkGenerator {
               "payment.amount.required",
               "Payment amount is required for " + channel + " recurring links."));
     }
-    if (amount.compareTo(MIN_AMOUNT) < 0) {
+    validateAmountIfPresent(paymentData);
+    return amount.toPlainString();
+  }
+
+  private static void validateAmountIfPresent(PaymentData paymentData) {
+    var amount = paymentData.getAmount();
+    if (amount != null && amount.compareTo(MIN_AMOUNT) < 0) {
       throw new ErrorsResponseException(
           ErrorsResponse.ofSingleError(
               "payment.amount.invalid", "Payment amount must be at least " + MIN_AMOUNT + "."));
     }
-    return amount.toPlainString();
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/payment/recurring/RecurringPaymentLinkGeneratorSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/payment/recurring/RecurringPaymentLinkGeneratorSpec.groovy
@@ -230,7 +230,25 @@ class RecurringPaymentLinkGeneratorSpec extends Specification {
     exception.errorsResponse.errors[0].code == "payment.amount.required"
 
     where:
-    channel << [COOP, COOP_WEB, PARTNER]
+    channel << [COOP]
+  }
+
+  def "builds #channel recurring link without amount so the Coop form collects the sum"() {
+    given:
+    def person = samplePerson
+    def paymentData = new PaymentData(samplePerson.personalCode, null, null, RECURRING, channel)
+
+    when:
+    def link = recurringPaymentLinkGenerator.getPaymentLink(paymentData, person) as PrefilledLink
+
+    then:
+    link.url() == url
+    link.amount() == null
+
+    where:
+    channel  | url
+    COOP_WEB | "i/standing-orders/new?bname=AS%20Pensionikeskus&bacc=EE362200221067235244&cur=EUR&desc=30101119828%2C%20EE3600001707&ref=993432432&date=10.01.2020&freq=2&lang=en"
+    PARTNER  | """{"accountNumber":"EE362200221067235244","recipientName":"AS Pensionikeskus","amount":null,"currency":null,"description":"30101119828, EE3600001707","reference":"993432432","interval":"MONTHLY","firstPaymentDate":"2020-01-10"}"""
   }
 
   def "rejects recurring payment without payment channel as 400"() {


### PR DESCRIPTION
Since e9104a840 (2026-04-30), recurring payment link requests without an amount get HTTP 400 (payment.amount.required) for all Coop channels. The Coop partner flow (mobile app webview) and Coop web flow never send an amount — the customer picks the sum on Coop's own standing-order form — so every click of the recurring-payment button in the partner flow has failed since then (~700 Sentry events in 90 days on ONBOARDING-SERVICE-37D, which was archived).

This restores the pre-April behavior for PARTNER and COOP_WEB: the amount is optional and the link/JSON is built with a null amount for Coop's form to fill. A present-but-below-minimum amount still returns 400, and the COOP channel (our own payment page, which always sends an amount) keeps requiring it.

A companion onboarding-client PR surfaces these failures instead of swallowing them.