### PR TITLE
FT confirmation ingestion: S3-drop migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@
 /.claude/skills/devloop/scripts/package-lock.json
 /.claude/skills/devloop/scripts/.env
 
+# appscripts: Apps Script projects (Node/Jest, isolated from the Gradle build)
+/appscripts/**/node_modules/
+
 ### STS ###
 .apt_generated
 .classpath

--- a/appscripts/seb-position-uploader/src/Code.js
+++ b/appscripts/seb-position-uploader/src/Code.js
@@ -50,6 +50,23 @@ var SOURCES = {
         ignorePatterns: [
             /^T\w+\s+NAV\s+arvutamine\s+\d{8}\.csv$/i
         ]
+    },
+    FT: {
+        senders: ["flowtraders@ullink.eu"],
+        files: [
+            {
+                // ASSUMPTION (unconfirmed against a real FT email attachment name —
+                // see appscripts/seb-position-uploader/README.md / migration plan):
+                // Flow Traders names the confirmation PDF by allocation id, e.g.
+                // "MID9BlFbos-00.pdf". One-line regex change if the real name differs.
+                pattern: /^(MID\w+-\d+)\.pdf$/i,
+                s3Prefix: "ft-confirmations/",
+                s3Suffix: ".pdf",
+                binary: true,
+                contentType: "application/pdf",
+                keyFromCapture: true
+            }
+        ]
     }
 };
 
@@ -256,11 +273,11 @@ function processMessage(message, thread) {
 
         var result = getFileConfigAndDate(source, filename);
         if (result) {
-            var s3Key = result.fileConfig.s3Prefix + result.reportDate + result.fileConfig.s3Suffix;
-            var content = attachment.getDataAsString();
+            var s3Key = result.fileConfig.s3Prefix + result.keyStem + result.fileConfig.s3Suffix;
+            var content = isBinaryFileConfig(result.fileConfig) ? attachment.getBytes() : attachment.getDataAsString();
 
             try {
-                uploadToS3(S3_BUCKET, s3Key, content, "text/csv");
+                uploadToS3(S3_BUCKET, s3Key, content, resolveContentType(result.fileConfig));
                 Logger.log("SUCCESS: Uploaded " + filename + " -> s3://" + S3_BUCKET + "/" + s3Key);
                 uploadedCount++;
             } catch (e) {
@@ -289,14 +306,26 @@ function getSourceForSender(sender) {
 
 function getFileConfigAndDate(source, filename) {
     for (var i = 0; i < source.files.length; i++) {
-        var match = filename.match(source.files[i].pattern);
+        var fileConfig = source.files[i];
+        var match = filename.match(fileConfig.pattern);
         if (match && match[1]) {
-            var ymd = match[1];
-            var reportDate = ymd.substring(0, 4) + "-" + ymd.substring(4, 6) + "-" + ymd.substring(6, 8);
-            return { fileConfig: source.files[i], reportDate: reportDate };
+            var keyStem = fileConfig.keyFromCapture ? match[1] : formatDateFromCapture(match[1]);
+            return { fileConfig: fileConfig, keyStem: keyStem };
         }
     }
     return null;
+}
+
+function formatDateFromCapture(ymd) {
+    return ymd.substring(0, 4) + "-" + ymd.substring(4, 6) + "-" + ymd.substring(6, 8);
+}
+
+function isBinaryFileConfig(fileConfig) {
+    return !!fileConfig.binary;
+}
+
+function resolveContentType(fileConfig) {
+    return fileConfig.contentType || "text/csv";
 }
 
 function incrementUploadLabel(thread) {
@@ -488,7 +517,7 @@ function dryRunThread(thread) {
             var filename = attachments[k].getName();
             var result = getFileConfigAndDate(source, filename);
             if (result) {
-                var s3Key = result.fileConfig.s3Prefix + result.reportDate + result.fileConfig.s3Suffix;
+                var s3Key = result.fileConfig.s3Prefix + result.keyStem + result.fileConfig.s3Suffix;
                 Logger.log("    -> Would UPLOAD: " + filename + " to s3://" + S3_BUCKET + "/" + s3Key);
             } else {
                 Logger.log("    -> Would SKIP: Unknown file pattern: " + filename);
@@ -529,5 +558,7 @@ if (typeof module !== "undefined" && module.exports) {
         dedupKeyFor,
         formatUnmatchedAttachmentAlert,
         isIgnoredFilename,
+        isBinaryFileConfig,
+        resolveContentType,
     };
 }

--- a/appscripts/seb-position-uploader/src/Code.js
+++ b/appscripts/seb-position-uploader/src/Code.js
@@ -212,6 +212,10 @@ function messageHasMatchingAttachments(message) {
         .map(function (a) { return a.getName(); });
     var partition = partitionFilenamesByMatch(source, filenames);
 
+    Logger.log("Attachments from known sender: sender=" + sender +
+        ", matched=[" + partition.matched.join(",") +
+        "], unmatched=[" + partition.unmatched.join(",") + "]");
+
     if (shouldAlertOnUnmatched(partition.matched.length, partition.unmatched.length)) {
         notifyOnceForUnmatchedAttachments(message.getId(), sender, partition.unmatched, partition.matched.length);
     }

--- a/appscripts/seb-position-uploader/test/Code.test.js
+++ b/appscripts/seb-position-uploader/test/Code.test.js
@@ -12,6 +12,8 @@ const {
   dedupKeyFor,
   formatUnmatchedAttachmentAlert,
   isIgnoredFilename,
+  isBinaryFileConfig,
+  resolveContentType,
 } = require("../src/Code");
 
 describe("getSourceForSender", () => {
@@ -25,6 +27,11 @@ describe("getSourceForSender", () => {
   test("matches each configured Swedbank sender", () => {
     SOURCES.SWEDBANK.senders.forEach((s) => {
       expect(getSourceForSender("Some Person <" + s + ">")).toBe(SOURCES.SWEDBANK);
+    });
+  });
+  test("matches each configured FT sender", () => {
+    SOURCES.FT.senders.forEach((s) => {
+      expect(getSourceForSender("Some Person <" + s + ">")).toBe(SOURCES.FT);
     });
   });
   test("rejects an arbitrary @tuleva.ee address that is not on the allowlist", () => {
@@ -50,7 +57,7 @@ describe("getFileConfigAndDate — SEB filenames (positive)", () => {
     const result = getFileConfigAndDate(SOURCES.SEB, filename);
     expect(result).not.toBeNull();
     expect(result.fileConfig.s3Suffix).toBe(expectedSuffix);
-    expect(result.reportDate).toBe(expectedDate);
+    expect(result.keyStem).toBe(expectedDate);
   });
 });
 
@@ -73,10 +80,65 @@ describe("getFileConfigAndDate — Swedbank filenames", () => {
     const result = getFileConfigAndDate(SOURCES.SWEDBANK, "TULEVA_PORTFOLIO_20260409.csv");
     expect(result).not.toBeNull();
     expect(result.fileConfig.s3Suffix).toBe(".csv");
-    expect(result.reportDate).toBe("2026-04-09");
+    expect(result.keyStem).toBe("2026-04-09");
   });
   test("rejects SEB filename", () => {
     expect(getFileConfigAndDate(SOURCES.SWEDBANK, "TULEVA_pos_raport_20260409.csv")).toBeNull();
+  });
+});
+
+describe("getFileConfigAndDate — FT filenames", () => {
+  test("matches an FT confirmation PDF, keyStem is the raw allocation id (not a date)", () => {
+    const result = getFileConfigAndDate(SOURCES.FT, "MID9BlFbos-00.pdf");
+    expect(result).not.toBeNull();
+    expect(result.keyStem).toBe("MID9BlFbos-00");
+    expect(result.fileConfig.s3Prefix).toBe("ft-confirmations/");
+    expect(result.fileConfig.s3Suffix).toBe(".pdf");
+  });
+  test("rejects a non-FT / garbage filename", () => {
+    expect(getFileConfigAndDate(SOURCES.FT, "random.pdf")).toBeNull();
+    expect(getFileConfigAndDate(SOURCES.FT, "TULEVA_pos_raport_20260409.csv")).toBeNull();
+  });
+  test("FT file config carries binary:true and contentType:application/pdf", () => {
+    const result = getFileConfigAndDate(SOURCES.FT, "MID9BlFbos-00.pdf");
+    expect(result.fileConfig.binary).toBe(true);
+    expect(result.fileConfig.contentType).toBe("application/pdf");
+  });
+});
+
+describe("getFileConfigAndDate — S3 key regression (CSV feeds stay date-based)", () => {
+  test("SEB filename still produces its exact date-based key", () => {
+    const result = getFileConfigAndDate(SOURCES.SEB, "TULEVA_pos_raport_20260409.csv");
+    const s3Key = result.fileConfig.s3Prefix + result.keyStem + result.fileConfig.s3Suffix;
+    expect(s3Key).toBe("seb/2026-04-09_positions.csv");
+  });
+  test("Swedbank filename still produces its exact date-based key", () => {
+    const result = getFileConfigAndDate(SOURCES.SWEDBANK, "TULEVA_PORTFOLIO_20260409.csv");
+    const s3Key = result.fileConfig.s3Prefix + result.keyStem + result.fileConfig.s3Suffix;
+    expect(s3Key).toBe("portfolio/2026-04-09.csv");
+  });
+  test("FT filename produces the allocation-id-based key", () => {
+    const result = getFileConfigAndDate(SOURCES.FT, "MID9BlFbos-00.pdf");
+    const s3Key = result.fileConfig.s3Prefix + result.keyStem + result.fileConfig.s3Suffix;
+    expect(s3Key).toBe("ft-confirmations/MID9BlFbos-00.pdf");
+  });
+});
+
+describe("isBinaryFileConfig / resolveContentType — attachment content selection", () => {
+  test("FT config reads as binary bytes with a PDF content-type", () => {
+    const ftFileConfig = getFileConfigAndDate(SOURCES.FT, "MID9BlFbos-00.pdf").fileConfig;
+    expect(isBinaryFileConfig(ftFileConfig)).toBe(true);
+    expect(resolveContentType(ftFileConfig)).toBe("application/pdf");
+  });
+  test("SEB config reads as text with the default text/csv content-type (binary/contentType omitted)", () => {
+    const sebFileConfig = getFileConfigAndDate(SOURCES.SEB, "TULEVA_pos_raport_20260409.csv").fileConfig;
+    expect(isBinaryFileConfig(sebFileConfig)).toBe(false);
+    expect(resolveContentType(sebFileConfig)).toBe("text/csv");
+  });
+  test("Swedbank config reads as text with the default text/csv content-type (binary/contentType omitted)", () => {
+    const swedbankFileConfig = getFileConfigAndDate(SOURCES.SWEDBANK, "TULEVA_PORTFOLIO_20260409.csv").fileConfig;
+    expect(isBinaryFileConfig(swedbankFileConfig)).toBe(false);
+    expect(resolveContentType(swedbankFileConfig)).toBe("text/csv");
   });
 });
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -164,6 +164,9 @@ dependencies {
     implementation("org.apache.commons:commons-csv:1.14.1")
     implementation("org.apache.poi:poi-ooxml:5.5.1")
     implementation("at.datenwort.openhtmltopdf:openhtmltopdf-pdfbox:1.1.4")
+    // Pinned to match the PDFBox version openhtmltopdf-pdfbox/digidoc4j already resolve to on
+    // runtimeClasspath (verified via `./gradlew dependencies`) — do not let this drift below it.
+    implementation("org.apache.pdfbox:pdfbox:3.0.4")
 
     implementation("net.javacrumbs.shedlock:shedlock-spring:7.7.0")
     implementation("net.javacrumbs.shedlock:shedlock-provider-jdbc-template:7.7.0")

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/FtAccountToFundResolver.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/FtAccountToFundResolver.java
@@ -1,0 +1,31 @@
+package ee.tuleva.onboarding.investment.transaction.ingest;
+
+import static ee.tuleva.onboarding.fund.TulevaFund.TKF100;
+import static ee.tuleva.onboarding.fund.TulevaFund.TUK75;
+import static ee.tuleva.onboarding.fund.TulevaFund.TUV100;
+
+import ee.tuleva.onboarding.fund.TulevaFund;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import org.jspecify.annotations.NullMarked;
+import org.springframework.stereotype.Component;
+
+@NullMarked
+@Component
+class FtAccountToFundResolver {
+
+  private static final Map<String, TulevaFund> BY_NORMALIZED_ACCOUNT =
+      Map.of(
+          normalize("Tuleva Additional Investment Fund"), TKF100,
+          normalize("TULEVA III SAMBA PENSIONIFOND"), TUV100,
+          normalize("MAAKPE"), TUK75);
+
+  Optional<TulevaFund> resolve(String account) {
+    return Optional.ofNullable(BY_NORMALIZED_ACCOUNT.get(normalize(account)));
+  }
+
+  private static String normalize(String account) {
+    return account.trim().toLowerCase(Locale.ROOT);
+  }
+}

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/FtAccountToFundResolver.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/FtAccountToFundResolver.java
@@ -19,6 +19,9 @@ class FtAccountToFundResolver {
       Map.of(
           normalize("Tuleva Additional Investment Fund"), TKF100,
           normalize("TULEVA III SAMBA PENSIONIFOND"), TUV100,
+          // MAAKPE->TUK75 is a provisional inference (ISIN IE000I9HGDZ3 is a TUK75 holding),
+          // not yet confirmed against the FT account setup; the M2 history backfill self-confirms
+          // it.
           normalize("MAAKPE"), TUK75);
 
   Optional<TulevaFund> resolve(String account) {

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationImportJob.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationImportJob.java
@@ -12,7 +12,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.jspecify.annotations.NullMarked;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Profile;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -21,9 +20,6 @@ import org.springframework.stereotype.Component;
 @Slf4j
 @Component
 @Profile({"production", "staging"})
-@ConditionalOnProperty(
-    name = "transaction-registry.ft-confirmation.import.enabled",
-    havingValue = "true")
 @RequiredArgsConstructor
 class FtConfirmationImportJob {
 

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationImportJob.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationImportJob.java
@@ -1,0 +1,92 @@
+package ee.tuleva.onboarding.investment.transaction.ingest;
+
+import static ee.tuleva.onboarding.investment.JobRunSchedule.IMPORT_BUSINESS_HOURS;
+import static ee.tuleva.onboarding.investment.JobRunSchedule.TIMEZONE;
+
+import ee.tuleva.onboarding.investment.transaction.FtConfirmation;
+import ee.tuleva.onboarding.investment.transaction.FtConfirmationBatchResult;
+import java.time.Clock;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.jspecify.annotations.NullMarked;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Profile;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@NullMarked
+@Slf4j
+@Component
+@Profile({"production", "staging"})
+@ConditionalOnProperty(
+    name = "transaction-registry.ft-confirmation.import.enabled",
+    havingValue = "true")
+@RequiredArgsConstructor
+class FtConfirmationImportJob {
+
+  static final String JOB_ACTOR = "ft-confirmation-import-job";
+
+  private final FtConfirmationS3Source s3Source;
+  private final FtConfirmationPdfParser parser;
+  private final FtConfirmationVerificationService verificationService;
+  private final Clock clock;
+
+  @Scheduled(cron = IMPORT_BUSINESS_HOURS, zone = TIMEZONE)
+  @SchedulerLock(name = "FtConfirmationImportJob", lockAtMostFor = "10m", lockAtLeastFor = "1m")
+  public void run() {
+    log.info("Starting FT confirmation import: now={}", clock.instant());
+    List<String> keys = s3Source.list();
+    if (keys.isEmpty()) {
+      log.info("No FT confirmation PDFs found");
+      return;
+    }
+
+    List<FtConfirmation> confirmations =
+        keys.stream().map(this::parse).flatMap(Optional::stream).toList();
+    if (confirmations.isEmpty()) {
+      log.info("No FT confirmation PDFs could be parsed: objectCount={}", keys.size());
+      return;
+    }
+
+    verifyAll(confirmations, keys.size());
+  }
+
+  private void verifyAll(List<FtConfirmation> confirmations, int objectCount) {
+    try {
+      List<FtConfirmationBatchResult> results =
+          verificationService.verifyAll(confirmations, JOB_ACTOR);
+      log.info(
+          "FT confirmation import completed: objectCount={}, parsedCount={}, verifiedCount={}",
+          objectCount,
+          confirmations.size(),
+          results.size());
+    } catch (RuntimeException e) {
+      log.error(
+          "FT confirmation verification failed: parsedCount={}, error={}",
+          confirmations.size(),
+          e.getMessage(),
+          e);
+    }
+  }
+
+  private Optional<FtConfirmation> parse(String key) {
+    Optional<byte[]> bytes = s3Source.get(key);
+    if (bytes.isEmpty()) {
+      log.warn("FT confirmation PDF disappeared before fetch: key={}", key);
+      return Optional.empty();
+    }
+    try {
+      return Optional.of(parser.parse(bytes.get()));
+    } catch (RuntimeException e) {
+      log.error(
+          "FT confirmation PDF failed to parse, skipping: key={}, error={}",
+          key,
+          e.getMessage(),
+          e);
+      return Optional.empty();
+    }
+  }
+}

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationImportJob.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationImportJob.java
@@ -75,7 +75,14 @@ class FtConfirmationImportJob {
       return Optional.empty();
     }
     try {
-      return Optional.of(parser.parse(bytes.get()));
+      FtConfirmation confirmation = parser.parse(bytes.get());
+      log.info(
+          "Parsed FT confirmation: key={}, fund={}, isin={}, type={}",
+          key,
+          confirmation.fund(),
+          confirmation.isin(),
+          confirmation.type());
+      return Optional.of(confirmation);
     } catch (RuntimeException e) {
       log.error(
           "FT confirmation PDF failed to parse, skipping: key={}, error={}",

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationPdfParseException.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationPdfParseException.java
@@ -1,0 +1,15 @@
+package ee.tuleva.onboarding.investment.transaction.ingest;
+
+import org.jspecify.annotations.NullMarked;
+
+@NullMarked
+class FtConfirmationPdfParseException extends RuntimeException {
+
+  FtConfirmationPdfParseException(String message) {
+    super(message);
+  }
+
+  FtConfirmationPdfParseException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationPdfParser.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationPdfParser.java
@@ -1,0 +1,154 @@
+package ee.tuleva.onboarding.investment.transaction.ingest;
+
+import static ee.tuleva.onboarding.investment.transaction.FtConfirmationType.CANCELLATION;
+import static ee.tuleva.onboarding.investment.transaction.FtConfirmationType.NORMAL;
+
+import ee.tuleva.onboarding.fund.TulevaFund;
+import ee.tuleva.onboarding.investment.transaction.FtConfirmation;
+import ee.tuleva.onboarding.investment.transaction.FtConfirmationType;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.Optional;
+import java.util.regex.Pattern;
+import lombok.RequiredArgsConstructor;
+import org.apache.pdfbox.Loader;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.text.PDFTextStripper;
+import org.jspecify.annotations.NullMarked;
+import org.springframework.stereotype.Component;
+
+@NullMarked
+@Component
+@RequiredArgsConstructor
+class FtConfirmationPdfParser {
+
+  private static final Pattern LINE_SEPARATOR = Pattern.compile("\\r\\n|\\r|\\n");
+  private static final DateTimeFormatter TRADE_DATE_FORMAT =
+      DateTimeFormatter.ofPattern("yyyyMMdd");
+  private static final Pattern TRAILING_EUR = Pattern.compile("(?i)\\s*EUR\\s*$");
+  private static final Pattern CANCELLATION_PHRASE = Pattern.compile("(?i)trade cancellation");
+
+  private final FtAccountToFundResolver accountToFundResolver;
+
+  FtConfirmation parse(byte[] pdfBytes) {
+    String text = extractText(pdfBytes);
+
+    String allocationId = extractRequired(text, "Allocation ID");
+    String account = extractRequired(text, "Account", allocationId);
+    TulevaFund fund =
+        accountToFundResolver
+            .resolve(account)
+            .orElseThrow(
+                () ->
+                    new FtConfirmationPdfParseException(
+                        "FT confirmation PDF has unrecognized Account: account="
+                            + account
+                            + ", allocationId="
+                            + allocationId));
+    String isin = extractRequired(text, "ISIN", allocationId);
+    LocalDate tradeDate = parseTradeDate(extractRequired(text, "Trade Date", allocationId));
+    BigDecimal quantity = parseQuantity(extractRequired(text, "Quantity", allocationId));
+    BigDecimal grossPrice = parseGrossPrice(extractRequired(text, "Gross Price", allocationId));
+    FtConfirmationType type = isCancellation(text) ? CANCELLATION : NORMAL;
+
+    return new FtConfirmation(fund, isin, tradeDate, quantity, grossPrice, type, account);
+  }
+
+  private static String extractText(byte[] pdfBytes) {
+    try (PDDocument document = Loader.loadPDF(pdfBytes)) {
+      return new PDFTextStripper().getText(document);
+    } catch (IOException e) {
+      throw new FtConfirmationPdfParseException("FT confirmation PDF could not be read", e);
+    }
+  }
+
+  private static String extractRequired(String text, String label) {
+    return extractField(text, label)
+        .orElseThrow(
+            () ->
+                new FtConfirmationPdfParseException(
+                    "FT confirmation PDF missing required field: field=" + label));
+  }
+
+  private static String extractRequired(String text, String label, String allocationId) {
+    return extractField(text, label)
+        .orElseThrow(
+            () ->
+                new FtConfirmationPdfParseException(
+                    "FT confirmation PDF missing required field: field="
+                        + label
+                        + ", allocationId="
+                        + allocationId));
+  }
+
+  static LocalDate parseTradeDate(String rawTradeDate) {
+    try {
+      return LocalDate.parse(rawTradeDate, TRADE_DATE_FORMAT);
+    } catch (DateTimeParseException e) {
+      throw new FtConfirmationPdfParseException(
+          "FT confirmation PDF has malformed Trade Date: value=" + rawTradeDate, e);
+    }
+  }
+
+  static BigDecimal parseQuantity(String rawQuantity) {
+    String cleaned = rawQuantity.replace(",", "");
+    try {
+      return new BigDecimal(cleaned);
+    } catch (NumberFormatException e) {
+      throw new FtConfirmationPdfParseException(
+          "FT confirmation PDF has malformed Quantity: value=" + rawQuantity, e);
+    }
+  }
+
+  static boolean isCancellation(String text) {
+    return CANCELLATION_PHRASE.matcher(text).find();
+  }
+
+  static BigDecimal parseGrossPrice(String rawGrossPrice) {
+    String cleaned = TRAILING_EUR.matcher(rawGrossPrice).replaceFirst("").trim();
+    try {
+      return new BigDecimal(cleaned);
+    } catch (NumberFormatException e) {
+      throw new FtConfirmationPdfParseException(
+          "FT confirmation PDF has malformed Gross Price: value=" + rawGrossPrice, e);
+    }
+  }
+
+  static Optional<String> extractField(String text, String label) {
+    String[] lines = LINE_SEPARATOR.split(text, -1);
+    Pattern sameLine =
+        Pattern.compile(Pattern.quote(label) + "\\s*:\\s*(.+)", Pattern.CASE_INSENSITIVE);
+    Pattern labelOnly = Pattern.compile(Pattern.quote(label) + "\\s*:?", Pattern.CASE_INSENSITIVE);
+    for (int i = 0; i < lines.length; i++) {
+      String line = lines[i].trim();
+      if (line.isEmpty()) {
+        continue;
+      }
+      var sameLineMatch = sameLine.matcher(line);
+      if (sameLineMatch.matches()) {
+        String value = sameLineMatch.group(1).trim();
+        if (!value.isEmpty()) {
+          return Optional.of(value);
+        }
+        return nextNonBlankLine(lines, i + 1);
+      }
+      if (labelOnly.matcher(line).matches()) {
+        return nextNonBlankLine(lines, i + 1);
+      }
+    }
+    return Optional.empty();
+  }
+
+  private static Optional<String> nextNonBlankLine(String[] lines, int fromIndex) {
+    for (int i = fromIndex; i < lines.length; i++) {
+      String line = lines[i].trim();
+      if (!line.isEmpty()) {
+        return Optional.of(line);
+      }
+    }
+    return Optional.empty();
+  }
+}

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationS3Source.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationS3Source.java
@@ -1,0 +1,84 @@
+package ee.tuleva.onboarding.investment.transaction.ingest;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NullMarked;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+import software.amazon.awssdk.services.s3.model.S3Object;
+
+@NullMarked
+@Slf4j
+@Component
+@RequiredArgsConstructor
+class FtConfirmationS3Source {
+
+  private static final String BUCKET = "tuleva-investment-reports";
+  private static final String PREFIX = "ft-confirmations/";
+
+  private final S3Client s3Client;
+
+  List<String> list() {
+    ListObjectsV2Request request =
+        ListObjectsV2Request.builder().bucket(BUCKET).prefix(PREFIX).build();
+    return s3Client.listObjectsV2(request).contents().stream()
+        .map(S3Object::key)
+        .filter(key -> !key.equals(PREFIX))
+        .toList();
+  }
+
+  Optional<byte[]> get(String key) {
+    try {
+      log.info("Fetching FT confirmation PDF: bucket={}, key={}", BUCKET, key);
+      GetObjectRequest request = GetObjectRequest.builder().bucket(BUCKET).key(key).build();
+      ResponseInputStream<GetObjectResponse> response = s3Client.getObject(request);
+      return Optional.of(response.readAllBytes());
+    } catch (NoSuchKeyException e) {
+      log.info("FT confirmation PDF not found: bucket={}, key={}", BUCKET, key);
+      return Optional.empty();
+    } catch (S3Exception e) {
+      if (e.statusCode() == 404) {
+        log.info("FT confirmation PDF not found: bucket={}, key={}", BUCKET, key);
+        return Optional.empty();
+      } else if (e.statusCode() == 403) {
+        log.error("Access denied to FT confirmation PDF: bucket={}, key={}", BUCKET, key, e);
+        return Optional.empty();
+      }
+      throw new RuntimeException(
+          "S3 error fetching FT confirmation PDF: bucket=" + BUCKET + ", key=" + key, e);
+    } catch (IOException e) {
+      throw new RuntimeException(
+          "Failed to read FT confirmation PDF bytes: bucket=" + BUCKET + ", key=" + key, e);
+    }
+  }
+
+  Optional<Instant> lastModified(String key) {
+    try {
+      HeadObjectRequest request = HeadObjectRequest.builder().bucket(BUCKET).key(key).build();
+      return Optional.ofNullable(s3Client.headObject(request).lastModified());
+    } catch (NoSuchKeyException e) {
+      return Optional.empty();
+    } catch (S3Exception e) {
+      if (e.statusCode() == 404 || e.statusCode() == 403) {
+        return Optional.empty();
+      }
+      throw new RuntimeException(
+          "S3 error checking last modified for FT confirmation PDF: bucket="
+              + BUCKET
+              + ", key="
+              + key,
+          e);
+    }
+  }
+}

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationS3Source.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationS3Source.java
@@ -32,10 +32,18 @@ class FtConfirmationS3Source {
   List<String> list() {
     ListObjectsV2Request request =
         ListObjectsV2Request.builder().bucket(BUCKET).prefix(PREFIX).build();
-    return s3Client.listObjectsV2(request).contents().stream()
-        .map(S3Object::key)
-        .filter(key -> !key.equals(PREFIX))
-        .toList();
+    List<String> keys =
+        s3Client.listObjectsV2(request).contents().stream()
+            .map(S3Object::key)
+            .filter(key -> !key.equals(PREFIX))
+            .toList();
+    log.info(
+        "Listed FT confirmation objects: bucket={}, prefix={}, count={}, keys={}",
+        BUCKET,
+        PREFIX,
+        keys.size(),
+        keys);
+    return keys;
   }
 
   Optional<byte[]> get(String key) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -223,11 +223,6 @@ transaction-registry:
     # GAS remains the alerting authority. Flip to true at cutover (after retiring the GAS
     # check) to start sending the Slack digest of ERROR/AMBIGUOUS/ORPHAN rows.
     registry-authoritative: ${TRANSACTION_REGISTRY_FT_CONFIRMATION_REGISTRY_AUTHORITATIVE:false}
-    import:
-      # Whether FtConfirmationImportJob pulls confirmation PDFs from S3 (ft-confirmations/)
-      # and runs them through the verification pipeline. Off by default: while false, GAS
-      # keeps pushing confirmations via the legacy endpoints and this job is inert.
-      enabled: ${TRANSACTION_REGISTRY_FT_CONFIRMATION_IMPORT_ENABLED:false}
 
 payment-provider:
   url: https://sandbox-stargate.montonio.com/api

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -223,6 +223,11 @@ transaction-registry:
     # GAS remains the alerting authority. Flip to true at cutover (after retiring the GAS
     # check) to start sending the Slack digest of ERROR/AMBIGUOUS/ORPHAN rows.
     registry-authoritative: ${TRANSACTION_REGISTRY_FT_CONFIRMATION_REGISTRY_AUTHORITATIVE:false}
+    import:
+      # Whether FtConfirmationImportJob pulls confirmation PDFs from S3 (ft-confirmations/)
+      # and runs them through the verification pipeline. Off by default: while false, GAS
+      # keeps pushing confirmations via the legacy endpoints and this job is inert.
+      enabled: ${TRANSACTION_REGISTRY_FT_CONFIRMATION_IMPORT_ENABLED:false}
 
 payment-provider:
   url: https://sandbox-stargate.montonio.com/api

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/FtAccountToFundResolverTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/FtAccountToFundResolverTest.java
@@ -1,0 +1,50 @@
+package ee.tuleva.onboarding.investment.transaction.ingest;
+
+import static ee.tuleva.onboarding.fund.TulevaFund.TKF100;
+import static ee.tuleva.onboarding.fund.TulevaFund.TUK75;
+import static ee.tuleva.onboarding.fund.TulevaFund.TUV100;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ee.tuleva.onboarding.fund.TulevaFund;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class FtAccountToFundResolverTest {
+
+  private final FtAccountToFundResolver resolver = new FtAccountToFundResolver();
+
+  @Test
+  void resolvesTkf100Alias() {
+    Optional<TulevaFund> result = resolver.resolve("Tuleva Additional Investment Fund");
+
+    assertThat(result).contains(TKF100);
+  }
+
+  @Test
+  void resolvesTuv100Alias() {
+    Optional<TulevaFund> result = resolver.resolve("TULEVA III SAMBA PENSIONIFOND");
+
+    assertThat(result).contains(TUV100);
+  }
+
+  @Test
+  void resolvesTuk75Alias() {
+    Optional<TulevaFund> result = resolver.resolve("MAAKPE");
+
+    assertThat(result).contains(TUK75);
+  }
+
+  @Test
+  void resolvesAliasCaseInsensitiveAndTrimmed() {
+    Optional<TulevaFund> result = resolver.resolve("  maakpe  ");
+
+    assertThat(result).contains(TUK75);
+  }
+
+  @Test
+  void returnsEmptyForUnrecognizedAccount() {
+    Optional<TulevaFund> result = resolver.resolve("Some Unknown Fund");
+
+    assertThat(result).isEmpty();
+  }
+}

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationImportJobIT.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationImportJobIT.java
@@ -1,0 +1,143 @@
+package ee.tuleva.onboarding.investment.transaction.ingest;
+
+import static ee.tuleva.onboarding.fund.TulevaFund.TKF100;
+import static ee.tuleva.onboarding.investment.transaction.ingest.FtConfirmationAuditRecorder.FT_CONFIRMATION_VERIFIED;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import ee.tuleva.onboarding.investment.transaction.TransactionAuditEvent;
+import ee.tuleva.onboarding.investment.transaction.TransactionAuditEventRepository;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.pdmodel.PDPageContentStream;
+import org.apache.pdfbox.pdmodel.common.PDRectangle;
+import org.apache.pdfbox.pdmodel.font.PDType1Font;
+import org.apache.pdfbox.pdmodel.font.Standard14Fonts;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.annotation.Transactional;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.http.AbortableInputStream;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
+import software.amazon.awssdk.services.s3.model.S3Object;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class FtConfirmationImportJobIT {
+
+  private static final Clock FIXED_CLOCK =
+      Clock.fixed(Instant.parse("2026-06-09T08:00:00Z"), ZoneOffset.UTC);
+  private static final String KEY = "ft-confirmations/allocation-1.pdf";
+  private static final String DEDUP_KEY =
+      TKF100.name() + "|IE00BFG1TM61|2026-01-15|2500|12.3456|NORMAL";
+
+  @MockitoBean private S3Client s3Client;
+
+  @Autowired private FtConfirmationPdfParser parser;
+  @Autowired private FtConfirmationVerificationService verificationService;
+  @Autowired private TransactionAuditEventRepository auditEventRepository;
+
+  private FtConfirmationImportJob job;
+
+  @BeforeEach
+  void setUp() {
+    FtConfirmationS3Source s3Source = new FtConfirmationS3Source(s3Client);
+    job = new FtConfirmationImportJob(s3Source, parser, verificationService, FIXED_CLOCK);
+  }
+
+  @Test
+  void run_recordsVerificationOutcomeForNewPdf_andSkipsDuplicateOnSecondRun() {
+    stubOneConfirmationPdfUnderPrefix();
+
+    job.run();
+
+    List<TransactionAuditEvent> events =
+        auditEventRepository.findByEventTypeAndDedupKey(FT_CONFIRMATION_VERIFIED, DEDUP_KEY);
+    assertThat(events).hasSize(1);
+
+    job.run();
+
+    List<TransactionAuditEvent> eventsAfterSecondRun =
+        auditEventRepository.findByEventTypeAndDedupKey(FT_CONFIRMATION_VERIFIED, DEDUP_KEY);
+    assertThat(eventsAfterSecondRun).hasSize(1);
+  }
+
+  private void stubOneConfirmationPdfUnderPrefix() {
+    given(s3Client.listObjectsV2(any(ListObjectsV2Request.class)))
+        .willReturn(
+            ListObjectsV2Response.builder()
+                .contents(S3Object.builder().key(KEY).build())
+                .isTruncated(false)
+                .build());
+
+    byte[] pdf = confirmationPdf();
+    var response =
+        new ResponseInputStream<>(
+            GetObjectResponse.builder().build(),
+            AbortableInputStream.create(new ByteArrayInputStream(pdf)));
+    given(s3Client.getObject(any(GetObjectRequest.class))).willReturn(response);
+  }
+
+  private static byte[] confirmationPdf() {
+    List<String> lines =
+        List.of(
+            "Trade Confirmation",
+            "Dear Sir/Madam,",
+            "We confirm the following trade .",
+            "Allocation ID: TEST0001-00",
+            "Counterparty: TULEVA FONDID AS",
+            "Account: Tuleva Additional Investment Fund",
+            "Trade Date Time: 20260115-09:32:44 UTC",
+            "Trade Date: 20260115",
+            "Settlement Date: 20260115",
+            "Security Description: SYNTHETIC TEST SECURITY",
+            "Bloomberg Ticker: TEST GY Equity",
+            "ISIN: IE00BFG1TM61",
+            "Your Direction: Buy",
+            "Quantity: 2,500",
+            "Gross Price: 12.345600 EUR",
+            "Net Price: 12.345600 EUR",
+            "Settlement Currency: EUR");
+    return renderPdf(lines);
+  }
+
+  private static byte[] renderPdf(List<String> lines) {
+    try (PDDocument doc = new PDDocument()) {
+      PDPage page = new PDPage(PDRectangle.A4);
+      doc.addPage(page);
+      PDType1Font font = new PDType1Font(Standard14Fonts.FontName.HELVETICA);
+      try (PDPageContentStream cs = new PDPageContentStream(doc, page)) {
+        cs.beginText();
+        cs.setFont(font, 10);
+        cs.newLineAtOffset(50, 750);
+        for (String line : lines) {
+          cs.showText(line);
+          cs.newLineAtOffset(0, -14);
+        }
+        cs.endText();
+      }
+      ByteArrayOutputStream out = new ByteArrayOutputStream();
+      doc.save(out);
+      return out.toByteArray();
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationImportJobScheduledTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationImportJobScheduledTest.java
@@ -4,12 +4,10 @@ import ee.tuleva.onboarding.config.ScheduledTest;
 import java.time.Clock;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @ScheduledTest(FtConfirmationImportJob.class)
 @ActiveProfiles("production")
-@TestPropertySource(properties = "transaction-registry.ft-confirmation.import.enabled=true")
 class FtConfirmationImportJobScheduledTest {
 
   @MockitoBean FtConfirmationS3Source s3Source;

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationImportJobScheduledTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationImportJobScheduledTest.java
@@ -1,0 +1,22 @@
+package ee.tuleva.onboarding.investment.transaction.ingest;
+
+import ee.tuleva.onboarding.config.ScheduledTest;
+import java.time.Clock;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+@ScheduledTest(FtConfirmationImportJob.class)
+@ActiveProfiles("production")
+@TestPropertySource(properties = "transaction-registry.ft-confirmation.import.enabled=true")
+class FtConfirmationImportJobScheduledTest {
+
+  @MockitoBean FtConfirmationS3Source s3Source;
+  @MockitoBean FtConfirmationPdfParser parser;
+  @MockitoBean FtConfirmationVerificationService verificationService;
+  @MockitoBean Clock clock;
+
+  @Test
+  void cronExpressionsResolve() {}
+}

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationImportJobTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationImportJobTest.java
@@ -1,0 +1,139 @@
+package ee.tuleva.onboarding.investment.transaction.ingest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import ee.tuleva.onboarding.fund.TulevaFund;
+import ee.tuleva.onboarding.investment.transaction.FtConfirmation;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class FtConfirmationImportJobTest {
+
+  private static final Clock FIXED_CLOCK =
+      Clock.fixed(Instant.parse("2026-06-09T08:00:00Z"), ZoneOffset.UTC);
+  private static final String KEY_1 = "ft-confirmations/a.pdf";
+  private static final String KEY_2 = "ft-confirmations/b.pdf";
+
+  @Mock private FtConfirmationS3Source s3Source;
+  @Mock private FtConfirmationPdfParser parser;
+  @Mock private FtConfirmationVerificationService verificationService;
+
+  private FtConfirmationImportJob job;
+
+  @BeforeEach
+  void setUp() {
+    job = new FtConfirmationImportJob(s3Source, parser, verificationService, FIXED_CLOCK);
+  }
+
+  @Test
+  void run_parsesAndVerifiesEachListedConfirmation() {
+    byte[] bytes1 = "pdf-1".getBytes();
+    byte[] bytes2 = "pdf-2".getBytes();
+    FtConfirmation confirmation1 = confirmation("IE00BFG1TM61");
+    FtConfirmation confirmation2 = confirmation("IE000I9HGDZ3");
+    given(s3Source.list()).willReturn(List.of(KEY_1, KEY_2));
+    given(s3Source.get(KEY_1)).willReturn(Optional.of(bytes1));
+    given(s3Source.get(KEY_2)).willReturn(Optional.of(bytes2));
+    given(parser.parse(bytes1)).willReturn(confirmation1);
+    given(parser.parse(bytes2)).willReturn(confirmation2);
+    given(verificationService.verifyAll(any(), any())).willReturn(List.of());
+
+    job.run();
+
+    verify(verificationService)
+        .verifyAll(List.of(confirmation1, confirmation2), FtConfirmationImportJob.JOB_ACTOR);
+  }
+
+  @Test
+  void run_noNewPdfs_doesNothing() {
+    given(s3Source.list()).willReturn(List.of());
+
+    job.run();
+
+    verifyNoInteractions(parser, verificationService);
+  }
+
+  @Test
+  void run_objectDisappearedBeforeFetch_skipsItAndVerifiesTheRest() {
+    byte[] bytes2 = "pdf-2".getBytes();
+    FtConfirmation confirmation2 = confirmation("IE000I9HGDZ3");
+    given(s3Source.list()).willReturn(List.of(KEY_1, KEY_2));
+    given(s3Source.get(KEY_1)).willReturn(Optional.empty());
+    given(s3Source.get(KEY_2)).willReturn(Optional.of(bytes2));
+    given(parser.parse(bytes2)).willReturn(confirmation2);
+    given(verificationService.verifyAll(any(), any())).willReturn(List.of());
+
+    job.run();
+
+    verify(verificationService)
+        .verifyAll(List.of(confirmation2), FtConfirmationImportJob.JOB_ACTOR);
+  }
+
+  @Test
+  void run_unparsablePdf_skipsItAndVerifiesTheRest() {
+    byte[] bytes1 = "bad-pdf".getBytes();
+    byte[] bytes2 = "pdf-2".getBytes();
+    FtConfirmation confirmation2 = confirmation("IE000I9HGDZ3");
+    given(s3Source.list()).willReturn(List.of(KEY_1, KEY_2));
+    given(s3Source.get(KEY_1)).willReturn(Optional.of(bytes1));
+    given(s3Source.get(KEY_2)).willReturn(Optional.of(bytes2));
+    given(parser.parse(bytes1)).willThrow(new FtConfirmationPdfParseException("malformed"));
+    given(parser.parse(bytes2)).willReturn(confirmation2);
+    given(verificationService.verifyAll(any(), any())).willReturn(List.of());
+
+    job.run();
+
+    verify(verificationService)
+        .verifyAll(List.of(confirmation2), FtConfirmationImportJob.JOB_ACTOR);
+  }
+
+  @Test
+  void run_allPdfsFailToParse_doesNotCallVerifyAll() {
+    byte[] bytes1 = "bad-pdf".getBytes();
+    given(s3Source.list()).willReturn(List.of(KEY_1));
+    given(s3Source.get(KEY_1)).willReturn(Optional.of(bytes1));
+    given(parser.parse(bytes1)).willThrow(new FtConfirmationPdfParseException("malformed"));
+
+    job.run();
+
+    verify(verificationService, never()).verifyAll(any(), any());
+  }
+
+  @Test
+  void run_verifyAllThrows_doesNotPropagate() {
+    byte[] bytes1 = "pdf-1".getBytes();
+    FtConfirmation confirmation1 = confirmation("IE00BFG1TM61");
+    given(s3Source.list()).willReturn(List.of(KEY_1));
+    given(s3Source.get(KEY_1)).willReturn(Optional.of(bytes1));
+    given(parser.parse(bytes1)).willReturn(confirmation1);
+    given(verificationService.verifyAll(any(), any())).willThrow(new RuntimeException("db down"));
+
+    assertThat(job).isNotNull();
+    job.run();
+  }
+
+  private static FtConfirmation confirmation(String isin) {
+    return new FtConfirmation(
+        TulevaFund.TKF100,
+        isin,
+        LocalDate.of(2026, 1, 15),
+        new BigDecimal("2500"),
+        new BigDecimal("12.345600"));
+  }
+}

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationPdfParserSamplesIT.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationPdfParserSamplesIT.java
@@ -1,0 +1,44 @@
+package ee.tuleva.onboarding.investment.transaction.ingest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ee.tuleva.onboarding.investment.transaction.FtConfirmation;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+@EnabledIfEnvironmentVariable(named = "FT_SAMPLES_DIR", matches = ".+")
+class FtConfirmationPdfParserSamplesIT {
+
+  private final FtConfirmationPdfParser parser =
+      new FtConfirmationPdfParser(new FtAccountToFundResolver());
+
+  @Test
+  void parsesEveryPdfInTheSamplesDirectory() throws IOException {
+    File dir = new File(System.getenv("FT_SAMPLES_DIR"));
+    File[] pdfs = dir.listFiles((d, name) -> name.toLowerCase().endsWith(".pdf"));
+    assertThat(pdfs).as("PDFs in FT_SAMPLES_DIR=%s", dir).isNotEmpty();
+
+    List<File> sorted = Arrays.stream(pdfs).sorted(Comparator.comparing(File::getName)).toList();
+
+    for (File pdf : sorted) {
+      byte[] bytes = Files.readAllBytes(pdf.toPath());
+      FtConfirmation result = parser.parse(bytes);
+      System.out.printf(
+          "%s -> fund=%s, isin=%s, tradeDate=%s, quantity=%s, grossPrice=%s, type=%s, account=%s%n",
+          pdf.getName(),
+          result.fund(),
+          result.isin(),
+          result.tradeDate(),
+          result.quantity(),
+          result.grossPrice(),
+          result.type(),
+          result.account());
+    }
+  }
+}

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationPdfParserTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationPdfParserTest.java
@@ -1,0 +1,282 @@
+package ee.tuleva.onboarding.investment.transaction.ingest;
+
+import static ee.tuleva.onboarding.fund.TulevaFund.TKF100;
+import static ee.tuleva.onboarding.fund.TulevaFund.TUK75;
+import static ee.tuleva.onboarding.fund.TulevaFund.TUV100;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import ee.tuleva.onboarding.investment.transaction.FtConfirmation;
+import ee.tuleva.onboarding.investment.transaction.FtConfirmationType;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.pdmodel.PDPageContentStream;
+import org.apache.pdfbox.pdmodel.common.PDRectangle;
+import org.apache.pdfbox.pdmodel.font.PDType1Font;
+import org.apache.pdfbox.pdmodel.font.Standard14Fonts;
+import org.junit.jupiter.api.Test;
+
+class FtConfirmationPdfParserTest {
+
+  private final FtConfirmationPdfParser parser =
+      new FtConfirmationPdfParser(new FtAccountToFundResolver());
+
+  @Test
+  void extractField_matchesLabelAndValueOnSameLine() {
+    String text = "Allocation ID: MID9BlFbos-00\nISIN: IE00BJZ2DC62";
+
+    Optional<String> result = FtConfirmationPdfParser.extractField(text, "Allocation ID");
+
+    assertThat(result).contains("MID9BlFbos-00");
+  }
+
+  @Test
+  void extractField_fallsBackToValueOnNextLine() {
+    String text = "Allocation ID:\nMID9BlFbos-00\nISIN: IE00BJZ2DC62";
+
+    Optional<String> result = FtConfirmationPdfParser.extractField(text, "Allocation ID");
+
+    assertThat(result).contains("MID9BlFbos-00");
+  }
+
+  @Test
+  void extractField_doesNotMatchLabelThatIsAPrefixOfAnotherLabel() {
+    String text = "Trade Date Time: 20260717-09:32:44 UTC\nTrade Date: 20260717";
+
+    Optional<String> result = FtConfirmationPdfParser.extractField(text, "Trade Date");
+
+    assertThat(result).contains("20260717");
+  }
+
+  @Test
+  void parseTradeDate_parsesYyyyMMdd() {
+    LocalDate result = FtConfirmationPdfParser.parseTradeDate("20260717");
+
+    assertThat(result).isEqualTo(LocalDate.of(2026, 7, 17));
+  }
+
+  @Test
+  void parseTradeDate_malformedValueThrows() {
+    assertThatThrownBy(() -> FtConfirmationPdfParser.parseTradeDate("2026-07-17"))
+        .isInstanceOf(FtConfirmationPdfParseException.class);
+  }
+
+  @Test
+  void parseQuantity_stripsCommaThousandsSeparators() {
+    BigDecimal result = FtConfirmationPdfParser.parseQuantity("1,047");
+
+    assertThat(result).isEqualByComparingTo("1047");
+  }
+
+  @Test
+  void parseQuantity_malformedValueThrows() {
+    assertThatThrownBy(() -> FtConfirmationPdfParser.parseQuantity("abc"))
+        .isInstanceOf(FtConfirmationPdfParseException.class);
+  }
+
+  @Test
+  void parseGrossPrice_stripsTrailingEurAndKeepsSixDecimalPrecision() {
+    BigDecimal result = FtConfirmationPdfParser.parseGrossPrice("56.850000 EUR");
+
+    assertThat(result).isEqualByComparingTo("56.850000");
+    assertThat(result.scale()).isEqualTo(6);
+  }
+
+  @Test
+  void parseGrossPrice_malformedValueThrows() {
+    assertThatThrownBy(() -> FtConfirmationPdfParser.parseGrossPrice("not-a-price EUR"))
+        .isInstanceOf(FtConfirmationPdfParseException.class);
+  }
+
+  @Test
+  void isCancellation_detectsCancellationPhraseCaseInsensitively() {
+    String text = "Dear Sir/Madam,\nWe confirm the following Trade Cancellation.\n";
+
+    assertThat(FtConfirmationPdfParser.isCancellation(text)).isTrue();
+  }
+
+  @Test
+  void isCancellation_normalTradeIsNotACancellation() {
+    String text = "Dear Sir/Madam,\nWe confirm the following trade .\n";
+
+    assertThat(FtConfirmationPdfParser.isCancellation(text)).isFalse();
+  }
+
+  @Test
+  void parse_extractsAllFieldsFromACleanConfirmationPdf() {
+    byte[] pdf =
+        confirmationPdf(
+            "TEST0001-00",
+            "Tuleva Additional Investment Fund",
+            "20260115",
+            "IE00BFG1TM61",
+            "2,500",
+            "12.345600 EUR",
+            false);
+
+    FtConfirmation result = parser.parse(pdf);
+
+    assertThat(result)
+        .isEqualTo(
+            new FtConfirmation(
+                TKF100,
+                "IE00BFG1TM61",
+                LocalDate.of(2026, 1, 15),
+                new BigDecimal("2500"),
+                new BigDecimal("12.345600"),
+                FtConfirmationType.NORMAL,
+                "Tuleva Additional Investment Fund"));
+  }
+
+  @Test
+  void parse_resolvesTuv100FromAccountAlias() {
+    byte[] pdf =
+        confirmationPdf(
+            "TEST0002-00",
+            "TULEVA III SAMBA PENSIONIFOND",
+            "20260115",
+            "IE000I9HGDZ3",
+            "88,496",
+            "9.920000 EUR",
+            false);
+
+    FtConfirmation result = parser.parse(pdf);
+
+    assertThat(result.fund()).isEqualTo(TUV100);
+  }
+
+  @Test
+  void parse_resolvesTuk75FromMaakpeAccountAlias() {
+    byte[] pdf =
+        confirmationPdf(
+            "TEST0003-00", "MAAKPE", "20260115", "IE000I9HGDZ3", "123,542", "9.920000 EUR", false);
+
+    FtConfirmation result = parser.parse(pdf);
+
+    assertThat(result.fund()).isEqualTo(TUK75);
+  }
+
+  @Test
+  void parse_detectsCancellationFromBodyPhrase() {
+    byte[] pdf =
+        confirmationPdf(
+            "TEST0004-00",
+            "Tuleva Additional Investment Fund",
+            "20260115",
+            "IE00BFG1TM61",
+            "2,500",
+            "12.345600 EUR",
+            true);
+
+    FtConfirmation result = parser.parse(pdf);
+
+    assertThat(result.type()).isEqualTo(FtConfirmationType.CANCELLATION);
+    assertThat(result.isCancellation()).isTrue();
+  }
+
+  @Test
+  void parse_unrecognizedAccountThrows() {
+    byte[] pdf =
+        confirmationPdf(
+            "TEST0005-00",
+            "Some Unmapped Fund Name",
+            "20260115",
+            "IE00BFG1TM61",
+            "2,500",
+            "12.345600 EUR",
+            false);
+
+    assertThatThrownBy(() -> parser.parse(pdf)).isInstanceOf(FtConfirmationPdfParseException.class);
+  }
+
+  @Test
+  void parse_missingRequiredFieldThrows() {
+    byte[] pdf =
+        confirmationPdfMissingIsin(
+            "TEST0006-00",
+            "Tuleva Additional Investment Fund",
+            "20260115",
+            "2,500",
+            "12.345600 EUR");
+
+    assertThatThrownBy(() -> parser.parse(pdf)).isInstanceOf(FtConfirmationPdfParseException.class);
+  }
+
+  private static byte[] confirmationPdfMissingIsin(
+      String allocationId, String account, String tradeDate, String quantity, String grossPrice) {
+    List<String> lines =
+        List.of(
+            "Trade Confirmation",
+            "Dear Sir/Madam,",
+            "We confirm the following trade .",
+            "Allocation ID: " + allocationId,
+            "Counterparty: TULEVA FONDID AS",
+            "Account: " + account,
+            "Trade Date: " + tradeDate,
+            "Quantity: " + quantity,
+            "Gross Price: " + grossPrice,
+            "Settlement Currency: EUR");
+    return renderPdf(lines);
+  }
+
+  private static byte[] confirmationPdf(
+      String allocationId,
+      String account,
+      String tradeDate,
+      String isin,
+      String quantity,
+      String grossPrice,
+      boolean cancellation) {
+    List<String> lines =
+        List.of(
+            "Trade Confirmation",
+            "Dear Sir/Madam,",
+            cancellation
+                ? "We confirm the following trade cancellation."
+                : "We confirm the following trade .",
+            "Allocation ID: " + allocationId,
+            "Counterparty: TULEVA FONDID AS",
+            "Account: " + account,
+            "Trade Date Time: " + tradeDate + "-09:32:44 UTC",
+            "Trade Date: " + tradeDate,
+            "Settlement Date: " + tradeDate,
+            "Security Description: SYNTHETIC TEST SECURITY",
+            "Bloomberg Ticker: TEST GY Equity",
+            "ISIN: " + isin,
+            "Your Direction: Buy",
+            "Quantity: " + quantity,
+            "Gross Price: " + grossPrice,
+            "Net Price: " + grossPrice,
+            "Settlement Currency: EUR");
+    return renderPdf(lines);
+  }
+
+  private static byte[] renderPdf(List<String> lines) {
+    try (PDDocument doc = new PDDocument()) {
+      PDPage page = new PDPage(PDRectangle.A4);
+      doc.addPage(page);
+      PDType1Font font = new PDType1Font(Standard14Fonts.FontName.HELVETICA);
+      try (PDPageContentStream cs = new PDPageContentStream(doc, page)) {
+        cs.beginText();
+        cs.setFont(font, 10);
+        cs.newLineAtOffset(50, 750);
+        for (String line : lines) {
+          cs.showText(line);
+          cs.newLineAtOffset(0, -14);
+        }
+        cs.endText();
+      }
+      ByteArrayOutputStream out = new ByteArrayOutputStream();
+      doc.save(out);
+      return out.toByteArray();
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationS3SourceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/FtConfirmationS3SourceTest.java
@@ -1,0 +1,152 @@
+package ee.tuleva.onboarding.investment.transaction.ingest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.http.AbortableInputStream;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+import software.amazon.awssdk.services.s3.model.S3Object;
+
+@ExtendWith(MockitoExtension.class)
+class FtConfirmationS3SourceTest {
+
+  @Mock private S3Client s3Client;
+
+  private FtConfirmationS3Source source;
+
+  @BeforeEach
+  void setUp() {
+    source = new FtConfirmationS3Source(s3Client);
+  }
+
+  @Test
+  void list_returnsKeysUnderPrefix() {
+    given(s3Client.listObjectsV2(any(ListObjectsV2Request.class)))
+        .willReturn(
+            ListObjectsV2Response.builder()
+                .contents(
+                    S3Object.builder().key("ft-confirmations/a.pdf").build(),
+                    S3Object.builder().key("ft-confirmations/b.pdf").build())
+                .isTruncated(false)
+                .build());
+
+    List<String> keys = source.list();
+
+    assertThat(keys).containsExactly("ft-confirmations/a.pdf", "ft-confirmations/b.pdf");
+  }
+
+  @Test
+  void list_excludesThePrefixPlaceholderKeyItself() {
+    given(s3Client.listObjectsV2(any(ListObjectsV2Request.class)))
+        .willReturn(
+            ListObjectsV2Response.builder()
+                .contents(
+                    S3Object.builder().key("ft-confirmations/").build(),
+                    S3Object.builder().key("ft-confirmations/a.pdf").build())
+                .isTruncated(false)
+                .build());
+
+    List<String> keys = source.list();
+
+    assertThat(keys).containsExactly("ft-confirmations/a.pdf");
+  }
+
+  @Test
+  void list_returnsEmptyListWhenNoObjectsFound() {
+    given(s3Client.listObjectsV2(any(ListObjectsV2Request.class)))
+        .willReturn(ListObjectsV2Response.builder().isTruncated(false).build());
+
+    List<String> keys = source.list();
+
+    assertThat(keys).isEmpty();
+  }
+
+  @Test
+  void get_returnsBytesForKey() {
+    String content = "test-pdf-bytes";
+    var response =
+        new ResponseInputStream<>(
+            GetObjectResponse.builder().build(),
+            AbortableInputStream.create(
+                new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8))));
+    given(s3Client.getObject(any(GetObjectRequest.class))).willReturn(response);
+
+    Optional<byte[]> result = source.get("ft-confirmations/a.pdf");
+
+    assertThat(result).isPresent();
+    assertThat(new String(result.get(), StandardCharsets.UTF_8)).isEqualTo(content);
+  }
+
+  @Test
+  void get_returnsEmptyWhenKeyNotFound() {
+    given(s3Client.getObject(any(GetObjectRequest.class)))
+        .willThrow(NoSuchKeyException.builder().message("Not found").build());
+
+    Optional<byte[]> result = source.get("ft-confirmations/missing.pdf");
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void get_returnsEmptyOnAccessDenied() {
+    S3Exception exception =
+        (S3Exception) S3Exception.builder().statusCode(403).message("Forbidden").build();
+    given(s3Client.getObject(any(GetObjectRequest.class))).willThrow(exception);
+
+    Optional<byte[]> result = source.get("ft-confirmations/a.pdf");
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void get_throwsRuntimeExceptionOnOtherS3Error() {
+    S3Exception exception =
+        (S3Exception) S3Exception.builder().statusCode(500).message("Server error").build();
+    given(s3Client.getObject(any(GetObjectRequest.class))).willThrow(exception);
+
+    assertThatThrownBy(() -> source.get("ft-confirmations/a.pdf"))
+        .isInstanceOf(RuntimeException.class);
+  }
+
+  @Test
+  void lastModified_returnsInstantFromHeadObject() {
+    Instant modified = Instant.parse("2026-06-09T08:00:00Z");
+    given(s3Client.headObject(any(HeadObjectRequest.class)))
+        .willReturn(HeadObjectResponse.builder().lastModified(modified).build());
+
+    Optional<Instant> result = source.lastModified("ft-confirmations/a.pdf");
+
+    assertThat(result).contains(modified);
+  }
+
+  @Test
+  void lastModified_returnsEmptyWhenKeyNotFound() {
+    given(s3Client.headObject(any(HeadObjectRequest.class)))
+        .willThrow(NoSuchKeyException.builder().message("Not found").build());
+
+    Optional<Instant> result = source.lastModified("ft-confirmations/missing.pdf");
+
+    assertThat(result).isEmpty();
+  }
+}


### PR DESCRIPTION
Migrates Flow Traders (FT) ETF trade-confirmation ingestion off the GAS→Java HTTP push onto the S3-drop convention (ADR 0001: automated systems drop files in S3, they don't POST to our admin API). One PR for the whole plan — the additive milestones accumulate here.

## Milestones
- [x] **M1 — Java PDFBox parser.** `FtConfirmationPdfParser` turns a confirmation PDF into the existing `FtConfirmation` domain object for the unchanged `verifyAll` path. Additive, no wiring.
- [x] **M2 — land the PDF in S3.** Extends the in-repo `appscripts/seb-position-uploader` Gmail→S3 uploader (the same one that already lands SEB/Swedbank CSVs) with an FT source dropping confirmation PDFs at `ft-confirmations/<allocationId>.pdf`. Two tweaks: binary attachment bytes + `application/pdf` (the CSV `getDataAsString()` path corrupts a PDF), and an allocation-id S3 key instead of a date. SEB/Swedbank behavior byte-for-byte unchanged; Jest 74/74. Auto-deploys to the live Apps Script via the CircleCI `appscript-deploy` job (`clasp push --force`, master-only) on merge. ⚠️ The FT attachment-filename pattern (`MID…-NN.pdf`) is assumed pending confirmation against a live FT email (one-line change if different).
- [x] **M3 — Java S3 pull job.** `FtConfirmationS3Source` (`ListObjectsV2` under `ft-confirmations/`) + `FtConfirmationImportJob` (scheduled + `@SchedulerLock`, `Clock`-injected, `@Profile({production,staging})`). Parses each PDF → `verifyAll`; idempotent via the existing audit/digest dedup. **No enable flag** — the pipeline starts as soon as the code is live in production/staging. No migration, no new dependency.
- [ ] **M4 — parallel run (no action needed to start).** Once merged/deployed the S3 job runs automatically, in shadow mode alongside the live GAS push (FT verification records outcomes but doesn't alert while `transaction-registry.ft-confirmation.registry-authoritative` is false). Observe that the S3-job audit outcomes agree with the GAS push; the dedup keeps double-ingestion idempotent.
- [ ] **M5 — retire the push + cut over** (behavior change, its own final step): remove the GAS push trigger, delete both `/admin/transaction-registry/ft-confirmation(s)` endpoints + DTOs and the GAS PDF parser, and flip `registry-authoritative` to make the S3 pipeline the alerting authority. Keep `FtConfirmation` + `verifyAll`, now job-fed.

## Notes
- **M1**: `PDFTextStripper` → ported `label:value` extraction → `FtConfirmation` (`yyyyMMdd` UTC `tradeDate`, comma-thousands + ` EUR` stripping, cancellation via the `trade cancellation` body phrase). `FtAccountToFundResolver` fail-loud alias table; unrecognized account throws. `MAAKPE`→TUK75 provisional (noted in code). Pinned `pdfbox:3.0.4` to match the transitively-resolved version.
- **End-to-end**: FT email → the GAS uploader (M2) drops the PDF in S3 → `FtConfirmationImportJob` (M3) lists/parses (M1) → the existing `verifyAll`. Same `tuleva-investment-reports` bucket + IAM as SEB/Swedbank.
- **Shadow safety without an import flag**: the job going live only means it *verifies and records*; it does not become the alerting authority until `registry-authoritative` flips at cutover (M5).

## Testing
M1: 22 unit tests + an env-gated samples test validated against 10 real confirmations (committed fixtures are synthetic — no real PDFs in this open-source repo). M2: Jest 74/74 (10 new), all pre-existing SEB/Swedbank tests green. M3: S3 source + job unit tests, a `@SpringBootTest` integration test asserting the business outcome + no-duplicate-on-rerun through the real audit dedup, and a cron/lock sanity test. Java suite green via the pre-commit hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RVVx5WzvD3huZ5jKpA3M5C