### PR TITLE
Re-screen savings fund customers weekly, not just third pillar

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/aml/AmlService.java
+++ b/src/main/java/ee/tuleva/onboarding/aml/AmlService.java
@@ -29,6 +29,7 @@ import io.micrometer.core.instrument.MeterRegistry;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 import lombok.RequiredArgsConstructor;
@@ -195,37 +196,8 @@ public class AmlService {
 
   public void runAmlChecksOnThirdPillarCustomers() {
     List<AnalyticsRecentThirdPillar> records = analyticsRecentThirdPillarRepository.findAll();
-
-    log.info("Running III pillar AML checks on {} records", records.size());
     eventPublisher.publishEvent(new AmlChecksRunEvent(this, records));
-
-    int failureCount = 0;
-    for (AnalyticsRecentThirdPillar record : records) {
-      try {
-        if (screenForSanctionAndPep(record, new Country(record.getCountry())).failed()) {
-          failureCount++;
-        }
-      } catch (RuntimeException e) {
-        handleScreeningFailure(record, "batch", e);
-        failureCount++;
-      }
-    }
-
-    if (failureCount > 0) {
-      try {
-        notificationService.sendMessage(
-            "AML batch: sanction/PEP screening failed for %d of %d third-pillar customers this run"
-                .formatted(failureCount, records.size()),
-            OperationsNotificationService.Channel.AML);
-      } catch (RuntimeException e) {
-        log.error("Failed to send aggregated AML batch screening-failure alert", e);
-      }
-    }
-
-    log.info(
-        "Successfully ran III pillar AML checks on {} records ({} screening failures)",
-        records.size(),
-        failureCount);
+    screenBatch(ScreeningBatch.THIRD_PILLAR, records, record -> new Country(record.getCountry()));
   }
 
   public void runAmlChecksOnSavingsFundCustomers() {
@@ -233,37 +205,64 @@ public class AmlService {
     List<User> customers = userRepository.findAllByPersonalCodeIn(personalCodes);
 
     log.info(
-        "Running savings fund AML checks on {} of {} onboarded persons",
-        customers.size(),
-        personalCodes.size());
+        "Resolved savings fund customers to screen: onboarded={}, resolved={}",
+        personalCodes.size(),
+        customers.size());
+
+    screenBatch(ScreeningBatch.SAVINGS_FUND, customers, customer -> new Country(null));
+  }
+
+  private <T extends Person> void screenBatch(
+      ScreeningBatch batch, List<T> people, Function<T, Country> countryOf) {
+    log.info(
+        "Running AML screening batch: population={}, people={}", batch.population, people.size());
 
     int failureCount = 0;
-    for (User customer : customers) {
+    for (T person : people) {
       try {
-        if (screenForSanctionAndPep(customer, new Country(null)).failed()) {
+        if (screenForSanctionAndPep(person, countryOf.apply(person)).failed()) {
           failureCount++;
         }
       } catch (RuntimeException e) {
-        handleScreeningFailure(customer, "savings-fund-batch", e);
+        handleScreeningFailure(person, batch.metricPhase, e);
         failureCount++;
       }
     }
 
-    if (failureCount > 0) {
-      try {
-        notificationService.sendMessage(
-            "AML batch: sanction/PEP screening failed for %d of %d savings fund customers this run"
-                .formatted(failureCount, customers.size()),
-            OperationsNotificationService.Channel.AML);
-      } catch (RuntimeException e) {
-        log.error("Failed to send aggregated savings fund AML batch screening-failure alert", e);
-      }
-    }
+    alertOnBatchScreeningFailures(batch, failureCount, people.size());
 
     log.info(
-        "Successfully ran savings fund AML checks on {} customers ({} screening failures)",
-        customers.size(),
+        "Finished AML screening batch: population={}, people={}, screeningFailures={}",
+        batch.population,
+        people.size(),
         failureCount);
+  }
+
+  private void alertOnBatchScreeningFailures(
+      ScreeningBatch batch, int failureCount, int peopleCount) {
+    if (failureCount == 0) {
+      return;
+    }
+    try {
+      notificationService.sendMessage(
+          "AML batch: sanction/PEP screening failed for %d of %d %s customers this run"
+              .formatted(failureCount, peopleCount, batch.population),
+          OperationsNotificationService.Channel.AML);
+    } catch (RuntimeException e) {
+      log.error(
+          "Failed to send aggregated AML batch screening-failure alert: population={}",
+          batch.population,
+          e);
+    }
+  }
+
+  @RequiredArgsConstructor
+  private enum ScreeningBatch {
+    THIRD_PILLAR("third-pillar", "batch"),
+    SAVINGS_FUND("savings fund", "savings-fund-batch");
+
+    private final String population;
+    private final String metricPhase;
   }
 
   private Map<String, Object> metadata(JsonNode results, JsonNode query) {

--- a/src/main/java/ee/tuleva/onboarding/aml/AmlService.java
+++ b/src/main/java/ee/tuleva/onboarding/aml/AmlService.java
@@ -22,7 +22,9 @@ import ee.tuleva.onboarding.event.TrackableEventType;
 import ee.tuleva.onboarding.kyc.KycCheck;
 import ee.tuleva.onboarding.mandate.Mandate;
 import ee.tuleva.onboarding.notification.OperationsNotificationService;
+import ee.tuleva.onboarding.savings.fund.SavingsFundOnboardingRepository;
 import ee.tuleva.onboarding.user.User;
+import ee.tuleva.onboarding.user.UserRepository;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.util.List;
 import java.util.Map;
@@ -46,6 +48,8 @@ public class AmlService {
   private final ApplicationEventPublisher eventPublisher;
   private final PepAndSanctionCheckService pepAndSanctionCheckService;
   private final AnalyticsRecentThirdPillarRepository analyticsRecentThirdPillarRepository;
+  private final SavingsFundOnboardingRepository savingsFundOnboardingRepository;
+  private final UserRepository userRepository;
   private final UserConversionService userConversionService;
   private final JsonMapper jsonMapper;
   private final MeterRegistry meterRegistry;
@@ -221,6 +225,44 @@ public class AmlService {
     log.info(
         "Successfully ran III pillar AML checks on {} records ({} screening failures)",
         records.size(),
+        failureCount);
+  }
+
+  public void runAmlChecksOnSavingsFundCustomers() {
+    List<String> personalCodes = savingsFundOnboardingRepository.findPersonCodes();
+    List<User> customers = userRepository.findAllByPersonalCodeIn(personalCodes);
+
+    log.info(
+        "Running savings fund AML checks on {} of {} onboarded persons",
+        customers.size(),
+        personalCodes.size());
+
+    int failureCount = 0;
+    for (User customer : customers) {
+      try {
+        if (screenForSanctionAndPep(customer, new Country(null)).failed()) {
+          failureCount++;
+        }
+      } catch (RuntimeException e) {
+        handleScreeningFailure(customer, "savings-fund-batch", e);
+        failureCount++;
+      }
+    }
+
+    if (failureCount > 0) {
+      try {
+        notificationService.sendMessage(
+            "AML batch: sanction/PEP screening failed for %d of %d savings fund customers this run"
+                .formatted(failureCount, customers.size()),
+            OperationsNotificationService.Channel.AML);
+      } catch (RuntimeException e) {
+        log.error("Failed to send aggregated savings fund AML batch screening-failure alert", e);
+      }
+    }
+
+    log.info(
+        "Successfully ran savings fund AML checks on {} customers ({} screening failures)",
+        customers.size(),
         failureCount);
   }
 

--- a/src/main/java/ee/tuleva/onboarding/aml/ScheduledAmlCheckJob.java
+++ b/src/main/java/ee/tuleva/onboarding/aml/ScheduledAmlCheckJob.java
@@ -20,5 +20,6 @@ public class ScheduledAmlCheckJob {
   @SchedulerLock(name = "ScheduledAmlCheckJob_run", lockAtMostFor = "6h", lockAtLeastFor = "30m")
   public void run() {
     amlService.runAmlChecksOnThirdPillarCustomers();
+    amlService.runAmlChecksOnSavingsFundCustomers();
   }
 }

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/SavingsFundOnboardingRepository.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/SavingsFundOnboardingRepository.java
@@ -20,6 +20,13 @@ public class SavingsFundOnboardingRepository {
 
   private final JdbcClient jdbcClient;
 
+  public List<String> findPersonCodes() {
+    return jdbcClient
+        .sql("SELECT code FROM savings_fund_onboarding WHERE type = 'PERSON'")
+        .query(String.class)
+        .list();
+  }
+
   public boolean isOnboardingCompleted(String code, PartyId.Type type) {
     return findStatus(code, type).filter(status -> status == COMPLETED).isPresent();
   }

--- a/src/main/java/ee/tuleva/onboarding/user/UserRepository.java
+++ b/src/main/java/ee/tuleva/onboarding/user/UserRepository.java
@@ -1,5 +1,7 @@
 package ee.tuleva.onboarding.user;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.data.jpa.repository.EntityGraph;
@@ -12,6 +14,9 @@ public interface UserRepository extends CrudRepository<User, Long> {
 
   @NotNull
   Optional<User> findByEmail(@NotNull String email);
+
+  @NotNull
+  List<User> findAllByPersonalCodeIn(@NotNull Collection<String> personalCodes);
 
   @NotNull
   @EntityGraph(attributePaths = "member")

--- a/src/test/groovy/ee/tuleva/onboarding/aml/AmlServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/aml/AmlServiceTest.java
@@ -31,8 +31,10 @@ import ee.tuleva.onboarding.event.TrackableEvent;
 import ee.tuleva.onboarding.kyc.KycCheck;
 import ee.tuleva.onboarding.mandate.Mandate;
 import ee.tuleva.onboarding.notification.OperationsNotificationService;
+import ee.tuleva.onboarding.savings.fund.SavingsFundOnboardingRepository;
 import ee.tuleva.onboarding.time.ClockHolder;
 import ee.tuleva.onboarding.user.User;
+import ee.tuleva.onboarding.user.UserRepository;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Clock;
@@ -72,6 +74,8 @@ class AmlServiceTest {
   @Mock private ApplicationEventPublisher eventPublisher;
   @Mock private PepAndSanctionCheckService pepAndSanctionCheckService;
   @Mock private AnalyticsRecentThirdPillarRepository analyticsRecentThirdPillarRepository;
+  @Mock private SavingsFundOnboardingRepository savingsFundOnboardingRepository;
+  @Mock private UserRepository userRepository;
   @Mock private UserConversionService userConversionService;
   @Spy private JsonMapper jsonMapper = JsonMapper.builder().build();
   @Spy private MeterRegistry meterRegistry = new SimpleMeterRegistry();
@@ -1074,5 +1078,107 @@ class AmlServiceTest {
     amlService.addSanctionAndPepCheckIfMissing(user, new Country("EE"));
 
     verify(amlCheckRepository, times(2)).save(any(AmlCheck.class));
+  }
+
+  private User savingsFundCustomer(String personalCode) {
+    return User.builder()
+        .personalCode(personalCode)
+        .firstName("First" + personalCode)
+        .lastName("Last" + personalCode)
+        .build();
+  }
+
+  @Test
+  void runAmlChecksOnSavingsFundCustomers_screensEveryOnboardedPerson() {
+    User first = savingsFundCustomer("38888888881");
+    User second = savingsFundCustomer("38888888882");
+    when(savingsFundOnboardingRepository.findPersonCodes())
+        .thenReturn(List.of(first.getPersonalCode(), second.getPersonalCode()));
+    when(userRepository.findAllByPersonalCodeIn(
+            List.of(first.getPersonalCode(), second.getPersonalCode())))
+        .thenReturn(List.of(first, second));
+    when(pepAndSanctionCheckService.match(any(Person.class), any(Country.class)))
+        .thenReturn(
+            new MatchResponse(objectMapper.createArrayNode(), objectMapper.createObjectNode()));
+    when(amlCheckRepository.existsByPersonalCodeAndTypeAndCreatedTimeAfter(
+            anyString(), any(AmlCheckType.class), any(Instant.class)))
+        .thenReturn(false);
+
+    amlService.runAmlChecksOnSavingsFundCustomers();
+
+    verify(pepAndSanctionCheckService).match(eq(first), any(Country.class));
+    verify(pepAndSanctionCheckService).match(eq(second), any(Country.class));
+    verify(notificationService, never()).sendMessage(anyString(), any());
+  }
+
+  @Test
+  void runAmlChecksOnSavingsFundCustomers_sendsSingleAggregatedAlertOnScreeningFailures() {
+    User ok = savingsFundCustomer("38888888881");
+    User failing = savingsFundCustomer("38888888882");
+    when(savingsFundOnboardingRepository.findPersonCodes())
+        .thenReturn(List.of(ok.getPersonalCode(), failing.getPersonalCode()));
+    when(userRepository.findAllByPersonalCodeIn(any())).thenReturn(List.of(ok, failing));
+    when(pepAndSanctionCheckService.match(eq(ok), any(Country.class)))
+        .thenReturn(
+            new MatchResponse(objectMapper.createArrayNode(), objectMapper.createObjectNode()));
+    when(pepAndSanctionCheckService.match(eq(failing), any(Country.class)))
+        .thenThrow(new RuntimeException("Match service error"));
+    when(amlCheckRepository.existsByPersonalCodeAndTypeAndCreatedTimeAfter(
+            anyString(), any(AmlCheckType.class), any(Instant.class)))
+        .thenReturn(false);
+
+    amlService.runAmlChecksOnSavingsFundCustomers();
+
+    verify(notificationService, times(1))
+        .sendMessage(
+            "AML batch: sanction/PEP screening failed for 1 of 2 savings fund customers this run",
+            OperationsNotificationService.Channel.AML);
+  }
+
+  @Test
+  void runAmlChecksOnSavingsFundCustomers_countsCheckPersistenceFailuresAndContinues() {
+    User failing = savingsFundCustomer("38888888881");
+    when(savingsFundOnboardingRepository.findPersonCodes())
+        .thenReturn(List.of(failing.getPersonalCode()));
+    when(userRepository.findAllByPersonalCodeIn(any())).thenReturn(List.of(failing));
+    when(pepAndSanctionCheckService.match(any(Person.class), any(Country.class)))
+        .thenReturn(
+            new MatchResponse(objectMapper.createArrayNode(), objectMapper.createObjectNode()));
+    when(amlCheckRepository.existsByPersonalCodeAndTypeAndCreatedTimeAfter(
+            anyString(), any(AmlCheckType.class), any(Instant.class)))
+        .thenThrow(new RuntimeException("Database unavailable"));
+
+    assertDoesNotThrow(() -> amlService.runAmlChecksOnSavingsFundCustomers());
+
+    verify(notificationService)
+        .sendMessage(
+            "AML batch: sanction/PEP screening failed for 1 of 1 savings fund customers this run",
+            OperationsNotificationService.Channel.AML);
+  }
+
+  @Test
+  void runAmlChecksOnSavingsFundCustomers_slackFailureDoesNotAbortBatch() {
+    User failing = savingsFundCustomer("38888888881");
+    when(savingsFundOnboardingRepository.findPersonCodes())
+        .thenReturn(List.of(failing.getPersonalCode()));
+    when(userRepository.findAllByPersonalCodeIn(any())).thenReturn(List.of(failing));
+    when(pepAndSanctionCheckService.match(any(Person.class), any(Country.class)))
+        .thenThrow(new RuntimeException("Match service error"));
+    doThrow(new RuntimeException("Slack down"))
+        .when(notificationService)
+        .sendMessage(anyString(), any());
+
+    assertDoesNotThrow(() -> amlService.runAmlChecksOnSavingsFundCustomers());
+  }
+
+  @Test
+  void runAmlChecksOnSavingsFundCustomers_doesNothingWhenNobodyIsOnboarded() {
+    when(savingsFundOnboardingRepository.findPersonCodes()).thenReturn(List.of());
+    when(userRepository.findAllByPersonalCodeIn(List.of())).thenReturn(List.of());
+
+    amlService.runAmlChecksOnSavingsFundCustomers();
+
+    verify(pepAndSanctionCheckService, never()).match(any(Person.class), any(Country.class));
+    verify(notificationService, never()).sendMessage(anyString(), any());
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/aml/AmlServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/aml/AmlServiceTest.java
@@ -965,6 +965,7 @@ class AmlServiceTest {
     // then
     verify(eventPublisher).publishEvent(any(AmlChecksRunEvent.class));
 
+    verify(pepAndSanctionCheckService).match(record1, new Country("EE"));
     verify(amlCheckRepository, times(2)).save(any(AmlCheck.class));
     verify(eventPublisher, times(2)).publishEvent(any(AmlCheckCreatedEvent.class));
   }
@@ -1106,8 +1107,8 @@ class AmlServiceTest {
 
     amlService.runAmlChecksOnSavingsFundCustomers();
 
-    verify(pepAndSanctionCheckService).match(eq(first), any(Country.class));
-    verify(pepAndSanctionCheckService).match(eq(second), any(Country.class));
+    verify(pepAndSanctionCheckService).match(first, new Country(null));
+    verify(pepAndSanctionCheckService).match(second, new Country(null));
     verify(notificationService, never()).sendMessage(anyString(), any());
   }
 
@@ -1154,6 +1155,8 @@ class AmlServiceTest {
         .sendMessage(
             "AML batch: sanction/PEP screening failed for 1 of 1 savings fund customers this run",
             OperationsNotificationService.Channel.AML);
+    assertEquals(
+        1.0, meterRegistry.counter("aml.screening.failure", "phase", "savings-fund-batch").count());
   }
 
   @Test

--- a/src/test/groovy/ee/tuleva/onboarding/aml/ScheduledAmlCheckJobTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/aml/ScheduledAmlCheckJobTest.java
@@ -3,7 +3,6 @@ package ee.tuleva.onboarding.aml;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -18,12 +17,20 @@ class ScheduledAmlCheckJobTest {
   @InjectMocks private ScheduledAmlCheckJob scheduledAmlCheckJob;
 
   @Test
-  @DisplayName("Should call AmlService to run checks on third pillar customers when job runs")
   void run_shouldExecuteAmlChecksOnThirdPillarCustomers() {
     // when
     scheduledAmlCheckJob.run();
 
     // then
     verify(amlService, times(1)).runAmlChecksOnThirdPillarCustomers();
+  }
+
+  @Test
+  void run_shouldExecuteAmlChecksOnSavingsFundCustomers() {
+    // when
+    scheduledAmlCheckJob.run();
+
+    // then
+    verify(amlService, times(1)).runAmlChecksOnSavingsFundCustomers();
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/SavingsFundOnboardingRepositoryTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/SavingsFundOnboardingRepositoryTest.java
@@ -106,6 +106,16 @@ class SavingsFundOnboardingRepositoryTest {
   }
 
   @Test
+  void findPersonCodes_returnsEveryOnboardedPersonRegardlessOfStatus() {
+    repository.saveOnboardingStatus("60001019906", PERSON, COMPLETED);
+    repository.saveOnboardingStatus("38888888888", PERSON, PENDING);
+    repository.saveOnboardingStatus("14118923", LEGAL_ENTITY, COMPLETED);
+
+    assertThat(repository.findPersonCodes())
+        .containsExactlyInAnyOrder("60001019906", "38888888888");
+  }
+
+  @Test
   void saveOnboardingStatus_separatesPersonAndLegalEntity() {
     repository.saveOnboardingStatus("14118923", LEGAL_ENTITY, COMPLETED);
 


### PR DESCRIPTION
## The gap

The sisekord requires existing clients to be re-screened against the sanctions list **"vähemalt kord nädalas"**. That is implemented for third pillar only: `ScheduledAmlCheckJob` (Sundays 19:10) calls `runAmlChecksOnThirdPillarCustomers`, which iterates `analytics.v_third_pillar_api_weekly_recent`.

**A savings fund (TKF) customer with no third pillar activity is not in that view, so nothing ever re-screens them.**

Two consequences, and the second is the bad one:

- **Adults** who joined TKF without a third pillar were screened once at onboarding and never again.
- **Minors** were never screened at all. They cannot log in (`MinorCannotSelfAuthenticateException`), create no mandate and complete no KYC survey, so none of the three event-driven screening paths (`beforeMandateCreated`, `beforeKycChecked`, `RedemptionVerificationService`) ever fire — and no batch would catch up. The SQL risk view then reads that absence as clean via `COALESCE(s.success, true)`, so rule 4 scores 0 for every child.

This was found while reviewing a separate change (#1803) that screens children at onboarding. The question "if OpenSanctions is down at onboarding, won't the weekly job catch it?" turned out to have the answer "no, not for this population" — which makes the batch gap the more important fix of the two.

## The change

`runAmlChecksOnSavingsFundCustomers`, mirroring the third pillar batch exactly: per-record failure isolation, the same aggregated Slack alert, the same `aml.screening.failure` metric.

- **Population:** every `PERSON` row in `savings_fund_onboarding`, resolved to users in a single `findAllByPersonalCodeIn` rather than a lookup per record. Legal entities are excluded — they go through KYB.
- **Status:** all statuses, not just `COMPLETED`. Someone mid-funnel is someone whose data we hold, and screening more is the cheap direction here.
- **Country:** passed as `null`. `OpenSanctionsService.getCountries` already tolerates it and omits the country filter, which *widens* matching rather than narrowing it — the safe direction for AML. TKF customers have no equivalent of the third pillar view's `country` column.

## ⚡ Performance

One extra weekly pass over `savings_fund_onboarding` (one row per onboarded party, ~39 today) plus one `IN` query against `users` on an indexed column, then one OpenSanctions call per customer. No per-row DB lookups, no new indexes needed, no hot path, no public endpoint. The existing `@SchedulerLock` (`lockAtMostFor = 6h`) still bounds the run.

Worth watching if TKF grows: at N customers this is N OpenSanctions calls in one weekly run, same shape as the third pillar batch already has.

## Tests

`AmlServiceTest` 46 → 51, whole `aml` package green (100% coverage is enforced there), `SavingsFundOnboardingRepositoryTest` 7 → 8. Covers: every onboarded person screened, aggregated alert on failures, check-persistence failure counted without aborting the batch, Slack outage not aborting the batch, and the empty-population case.

Also dropped a `@DisplayName` from `ScheduledAmlCheckJobTest` while adding to it — CLAUDE.md forbids them.

## Relationship to #1803

Independent; either can merge first. #1803 screens children *at onboarding* so they are checked immediately; this makes sure they — and every other TKF customer — are in the weekly batch at all.

## Correction: what this does NOT fix

An earlier version of this description claimed a transient OpenSanctions failure during child onboarding would now "self-heal within a week". That is only true for someone with **no** sanction check at all.

`addCheckIfMissing` suppresses a new check whenever one of the same type exists from the past year, **regardless of success** — `hasCheck` filters on personal code and type only. So for anyone already screened, a newly *failing* weekly result is discarded: no row, no `AmlCheckCreatedEvent`, no notifier alert, and the risk views keep reading the old passing check. The same class already has the right predicate in `addKycCheck`, which dedups only successes via `hasSuccessfulCheck`.

That affects the pre-existing third-pillar batch identically and is out of scope here. Written up for discussion rather than fixed silently, since it changes how every AML check is persisted.

**So the honest scope of this PR:** it puts savings fund customers into the weekly batch, which fixes the never-screened population (minors, TKF-only adults). It does not by itself make re-screening detect *newly* sanctioned existing customers — that needs the dedup change discussed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)