### PR TITLE
Document S3-drop integration ADR and FT confirmation migration plan

### DIFF
--- a/docs/adr-0001-external-integration-via-s3-drop.md
+++ b/docs/adr-0001-external-integration-via-s3-drop.md
@@ -1,0 +1,93 @@
+# ADR 0001 — External systems integrate via S3 file-drop, not by calling our HTTP API
+
+**Status:** Accepted — 2026-07-23
+**Deciders:** J (product/eng owner), engineering
+**Applies to:** the transaction-registry pipeline and every future external data feed into onboarding-service
+
+## Context
+
+onboarding-service ingests data from several external / automated sources:
+
+- **SEB** pending-transaction and position CSVs
+- **Swedbank** position CSVs
+- **First Trust / Allfunds ("FT")** trade confirmations (PDF, delivered by email)
+- **EPIS** reports R16 / R17 / R21 / R45 (no API — a human fetches them from the EPIS portal)
+
+SEB and Swedbank already follow one consistent shape: the external system **drops a file in
+S3**, and onboarding-service **pulls and parses it** on a schedule
+(`ReportImportJob` + `SebReportSource` / `SwedbankReportSource`, landing raw bytes in
+`investment_report.raw_data`). That shape is durable, replayable, decoupled from our uptime,
+and authenticated by IAM.
+
+**FT confirmations broke the pattern.** A Google Apps Script (GAS) parses the confirmation PDF
+and **pushes** the parsed rows to our HTTP API
+(`POST /admin/transaction-registry/ft-confirmations`, gated by a shared `X-Admin-Token` plus a
+self-declared `X-Admin-Actor`). This was an interim bridge — it reused the PDF parser that
+already existed in GAS to get FT into shadow-mode verification quickly. But a machine calling
+our admin API fragments the ingestion architecture (two mechanisms, two failure modes, two auth
+models) and is what created the forgeable-`actor` / shared-admin-token coupling in the audit
+trail. We keep re-discovering that this endpoint "feels wrong"; this ADR records why, once.
+
+## Decision
+
+**Automated / external systems integrate with onboarding-service by dropping files into S3,
+which onboarding-service pulls and processes. They MUST NOT call our HTTP endpoints to push data
+in.**
+
+GAS does not call the Java app. Where GAS currently owns parsing or format logic for an inbound
+feed, that logic is **ported into onboarding-service** (e.g. FT PDF parsing via PDFBox) and the
+raw file lands in S3 the same way SEB / Swedbank reports do. New integration work starts from
+*"how does the file get to S3?"* — never *"which endpoint do we POST to?"*
+
+## Scope — what this covers and what it does not
+
+**IN (must be S3-drop, never push):**
+- Any recurring data feed produced by an automated system — broker files, GAS-produced files,
+  scheduled exports, etc.
+
+**OUT (HTTP is correct and stays):**
+- **Human-operator commands** — create / confirm / cancel a trade batch, trigger a calc or a
+  reconciliation match. A person invoking an action is not a system pushing data; these stay as
+  `/admin` HTTP endpoints (attribution handled by per-operator identity, separate decision).
+- **Reads / dashboards** — status, daily summary, settlement warnings, export download.
+- **Human bridge uploads where there is no automated source** — EPIS reports (`import-report`)
+  and the one-time historical backfill (`import-history`). A human fetches these because the
+  upstream has no API. Legitimate. Landing a durable raw copy in S3 for replayability is
+  *encouraged* but not required, and their absence of an S3 drop is **not** a violation of this
+  ADR.
+
+## Consequences
+
+- The FT confirmation push endpoints — `POST /admin/transaction-registry/ft-confirmation`
+  (singular) and `.../ft-confirmations` (plural) — are to be **retired** once the S3-drop path
+  is live and parallel-verified. They stay until then (shadow mode) so FT ingestion is never
+  interrupted, and so the live GAS trigger keeps working until it is removed.
+- **Attribution simplifies.** With no machine caller left on `/admin`, the only actors on those
+  endpoints are human operators — which is what makes per-operator-token attribution clean (no
+  awkward `gas-ft-push` service identity to special-case).
+- Each S3-drop feed needs three parts in Java: the **parser**, an **S3 landing** for the raw
+  file, and a **pull job / `*ReportSource`**. For email-delivered files (FT), the S3 landing is
+  an infra prerequisite (an SES inbound-email rule → S3, or a scheduled mail-fetch job) and is a
+  decision to make before that feed can go pull-based.
+
+## Migration — FT confirmations (the one current violation)
+
+Ordered so the working path is never broken (refactor/add first, delete last):
+
+1. **Port the parser.** Port the GAS FT PDF parser (`apps/seb-import/tehingukinnitused_parse.gs`,
+   the current format spec) to a Java **PDFBox** parser — TDD against the field spec (`Allocation
+   ID`, `Trade Date Time` UTC, `Gross Price` `10.916000 EUR`, comma-thousands `Quantity`, etc.).
+2. **Land the file in S3.** Decide + build the email→S3 landing for the confirmation PDF.
+3. **Pull + parse.** Add an `FtConfirmationReportSource` + pull job that reads the PDF from S3
+   and calls the existing `FtConfirmationVerificationService.verifyAll`. Confirm the `Allocation
+   ID` dedup makes double-ingestion during parallel run idempotent.
+4. **Parallel run** S3-pull alongside the GAS push until outcomes agree.
+5. **Delete.** Remove the GAS `pushFtConfirmationsToRegistry` trigger, then delete the two push
+   endpoints and their HTTP DTOs — keeping the domain `FtConfirmation` type + `verifyAll`, now
+   fed by the job.
+
+## References
+
+- Gap doc §4.1 (FT confirmation ingestion — "End state, STILL OPEN: port PDF parsing into
+  onboarding-service; FT email → S3, the way SEB reports arrive; retire the GAS parser").
+- `ReportImportJob`, `SebReportSource`, `SwedbankReportSource` — the pull pattern to mirror.

--- a/docs/adr-0001-external-integration-via-s3-drop.md
+++ b/docs/adr-0001-external-integration-via-s3-drop.md
@@ -10,7 +10,7 @@ onboarding-service ingests data from several external / automated sources:
 
 - **SEB** pending-transaction and position CSVs
 - **Swedbank** position CSVs
-- **First Trust / Allfunds ("FT")** trade confirmations (PDF, delivered by email)
+- **Flow Traders ("FT")** ETF trade confirmations (PDF, from `flowtraders@ullink.eu`)
 - **EPIS** reports R16 / R17 / R21 / R45 (no API — a human fetches them from the EPIS portal)
 
 SEB and Swedbank already follow one consistent shape: the external system **drops a file in
@@ -65,10 +65,11 @@ raw file lands in S3 the same way SEB / Swedbank reports do. New integration wor
 - **Attribution simplifies.** With no machine caller left on `/admin`, the only actors on those
   endpoints are human operators — which is what makes per-operator-token attribution clean (no
   awkward `gas-ft-push` service identity to special-case).
-- Each S3-drop feed needs three parts in Java: the **parser**, an **S3 landing** for the raw
-  file, and a **pull job / `*ReportSource`**. For email-delivered files (FT), the S3 landing is
-  an infra prerequisite (an SES inbound-email rule → S3, or a scheduled mail-fetch job) and is a
-  decision to make before that feed can go pull-based.
+- Each S3-drop feed needs a **parser** and a **pull job** in Java, plus an **S3 landing** for the raw
+  file. The landing already exists for email-delivered files: the production `investment_reports_gs.gs`
+  GAS→S3 uploader (Gmail `funds@tuleva.ee` → `tuleva-investment-reports`, with SigV4 + idempotency +
+  backfill). New feeds add a `SOURCES` entry there rather than standing up new email infra — GAS keeps a
+  dumb file-mover role, which is a file drop, not an API call, and so is ADR-compliant.
 
 ## Migration — FT confirmations (the one current violation)
 

--- a/docs/ft-confirmation-s3-migration-plan.md
+++ b/docs/ft-confirmation-s3-migration-plan.md
@@ -1,8 +1,10 @@
 # FT Confirmation Ingestion — S3-Drop Migration Plan
 
-Realizes **ADR 0001** (`adr-0001-external-integration-via-s3-drop.md`) for the FT (First Trust /
-Allfunds) trade-confirmation feed. Moves FT from **GAS-push** (`POST /admin/transaction-registry/
-ft-confirmations`) to **S3-drop + Java PDFBox parse**, mirroring how SEB/Swedbank reports arrive.
+Realizes **ADR 0001** (`adr-0001-external-integration-via-s3-drop.md`) for the **FT = Flow Traders**
+(ETF market-maker; sender `flowtraders@ullink.eu`) trade-confirmation feed. Moves FT from **GAS-push**
+(`POST /admin/transaction-registry/ft-confirmations`) to **S3-drop + Java PDFBox parse** — landed the
+same way SEB/Swedbank reports already arrive: via the existing **`investment_reports_gs.gs` GAS→S3
+uploader** into `tuleva-investment-reports`, which `ReportImportJob` already consumes.
 
 ## What changes, what doesn't
 
@@ -10,7 +12,12 @@ ft-confirmations`) to **S3-drop + Java PDFBox parse**, mirroring how SEB/Swedban
   everything downstream — order matching, `FtConfirmationAuditRecorder` (dedup), `FtConfirmationDigest`,
   `PositionPriceResolver`. Only the **entry** changes: from an HTTP POST of parsed rows to an S3-pull
   job that parses PDFs into the same `FtConfirmation` objects.
-- **Removed at the end (M5):** the two push endpoints + their DTOs, and the GAS PDF parser + trigger.
+- **Removed at the end (M5):** the two push endpoints + their DTOs, the GAS PDF parser + the GAS→Java
+  push trigger, and the redundant GAS FT-PDF-to-Drive save.
+- **GAS is NOT fully retired — and that's ADR-compliant.** It keeps one job: the `investment_reports_gs.gs`
+  uploader dropping the raw FT PDF into S3 (a file drop, *not* an API call). The parsing logic moves to
+  Java, which is the ADR's actual requirement. Fully retiring GAS from ingestion (SES inbound) is a
+  possible far-future cleanup, not part of this migration.
 
 ## Key design decisions
 
@@ -22,9 +29,11 @@ ft-confirmations`) to **S3-drop + Java PDFBox parse**, mirroring how SEB/Swedban
 2. **Parse with Apache PDFBox `PDFTextStripper`** (add explicit `org.apache.pdfbox:pdfbox`; only the
    `openhtmltopdf-pdfbox` *generator* is present today). Port GAS's label→value strategy: `extractField`
    matches `Label: Value` on the same line or `Label⏎Value` on the next, case-insensitive.
-3. **SES inbound → S3** stores the raw email; a Java `jakarta.mail` seam extracts the PDF attachment,
-   then PDFBox parses it. (Alternative: SES → Lambda → clean PDF to S3, and the job reads PDFs directly.
-   Not recommended — keep the logic in Java per the ADR.)
+3. **Land the PDF via the existing GAS→S3 uploader**, not new infra. `investment_reports_gs.gs` already
+   polls `funds@tuleva.ee` and uploads matched attachments to `tuleva-investment-reports` with working
+   SigV4 signing, per-thread idempotency labels, and historical backfill. FT confirmations **already
+   arrive at `funds@tuleva.ee`** (confirmed), so this is a `SOURCES` config addition + two small tweaks
+   (see M2) — no SES, no Lambda, no MIME parsing in Java (the job reads a clean PDF straight from S3).
 4. **Idempotency** rides on the existing audit dedup (`recordOutcome` returns `recorded=false` on a
    repeat) + digest dedup, so re-parsing the same PDF on a later poll records or alerts nothing twice.
    Optionally track processed S3 keys to skip re-parse (efficiency only; no migration if we skip it).
@@ -54,11 +63,11 @@ ft-confirmations`) to **S3-drop + Java PDFBox parse**, mirroring how SEB/Swedban
   confirmation, and `MAAKPE` ≈ a contraction of *MAAilma aKtsiate PEnsionifond*. **Confirm with J / the FT
   account setup before shipping.** The sample is small (8× TKF100, 1× TUV100, 1× TUK75), so treat the alias
   table as extensible + fail-loud, not exhaustive.
-- **R3 — SES routing (infra, J-owned).** Source is now concrete: **`from:flowtraders@ullink.eu`,
-  `subject:"Trade Confirmation"`, PDF attachment** (per GAS `SEB_raport_import_convert.gs` OSA 3). Cleanest
-  path: a **Gmail filter** on that sender/subject **auto-forwards to an SES-inbound address** (e.g.
-  `ft-confirmations@in.tuleva.ee`, MX → SES) → SES stores raw email to S3. Replaces the GAS Drive-save;
-  mailbox stays put.
+- **R3 — S3 landing — ✅ RESOLVED 2026-07-23 (SES dropped).** No new email infra. The production
+  `investment_reports_gs.gs` GAS→S3 uploader already does exactly this for every other feed, and the FT
+  emails (`from:flowtraders@ullink.eu`, `subject:"Trade Confirmation"`) **already land in `funds@tuleva.ee`**
+  (confirmed by J), which the uploader searches (`to:funds@tuleva.ee has:attachment`). So the landing is a
+  `SOURCES` addition + the two M2 tweaks, not the SES/MX/forwarding project previously scoped here.
 - **R4 — formats — ✅ confirmed against the sample.** `Trade Date: 20260717` (`yyyyMMdd`, use directly for
   `tradeDate`); `Trade Date Time: 20260717-09:32:44 UTC`; `Quantity: 1,047` (strip comma); `Gross Price:
   56.850000 EUR` (strip ` EUR`, 6 dp); `Your Direction: Buy`; `Allocation ID: MID9BlFbos-00`; cancellation
@@ -80,28 +89,40 @@ as `MID9AoF5Ik-01` @ 4.970000 (note the `-01` allocation-id suffix on the rebook
 
 ## Milestones (TDD-first, refactor/add before delete)
 
-### M1 — FT PDF parser in Java (additive, no wiring)
-- **Prereq:** ≥1 real sample confirmation PDF (+ ideally one cancellation) — resolves R1/R2/R4.
+### M1 — FT PDF parser in Java (additive, no wiring) — **ready to build; R1/R2/R4 resolved**
+- **Samples in hand:** 11 real confirmations (10 in `/Users/j/scratch`, 1 uploaded) covering all 3 funds,
+  a cancellation + its rebook, comma-thousands quantities, 6-dp prices. R1/R2/R4 all resolved above.
 - **Failing test (business outcome):** given a real FT confirmation PDF, the parser yields the correct
   `FtConfirmation` (fund, isin, UTC tradeDate, quantity, grossPrice, type, account [+ allocationId]).
 - **Steps:** add the pdfbox dependency; `FtConfirmationPdfParser` = `PDFTextStripper` → text → ported
-  `extractField` regex → field mapping (UTC dates, strip ` EUR`/thousands, `Account`→`TulevaFund`,
-  cancellation via `/trade cancellation/i`); unit test per field + cancellation + **malformed → throws**
-  (fail loud, per the economics policy — never substitute).
-- **If R1 fails (image-only):** stop and escalate the Tesseract decision before writing more.
+  `extractField` regex → field mapping (UTC dates, strip ` EUR`/thousands, `Account`→`TulevaFund` via the
+  fail-loud alias table, cancellation via `/trade cancellation/i`); unit test per field + cancellation +
+  unmapped-account + **malformed → throws** (fail loud, per the economics policy — never substitute).
 
-### M2 — SES → S3 landing (infra J-owned + a Java MIME seam)
-- SES inbound receipt rule writes the raw email under `ft-confirmations-raw/` in the reports bucket.
-- `FtEmailPdfExtractor` (`jakarta.mail`): raw MIME → PDF attachment bytes. TDD against a saved raw-email
-  fixture (scrubbed). *(If we pick SES→Lambda→clean-PDF instead, this Java seam drops and the job reads
-  PDFs directly.)*
+### M2 — extend the existing GAS→S3 uploader for FT (in `investment_reports_gs.gs`)
+Add FT to the `SOURCES` config so the raw PDF lands at `ft-confirmations/<allocationId>.pdf`:
+```js
+FT: { senders: ["flowtraders@ullink.eu"],
+      files: [{ pattern: /^(MID\w+-\d+)\.pdf$/i, s3Prefix: "ft-confirmations/", s3Suffix: ".pdf" }] }
+```
+Two real tweaks (the uploader was built for dated CSVs):
+1. **Binary bytes.** `processMessage` (`:260`) reads `attachment.getDataAsString()` — fine for CSV text,
+   **corrupts a PDF**. Use `attachment.getBytes()` (or `copyBlob()`) + content-type `application/pdf` into
+   `uploadToS3` (which already accepts a byte payload for the SigV4 hash).
+2. **Allocation-id keys, not date keys.** `getFileConfigAndDate` (`:290`) builds the key from a **date**
+   captured in the filename (`prefix + yyyy-mm-dd + suffix`). FT filenames carry an **allocation id**
+   (`MID9BlFbos-00`) and there are many per day → key must be `ft-confirmations/<allocationId>.pdf`.
+   Add a per-file `keyFromCapture` (or similar) branch so `match[1]` is used verbatim as the key stem.
+- **Backfill for free:** the same uploader's `processHistoricalEmails30Days()` (with the FT source added)
+  bulk-lands historical confirmations — giving the full fixture set + every real `Account` alias (locks R2).
+- The GAS change is small; validate with the uploader's existing `testUpload` path against a scrubbed PDF.
 
-### M3 — S3 pull job (additive; shadow mode, no alerts)
-- `FtConfirmationS3Source`: `ListObjectsV2` under the prefix (net-new — no existing list usage), get
-  object, HeadObject `lastModified`.
+### M3 — Java S3 pull job (additive; shadow mode, no alerts)
+- `FtConfirmationS3Source`: `ListObjectsV2` under `ft-confirmations/` (net-new — no existing list usage),
+  get object, HeadObject `lastModified`.
 - `FtConfirmationImportJob`: `@Scheduled` + `@SchedulerLock`, `Clock`-injected, behind an enable flag
-  (`@ConditionalOnProperty`); list new objects → extract PDF (M2) → parse (M1) → `verifyAll`. Idempotent
-  via audit dedup.
+  (`@ConditionalOnProperty`); list new objects → parse each PDF (M1) → `verifyAll`. The object is already a
+  clean PDF (GAS dropped it), so no MIME/attachment extraction is needed. Idempotent via audit dedup.
 - **Failing integration test:** a PDF object in a mocked/LocalStack S3 prefix → verified outcome recorded;
   second run → no duplicate audit/alert. Confirm the audit dedup key holds across both entry paths (push
   + job) during the parallel run.
@@ -116,8 +137,9 @@ as `MID9AoF5Ik-01` @ 4.970000 (note the `-01` allocation-id suffix on the rebook
 2. Delete `POST /admin/transaction-registry/ft-confirmation` (singular) + `.../ft-confirmations` (plural)
    + their request DTOs/tests. Keep the domain `FtConfirmation` + `verifyAll` (now job-fed). The
    `X-Admin-Actor` on those endpoints goes away with them.
-3. Remove the GAS parser `tehingukinnitused_parse.gs` + Drive/OCR plumbing (tuleva repo) once the S3 path
-   is proven.
+3. Remove the GAS parser `tehingukinnitused_parse.gs` (OCR + sheet) and the now-redundant FT-PDF-to-Drive
+   save in `SEB_raport_import_convert.gs` (OSA 3), once the S3 path is proven. **Keep** the new FT `SOURCES`
+   entry in `investment_reports_gs.gs` — that S3 upload is the ongoing feed.
 
 ## Testing & conventions
 - **No PII in fixtures** (CLAUDE.md): scrub sample PDFs/emails — synthetic names, opaque IDs.

--- a/docs/ft-confirmation-s3-migration-plan.md
+++ b/docs/ft-confirmation-s3-migration-plan.md
@@ -38,10 +38,22 @@ ft-confirmations`) to **S3-drop + Java PDFBox parse**, mirroring how SEB/Swedban
   garbling. So **PDFBox `PDFTextStripper` reads it directly; no OCR / no Tesseract.** (GAS OCRs only because
   Apps Script has no PDF-text API — not because the PDF needs it.) Contrast: the SEB *fund* confirmation's
   text layer is broken (font-encoding) and would need OCR — but SEB is out of scope (covered by the pending CSV).
-- **R2 — `Account` → `TulevaFund` mapping — partially resolved.** `Account` is the **full English fund
-  name**. Confirmed from the sample: `Tuleva Additional Investment Fund` → **TKF100**. Still need the exact
-  `Account` strings for **TUK75** (Maailma Aktsiate) and **TUV100** (III Samba) — get from one confirmation
-  each, or map from the known fund set. `TulevaFund.fromCode` exists; add a name/account lookup.
+- **R2 — `Account` → `TulevaFund` mapping — ✅ RESOLVED 2026-07-23 (10 real confirmations), with one item
+  to confirm.** **The `Account` field is NOT uniformly named** — each fund uses a *different* convention, and
+  none is derivable from the `TulevaFund.displayName`:
+  | FT `Account` string | → fund | vs enum `displayName` |
+  | --- | --- | --- |
+  | `Tuleva Additional Investment Fund` | **TKF100** | enum = "Tuleva Täiendav Kogumisfond" (English marketing name, no match) |
+  | `TULEVA III SAMBA PENSIONIFOND` | **TUV100** | enum = "Tuleva III Samba Pensionifond" (matches case-insensitively) |
+  | `MAAKPE` | **TUK75** ⚠️ | enum = "Tuleva Maailma Aktsiate Pensionifond" (cryptic code, no match) |
+
+  So the parser needs an **explicit FT-account-alias → fund table** (normalize by trim + case-insensitive),
+  **failing loud (ORPHAN/error) on any unrecognized `Account`** so a new/changed variant surfaces instead of
+  silently mis-mapping. `MAAKPE` is **not** in our codebase — inferred as TUK75 because its ISIN
+  `IE000I9HGDZ3` is a TUK75 holding, it appears on the same date/price as the separate `III SAMBA`
+  confirmation, and `MAAKPE` ≈ a contraction of *MAAilma aKtsiate PEnsionifond*. **Confirm with J / the FT
+  account setup before shipping.** The sample is small (8× TKF100, 1× TUV100, 1× TUK75), so treat the alias
+  table as extensible + fail-loud, not exhaustive.
 - **R3 — SES routing (infra, J-owned).** Source is now concrete: **`from:flowtraders@ullink.eu`,
   `subject:"Trade Confirmation"`, PDF attachment** (per GAS `SEB_raport_import_convert.gs` OSA 3). Cleanest
   path: a **Gmail filter** on that sender/subject **auto-forwards to an SES-inbound address** (e.g.
@@ -59,6 +71,12 @@ ft-confirmations`) to **S3-drop + Java PDFBox parse**, mirroring how SEB/Swedban
 `ISIN`, `Your Direction`, `Quantity`, `Gross Price ... EUR`, `Net Price`, `Transaction Cost`, `Net Amount`,
 `Settlement Currency`, plus settlement-instruction blocks and a legal footer (ignored). Contact:
 `midoffice.amsterdam@nl.flowtraders.com`. The ported `extractField` (`Label\s*:\s*(value)`) handles it.
+
+**Cancellation detection:** the title is always `Trade Confirmation` (not a reliable signal). The
+discriminator is the body line — normal: `We confirm the following trade .`; cancellation: `We confirm the
+following trade cancellation.` Detect the phrase `trade cancellation` (case-insensitive), matching GAS.
+Real example in the sample set: `MID9AiyZwO-00` cancels a TKF100 buy of `IE000F60HVH9` @ 4.951500, re-booked
+as `MID9AoF5Ik-01` @ 4.970000 (note the `-01` allocation-id suffix on the rebook).
 
 ## Milestones (TDD-first, refactor/add before delete)
 

--- a/docs/ft-confirmation-s3-migration-plan.md
+++ b/docs/ft-confirmation-s3-migration-plan.md
@@ -1,0 +1,119 @@
+# FT Confirmation Ingestion — S3-Drop Migration Plan
+
+Realizes **ADR 0001** (`adr-0001-external-integration-via-s3-drop.md`) for the FT (First Trust /
+Allfunds) trade-confirmation feed. Moves FT from **GAS-push** (`POST /admin/transaction-registry/
+ft-confirmations`) to **S3-drop + Java PDFBox parse**, mirroring how SEB/Swedbank reports arrive.
+
+## What changes, what doesn't
+
+- **Unchanged:** `FtConfirmationVerificationService.verifyAll(List<FtConfirmation>, actor)` and
+  everything downstream — order matching, `FtConfirmationAuditRecorder` (dedup), `FtConfirmationDigest`,
+  `PositionPriceResolver`. Only the **entry** changes: from an HTTP POST of parsed rows to an S3-pull
+  job that parses PDFs into the same `FtConfirmation` objects.
+- **Removed at the end (M5):** the two push endpoints + their DTOs, and the GAS PDF parser + trigger.
+
+## Key design decisions
+
+1. **Standalone FT ingest, not the CSV `ReportSource` framework.** FT is *many PDFs under a prefix*
+   (not one CSV per date), PDF not CSV, and calls `verifyAll` directly (not via `ReportImportCompleted`).
+   Build a dedicated job in `transaction.ingest` that mirrors the *conventions* of `ReportImportJob`
+   (`S3Client`, `@Scheduled` + `@SchedulerLock`, injected `Clock`, `s3LastModified` idempotency) without
+   reusing the CSV-specific `ReportSource`/`InvestmentReportService.saveReport` path.
+2. **Parse with Apache PDFBox `PDFTextStripper`** (add explicit `org.apache.pdfbox:pdfbox`; only the
+   `openhtmltopdf-pdfbox` *generator* is present today). Port GAS's label→value strategy: `extractField`
+   matches `Label: Value` on the same line or `Label⏎Value` on the next, case-insensitive.
+3. **SES inbound → S3** stores the raw email; a Java `jakarta.mail` seam extracts the PDF attachment,
+   then PDFBox parses it. (Alternative: SES → Lambda → clean PDF to S3, and the job reads PDFs directly.
+   Not recommended — keep the logic in Java per the ADR.)
+4. **Idempotency** rides on the existing audit dedup (`recordOutcome` returns `recorded=false` on a
+   repeat) + digest dedup, so re-parsing the same PDF on a later poll records or alerts nothing twice.
+   Optionally track processed S3 keys to skip re-parse (efficiency only; no migration if we skip it).
+5. **Reuse the `tuleva-investment-reports` bucket** under a new prefix (e.g. `ft-confirmations/`) — same
+   IAM/access as SEB/Swedbank.
+
+## Risks / unknowns
+
+- **R1 — text layer vs OCR (GATING) — ✅ RESOLVED 2026-07-23.** Tested `pdftotext` against a real Flow
+  Traders confirmation (`MID9BlFbos-00`): **the text layer extracts perfectly** — every field clean, no
+  garbling. So **PDFBox `PDFTextStripper` reads it directly; no OCR / no Tesseract.** (GAS OCRs only because
+  Apps Script has no PDF-text API — not because the PDF needs it.) Contrast: the SEB *fund* confirmation's
+  text layer is broken (font-encoding) and would need OCR — but SEB is out of scope (covered by the pending CSV).
+- **R2 — `Account` → `TulevaFund` mapping — partially resolved.** `Account` is the **full English fund
+  name**. Confirmed from the sample: `Tuleva Additional Investment Fund` → **TKF100**. Still need the exact
+  `Account` strings for **TUK75** (Maailma Aktsiate) and **TUV100** (III Samba) — get from one confirmation
+  each, or map from the known fund set. `TulevaFund.fromCode` exists; add a name/account lookup.
+- **R3 — SES routing (infra, J-owned).** Source is now concrete: **`from:flowtraders@ullink.eu`,
+  `subject:"Trade Confirmation"`, PDF attachment** (per GAS `SEB_raport_import_convert.gs` OSA 3). Cleanest
+  path: a **Gmail filter** on that sender/subject **auto-forwards to an SES-inbound address** (e.g.
+  `ft-confirmations@in.tuleva.ee`, MX → SES) → SES stores raw email to S3. Replaces the GAS Drive-save;
+  mailbox stays put.
+- **R4 — formats — ✅ confirmed against the sample.** `Trade Date: 20260717` (`yyyyMMdd`, use directly for
+  `tradeDate`); `Trade Date Time: 20260717-09:32:44 UTC`; `Quantity: 1,047` (strip comma); `Gross Price:
+  56.850000 EUR` (strip ` EUR`, 6 dp); `Your Direction: Buy`; `Allocation ID: MID9BlFbos-00`; cancellation
+  from confirmation text. `tradeDate` is the **UTC** `LocalDate` (matches the existing `hasTradeDate`).
+
+## Confirmed field layout (sample `MID9BlFbos-00`, Flow Traders B.V., 2026-07-17)
+
+`Label:  Value`, one field per line. Fields present: `Allocation ID`, `Counterparty` (=`TULEVA FONDID AS`),
+`Account`, `Trade Date Time`, `Trade Date`, `Settlement Date`, `Security Description`, `Bloomberg Ticker`,
+`ISIN`, `Your Direction`, `Quantity`, `Gross Price ... EUR`, `Net Price`, `Transaction Cost`, `Net Amount`,
+`Settlement Currency`, plus settlement-instruction blocks and a legal footer (ignored). Contact:
+`midoffice.amsterdam@nl.flowtraders.com`. The ported `extractField` (`Label\s*:\s*(value)`) handles it.
+
+## Milestones (TDD-first, refactor/add before delete)
+
+### M1 — FT PDF parser in Java (additive, no wiring)
+- **Prereq:** ≥1 real sample confirmation PDF (+ ideally one cancellation) — resolves R1/R2/R4.
+- **Failing test (business outcome):** given a real FT confirmation PDF, the parser yields the correct
+  `FtConfirmation` (fund, isin, UTC tradeDate, quantity, grossPrice, type, account [+ allocationId]).
+- **Steps:** add the pdfbox dependency; `FtConfirmationPdfParser` = `PDFTextStripper` → text → ported
+  `extractField` regex → field mapping (UTC dates, strip ` EUR`/thousands, `Account`→`TulevaFund`,
+  cancellation via `/trade cancellation/i`); unit test per field + cancellation + **malformed → throws**
+  (fail loud, per the economics policy — never substitute).
+- **If R1 fails (image-only):** stop and escalate the Tesseract decision before writing more.
+
+### M2 — SES → S3 landing (infra J-owned + a Java MIME seam)
+- SES inbound receipt rule writes the raw email under `ft-confirmations-raw/` in the reports bucket.
+- `FtEmailPdfExtractor` (`jakarta.mail`): raw MIME → PDF attachment bytes. TDD against a saved raw-email
+  fixture (scrubbed). *(If we pick SES→Lambda→clean-PDF instead, this Java seam drops and the job reads
+  PDFs directly.)*
+
+### M3 — S3 pull job (additive; shadow mode, no alerts)
+- `FtConfirmationS3Source`: `ListObjectsV2` under the prefix (net-new — no existing list usage), get
+  object, HeadObject `lastModified`.
+- `FtConfirmationImportJob`: `@Scheduled` + `@SchedulerLock`, `Clock`-injected, behind an enable flag
+  (`@ConditionalOnProperty`); list new objects → extract PDF (M2) → parse (M1) → `verifyAll`. Idempotent
+  via audit dedup.
+- **Failing integration test:** a PDF object in a mocked/LocalStack S3 prefix → verified outcome recorded;
+  second run → no duplicate audit/alert. Confirm the audit dedup key holds across both entry paths (push
+  + job) during the parallel run.
+
+### M4 — Parallel run + verification
+- Deploy M1–M3. FT PDFs land in S3 and the job verifies them alongside the live GAS push. Compare audit
+  outcomes for agreement over a period. No flag flip needed (already shadow mode).
+
+### M5 — Retire the push (behavior change; its own PR, delete LAST)
+1. Remove the GAS `pushFtConfirmationsToRegistry` trigger (tuleva repo, `clasp`) **first**, so nothing
+   still POSTs.
+2. Delete `POST /admin/transaction-registry/ft-confirmation` (singular) + `.../ft-confirmations` (plural)
+   + their request DTOs/tests. Keep the domain `FtConfirmation` + `verifyAll` (now job-fed). The
+   `X-Admin-Actor` on those endpoints goes away with them.
+3. Remove the GAS parser `tehingukinnitused_parse.gs` + Drive/OCR plumbing (tuleva repo) once the S3 path
+   is proven.
+
+## Testing & conventions
+- **No PII in fixtures** (CLAUDE.md): scrub sample PDFs/emails — synthetic names, opaque IDs.
+- Unit tests per field (M1); LocalStack/mocked-S3 integration test (M3) — object → verify → idempotent
+  re-run. Full suite green each commit (pre-commit hook).
+- **No migration expected.** Only needed if we add a processed-keys table or an `allocationId` column —
+  flag if so; next free migration is **V1_234** (master max is V1_233; V1_230–233 are non-registry).
+
+## Optional improvement the port unlocks
+The current `FtConfirmation` has **no `allocationId`** — dedup is attribute-based (isin/date/qty/price).
+Parsing the PDF ourselves recovers FT's stable `Allocation ID`; carrying it into the DTO would make dedup
+robust. Deferred: changing the dedup key causes a one-time re-alert at transition (like the #1764
+null-`dedup_key` note), so decide separately from the core port.
+
+## Rollback
+Until M5 the GAS push stays the live path and the S3 job is additive/shadow; disabling the job (flag off)
+reverts with no data loss (audit dedup).


### PR DESCRIPTION
## Summary
- **ADR 0001**: external/automated systems integrate with onboarding-service via S3 file-drop, never by pushing to our HTTP API. Records the decision once, with scope (human-operator commands and reads stay HTTP; human bridge uploads like EPIS are legitimate).
- **FT confirmation migration plan**: 5-milestone plan to move Flow Traders trade-confirmation ingestion off the GAS→Java HTTP push onto S3-drop + Java PDFBox parsing, reusing the existing `investment_reports_gs.gs` GAS→S3 uploader (no SES/new infra). All gating risks resolved against 10 real confirmations: clean PDF text layer (no OCR), confirmed field formats, and a fail-loud `Account`→fund alias table (`MAAKPE`→TUK75 provisional, flagged for confirmation).

Docs only — no code changes. M1 (the Java PDFBox parser) follows on a separate branch off master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RVVx5WzvD3huZ5jKpA3M5C