### PR TITLE
Capture child citizenship from the register and screen children at onboarding

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/country/CountryCodes.java
+++ b/src/main/java/ee/tuleva/onboarding/country/CountryCodes.java
@@ -5,9 +5,11 @@ import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toUnmodifiableMap;
 
 import jakarta.annotation.Nullable;
+import java.util.Arrays;
 import java.util.Locale;
 import java.util.Map;
 import java.util.MissingResourceException;
+import java.util.Set;
 
 public final class CountryCodes {
 
@@ -15,6 +17,31 @@ public final class CountryCodes {
       Locale.getISOCountries(PART1_ALPHA2).stream()
           .filter(alpha2 -> iso3Of(alpha2) != null)
           .collect(toUnmodifiableMap(CountryCodes::iso3Of, identity()));
+
+  // ISO 3166-1 numeric, the classifier the Estonian population register returns as
+  // citizenship.riik.elemendiKood. Covers every EEA and AML high-risk country the risk views
+  // score on, plus common others; CountryCodesSpec fails if one of those goes missing.
+  private static final String NUMERIC_PAIRS =
+      """
+      004=AF,012=DZ,024=AO,036=AU,040=AT,056=BE,070=BA,100=BG,104=MM,108=BI,
+      112=BY,120=CM,124=CA,140=CF,156=CN,180=CD,191=HR,192=CU,196=CY,203=CZ,
+      208=DK,233=EE,246=FI,250=FR,275=PS,276=DE,300=GR,320=GT,324=GN,332=HT,
+      348=HU,352=IS,356=IN,364=IR,368=IQ,372=IE,380=IT,392=JP,400=JO,408=KP,
+      417=KG,422=LB,428=LV,434=LY,438=LI,440=LT,442=LU,466=ML,470=MT,499=ME,
+      504=MA,508=MZ,528=NL,558=NI,562=NE,566=NG,578=NO,586=PK,616=PL,620=PT,
+      624=GW,642=RO,643=RU,688=RS,703=SK,705=SI,706=SO,716=ZW,724=ES,728=SS,
+      729=SD,752=SE,756=CH,760=SY,762=TJ,784=AE,788=TN,792=TR,795=TM,804=UA,
+      818=EG,826=GB,840=US,854=BF,862=VE,887=YE
+      """;
+
+  private static final Map<Integer, String> NUMERIC_TO_ALPHA2 =
+      NUMERIC_PAIRS
+          .lines()
+          .flatMap(line -> Arrays.stream(line.split(",")))
+          .map(String::strip)
+          .filter(pair -> !pair.isEmpty())
+          .map(pair -> pair.split("="))
+          .collect(toUnmodifiableMap(pair -> Integer.valueOf(pair[0]), pair -> pair[1]));
 
   private CountryCodes() {}
 
@@ -24,6 +51,21 @@ public final class CountryCodes {
     }
     var alpha3 = code.strip().toUpperCase(Locale.ROOT);
     return ALPHA3_TO_ALPHA2.getOrDefault(alpha3, code);
+  }
+
+  public static @Nullable String numericToAlpha2(@Nullable String code) {
+    if (code == null || code.isBlank()) {
+      return null;
+    }
+    var trimmed = code.strip();
+    if (!trimmed.chars().allMatch(Character::isDigit)) {
+      return trimmed;
+    }
+    return NUMERIC_TO_ALPHA2.getOrDefault(Integer.valueOf(trimmed), trimmed);
+  }
+
+  public static Set<String> mappedAlpha2Codes() {
+    return Set.copyOf(NUMERIC_TO_ALPHA2.values());
   }
 
   private static @Nullable String iso3Of(String alpha2) {

--- a/src/main/java/ee/tuleva/onboarding/country/CountryCodes.java
+++ b/src/main/java/ee/tuleva/onboarding/country/CountryCodes.java
@@ -18,30 +18,19 @@ public final class CountryCodes {
           .filter(alpha2 -> iso3Of(alpha2) != null)
           .collect(toUnmodifiableMap(CountryCodes::iso3Of, identity()));
 
-  // ISO 3166-1 numeric, the classifier the Estonian population register returns as
-  // citizenship.riik.elemendiKood. Covers every EEA and AML high-risk country the risk views
-  // score on, plus common others; CountryCodesSpec fails if one of those goes missing.
-  private static final String NUMERIC_PAIRS =
-      """
-      004=AF,012=DZ,024=AO,036=AU,040=AT,056=BE,070=BA,100=BG,104=MM,108=BI,
-      112=BY,120=CM,124=CA,140=CF,156=CN,180=CD,191=HR,192=CU,196=CY,203=CZ,
-      208=DK,233=EE,246=FI,250=FR,275=PS,276=DE,300=GR,320=GT,324=GN,332=HT,
-      348=HU,352=IS,356=IN,364=IR,368=IQ,372=IE,380=IT,392=JP,400=JO,408=KP,
-      417=KG,422=LB,428=LV,434=LY,438=LI,440=LT,442=LU,466=ML,470=MT,499=ME,
-      504=MA,508=MZ,528=NL,558=NI,562=NE,566=NG,578=NO,586=PK,616=PL,620=PT,
-      624=GW,642=RO,643=RU,688=RS,703=SK,705=SI,706=SO,716=ZW,724=ES,728=SS,
-      729=SD,752=SE,756=CH,760=SY,762=TJ,784=AE,788=TN,792=TR,795=TM,804=UA,
-      818=EG,826=GB,840=US,854=BF,862=VE,887=YE
-      """;
-
-  private static final Map<Integer, String> NUMERIC_TO_ALPHA2 =
-      NUMERIC_PAIRS
-          .lines()
-          .flatMap(line -> Arrays.stream(line.split(",")))
-          .map(String::strip)
-          .filter(pair -> !pair.isEmpty())
-          .map(pair -> pair.split("="))
-          .collect(toUnmodifiableMap(pair -> Integer.valueOf(pair[0]), pair -> pair[1]));
+  private static final Map<Integer, String> ISO_3166_1_NUMERIC_TO_ALPHA2 =
+      parseNumericToAlpha2Pairs(
+          """
+          004=AF,012=DZ,024=AO,036=AU,040=AT,056=BE,070=BA,100=BG,104=MM,108=BI,
+          112=BY,120=CM,124=CA,140=CF,156=CN,180=CD,191=HR,192=CU,196=CY,203=CZ,
+          208=DK,233=EE,246=FI,250=FR,275=PS,276=DE,300=GR,320=GT,324=GN,332=HT,
+          348=HU,352=IS,356=IN,364=IR,368=IQ,372=IE,380=IT,392=JP,400=JO,408=KP,
+          417=KG,422=LB,428=LV,434=LY,438=LI,440=LT,442=LU,466=ML,470=MT,499=ME,
+          504=MA,508=MZ,528=NL,558=NI,562=NE,566=NG,578=NO,586=PK,616=PL,620=PT,
+          624=GW,642=RO,643=RU,688=RS,703=SK,705=SI,706=SO,716=ZW,724=ES,728=SS,
+          729=SD,752=SE,756=CH,760=SY,762=TJ,784=AE,788=TN,792=TR,795=TM,804=UA,
+          818=EG,826=GB,840=US,854=BF,862=VE,887=YE
+          """);
 
   private CountryCodes() {}
 
@@ -61,11 +50,21 @@ public final class CountryCodes {
     if (!trimmed.chars().allMatch(Character::isDigit)) {
       return trimmed;
     }
-    return NUMERIC_TO_ALPHA2.getOrDefault(Integer.valueOf(trimmed), trimmed);
+    return ISO_3166_1_NUMERIC_TO_ALPHA2.getOrDefault(Integer.valueOf(trimmed), trimmed);
   }
 
-  public static Set<String> mappedAlpha2Codes() {
-    return Set.copyOf(NUMERIC_TO_ALPHA2.values());
+  static Set<String> mappedAlpha2Codes() {
+    return Set.copyOf(ISO_3166_1_NUMERIC_TO_ALPHA2.values());
+  }
+
+  private static Map<Integer, String> parseNumericToAlpha2Pairs(String pairs) {
+    return pairs
+        .lines()
+        .flatMap(line -> Arrays.stream(line.split(",")))
+        .map(String::strip)
+        .filter(pair -> !pair.isEmpty())
+        .map(pair -> pair.split("="))
+        .collect(toUnmodifiableMap(pair -> Integer.valueOf(pair[0]), pair -> pair[1]));
   }
 
   private static @Nullable String iso3Of(String alpha2) {

--- a/src/main/java/ee/tuleva/onboarding/party/ChildOnboardingService.java
+++ b/src/main/java/ee/tuleva/onboarding/party/ChildOnboardingService.java
@@ -2,6 +2,7 @@ package ee.tuleva.onboarding.party;
 
 import static ee.tuleva.onboarding.event.TrackableEventType.MINOR_CUSTODY_VERIFICATION;
 import static ee.tuleva.onboarding.party.PartyId.Type.PERSON;
+import static java.util.Collections.unmodifiableMap;
 
 import ee.tuleva.onboarding.aml.AmlService;
 import ee.tuleva.onboarding.auth.principal.AuthenticatedPerson;
@@ -60,7 +61,7 @@ public class ChildOnboardingService {
     }
     var evidence = new LinkedHashMap<String, Object>(verification.evidence());
     evidence.put("citizenship", child.citizenship());
-    return Map.copyOf(evidence);
+    return unmodifiableMap(evidence);
   }
 
   private void screenForSanctionsAndPep(PopulationRegisterPerson child) {

--- a/src/main/java/ee/tuleva/onboarding/party/ChildOnboardingService.java
+++ b/src/main/java/ee/tuleva/onboarding/party/ChildOnboardingService.java
@@ -5,6 +5,8 @@ import static ee.tuleva.onboarding.party.PartyId.Type.PERSON;
 
 import ee.tuleva.onboarding.aml.AmlService;
 import ee.tuleva.onboarding.auth.principal.AuthenticatedPerson;
+import ee.tuleva.onboarding.auth.principal.PersonImpl;
+import ee.tuleva.onboarding.country.Country;
 import ee.tuleva.onboarding.event.TrackableEvent;
 import ee.tuleva.onboarding.populationregister.PopulationRegisterPerson;
 import ee.tuleva.onboarding.savings.fund.SavingsFundOnboardingService;
@@ -12,7 +14,9 @@ import ee.tuleva.onboarding.user.personalcode.PersonalCode;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.LocalDate;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
@@ -49,6 +53,22 @@ public class ChildOnboardingService {
         .toList();
   }
 
+  private Map<String, Object> custodyEvidence(CustodyVerification verification) {
+    PopulationRegisterPerson child = verification.child();
+    if (child == null || child.citizenship() == null) {
+      return verification.evidence();
+    }
+    var evidence = new LinkedHashMap<String, Object>(verification.evidence());
+    evidence.put("citizenship", child.citizenship());
+    return Map.copyOf(evidence);
+  }
+
+  private void screenForSanctionsAndPep(PopulationRegisterPerson child) {
+    amlService.addSanctionAndPepCheckIfMissing(
+        new PersonImpl(child.personalCode(), child.firstName(), child.lastName()),
+        new Country(child.citizenship()));
+  }
+
   private boolean hasBeenOnboarded(String childPersonalCode) {
     return savingsFundOnboardingService.getOnboardingStatus(new PartyId(PERSON, childPersonalCode))
         != null;
@@ -63,7 +83,7 @@ public class ChildOnboardingService {
     applicationEventPublisher.publishEvent(
         new TrackableEvent(parent, MINOR_CUSTODY_VERIFICATION, verification.evidence()));
     amlService.addCustodyRightCheck(
-        childPersonalCode, verification.isVerified(), verification.evidence());
+        childPersonalCode, verification.isVerified(), custodyEvidence(verification));
 
     if (!verification.isVerified()) {
       log.info(
@@ -78,6 +98,7 @@ public class ChildOnboardingService {
     parentChildLinkRegistrationService.register(
         parentPersonalCode, childPersonalCode, child.firstName(), child.lastName());
     savingsFundOnboardingService.seedPersonOnboardingIfAbsent(childPersonalCode);
+    screenForSanctionsAndPep(child);
 
     applicationEventPublisher.publishEvent(
         new ChildOnboardedEvent(

--- a/src/main/java/ee/tuleva/onboarding/populationregister/PersonMapper.java
+++ b/src/main/java/ee/tuleva/onboarding/populationregister/PersonMapper.java
@@ -10,6 +10,7 @@ import static ee.tuleva.onboarding.populationregister.PopulationRegisterPerson.S
 import static ee.tuleva.onboarding.populationregister.PopulationRegisterPerson.Status.UNKNOWN;
 import static org.apache.commons.lang3.text.WordUtils.capitalizeFully;
 
+import ee.tuleva.onboarding.country.CountryCodes;
 import ee.tuleva.onboarding.populationregister.PersonResponse.Citizenship;
 import ee.tuleva.onboarding.populationregister.PersonResponse.Code;
 import ee.tuleva.onboarding.populationregister.PersonResponse.Custody;
@@ -102,7 +103,7 @@ class PersonMapper {
     if (citizenship == null || citizenship.country() == null) {
       return null;
     }
-    return citizenship.country().name();
+    return CountryCodes.numericToAlpha2(citizenship.country().code());
   }
 
   private static boolean hasCode(@Nullable Code value, String expected) {

--- a/src/test/groovy/ee/tuleva/onboarding/country/CountryCodesSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/country/CountryCodesSpec.groovy
@@ -21,4 +21,41 @@ class CountryCodesSpec extends Specification {
         "XXX"   | "XXX"
         "EE"    | "EE"
     }
+
+    @Unroll
+    def "converts ISO 3166-1 numeric country code #input to alpha-2 #expected"() {
+        expect:
+        CountryCodes.numericToAlpha2(input) == expected
+        where:
+        input   | expected
+        "233"   | "EE"
+        "578"   | "NO"
+        "643"   | "RU"
+        "408"   | "KP"
+        "826"   | "GB"
+        "004"   | "AF"
+        "4"     | "AF"
+        " 233 " | "EE"
+        null    | null
+        ""      | null
+        "   "   | null
+        "999"   | "999"
+        "EE"    | "EE"
+    }
+
+    def "every AML high-risk and EEA country used by the risk views is mapped"() {
+        given:
+        def required = [
+            "AT", "BE", "BG", "HR", "CY", "CZ", "DK", "EE", "FI", "FR", "DE", "GR", "HU", "IE",
+            "IT", "LV", "LT", "LU", "MT", "NL", "PL", "PT", "RO", "SK", "SI", "ES", "SE",
+            "IS", "LI", "NO",
+            "AF", "DZ", "AO", "BY", "BA", "BF", "BI", "CM", "CF", "CN", "CU", "CD", "EG", "GT",
+            "GN", "GW", "HT", "IR", "IQ", "JO", "KG", "LB", "LY", "ML", "ME", "MA", "MZ", "MM",
+            "NI", "NE", "NG", "KP", "PK", "PS", "RU", "RS", "SO", "SS", "SD", "SY", "TJ", "TN",
+            "TM", "AE", "VE", "YE", "ZW"
+        ] as Set
+
+        expect:
+        CountryCodes.mappedAlpha2Codes().containsAll(required)
+    }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/country/CountryCodesSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/country/CountryCodesSpec.groovy
@@ -43,6 +43,31 @@ class CountryCodesSpec extends Specification {
         "EE"    | "EE"
     }
 
+    @Unroll
+    def "sanctions-critical numeric #input maps to exactly #expected"() {
+        expect:
+        CountryCodes.numericToAlpha2(input) == expected
+        where:
+        input | expected
+        "643" | "RU"
+        "408" | "KP"
+        "364" | "IR"
+        "760" | "SY"
+        "112" | "BY"
+        "192" | "CU"
+        "104" | "MM"
+        "004" | "AF"
+        "862" | "VE"
+        "156" | "CN"
+        "784" | "AE"
+        "729" | "SD"
+        "728" | "SS"
+        "233" | "EE"
+        "352" | "IS"
+        "438" | "LI"
+        "578" | "NO"
+    }
+
     def "every AML high-risk and EEA country used by the risk views is mapped"() {
         given:
         def required = [

--- a/src/test/groovy/ee/tuleva/onboarding/party/ChildOnboardingServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/party/ChildOnboardingServiceTest.java
@@ -18,6 +18,8 @@ import static org.mockito.Mockito.verify;
 
 import ee.tuleva.onboarding.aml.AmlService;
 import ee.tuleva.onboarding.auth.principal.AuthenticatedPerson;
+import ee.tuleva.onboarding.auth.principal.PersonImpl;
+import ee.tuleva.onboarding.country.Country;
 import ee.tuleva.onboarding.event.TrackableEvent;
 import ee.tuleva.onboarding.populationregister.CustodyRight;
 import ee.tuleva.onboarding.populationregister.PopulationRegisterPerson;
@@ -26,6 +28,7 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
@@ -68,7 +71,7 @@ class ChildOnboardingServiceTest {
 
   private final PopulationRegisterPerson child =
       new PopulationRegisterPerson(
-          CHILD, "MARI", "MAASIKAS", LocalDate.of(2015, 6, 15), ALIVE, "EESTI VABARIIK");
+          CHILD, "MARI", "MAASIKAS", LocalDate.of(2015, 6, 15), ALIVE, "EE");
 
   private static final String CUSTODY_MESSAGE_ID = "11111111-1111-1111-1111-111111111111";
 
@@ -140,9 +143,52 @@ class ChildOnboardingServiceTest {
     assertThat(result.dateOfBirth()).isEqualTo(LocalDate.of(2015, 6, 15));
     verify(parentChildLinkRegistrationService).register(PARENT, CHILD, "MARI", "MAASIKAS");
     verify(savingsFundOnboardingService).seedPersonOnboardingIfAbsent(CHILD);
-    verify(amlService).addCustodyRightCheck(CHILD, true, evidence);
+    var evidenceWithCitizenship = new LinkedHashMap<String, Object>(evidence);
+    evidenceWithCitizenship.put("citizenship", "EE");
+    verify(amlService).addCustodyRightCheck(CHILD, true, evidenceWithCitizenship);
     verify(applicationEventPublisher)
         .publishEvent(new TrackableEvent(parent, MINOR_CUSTODY_VERIFICATION, evidence));
+  }
+
+  @Test
+  void verifiedCustody_screensTheChildForSanctionsAndPepUsingRegisterCitizenship() {
+    var evidence = Map.<String, Object>of("outcome", "OK", "childPersonalCode", CHILD);
+    given(custodyVerificationService.verify(PARENT, CHILD, CUSTODY_MAX_AGE))
+        .willReturn(new CustodyVerification(OK, child, evidence));
+
+    service.onboardChild(parent, CHILD);
+
+    verify(amlService)
+        .addSanctionAndPepCheckIfMissing(
+            new PersonImpl(CHILD, "MARI", "MAASIKAS"), new Country("EE"));
+  }
+
+  @Test
+  void verifiedCustody_screensTheChildEvenWhenTheRegisterReportsNoCitizenship() {
+    var childWithoutCitizenship =
+        new PopulationRegisterPerson(
+            CHILD, "MARI", "MAASIKAS", LocalDate.of(2015, 6, 15), ALIVE, null);
+    var evidence = Map.<String, Object>of("outcome", "OK", "childPersonalCode", CHILD);
+    given(custodyVerificationService.verify(PARENT, CHILD, CUSTODY_MAX_AGE))
+        .willReturn(new CustodyVerification(OK, childWithoutCitizenship, evidence));
+
+    service.onboardChild(parent, CHILD);
+
+    verify(amlService)
+        .addSanctionAndPepCheckIfMissing(
+            new PersonImpl(CHILD, "MARI", "MAASIKAS"), new Country(null));
+    verify(amlService).addCustodyRightCheck(CHILD, true, evidence);
+  }
+
+  @Test
+  void unverifiedCustody_doesNotScreenTheChild() {
+    var evidence = Map.<String, Object>of("outcome", "NO_CUSTODY", "childPersonalCode", CHILD);
+    given(custodyVerificationService.verify(PARENT, CHILD, CUSTODY_MAX_AGE))
+        .willReturn(new CustodyVerification(NO_CUSTODY, null, evidence));
+
+    service.onboardChild(parent, CHILD);
+
+    verify(amlService, never()).addSanctionAndPepCheckIfMissing(any(), any());
   }
 
   @Test

--- a/src/test/groovy/ee/tuleva/onboarding/populationregister/PopulationRegisterClientTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/populationregister/PopulationRegisterClientTest.java
@@ -95,12 +95,7 @@ class PopulationRegisterClientTest {
     assertThat(person)
         .isEqualTo(
             new PopulationRegisterPerson(
-                PERSONAL_CODE,
-                "Mari",
-                "Maasikas",
-                LocalDate.of(1985, 3, 15),
-                ALIVE,
-                "EESTI VABARIIK"));
+                PERSONAL_CODE, "Mari", "Maasikas", LocalDate.of(1985, 3, 15), ALIVE, "EE"));
     assertThat(person.isAlive()).isTrue();
     server.verify();
   }


### PR DESCRIPTION
Milestone 1 of bringing minors into AML scoring. Plan: `AML/minors-aml-plan.md`.

## Why

Minors are invisible to **seven of the sixteen** TKF AML rules, and it fails **open**.

Children are never asked for citizenship or PEP status. Separately, they are never screened: sanction/PEP screening fires only from `AmlAutoChecker.beforeMandateCreated`, `AmlAutoChecker.beforeKycChecked` and `RedemptionVerificationService`, and a minor creates no mandate and completes no KYC survey. (`RedemptionVerificationService` also needs a KYC country it does not have, so even the withdrawal path likely throws rather than screening.)

The risk view then reads every absence as innocence:

```sql
COALESCE(k.is_est_citizen, true)   -- no KYC        -> "Estonian citizen"
COALESCE(k.is_pep, false)          -- no KYC        -> "not a PEP"
COALESCE(s.success, true)          -- never screened -> "not sanctioned"
```

So rules 1–7 score 0 for every child, always — a sanctioned child is indistinguishable from a clean one. This PR is the onboarding-service half: **record the facts** so the scoring side has something to read. No SQL here.

## What changed

**Citizenship comes from the register, not a KYC answer the child never gives.** `PersonMapper` returned `citizenship.country().name()` — the Estonian-language name `"EESTI VABARIIK"`. The register also carries `citizenship.country().code()`, which is **ISO 3166-1 numeric** (`"233"`), so the mapper now returns that translated to alpha-2.

`CountryCodes` gains `numericToAlpha2` beside the existing alpha-3 conversion, with the same passthrough-on-unknown semantics — an unmapped numeric stays as-is, which is correctly neither `EE` nor any high-risk country. `CountryCodesSpec` asserts every EEA and AML high-risk country the risk views score on is mapped, so an omission fails the build instead of silently scoring a child as clean.

**Children are screened at onboarding**, once custody verifies, instead of never. `OpenSanctionsService.getCountries` already tolerates a null country, so a child whose citizenship the register does not report is still screened, just without the country filter.

**Citizenship is filed into the existing `CUSTODY_RIGHT` evidence metadata**, not a new `AmlCheckType`. It comes from the same register call so it belongs with that call's evidence, and unlike `population_register_response` it is append-only and survives the 365-day purge. Deliberately *not* written into `kyc_survey`: a survey means "the client told us this", and the child told us nothing.

## Tests

178 tests green across party, country, populationregister and `AmlServiceTest`. New coverage:

- numeric → alpha-2 including leading zeros (`"004"` and `"4"` both → `AF`), unknown passthrough, blank/null
- the guard that every EEA + high-risk country is mapped
- child screened using register citizenship
- child screened **even when the register reports no citizenship**
- unverified custody does **not** screen
- citizenship lands in the custody evidence

## Decisions worth challenging

1. **No backfill.** Children onboarded before this keep no citizenship and no screening. The scoring side will surface them as data-missing rather than clean. Sten's call; the population is tiny (~39 TKF customers, product launched this month).
2. **Numeric passthrough on unknown.** An unmapped country code flows through unchanged rather than becoming null. Correct for scoring — it is provably not `EE` and not high-risk — but it means the table needs extending if we ever score on a wider country list.
3. **Screening with a null country** when the register reports no citizenship, rather than skipping the screen. Screening with less precision beats not screening.

## Follow-up, not in this PR

Milestone 2 is the `V25` migration in database-administration that actually reads this: guardian carve-out for third-party deposits, guardian-derived rules, and `rule_m_profile_data_missing` so absence stops reading as innocence. It is gated on database-administration PR #8 merging first.

Also still open: custody revoked at the register after onboarding is invisible to everything we have — nothing re-queries the register.

🤖 Generated with [Claude Code](https://claude.com/claude-code)