### PR TITLE
Screen the guardian when onboarding a child and before the child's KYC risk assessment

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/party/ChildCoParentCaptureListener.java
+++ b/src/main/java/ee/tuleva/onboarding/party/ChildCoParentCaptureListener.java
@@ -2,6 +2,9 @@ package ee.tuleva.onboarding.party;
 
 import static org.springframework.transaction.event.TransactionPhase.AFTER_COMMIT;
 
+import ee.tuleva.onboarding.aml.AmlService;
+import ee.tuleva.onboarding.country.Country;
+import ee.tuleva.onboarding.user.UserService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -16,6 +19,8 @@ public class ChildCoParentCaptureListener {
 
   private final CustodyVerificationService custodyVerificationService;
   private final ParentChildLinkRegistrationService parentChildLinkRegistrationService;
+  private final UserService userService;
+  private final AmlService amlService;
 
   @Async
   @TransactionalEventListener(phase = AFTER_COMMIT)
@@ -48,6 +53,28 @@ public class ChildCoParentCaptureListener {
           "Failed to capture pending co-parent: coParentCode={}, childCode={}",
           coParentPersonalCode,
           event.childPersonalCode(),
+          e);
+      return;
+    }
+    screenCoParent(coParentPersonalCode, event.childPersonalCode());
+  }
+
+  private void screenCoParent(String coParentPersonalCode, String childPersonalCode) {
+    try {
+      userService
+          .findByPersonalCode(coParentPersonalCode)
+          .ifPresentOrElse(
+              coParent -> amlService.addSanctionAndPepCheckIfMissing(coParent, new Country(null)),
+              () ->
+                  log.info(
+                      "Co-parent has no user account, skipping sanction/PEP screening: coParentCode={}, childCode={}",
+                      coParentPersonalCode,
+                      childPersonalCode));
+    } catch (RuntimeException e) {
+      log.error(
+          "Co-parent screening failed: coParentCode={}, childCode={}",
+          coParentPersonalCode,
+          childPersonalCode,
           e);
     }
   }

--- a/src/main/java/ee/tuleva/onboarding/party/ChildOnboardingService.java
+++ b/src/main/java/ee/tuleva/onboarding/party/ChildOnboardingService.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.Nullable;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -54,13 +55,21 @@ public class ChildOnboardingService {
         .toList();
   }
 
-  private Map<String, Object> custodyEvidence(CustodyVerification verification) {
-    PopulationRegisterPerson child = verification.child();
-    if (child == null || child.citizenship() == null) {
-      return verification.evidence();
-    }
+  private Map<String, Object> custodyEvidence(
+      CustodyVerification verification,
+      String guardianPersonalCode,
+      @Nullable String guardianCitizenship) {
     var evidence = new LinkedHashMap<String, Object>(verification.evidence());
-    evidence.put("citizenship", child.citizenship());
+    PopulationRegisterPerson child = verification.child();
+    if (child != null && child.citizenship() != null) {
+      evidence.put("citizenship", child.citizenship());
+    }
+    if (verification.isVerified()) {
+      evidence.put("guardianPersonalCode", guardianPersonalCode);
+      if (guardianCitizenship != null) {
+        evidence.put("guardianCitizenship", guardianCitizenship);
+      }
+    }
     return unmodifiableMap(evidence);
   }
 
@@ -68,6 +77,12 @@ public class ChildOnboardingService {
     amlService.addSanctionAndPepCheckIfMissing(
         new PersonImpl(child.personalCode(), child.firstName(), child.lastName()),
         new Country(child.citizenship()));
+  }
+
+  private void screenGuardian(AuthenticatedPerson parent, @Nullable String citizenship) {
+    amlService.addSanctionAndPepCheckIfMissing(
+        new PersonImpl(parent.getPersonalCode(), parent.getFirstName(), parent.getLastName()),
+        new Country(citizenship));
   }
 
   private boolean hasBeenOnboarded(String childPersonalCode) {
@@ -83,8 +98,15 @@ public class ChildOnboardingService {
 
     applicationEventPublisher.publishEvent(
         new TrackableEvent(parent, MINOR_CUSTODY_VERIFICATION, verification.evidence()));
+    String guardianCitizenship =
+        verification.isVerified()
+            ? custodyVerificationService.fetchGuardianCitizenship(
+                parentPersonalCode, CUSTODY_MAX_AGE)
+            : null;
     amlService.addCustodyRightCheck(
-        childPersonalCode, verification.isVerified(), custodyEvidence(verification));
+        childPersonalCode,
+        verification.isVerified(),
+        custodyEvidence(verification, parentPersonalCode, guardianCitizenship));
 
     if (!verification.isVerified()) {
       log.info(
@@ -100,6 +122,7 @@ public class ChildOnboardingService {
         parentPersonalCode, childPersonalCode, child.firstName(), child.lastName());
     savingsFundOnboardingService.seedPersonOnboardingIfAbsent(childPersonalCode);
     screenForSanctionsAndPep(child);
+    screenGuardian(parent, guardianCitizenship);
 
     applicationEventPublisher.publishEvent(
         new ChildOnboardedEvent(

--- a/src/main/java/ee/tuleva/onboarding/party/CustodyVerificationService.java
+++ b/src/main/java/ee/tuleva/onboarding/party/CustodyVerificationService.java
@@ -18,6 +18,7 @@ import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.Nullable;
 import org.springframework.stereotype.Service;
 
 @Slf4j
@@ -26,6 +27,20 @@ import org.springframework.stereotype.Service;
 public class CustodyVerificationService {
 
   private final PopulationRegisterClient populationRegisterClient;
+
+  // Best-effort AML data capture — a register failure must never block child onboarding,
+  // the risk assessment treats a missing citizenship as unknown.
+  public @Nullable String fetchGuardianCitizenship(String guardianPersonalCode, Duration maxAge) {
+    try {
+      return populationRegisterClient
+          .fetchPerson(guardianPersonalCode, guardianPersonalCode, maxAge)
+          .data()
+          .citizenship();
+    } catch (RuntimeException e) {
+      log.warn("Guardian citizenship lookup failed: guardianCode={}", guardianPersonalCode, e);
+      return null;
+    }
+  }
 
   public List<String> findGuardiansWithAssetManagement(
       String childPersonalCode, String requesterPersonalCode) {

--- a/src/main/java/ee/tuleva/onboarding/party/GuardianKycScreeningListener.java
+++ b/src/main/java/ee/tuleva/onboarding/party/GuardianKycScreeningListener.java
@@ -1,0 +1,51 @@
+package ee.tuleva.onboarding.party;
+
+import ee.tuleva.onboarding.aml.AmlService;
+import ee.tuleva.onboarding.country.Country;
+import ee.tuleva.onboarding.kyc.BeforeKycCheckedEvent;
+import ee.tuleva.onboarding.user.UserService;
+import ee.tuleva.onboarding.user.personalcode.PersonalCode;
+import java.time.Clock;
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NullMarked;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+// Must stay synchronous: the guardian screening has to land before the minor's risk
+// assessment (check_24 in kyc_ob_assess_user_risk) reads it in the same request.
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@NullMarked
+class GuardianKycScreeningListener {
+
+  private final ParentChildLinkService parentChildLinkService;
+  private final UserService userService;
+  private final AmlService amlService;
+  private final Clock clock;
+
+  @EventListener
+  public void beforeKycChecked(BeforeKycCheckedEvent event) {
+    String subjectPersonalCode = event.person().getPersonalCode();
+    if (!PersonalCode.isMinor(subjectPersonalCode, LocalDate.now(clock))) {
+      return;
+    }
+    parentChildLinkService
+        .findGuardianCodes(subjectPersonalCode)
+        .forEach(guardianCode -> screenGuardian(guardianCode, subjectPersonalCode));
+  }
+
+  private void screenGuardian(String guardianPersonalCode, String childPersonalCode) {
+    userService
+        .findByPersonalCode(guardianPersonalCode)
+        .ifPresentOrElse(
+            guardian -> amlService.addSanctionAndPepCheckIfMissing(guardian, new Country(null)),
+            () ->
+                log.warn(
+                    "Guardian has no user account, skipping sanction/PEP screening: guardianCode={}, childCode={}",
+                    guardianPersonalCode,
+                    childPersonalCode));
+  }
+}

--- a/src/main/java/ee/tuleva/onboarding/party/ParentChildLinkRepository.java
+++ b/src/main/java/ee/tuleva/onboarding/party/ParentChildLinkRepository.java
@@ -14,6 +14,9 @@ public interface ParentChildLinkRepository extends JpaRepository<ParentChildLink
   List<ParentChildLink> findByChildPersonalCodeAndStatusAndSuspendedAtIsNullAndValidUntilAfter(
       String childPersonalCode, ParentChildLinkStatus status, LocalDate date);
 
+  List<ParentChildLink> findByChildPersonalCodeAndValidUntilAfter(
+      String childPersonalCode, LocalDate date);
+
   boolean
       existsByParentPersonalCodeAndChildPersonalCodeAndStatusAndSuspendedAtIsNullAndValidUntilAfter(
           String parentPersonalCode,

--- a/src/main/java/ee/tuleva/onboarding/party/ParentChildLinkService.java
+++ b/src/main/java/ee/tuleva/onboarding/party/ParentChildLinkService.java
@@ -31,6 +31,17 @@ public class ParentChildLinkService {
             parentPersonalCode, childPersonalCode, ACTIVE, today());
   }
 
+  // AML screening scope, not an authorization check: suspended and PENDING_KYC links count,
+  // because suspension does not cleanse the guardian-risk association (mirrors check_24).
+  public List<String> findGuardianCodes(String childPersonalCode) {
+    return parentChildLinkRepository
+        .findByChildPersonalCodeAndValidUntilAfter(childPersonalCode, today())
+        .stream()
+        .map(ParentChildLink::getParentPersonalCode)
+        .distinct()
+        .toList();
+  }
+
   public List<String> findPendingChildCodes(String parentPersonalCode) {
     return parentChildLinkRepository
         .findByParentPersonalCodeAndStatusAndSuspendedAtIsNullAndValidUntilAfter(

--- a/src/test/groovy/ee/tuleva/onboarding/kyc/survey/ChildRoleAwareKycIntegrationTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyc/survey/ChildRoleAwareKycIntegrationTest.java
@@ -1,6 +1,8 @@
 package ee.tuleva.onboarding.kyc.survey;
 
 import static ee.tuleva.onboarding.aml.AmlCheckType.KYC_CHECK;
+import static ee.tuleva.onboarding.aml.AmlCheckType.POLITICALLY_EXPOSED_PERSON_AUTO;
+import static ee.tuleva.onboarding.aml.AmlCheckType.SANCTION;
 import static ee.tuleva.onboarding.auth.AuthenticatedPersonFixture.authenticatedPersonFromUser;
 import static ee.tuleva.onboarding.auth.UserFixture.sampleUserNonMember;
 import static ee.tuleva.onboarding.auth.authority.Authority.USER;
@@ -8,6 +10,8 @@ import static ee.tuleva.onboarding.party.PartyId.Type.PERSON;
 import static ee.tuleva.onboarding.savings.fund.SavingsFundOnboardingStatus.COMPLETED;
 import static ee.tuleva.onboarding.time.ClockHolder.aYearAgo;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -17,15 +21,21 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import ee.tuleva.onboarding.aml.AmlCheck;
 import ee.tuleva.onboarding.aml.AmlCheckRepository;
+import ee.tuleva.onboarding.aml.sanctions.MatchResponse;
+import ee.tuleva.onboarding.aml.sanctions.PepAndSanctionCheckService;
 import ee.tuleva.onboarding.auth.role.Role;
 import ee.tuleva.onboarding.auth.role.RoleType;
 import ee.tuleva.onboarding.kyc.BeforeKycCheckedEvent;
 import ee.tuleva.onboarding.kyc.KycCheckPerformedEvent;
 import ee.tuleva.onboarding.kyc.TestKycChecker;
 import ee.tuleva.onboarding.kyc.TestKycCheckerConfiguration;
+import ee.tuleva.onboarding.party.ParentChildLink;
+import ee.tuleva.onboarding.party.ParentChildLinkRepository;
+import ee.tuleva.onboarding.party.RepresentationType;
 import ee.tuleva.onboarding.savings.fund.SavingsFundOnboardingRepository;
 import ee.tuleva.onboarding.user.User;
 import ee.tuleva.onboarding.user.UserRepository;
+import java.time.LocalDate;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -37,10 +47,12 @@ import org.springframework.http.MediaType;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.event.ApplicationEvents;
 import org.springframework.test.context.event.RecordApplicationEvents;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.json.JsonMapper;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -129,8 +141,13 @@ class ChildRoleAwareKycIntegrationTest {
   @Autowired private KycSurveyRepository kycSurveyRepository;
   @Autowired private SavingsFundOnboardingRepository savingsFundOnboardingRepository;
   @Autowired private AmlCheckRepository amlCheckRepository;
+  @Autowired private ParentChildLinkRepository parentChildLinkRepository;
   @Autowired private ApplicationEvents applicationEvents;
   @Autowired private TestKycChecker testKycChecker;
+
+  @MockitoBean private PepAndSanctionCheckService pepAndSanctionCheckService;
+
+  private static final JsonMapper objectMapper = JsonMapper.builder().build();
 
   private User parent;
   private User child;
@@ -139,6 +156,9 @@ class ChildRoleAwareKycIntegrationTest {
   @BeforeEach
   void setUp() {
     testKycChecker.reset();
+    given(pepAndSanctionCheckService.match(any(), any()))
+        .willReturn(
+            new MatchResponse(objectMapper.createArrayNode(), objectMapper.createObjectNode()));
     parent =
         userRepository.save(
             sampleUserNonMember()
@@ -158,6 +178,13 @@ class ChildRoleAwareKycIntegrationTest {
                 .email("child@example.com")
                 .phoneNumber("+37255500000")
                 .build());
+    parentChildLinkRepository.save(
+        ParentChildLink.builder()
+            .parentPersonalCode(PARENT_CODE)
+            .childPersonalCode(CHILD_CODE)
+            .relationshipType(RepresentationType.LEGAL_REPRESENTATIVE)
+            .validUntil(LocalDate.now().plusYears(2))
+            .build());
 
     parentActingAsChild =
         authenticatedAs(parent, new Role(RoleType.PERSON, CHILD_CODE, "Child Person"));
@@ -183,13 +210,13 @@ class ChildRoleAwareKycIntegrationTest {
   }
 
   @Test
-  void parentActingAsChild_screensTheChildNotTheParent() throws Exception {
+  void parentActingAsChild_screensTheChildAndTheLinkedGuardian() throws Exception {
     submitOnboardingSurvey(parentActingAsChild);
 
     var beforeKycEvents = applicationEvents.stream(BeforeKycCheckedEvent.class).toList();
     assertThat(beforeKycEvents).hasSize(1);
     assertThat(beforeKycEvents.getFirst().person().getPersonalCode())
-        .as("sanction/PEP screening is aimed at the child")
+        .as("the KYC check itself is aimed at the child")
         .isEqualTo(CHILD_CODE);
 
     var kycCheckEvents = applicationEvents.stream(KycCheckPerformedEvent.class).toList();
@@ -198,10 +225,12 @@ class ChildRoleAwareKycIntegrationTest {
 
     assertThat(amlCheckRepository.findAllByPersonalCodeAndCreatedTimeAfter(CHILD_CODE, aYearAgo()))
         .extracting(AmlCheck::getType)
-        .contains(KYC_CHECK);
+        .contains(KYC_CHECK, SANCTION, POLITICALLY_EXPOSED_PERSON_AUTO);
     assertThat(amlCheckRepository.findAllByPersonalCodeAndCreatedTimeAfter(PARENT_CODE, aYearAgo()))
-        .as("no AML checks are written against the parent")
-        .isEmpty();
+        .as("the linked guardian is sanction/PEP screened before the child's risk assessment")
+        .extracting(AmlCheck::getType)
+        .contains(SANCTION, POLITICALLY_EXPOSED_PERSON_AUTO)
+        .doesNotContain(KYC_CHECK);
   }
 
   @Test

--- a/src/test/groovy/ee/tuleva/onboarding/party/ChildCoParentCaptureListenerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/party/ChildCoParentCaptureListenerTest.java
@@ -1,10 +1,18 @@
 package ee.tuleva.onboarding.party;
 
+import static ee.tuleva.onboarding.auth.UserFixture.sampleUserNonMember;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
+import ee.tuleva.onboarding.aml.AmlService;
+import ee.tuleva.onboarding.country.Country;
+import ee.tuleva.onboarding.user.User;
+import ee.tuleva.onboarding.user.UserService;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -21,6 +29,8 @@ class ChildCoParentCaptureListenerTest {
 
   @Mock private CustodyVerificationService custodyVerificationService;
   @Mock private ParentChildLinkRegistrationService parentChildLinkRegistrationService;
+  @Mock private UserService userService;
+  @Mock private AmlService amlService;
 
   @InjectMocks private ChildCoParentCaptureListener listener;
 
@@ -28,6 +38,47 @@ class ChildCoParentCaptureListenerTest {
   void capturesPendingLinksForTheOtherGuardians() {
     given(custodyVerificationService.findGuardiansWithAssetManagement(CHILD, PARENT))
         .willReturn(List.of(CO_PARENT));
+    given(userService.findByPersonalCode(CO_PARENT)).willReturn(Optional.empty());
+
+    listener.onChildOnboarded(new ChildOnboardedEvent(PARENT, CHILD, "Mari", "Maasikas"));
+
+    verify(parentChildLinkRegistrationService)
+        .registerPending(CO_PARENT, CHILD, "Mari", "Maasikas");
+  }
+
+  @Test
+  void screensTheCapturedCoParentForSanctionsAndPep() {
+    User coParent = sampleUserNonMember().personalCode(CO_PARENT).build();
+    given(custodyVerificationService.findGuardiansWithAssetManagement(CHILD, PARENT))
+        .willReturn(List.of(CO_PARENT));
+    given(userService.findByPersonalCode(CO_PARENT)).willReturn(Optional.of(coParent));
+
+    listener.onChildOnboarded(new ChildOnboardedEvent(PARENT, CHILD, "Mari", "Maasikas"));
+
+    verify(amlService).addSanctionAndPepCheckIfMissing(coParent, new Country(null));
+  }
+
+  @Test
+  void skipsScreeningWhenTheCoParentHasNoUserAccount() {
+    given(custodyVerificationService.findGuardiansWithAssetManagement(CHILD, PARENT))
+        .willReturn(List.of(CO_PARENT));
+    given(userService.findByPersonalCode(CO_PARENT)).willReturn(Optional.empty());
+
+    listener.onChildOnboarded(new ChildOnboardedEvent(PARENT, CHILD, "Mari", "Maasikas"));
+
+    verify(parentChildLinkRegistrationService)
+        .registerPending(CO_PARENT, CHILD, "Mari", "Maasikas");
+    verify(amlService, never()).addSanctionAndPepCheckIfMissing(any(), any());
+  }
+
+  @Test
+  void screeningFailureDoesNotUndoTheCapturedLink() {
+    User coParent = sampleUserNonMember().personalCode(CO_PARENT).build();
+    given(custodyVerificationService.findGuardiansWithAssetManagement(CHILD, PARENT))
+        .willReturn(List.of(CO_PARENT));
+    given(userService.findByPersonalCode(CO_PARENT)).willReturn(Optional.of(coParent));
+    given(amlService.addSanctionAndPepCheckIfMissing(coParent, new Country(null)))
+        .willThrow(new RuntimeException("screening unavailable"));
 
     listener.onChildOnboarded(new ChildOnboardedEvent(PARENT, CHILD, "Mari", "Maasikas"));
 
@@ -51,10 +102,12 @@ class ChildCoParentCaptureListenerTest {
         .willReturn(List.of(CO_PARENT, OTHER_CO_PARENT));
     given(parentChildLinkRegistrationService.registerPending(CO_PARENT, CHILD, "Mari", "Maasikas"))
         .willThrow(new RuntimeException("constraint violation"));
+    given(userService.findByPersonalCode(OTHER_CO_PARENT)).willReturn(Optional.empty());
 
     listener.onChildOnboarded(new ChildOnboardedEvent(PARENT, CHILD, "Mari", "Maasikas"));
 
     verify(parentChildLinkRegistrationService)
         .registerPending(OTHER_CO_PARENT, CHILD, "Mari", "Maasikas");
+    verify(userService, never()).findByPersonalCode(CO_PARENT);
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/party/ChildOnboardingServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/party/ChildOnboardingServiceTest.java
@@ -147,6 +147,8 @@ class ChildOnboardingServiceTest {
             CUSTODY_MESSAGE_ID);
     given(custodyVerificationService.verify(PARENT, CHILD, CUSTODY_MAX_AGE))
         .willReturn(new CustodyVerification(OK, child, evidence));
+    given(custodyVerificationService.fetchGuardianCitizenship(PARENT, CUSTODY_MAX_AGE))
+        .willReturn("EE");
 
     ChildOnboardingResult result = service.onboardChild(parent, CHILD);
 
@@ -156,9 +158,11 @@ class ChildOnboardingServiceTest {
     assertThat(result.dateOfBirth()).isEqualTo(LocalDate.of(2015, 6, 15));
     verify(parentChildLinkRegistrationService).register(PARENT, CHILD, "MARI", "MAASIKAS");
     verify(savingsFundOnboardingService).seedPersonOnboardingIfAbsent(CHILD);
-    var evidenceWithCitizenship = new LinkedHashMap<String, Object>(evidence);
-    evidenceWithCitizenship.put("citizenship", "EE");
-    verify(amlService).addCustodyRightCheck(CHILD, true, evidenceWithCitizenship);
+    var expectedEvidence = new LinkedHashMap<String, Object>(evidence);
+    expectedEvidence.put("citizenship", "EE");
+    expectedEvidence.put("guardianPersonalCode", PARENT);
+    expectedEvidence.put("guardianCitizenship", "EE");
+    verify(amlService).addCustodyRightCheck(CHILD, true, expectedEvidence);
     verify(applicationEventPublisher)
         .publishEvent(new TrackableEvent(parent, MINOR_CUSTODY_VERIFICATION, evidence));
   }
@@ -177,6 +181,41 @@ class ChildOnboardingServiceTest {
   }
 
   @Test
+  void verifiedCustody_screensTheGuardianForSanctionsAndPepUsingRegisterCitizenship() {
+    var evidence = Map.<String, Object>of("outcome", "OK", "childPersonalCode", CHILD);
+    given(custodyVerificationService.verify(PARENT, CHILD, CUSTODY_MAX_AGE))
+        .willReturn(new CustodyVerification(OK, child, evidence));
+    given(custodyVerificationService.fetchGuardianCitizenship(PARENT, CUSTODY_MAX_AGE))
+        .willReturn("RU");
+
+    service.onboardChild(parent, CHILD);
+
+    verify(amlService)
+        .addSanctionAndPepCheckIfMissing(
+            new PersonImpl(PARENT, "Jordan", "Valdma"), new Country("RU"));
+    var expectedEvidence = new LinkedHashMap<String, Object>(evidence);
+    expectedEvidence.put("citizenship", "EE");
+    expectedEvidence.put("guardianPersonalCode", PARENT);
+    expectedEvidence.put("guardianCitizenship", "RU");
+    verify(amlService).addCustodyRightCheck(CHILD, true, expectedEvidence);
+  }
+
+  @Test
+  void verifiedCustody_screensTheGuardianEvenWhenTheirCitizenshipIsUnknown() {
+    var evidence = Map.<String, Object>of("outcome", "OK", "childPersonalCode", CHILD);
+    given(custodyVerificationService.verify(PARENT, CHILD, CUSTODY_MAX_AGE))
+        .willReturn(new CustodyVerification(OK, child, evidence));
+    given(custodyVerificationService.fetchGuardianCitizenship(PARENT, CUSTODY_MAX_AGE))
+        .willReturn(null);
+
+    service.onboardChild(parent, CHILD);
+
+    verify(amlService)
+        .addSanctionAndPepCheckIfMissing(
+            new PersonImpl(PARENT, "Jordan", "Valdma"), new Country(null));
+  }
+
+  @Test
   void verifiedCustody_screensTheChildEvenWhenTheRegisterReportsNoCitizenship() {
     var childWithoutCitizenship =
         new PopulationRegisterPerson(
@@ -190,7 +229,9 @@ class ChildOnboardingServiceTest {
     verify(amlService)
         .addSanctionAndPepCheckIfMissing(
             new PersonImpl(CHILD, "MARI", "MAASIKAS"), new Country(null));
-    verify(amlService).addCustodyRightCheck(CHILD, true, evidence);
+    var expectedEvidence = new LinkedHashMap<String, Object>(evidence);
+    expectedEvidence.put("guardianPersonalCode", PARENT);
+    verify(amlService).addCustodyRightCheck(CHILD, true, expectedEvidence);
   }
 
   @Test

--- a/src/test/groovy/ee/tuleva/onboarding/party/GuardianKycScreeningListenerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/party/GuardianKycScreeningListenerTest.java
@@ -1,0 +1,83 @@
+package ee.tuleva.onboarding.party;
+
+import static ee.tuleva.onboarding.auth.UserFixture.sampleUserNonMember;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import ee.tuleva.onboarding.aml.AmlService;
+import ee.tuleva.onboarding.auth.principal.PersonImpl;
+import ee.tuleva.onboarding.country.Country;
+import ee.tuleva.onboarding.kyc.BeforeKycCheckedEvent;
+import ee.tuleva.onboarding.user.User;
+import ee.tuleva.onboarding.user.UserService;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class GuardianKycScreeningListenerTest {
+
+  private static final String CHILD = "61506150006";
+  private static final String ADULT = "38812121215";
+  private static final String GUARDIAN = "38002020008";
+  private static final String OTHER_GUARDIAN = "48002020009";
+
+  @Mock private ParentChildLinkService parentChildLinkService;
+  @Mock private UserService userService;
+  @Mock private AmlService amlService;
+
+  private final Clock clock = Clock.fixed(Instant.parse("2026-05-22T00:00:00Z"), ZoneOffset.UTC);
+
+  private GuardianKycScreeningListener listener;
+
+  @BeforeEach
+  void setUp() {
+    listener =
+        new GuardianKycScreeningListener(parentChildLinkService, userService, amlService, clock);
+  }
+
+  @Test
+  void screensEveryGuardianOfAMinorKycSubject() {
+    User guardian = sampleUserNonMember().personalCode(GUARDIAN).build();
+    User otherGuardian = sampleUserNonMember().personalCode(OTHER_GUARDIAN).build();
+    given(parentChildLinkService.findGuardianCodes(CHILD))
+        .willReturn(List.of(GUARDIAN, OTHER_GUARDIAN));
+    given(userService.findByPersonalCode(GUARDIAN)).willReturn(Optional.of(guardian));
+    given(userService.findByPersonalCode(OTHER_GUARDIAN)).willReturn(Optional.of(otherGuardian));
+
+    listener.beforeKycChecked(
+        new BeforeKycCheckedEvent(new PersonImpl(CHILD, "Mari", "Maasikas"), new Country("EE")));
+
+    verify(amlService).addSanctionAndPepCheckIfMissing(guardian, new Country(null));
+    verify(amlService).addSanctionAndPepCheckIfMissing(otherGuardian, new Country(null));
+  }
+
+  @Test
+  void doesNothingForAnAdultKycSubject() {
+    listener.beforeKycChecked(
+        new BeforeKycCheckedEvent(new PersonImpl(ADULT, "Jordan", "Valdma"), new Country("EE")));
+
+    verifyNoInteractions(parentChildLinkService, userService, amlService);
+  }
+
+  @Test
+  void skipsGuardiansWithoutAUserAccount() {
+    given(parentChildLinkService.findGuardianCodes(CHILD)).willReturn(List.of(GUARDIAN));
+    given(userService.findByPersonalCode(GUARDIAN)).willReturn(Optional.empty());
+
+    listener.beforeKycChecked(
+        new BeforeKycCheckedEvent(new PersonImpl(CHILD, "Mari", "Maasikas"), new Country("EE")));
+
+    verify(amlService, never()).addSanctionAndPepCheckIfMissing(any(), any());
+  }
+}

--- a/src/test/groovy/ee/tuleva/onboarding/party/ParentChildLinkServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/party/ParentChildLinkServiceTest.java
@@ -70,6 +70,29 @@ class ParentChildLinkServiceTest {
   }
 
   @Test
+  void findsGuardianCodesAcrossAllUnexpiredLinksIncludingSuspendedAndPending() {
+    var active =
+        ParentChildLink.builder()
+            .parentPersonalCode(PARENT)
+            .childPersonalCode(CHILD)
+            .relationshipType(LEGAL_REPRESENTATIVE)
+            .validUntil(LocalDate.of(2030, 1, 1))
+            .build();
+    var pendingCoParent =
+        ParentChildLink.builder()
+            .parentPersonalCode("48002020009")
+            .childPersonalCode(CHILD)
+            .relationshipType(LEGAL_REPRESENTATIVE)
+            .validUntil(LocalDate.of(2030, 1, 1))
+            .status(PENDING_KYC)
+            .build();
+    given(parentChildLinkRepository.findByChildPersonalCodeAndValidUntilAfter(CHILD, TODAY))
+        .willReturn(List.of(active, pendingCoParent));
+
+    assertThat(service.findGuardianCodes(CHILD)).containsExactly(PARENT, "48002020009");
+  }
+
+  @Test
   void findsPendingChildCodesForParent() {
     var pending =
         ParentChildLink.builder()


### PR DESCRIPTION
## Why

The internal AML screening procedure ("Klientide skriinimine ja monitoorimine", rows 22b–25 of the minor section) forbids onboarding a minor whose representative is high-risk, sanctioned, or a citizen of a high-risk country — but the guardian was never screened anywhere in the child onboarding path (`ChildRoleAwareKycIntegrationTest` even asserted "no AML checks are written against the parent"). The preventive gate itself lives in `kyc_ob_assess_user_risk` (database-administration), where `check_24_minor_representative_high_risk` is currently hardcoded to 0; a follow-up DA migration will implement it and read the data this PR starts producing.

## What

- **`ChildOnboardingService`**: after custody verification, the onboarding parent is sanction/PEP-screened via OpenSanctions, and their citizenship (population-register self-lookup, best-effort) is captured into the CUSTODY_RIGHT evidence as `guardianPersonalCode` + `guardianCitizenship` — the data source for the upcoming check_24 high-risk-country branch.
- **`ChildCoParentCaptureListener`**: the captured co-parent is sanction/PEP-screened right after their PENDING_KYC link is registered (skipped with a log line if they have no user account yet — they are re-screened when they onboard themselves).
- **`GuardianKycScreeningListener` (new)**: when a KYC survey is submitted for a minor, all guardians with unexpired links are re-screened synchronously before the risk assessment runs, so check_24 always sees fresh screening data even when the link was created weeks earlier. Screening scope deliberately includes suspended and PENDING_KYC links — suspension does not cleanse the risk association.
- **`ParentChildLinkService.findGuardianCodes`** + repository finder over the existing `idx_parent_child_link_child` index.

Screening failures (OpenSanctions or population register down) never block the child flow — the risk assessment treats missing data as unknown. Whether missing guardian screening should instead fail closed is an open compliance decision for the DA-side check_24 PR.

## Population-register self-lookup

`fetchPerson(parentCode, parentCode)` queries the parent's own record for citizenship. Confirmed OK by Sten 2026-07-29; the code degrades gracefully (citizenship stays unknown) if the register ever rejects the query.

## Merge order

This PR should deploy **before** the database-administration check_24 migration, so guardian screening data is fresh by the time the gate starts enforcing.

## Performance

No new public endpoints. The new `parent_child_link` finder runs only on minor KYC submissions (authenticated, low volume) and is served by the existing child-code index. Adds 1 population-register call per child onboarding and 1–3 OpenSanctions calls per child onboarding / minor KYC submission — same volume class as the existing child screening on those flows. No caching needed, no N+1, no unbounded result sets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Known limitation (deliberate, layer-3 scope)

Co-parent capture is async (`AFTER_COMMIT`): if the child's KYC survey is submitted in the same seconds the capture is still running, the co-parent's link may not exist yet and `GuardianKycScreeningListener` screens only the initiating parent. In practice the capture completes while the parent is still filling the survey, the co-parent is screened before they ever gain access (their PENDING_KYC link grants none), and continuous guardian-risk monitoring after COMPLETED is explicitly out of scope for this change. Flagged by Codex review as P2; accepted and documented rather than gating child KYC on an async external call.

