### PR TITLE
Accept CHILD_BENEFIT as a child funding source

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/kyc/survey/KycSurveyResponseItem.java
+++ b/src/main/java/ee/tuleva/onboarding/kyc/survey/KycSurveyResponseItem.java
@@ -167,7 +167,8 @@ public sealed interface KycSurveyResponseItem extends Serializable {
     PARENT_INCOME_AND_SAVINGS,
     GIFTS,
     INHERITANCE,
-    CHILD_OWN
+    CHILD_OWN,
+    CHILD_BENEFIT
   }
 
   enum TermsAccepted {

--- a/src/test/groovy/ee/tuleva/onboarding/kyc/survey/KycSurveyResponseTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyc/survey/KycSurveyResponseTest.java
@@ -2,6 +2,7 @@ package ee.tuleva.onboarding.kyc.survey;
 
 import static ee.tuleva.onboarding.kyc.KycSurveyPurpose.IDENTITY_ONLY;
 import static ee.tuleva.onboarding.kyc.KycSurveyPurpose.PERSONAL_ONBOARDING;
+import static ee.tuleva.onboarding.kyc.survey.KycSurveyResponseItem.FundingSource.CHILD_BENEFIT;
 import static ee.tuleva.onboarding.kyc.survey.KycSurveyResponseItem.FundingSource.PARENT_INCOME_AND_SAVINGS;
 import static ee.tuleva.onboarding.kyc.survey.KycSurveyResponseItem.InvestmentGoal.EDUCATION;
 import static ee.tuleva.onboarding.kyc.survey.KycSurveyResponseItem.InvestmentGoal.FIRST_HOME;
@@ -173,6 +174,27 @@ class KycSurveyResponseTest {
     var roundTripped =
         objectMapper.readValue(objectMapper.writeValueAsString(response), KycSurveyResponse.class);
     assertThat(roundTripped).isEqualTo(response);
+  }
+
+  @Test
+  void fundingSourcesAcceptChildBenefit() throws Exception {
+    var json =
+        """
+        {
+          "answers": [
+            {
+              "type": "FUNDING_SOURCES",
+              "value": [{ "type": "OPTION", "value": "CHILD_BENEFIT" }]
+            }
+          ]
+        }
+        """;
+
+    var response = objectMapper.readValue(json, KycSurveyResponse.class);
+
+    assertThat(response.answers())
+        .isEqualTo(
+            List.of(new FundingSources(List.of(new FundingSourceValueItem.Option(CHILD_BENEFIT)))));
   }
 
   @Test


### PR DESCRIPTION
## Problem

The child onboarding asks "Kust raha lapse kontole tuleb?" and offers: parent's income and savings, gifts, inheritance, the child's own money, and free-text other.

**Lapsetoetus (the state child benefit) is missing** — arguably one of the most common sources of money landing on a child's account. Today a parent can only record it by typing it into "Muu", which is worse AML data than an enumerated answer.

Spotted by Sten while dogfooding the now-launched child flow.

## Change

One value added to `FundingSource`. That's it.

The survey is persisted as JSON (`KycSurvey` uses `@JdbcTypeCode(JSON)`), so:
- no migration,
- existing stored responses are unaffected,
- nothing switches on `FundingSource` (it appears only in the DTO and this test), so there is no missing-case path.

## Ordering

**Backend first.** The frontend option is a separate PR on `onboarding-client`; until this is deployed, sending `CHILD_BENEFIT` would fail deserialization. Merge and deploy this before the client PR goes out.

## Tests

Written test-first: `fundingSourcesAcceptChildBenefit()` verified failing (`cannot find symbol: CHILD_BENEFIT`) before the enum value existed.

`KycSurveyResponseTest`: 11 tests, 0 failures. `spotlessApply`/`spotlessCheck` clean.

## Compliance note

✅ **Signed off by Maria** — the wording of the new option is approved (confirmed by Sten, 2026-07-22).

This changes a regulated AML/KYC questionnaire on a **live** flow, so it needed that sign-off before the client side ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
