### PR TITLE
Record sanction/PEP screening results when the outcome changes

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/aml/AmlCheckRepository.java
+++ b/src/main/java/ee/tuleva/onboarding/aml/AmlCheckRepository.java
@@ -2,6 +2,7 @@ package ee.tuleva.onboarding.aml;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -26,4 +27,7 @@ public interface AmlCheckRepository extends JpaRepository<AmlCheck, Long> {
 
   boolean existsByPersonalCodeAndTypeAndSuccessAndCreatedTimeAfter(
       String personalCode, AmlCheckType type, boolean success, Instant createdAfter);
+
+  Optional<AmlCheck> findFirstByPersonalCodeAndTypeOrderByCreatedTimeDesc(
+      String personalCode, AmlCheckType type);
 }

--- a/src/main/java/ee/tuleva/onboarding/aml/AmlService.java
+++ b/src/main/java/ee/tuleva/onboarding/aml/AmlService.java
@@ -130,7 +130,7 @@ public class AmlService {
             .success(isSuccess(person, SANCTION_OVERRIDE, response, "sanction"))
             .metadata(metadata(response.results(), response.query()))
             .build();
-    return addCheckIfMissing(sanctionCheck);
+    return addScreeningCheck(sanctionCheck);
   }
 
   private Optional<AmlCheck> addPepCheckIfMissing(Person person, MatchResponse response) {
@@ -141,7 +141,23 @@ public class AmlService {
             .success(isSuccess(person, POLITICALLY_EXPOSED_PERSON_OVERRIDE, response, "role"))
             .metadata(metadata(response.results(), response.query()))
             .build();
-    return addCheckIfMissing(pepCheck);
+    return addScreeningCheck(pepCheck);
+  }
+
+  private Optional<AmlCheck> addScreeningCheck(AmlCheck screeningCheck) {
+    if (hasCheck(screeningCheck.getPersonalCode(), screeningCheck.getType())
+        && outcomeUnchanged(screeningCheck)) {
+      return Optional.empty();
+    }
+    return Optional.of(addCheck(screeningCheck));
+  }
+
+  private boolean outcomeUnchanged(AmlCheck screeningCheck) {
+    return amlCheckRepository
+        .findFirstByPersonalCodeAndTypeOrderByCreatedTimeDesc(
+            screeningCheck.getPersonalCode(), screeningCheck.getType())
+        .map(latest -> latest.isSuccess() == screeningCheck.isSuccess())
+        .orElse(false);
   }
 
   private boolean isSuccess(

--- a/src/test/groovy/ee/tuleva/onboarding/aml/AmlServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/aml/AmlServiceTest.java
@@ -7,6 +7,7 @@ import static ee.tuleva.onboarding.kyc.KycCheck.RiskLevel.LOW;
 import static ee.tuleva.onboarding.mandate.MandateFixture.*;
 import static java.util.Arrays.stream;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -974,5 +975,104 @@ class AmlServiceTest {
     return stream(checkTypes)
         .map(type -> AmlCheck.builder().type(type).success(false).build())
         .toList();
+  }
+
+  private MatchResponse sanctionAndPepMatch() {
+    ArrayNode results = objectMapper.createArrayNode();
+    ObjectNode result = JsonNodeFactory.instance.objectNode();
+    result.put("id", "matchId123");
+    result.put("match", true);
+    ObjectNode properties = JsonNodeFactory.instance.objectNode();
+    properties.set("topics", JsonNodeFactory.instance.arrayNode().add("role.pep").add("sanction"));
+    result.set("properties", properties);
+    results.add(result);
+    return new MatchResponse(results, JsonNodeFactory.instance.objectNode());
+  }
+
+  private void latestCheckIs(AmlCheckType type, boolean success) {
+    when(amlCheckRepository.findFirstByPersonalCodeAndTypeOrderByCreatedTimeDesc(
+            anyString(), eq(type)))
+        .thenReturn(
+            Optional.of(
+                AmlCheck.builder()
+                    .personalCode("38812121215")
+                    .type(type)
+                    .success(success)
+                    .build()));
+  }
+
+  @Test
+  void screening_recordsNewlyFailingResultDespiteARecentPassingCheck() {
+    User user = createUser("38812121215", "Test", "User", 1L);
+    when(pepAndSanctionCheckService.match(eq(user), any(Country.class)))
+        .thenReturn(sanctionAndPepMatch());
+    when(amlCheckRepository.existsByPersonalCodeAndTypeAndCreatedTimeAfter(
+            anyString(), any(AmlCheckType.class), any(Instant.class)))
+        .thenReturn(true);
+    latestCheckIs(SANCTION, true);
+    latestCheckIs(POLITICALLY_EXPOSED_PERSON_AUTO, true);
+
+    amlService.addSanctionAndPepCheckIfMissing(user, new Country("EE"));
+
+    verify(amlCheckRepository, times(2)).save(amlCheckCaptor.capture());
+    assertThat(amlCheckCaptor.getAllValues())
+        .extracting(AmlCheck::getType, AmlCheck::isSuccess)
+        .containsExactlyInAnyOrder(
+            tuple(POLITICALLY_EXPOSED_PERSON_AUTO, false), tuple(SANCTION, false));
+  }
+
+  @Test
+  void screening_recordsRecoveryWhenAPreviouslyFailingPersonNoLongerMatches() {
+    User user = createUser("38812121215", "Test", "User", 1L);
+    when(pepAndSanctionCheckService.match(eq(user), any(Country.class)))
+        .thenReturn(
+            new MatchResponse(objectMapper.createArrayNode(), objectMapper.createObjectNode()));
+    when(amlCheckRepository.existsByPersonalCodeAndTypeAndCreatedTimeAfter(
+            anyString(), any(AmlCheckType.class), any(Instant.class)))
+        .thenReturn(true);
+    latestCheckIs(SANCTION, false);
+    latestCheckIs(POLITICALLY_EXPOSED_PERSON_AUTO, false);
+
+    amlService.addSanctionAndPepCheckIfMissing(user, new Country("EE"));
+
+    verify(amlCheckRepository, times(2)).save(amlCheckCaptor.capture());
+    assertThat(amlCheckCaptor.getAllValues())
+        .extracting(AmlCheck::getType, AmlCheck::isSuccess)
+        .containsExactlyInAnyOrder(
+            tuple(POLITICALLY_EXPOSED_PERSON_AUTO, true), tuple(SANCTION, true));
+  }
+
+  @Test
+  void screening_doesNotRecordAnUnchangedOutcomeWithinTheWindow() {
+    User user = createUser("38812121215", "Test", "User", 1L);
+    when(pepAndSanctionCheckService.match(eq(user), any(Country.class)))
+        .thenReturn(
+            new MatchResponse(objectMapper.createArrayNode(), objectMapper.createObjectNode()));
+    when(amlCheckRepository.existsByPersonalCodeAndTypeAndCreatedTimeAfter(
+            anyString(), any(AmlCheckType.class), any(Instant.class)))
+        .thenReturn(true);
+    latestCheckIs(SANCTION, true);
+    latestCheckIs(POLITICALLY_EXPOSED_PERSON_AUTO, true);
+
+    amlService.addSanctionAndPepCheckIfMissing(user, new Country("EE"));
+
+    verify(amlCheckRepository, never()).save(any(AmlCheck.class));
+  }
+
+  @Test
+  void screening_recordsAnUnchangedOutcomeOnceTheWindowHasExpired() {
+    User user = createUser("38812121215", "Test", "User", 1L);
+    when(pepAndSanctionCheckService.match(eq(user), any(Country.class)))
+        .thenReturn(
+            new MatchResponse(objectMapper.createArrayNode(), objectMapper.createObjectNode()));
+    when(amlCheckRepository.existsByPersonalCodeAndTypeAndCreatedTimeAfter(
+            anyString(), any(AmlCheckType.class), any(Instant.class)))
+        .thenReturn(false);
+    latestCheckIs(SANCTION, true);
+    latestCheckIs(POLITICALLY_EXPOSED_PERSON_AUTO, true);
+
+    amlService.addSanctionAndPepCheckIfMissing(user, new Country("EE"));
+
+    verify(amlCheckRepository, times(2)).save(any(AmlCheck.class));
   }
 }


### PR DESCRIPTION
## What is wrong

The weekly job calls OpenSanctions for every customer and gets a real answer — then throws it away if a check of that type already exists from the past year. `addCheckIfMissing` asks `hasCheck`, which filters on personal code and type only, **never on `success`**:

```java
private boolean hasCheck(String personalCode, AmlCheckType checkType) {
  return amlCheckRepository.existsByPersonalCodeAndTypeAndCreatedTimeAfter(
      personalCode, checkType, aYearAgo());
}
```

So a customer screened clean in January who is sanctioned in April is matched every Sunday from April onward and **nothing is written**: no row, no `AmlCheckCreatedEvent`, so no `AmlCheckNotifier` alert either. `v_aml_risk_metadata` and `v_tkf_risk_metadata` keep reading the January check and score them clean.

## Production data confirms it

Every recorded clean→failing transition sits at **365–368 days**:

```
365d 10h · 366d 4h · 366d 22h · 366d 23h · 366d 23h · 367d 22h
```

None inside the year. Real status changes would scatter across the calendar — a three-day band immediately after the window expires is the suppression lifting and the next Sunday run finally being allowed to write. **Those were detected up to a year late.**

| | SANCTION | PEP_AUTO |
|---|---|---|
| Latest check passing, under a year old (**blind spot**) | 74,289 | 74,221 |
| Latest check failing | 2 | 68 |

Monthly writes corroborate: 9,823 / 9,829 rows in June 2026 against 851 in July and 1,489 in May — cohorts ageing out together, not weekly detection.

**Estimated exposure:** June is a natural experiment, since that cohort aged out and was genuinely re-screened — 11 PEP failures in 9,829, or 0.11%. Applied to the ~74k currently suppressed, roughly **80 people are matched right now and showing clean**. Order of magnitude, not a count.

## The fix

Sanction and PEP now go through `addScreeningCheck`, which writes when the outcome differs from that person's most recent check of that type, and otherwise keeps the existing yearly cadence.

- Newly failing → recorded immediately, alert fires.
- Recovery from failing to passing → also recorded, so the risk views can clear someone.
- Status unchanged → no weekly duplicate rows; the yearly heartbeat still writes, so the audit trail that we screened on date X is preserved.

`addKycCheck` in the same class already had the right shape (dedup only successes) — this is the same idea, extended to cover both directions.

**Deliberately scoped to the screening path.** `DOCUMENT`, `RESIDENCY_AUTO`, `SK_NAME`, `CONTACT_DETAILS` and `PENSION_REGISTRY_NAME` keep using `addCheckIfMissing` unchanged. They are login-driven rather than a standing monitoring control, and widening this would change behaviour well beyond the bug.

## ⚡ Performance

One extra indexed lookup (`findFirstByPersonalCodeAndTypeOrderByCreatedTimeDesc`) per screened person per run, only reached when a check already exists in the window. The weekly batch already makes one OpenSanctions HTTP call per person, which dominates. No new endpoints, no hot path, no new indexes — `aml_check(personal_code, type)` access is already served by existing indexes; worth an `EXPLAIN` on the replica before merge.

## 🔴 Heads-up for ops before this deploys

The first Sunday run after deploy **is the detector**: everyone currently matched but hidden gets a failing check written in one batch. Expect roughly **80–90 new flags at once** rather than a trickle. Ops should be warned, and it is worth agreeing who triages them before this merges.

## Tests

`AmlServiceTest` 46 → 50, whole `aml` package green across 43 classes (100% coverage is enforced there). New cases: newly-failing recorded despite a recent passing check, recovery recorded, unchanged outcome not recorded within the window, unchanged outcome recorded once the window expires.

## Open questions

1. Is the one-year window deliberate, or inherited from an "onboarding check valid for a year" rule that re-screening was later bolted onto?
2. Does a year of undetected matches need reporting? That is a compliance call, not an engineering one — flagging it rather than deciding it.

## Related

- #1804 puts savings fund customers into the weekly batch at all (they were never in it).
- #1803 screens children at onboarding (they were never screened by any path).

Writeup with the queries used: `AML/rescreen-dedup-note.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)