### PR TITLE
Fail closed on payout screening + hold high-risk clients' redemptions for AML review

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/admin/AdminController.java
+++ b/src/main/java/ee/tuleva/onboarding/admin/AdminController.java
@@ -37,6 +37,7 @@ import ee.tuleva.onboarding.savings.fund.nav.NavCalculationResult;
 import ee.tuleva.onboarding.savings.fund.nav.NavCalculationService;
 import ee.tuleva.onboarding.savings.fund.nav.NavPublisher;
 import ee.tuleva.onboarding.savings.fund.redemption.RedemptionBatchJob;
+import ee.tuleva.onboarding.savings.fund.redemption.RedemptionReviewService;
 import jakarta.transaction.Transactional;
 import jakarta.validation.Valid;
 import java.math.BigDecimal;
@@ -83,6 +84,7 @@ public class AdminController {
   private final ReportImportJob reportImportJob;
   private final FundPositionImportJob fundPositionImportJob;
   private final RedemptionBatchJob redemptionBatchJob;
+  private final RedemptionReviewService redemptionReviewService;
   private final SavingsFundOnboardingService savingsFundOnboardingService;
   private final KybCheckOverrideService kybCheckOverrideService;
   private final ParentChildLinkRegistrationService parentChildLinkRegistrationService;
@@ -308,6 +310,27 @@ public class AdminController {
     redemptionBatchJob.retryFailedPayout(id);
 
     return "Retried redemption payout for " + id;
+  }
+
+  @PostMapping("/redemptions/{id}/approve-review")
+  public String approveRedemptionReview(
+      @RequestHeader("X-Admin-Token") String token,
+      @PathVariable UUID id,
+      @RequestParam String approvedBy,
+      @RequestParam String reason) {
+
+    validateTokenWithOpsAccess(token);
+    if (approvedBy.isBlank()) {
+      throw new ResponseStatusException(BAD_REQUEST, "approvedBy is required");
+    }
+    if (reason.isBlank()) {
+      throw new ResponseStatusException(BAD_REQUEST, "A reason is required");
+    }
+
+    log.info("Admin approving redemption review: id={}, approvedBy={}", id, approvedBy);
+    redemptionReviewService.approve(id, approvedBy, reason);
+
+    return "Approved redemption review: id=" + id;
   }
 
   @PostMapping("/override-kyb-check")

--- a/src/main/java/ee/tuleva/onboarding/aml/AmlCheckRepository.java
+++ b/src/main/java/ee/tuleva/onboarding/aml/AmlCheckRepository.java
@@ -1,6 +1,7 @@
 package ee.tuleva.onboarding.aml;
 
 import java.time.Instant;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -30,4 +31,7 @@ public interface AmlCheckRepository extends JpaRepository<AmlCheck, Long> {
 
   Optional<AmlCheck> findFirstByPersonalCodeAndTypeOrderByCreatedTimeDesc(
       String personalCode, AmlCheckType type);
+
+  Optional<AmlCheck> findFirstByPersonalCodeAndTypeInOrderByCreatedTimeDesc(
+      String personalCode, Collection<AmlCheckType> types);
 }

--- a/src/main/java/ee/tuleva/onboarding/aml/AmlService.java
+++ b/src/main/java/ee/tuleva/onboarding/aml/AmlService.java
@@ -100,6 +100,21 @@ public class AmlService {
     return screenForSanctionAndPep(person, country).checks();
   }
 
+  public boolean isSanctionAndPepClear(Person person, Country country) {
+    if (screenForSanctionAndPep(person, country).failed()) {
+      return false;
+    }
+    return latestCheckPassed(person, SANCTION)
+        && latestCheckPassed(person, POLITICALLY_EXPOSED_PERSON_AUTO);
+  }
+
+  private boolean latestCheckPassed(Person person, AmlCheckType type) {
+    return amlCheckRepository
+        .findFirstByPersonalCodeAndTypeOrderByCreatedTimeDesc(person.getPersonalCode(), type)
+        .map(AmlCheck::isSuccess)
+        .orElse(false);
+  }
+
   private record ScreeningResult(List<AmlCheck> checks, boolean failed) {}
 
   private ScreeningResult screenForSanctionAndPep(Person person, Country country) {

--- a/src/main/java/ee/tuleva/onboarding/aml/risklevel/RiskLevelService.java
+++ b/src/main/java/ee/tuleva/onboarding/aml/risklevel/RiskLevelService.java
@@ -13,6 +13,7 @@ import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -30,8 +31,39 @@ public class RiskLevelService {
   private final AmlCheckRepository amlCheckRepository;
   private final ApplicationEventPublisher eventPublisher;
 
+  private static final int HIGH_RISK_LEVEL = 1;
+
   public void runRiskLevelCheck(double mediumRiskIndividualSelectionProbability) {
     scorePillar("III pillar", amlRiskReader, RISK_LEVEL, mediumRiskIndividualSelectionProbability);
+  }
+
+  public boolean isHighRisk(String personalCode) {
+    return latestLevelIsHigh(personalCode, List.of(RISK_LEVEL, RISK_LEVEL_OVERRIDE))
+        || latestLevelIsHigh(personalCode, List.of(TKF_RISK_LEVEL, TKF_RISK_LEVEL_OVERRIDE));
+  }
+
+  private boolean latestLevelIsHigh(String personalCode, List<AmlCheckType> types) {
+    return amlCheckRepository
+        .findFirstByPersonalCodeAndTypeInOrderByCreatedTimeDesc(personalCode, types)
+        .map(check -> Objects.equals(riskLevel(check), HIGH_RISK_LEVEL))
+        .orElse(false);
+  }
+
+  // An override row without a level is a specialist confirmation without a score change and does
+  // not keep the client high-risk.
+  private Integer riskLevel(AmlCheck check) {
+    Object level = check.getMetadata().get("level");
+    if (level instanceof Number number) {
+      return number.intValue();
+    }
+    if (level instanceof String string) {
+      try {
+        return Integer.parseInt(string);
+      } catch (NumberFormatException e) {
+        return null;
+      }
+    }
+    return null;
   }
 
   public void runTkfRiskLevelCheck(double mediumRiskIndividualSelectionProbability) {

--- a/src/main/java/ee/tuleva/onboarding/aml/risklevel/RiskLevelService.java
+++ b/src/main/java/ee/tuleva/onboarding/aml/risklevel/RiskLevelService.java
@@ -13,7 +13,6 @@ import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -45,20 +44,39 @@ public class RiskLevelService {
   private boolean latestLevelIsHigh(String personalCode, List<AmlCheckType> types) {
     return amlCheckRepository
         .findFirstByPersonalCodeAndTypeInOrderByCreatedTimeDesc(personalCode, types)
-        .map(check -> Objects.equals(riskLevel(check), HIGH_RISK_LEVEL))
+        .map(this::isHighRiskLevel)
         .orElse(false);
   }
 
-  // An override row without a level is a specialist confirmation without a score change and does
-  // not keep the client high-risk.
-  private Integer riskLevel(AmlCheck check) {
+  // A missing level on an override row is a specialist confirmation without a score change and
+  // does not keep the client high-risk. Anything else unexpected is treated as high risk.
+  private boolean isHighRiskLevel(AmlCheck check) {
     Object level = check.getMetadata().get("level");
+    if (level == null) {
+      return !isOverride(check.getType());
+    }
+    Integer parsedLevel = parseLevel(level);
+    if (parsedLevel == null) {
+      log.error(
+          "Malformed risk level metadata, treating as high risk: checkId={}, level={}",
+          check.getId(),
+          level);
+      return true;
+    }
+    return parsedLevel == HIGH_RISK_LEVEL;
+  }
+
+  private boolean isOverride(AmlCheckType type) {
+    return type == RISK_LEVEL_OVERRIDE || type == TKF_RISK_LEVEL_OVERRIDE;
+  }
+
+  private Integer parseLevel(Object level) {
     if (level instanceof Number number) {
       return number.intValue();
     }
     if (level instanceof String string) {
       try {
-        return Integer.parseInt(string);
+        return Integer.parseInt(string.trim());
       } catch (NumberFormatException e) {
         return null;
       }

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/redemption/RedemptionRequest.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/redemption/RedemptionRequest.java
@@ -71,6 +71,12 @@ public class RedemptionRequest {
 
   @Nullable private String errorReason;
 
+  @Nullable private String reviewedBy;
+
+  @Nullable private String reviewReason;
+
+  @Nullable private Instant reviewedAt;
+
   @Column(nullable = false)
   private Instant updatedAt;
 

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/redemption/RedemptionReviewService.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/redemption/RedemptionReviewService.java
@@ -1,0 +1,46 @@
+package ee.tuleva.onboarding.savings.fund.redemption;
+
+import static ee.tuleva.onboarding.savings.fund.redemption.RedemptionRequest.Status.IN_REVIEW;
+import static ee.tuleva.onboarding.savings.fund.redemption.RedemptionRequest.Status.VERIFIED;
+import static ee.tuleva.onboarding.time.ClockHolder.clock;
+
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class RedemptionReviewService {
+
+  private final RedemptionRequestRepository repository;
+  private final RedemptionStatusService redemptionStatusService;
+
+  @Transactional
+  public void approve(UUID id, String approvedBy, String reason) {
+    RedemptionRequest request =
+        repository
+            .findByIdForUpdate(id)
+            .orElseThrow(
+                () -> new IllegalArgumentException("Redemption request not found: id=" + id));
+
+    if (request.getStatus() != IN_REVIEW) {
+      throw new IllegalStateException(
+          "Only redemptions in review can be approved: id="
+              + id
+              + ", status="
+              + request.getStatus());
+    }
+
+    request.setReviewedBy(approvedBy);
+    request.setReviewReason(reason);
+    request.setReviewedAt(clock().instant());
+    repository.save(request);
+
+    redemptionStatusService.changeStatus(id, VERIFIED);
+
+    log.info("Redemption review approved: id={}, approvedBy={}", id, approvedBy);
+  }
+}

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/redemption/RedemptionVerificationService.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/redemption/RedemptionVerificationService.java
@@ -1,5 +1,6 @@
 package ee.tuleva.onboarding.savings.fund.redemption;
 
+import static ee.tuleva.onboarding.notification.OperationsNotificationService.Channel.AML;
 import static ee.tuleva.onboarding.party.PartyId.Type.LEGAL_ENTITY;
 import static ee.tuleva.onboarding.savings.fund.SavingsFundOnboardingStatus.PENDING;
 import static ee.tuleva.onboarding.savings.fund.redemption.RedemptionRequest.Status.IN_REVIEW;
@@ -10,6 +11,7 @@ import ee.tuleva.onboarding.aml.risklevel.RiskLevelService;
 import ee.tuleva.onboarding.country.Country;
 import ee.tuleva.onboarding.kyb.LegalEntityScreener;
 import ee.tuleva.onboarding.kyc.survey.KycSurveyService;
+import ee.tuleva.onboarding.notification.OperationsNotificationService;
 import ee.tuleva.onboarding.savings.fund.SavingsFundOnboardingRepository;
 import ee.tuleva.onboarding.user.User;
 import ee.tuleva.onboarding.user.UserService;
@@ -30,6 +32,7 @@ public class RedemptionVerificationService {
   private final RiskLevelService riskLevelService;
   private final SavingsFundOnboardingRepository savingsFundOnboardingRepository;
   private final LegalEntityScreener legalEntityScreener;
+  private final OperationsNotificationService notificationService;
 
   @Transactional
   public void process(RedemptionRequest request) {
@@ -48,6 +51,10 @@ public class RedemptionVerificationService {
       log.info(
           "Redemption requires review: id={}, party={}", request.getId(), request.getPartyId());
       redemptionStatusService.changeStatus(request.getId(), IN_REVIEW);
+      notificationService.sendMessage(
+          "AML: redemption held for review: id=%s, amount=%s EUR"
+              .formatted(request.getId(), request.getRequestedAmount().toPlainString()),
+          AML);
     } else {
       log.info(
           "Redemption verification passed: id={}, party={}", request.getId(), request.getPartyId());

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/redemption/RedemptionVerificationService.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/redemption/RedemptionVerificationService.java
@@ -5,15 +5,14 @@ import static ee.tuleva.onboarding.savings.fund.SavingsFundOnboardingStatus.PEND
 import static ee.tuleva.onboarding.savings.fund.redemption.RedemptionRequest.Status.IN_REVIEW;
 import static ee.tuleva.onboarding.savings.fund.redemption.RedemptionRequest.Status.VERIFIED;
 
-import ee.tuleva.onboarding.aml.AmlCheck;
 import ee.tuleva.onboarding.aml.AmlService;
+import ee.tuleva.onboarding.aml.risklevel.RiskLevelService;
 import ee.tuleva.onboarding.country.Country;
 import ee.tuleva.onboarding.kyb.LegalEntityScreener;
 import ee.tuleva.onboarding.kyc.survey.KycSurveyService;
 import ee.tuleva.onboarding.savings.fund.SavingsFundOnboardingRepository;
 import ee.tuleva.onboarding.user.User;
 import ee.tuleva.onboarding.user.UserService;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -28,6 +27,7 @@ public class RedemptionVerificationService {
   private final UserService userService;
   private final KycSurveyService kycSurveyService;
   private final AmlService amlService;
+  private final RiskLevelService riskLevelService;
   private final SavingsFundOnboardingRepository savingsFundOnboardingRepository;
   private final LegalEntityScreener legalEntityScreener;
 
@@ -71,8 +71,13 @@ public class RedemptionVerificationService {
                     new IllegalStateException(
                         "KYC survey with country not found: userId=" + user.getId()));
 
-    List<AmlCheck> checks = amlService.addSanctionAndPepCheckIfMissing(user, country);
-    return checks.stream().allMatch(AmlCheck::isSuccess);
+    boolean screeningClear = amlService.isSanctionAndPepClear(user, country);
+    boolean highRisk = riskLevelService.isHighRisk(user.getPersonalCode());
+    if (highRisk) {
+      log.info(
+          "Redemption party is high risk: id={}, party={}", request.getId(), request.getPartyId());
+    }
+    return screeningClear && !highRisk;
   }
 
   private boolean runLegalEntityChecks(RedemptionRequest request) {

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/redemption/RedemptionVerificationService.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/redemption/RedemptionVerificationService.java
@@ -51,14 +51,22 @@ public class RedemptionVerificationService {
       log.info(
           "Redemption requires review: id={}, party={}", request.getId(), request.getPartyId());
       redemptionStatusService.changeStatus(request.getId(), IN_REVIEW);
-      notificationService.sendMessage(
-          "AML: redemption held for review: id=%s, amount=%s EUR"
-              .formatted(request.getId(), request.getRequestedAmount().toPlainString()),
-          AML);
+      notifyAmlChannel(request);
     } else {
       log.info(
           "Redemption verification passed: id={}, party={}", request.getId(), request.getPartyId());
       redemptionStatusService.changeStatus(request.getId(), VERIFIED);
+    }
+  }
+
+  private void notifyAmlChannel(RedemptionRequest request) {
+    try {
+      notificationService.sendMessage(
+          "AML: redemption held for review: id=%s, amount=%s EUR"
+              .formatted(request.getId(), request.getRequestedAmount().toPlainString()),
+          AML);
+    } catch (RuntimeException e) {
+      log.error("Failed to notify AML channel about held redemption: id={}", request.getId(), e);
     }
   }
 

--- a/src/main/resources/db/migration/V1_237__add_redemption_review_audit.sql
+++ b/src/main/resources/db/migration/V1_237__add_redemption_review_audit.sql
@@ -1,0 +1,3 @@
+ALTER TABLE redemption_request ADD COLUMN reviewed_by TEXT;
+ALTER TABLE redemption_request ADD COLUMN review_reason TEXT;
+ALTER TABLE redemption_request ADD COLUMN reviewed_at TIMESTAMPTZ;

--- a/src/test/groovy/ee/tuleva/onboarding/admin/AdminControllerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/admin/AdminControllerTest.java
@@ -721,6 +721,22 @@ class AdminControllerTest {
   }
 
   @Test
+  void approveRedemptionReview_withBlankApprover_returnsBadRequest() throws Exception {
+    var requestId = UUID.randomUUID();
+
+    mockMvc
+        .perform(
+            post("/admin/redemptions/{id}/approve-review", requestId)
+                .with(csrf())
+                .header("X-Admin-Token", "ops-token")
+                .param("approvedBy", " ")
+                .param("reason", "reviewed"))
+        .andExpect(status().isBadRequest());
+
+    verify(redemptionReviewService, never()).approve(any(), any(), any());
+  }
+
+  @Test
   void approveRedemptionReview_withInvalidToken_returnsUnauthorized() throws Exception {
     var requestId = UUID.randomUUID();
 

--- a/src/test/groovy/ee/tuleva/onboarding/admin/AdminControllerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/admin/AdminControllerTest.java
@@ -45,6 +45,7 @@ import ee.tuleva.onboarding.savings.fund.nav.NavCalculationResult;
 import ee.tuleva.onboarding.savings.fund.nav.NavCalculationService;
 import ee.tuleva.onboarding.savings.fund.nav.NavPublisher;
 import ee.tuleva.onboarding.savings.fund.redemption.RedemptionBatchJob;
+import ee.tuleva.onboarding.savings.fund.redemption.RedemptionReviewService;
 import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.Instant;
@@ -83,6 +84,7 @@ class AdminControllerTest {
   @MockitoBean private ReportImportJob reportImportJob;
   @MockitoBean private FundPositionImportJob fundPositionImportJob;
   @MockitoBean private RedemptionBatchJob redemptionBatchJob;
+  @MockitoBean private RedemptionReviewService redemptionReviewService;
   @MockitoBean private SavingsFundOnboardingService savingsFundOnboardingService;
   @MockitoBean private KybCheckOverrideService kybCheckOverrideService;
   @MockitoBean private ParentChildLinkRegistrationService parentChildLinkRegistrationService;
@@ -683,6 +685,55 @@ class AdminControllerTest {
         .andExpect(status().isBadRequest());
 
     verify(redemptionBatchJob, never()).retryFailedPayout(any());
+  }
+
+  @Test
+  void approveRedemptionReview_withOpsToken_delegatesToService() throws Exception {
+    var requestId = UUID.fromString("2db696b5-00ee-4937-87b4-8192c675e4b5");
+
+    mockMvc
+        .perform(
+            post("/admin/redemptions/{id}/approve-review", requestId)
+                .with(csrf())
+                .header("X-Admin-Token", "ops-token")
+                .param("approvedBy", "AML Specialist")
+                .param("reason", "reviewed, source of funds clear"))
+        .andExpect(status().isOk());
+
+    verify(redemptionReviewService)
+        .approve(requestId, "AML Specialist", "reviewed, source of funds clear");
+  }
+
+  @Test
+  void approveRedemptionReview_withBlankReason_returnsBadRequest() throws Exception {
+    var requestId = UUID.randomUUID();
+
+    mockMvc
+        .perform(
+            post("/admin/redemptions/{id}/approve-review", requestId)
+                .with(csrf())
+                .header("X-Admin-Token", "ops-token")
+                .param("approvedBy", "AML Specialist")
+                .param("reason", " "))
+        .andExpect(status().isBadRequest());
+
+    verify(redemptionReviewService, never()).approve(any(), any(), any());
+  }
+
+  @Test
+  void approveRedemptionReview_withInvalidToken_returnsUnauthorized() throws Exception {
+    var requestId = UUID.randomUUID();
+
+    mockMvc
+        .perform(
+            post("/admin/redemptions/{id}/approve-review", requestId)
+                .with(csrf())
+                .header("X-Admin-Token", "wrong-token")
+                .param("approvedBy", "AML Specialist")
+                .param("reason", "reviewed"))
+        .andExpect(status().isUnauthorized());
+
+    verify(redemptionReviewService, never()).approve(any(), any(), any());
   }
 
   @Test

--- a/src/test/groovy/ee/tuleva/onboarding/aml/AmlServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/aml/AmlServiceTest.java
@@ -1184,4 +1184,76 @@ class AmlServiceTest {
     verify(pepAndSanctionCheckService, never()).match(any(Person.class), any(Country.class));
     verify(notificationService, never()).sendMessage(anyString(), any());
   }
+
+  @Test
+  void isSanctionAndPepClear_failsClosedWhenScreeningThrows() {
+    User user = createUser("123", "First", "Last", 1L);
+    Country country = new Country("EE");
+    when(pepAndSanctionCheckService.match(user, country))
+        .thenThrow(new RuntimeException("screening service down"));
+
+    assertFalse(amlService.isSanctionAndPepClear(user, country));
+  }
+
+  @Test
+  void isSanctionAndPepClear_trueWhenLatestScreeningChecksPass() {
+    User user = createUser("123", "First", "Last", 1L);
+    Country country = new Country("EE");
+    MatchResponse emptyResponse =
+        new MatchResponse(objectMapper.createArrayNode(), objectMapper.createObjectNode());
+    when(pepAndSanctionCheckService.match(user, country)).thenReturn(emptyResponse);
+    when(amlCheckRepository.findFirstByPersonalCodeAndTypeOrderByCreatedTimeDesc("123", SANCTION))
+        .thenReturn(
+            Optional.of(
+                AmlCheck.builder().personalCode("123").type(SANCTION).success(true).build()));
+    when(amlCheckRepository.findFirstByPersonalCodeAndTypeOrderByCreatedTimeDesc(
+            "123", POLITICALLY_EXPOSED_PERSON_AUTO))
+        .thenReturn(
+            Optional.of(
+                AmlCheck.builder()
+                    .personalCode("123")
+                    .type(POLITICALLY_EXPOSED_PERSON_AUTO)
+                    .success(true)
+                    .build()));
+
+    assertTrue(amlService.isSanctionAndPepClear(user, country));
+  }
+
+  @Test
+  void isSanctionAndPepClear_falseWhenLatestSanctionCheckHasFailed() {
+    User user = createUser("123", "First", "Last", 1L);
+    Country country = new Country("EE");
+    ArrayNode results = objectMapper.createArrayNode();
+    ObjectNode result = objectMapper.createObjectNode();
+    result.put("id", "sanction123");
+    result.put("match", true);
+    ArrayNode topics = objectMapper.createArrayNode();
+    topics.add("sanction");
+    ObjectNode properties = objectMapper.createObjectNode();
+    properties.set("topics", topics);
+    result.set("properties", properties);
+    results.add(result);
+    MatchResponse matchResponse = new MatchResponse(results, objectMapper.createObjectNode());
+    when(pepAndSanctionCheckService.match(user, country)).thenReturn(matchResponse);
+    when(amlCheckRepository.findFirstByPersonalCodeAndTypeOrderByCreatedTimeDesc("123", SANCTION))
+        .thenReturn(
+            Optional.of(
+                AmlCheck.builder().personalCode("123").type(SANCTION).success(false).build()));
+
+    assertFalse(amlService.isSanctionAndPepClear(user, country));
+  }
+
+  @Test
+  void isSanctionAndPepClear_falseWhenNoScreeningRecordExists() {
+    User user = createUser("123", "First", "Last", 1L);
+    Country country = new Country("EE");
+    MatchResponse emptyResponse =
+        new MatchResponse(objectMapper.createArrayNode(), objectMapper.createObjectNode());
+    when(pepAndSanctionCheckService.match(user, country)).thenReturn(emptyResponse);
+    when(amlCheckRepository.findFirstByPersonalCodeAndTypeOrderByCreatedTimeDesc(
+            eq("123"), any(AmlCheckType.class)))
+        .thenReturn(Optional.empty());
+
+    assertFalse(amlService.isSanctionAndPepClear(user, country));
+  }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/aml/risklevel/RiskLevelServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/aml/risklevel/RiskLevelServiceTest.java
@@ -30,6 +30,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -614,5 +615,63 @@ class RiskLevelServiceTest {
         ArgumentCaptor.forClass(AmlRiskLevelJobRunEvent.class);
     verify(eventPublisher).publishEvent(captor.capture());
     assertThat(captor.getValue().getLabel()).isEqualTo("TKF");
+  }
+
+  @Test
+  void isHighRisk_trueWhenLatestThirdPillarSnapshotIsHigh() {
+    when(amlCheckRepository.findFirstByPersonalCodeAndTypeInOrderByCreatedTimeDesc(
+            "123", List.of(RISK_LEVEL, RISK_LEVEL_OVERRIDE)))
+        .thenReturn(Optional.of(checkWithLevel(RISK_LEVEL, 1)));
+
+    assertTrue(riskLevelService.isHighRisk("123"));
+  }
+
+  @Test
+  void isHighRisk_trueWhenLatestTkfOverrideLevelIsHighString() {
+    when(amlCheckRepository.findFirstByPersonalCodeAndTypeInOrderByCreatedTimeDesc(
+            "123", List.of(RISK_LEVEL, RISK_LEVEL_OVERRIDE)))
+        .thenReturn(Optional.empty());
+    when(amlCheckRepository.findFirstByPersonalCodeAndTypeInOrderByCreatedTimeDesc(
+            "123", List.of(TKF_RISK_LEVEL, TKF_RISK_LEVEL_OVERRIDE)))
+        .thenReturn(Optional.of(checkWithLevel(TKF_RISK_LEVEL_OVERRIDE, "1")));
+
+    assertTrue(riskLevelService.isHighRisk("123"));
+  }
+
+  @Test
+  void isHighRisk_falseWhenLatestRowsAreNotHighOrMissing() {
+    when(amlCheckRepository.findFirstByPersonalCodeAndTypeInOrderByCreatedTimeDesc(
+            "123", List.of(RISK_LEVEL, RISK_LEVEL_OVERRIDE)))
+        .thenReturn(Optional.of(checkWithLevel(RISK_LEVEL, 2)));
+    when(amlCheckRepository.findFirstByPersonalCodeAndTypeInOrderByCreatedTimeDesc(
+            "123", List.of(TKF_RISK_LEVEL, TKF_RISK_LEVEL_OVERRIDE)))
+        .thenReturn(Optional.empty());
+
+    assertFalse(riskLevelService.isHighRisk("123"));
+  }
+
+  @Test
+  void isHighRisk_falseWhenLatestRowIsOverrideWithoutLevel() {
+    when(amlCheckRepository.findFirstByPersonalCodeAndTypeInOrderByCreatedTimeDesc(
+            "123", List.of(RISK_LEVEL, RISK_LEVEL_OVERRIDE)))
+        .thenReturn(Optional.of(checkWithLevel(RISK_LEVEL_OVERRIDE, null)));
+    when(amlCheckRepository.findFirstByPersonalCodeAndTypeInOrderByCreatedTimeDesc(
+            "123", List.of(TKF_RISK_LEVEL, TKF_RISK_LEVEL_OVERRIDE)))
+        .thenReturn(Optional.of(checkWithLevel(TKF_RISK_LEVEL_OVERRIDE, null)));
+
+    assertFalse(riskLevelService.isHighRisk("123"));
+  }
+
+  private AmlCheck checkWithLevel(AmlCheckType type, Object level) {
+    Map<String, Object> metadata = new HashMap<>();
+    if (level != null) {
+      metadata.put("level", level);
+    }
+    return AmlCheck.builder()
+        .personalCode("123")
+        .type(type)
+        .success(false)
+        .metadata(metadata)
+        .build();
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/aml/risklevel/RiskLevelServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/aml/risklevel/RiskLevelServiceTest.java
@@ -651,6 +651,24 @@ class RiskLevelServiceTest {
   }
 
   @Test
+  void isHighRisk_trueWhenLevelIsMalformed() {
+    when(amlCheckRepository.findFirstByPersonalCodeAndTypeInOrderByCreatedTimeDesc(
+            "123", List.of(RISK_LEVEL, RISK_LEVEL_OVERRIDE)))
+        .thenReturn(Optional.of(checkWithLevel(RISK_LEVEL, "not-a-number")));
+
+    assertTrue(riskLevelService.isHighRisk("123"));
+  }
+
+  @Test
+  void isHighRisk_trueWhenAutomaticSnapshotHasNoLevel() {
+    when(amlCheckRepository.findFirstByPersonalCodeAndTypeInOrderByCreatedTimeDesc(
+            "123", List.of(RISK_LEVEL, RISK_LEVEL_OVERRIDE)))
+        .thenReturn(Optional.of(checkWithLevel(RISK_LEVEL, null)));
+
+    assertTrue(riskLevelService.isHighRisk("123"));
+  }
+
+  @Test
   void isHighRisk_falseWhenLatestRowIsOverrideWithoutLevel() {
     when(amlCheckRepository.findFirstByPersonalCodeAndTypeInOrderByCreatedTimeDesc(
             "123", List.of(RISK_LEVEL, RISK_LEVEL_OVERRIDE)))

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/redemption/RedemptionReviewServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/redemption/RedemptionReviewServiceTest.java
@@ -1,0 +1,78 @@
+package ee.tuleva.onboarding.savings.fund.redemption;
+
+import static ee.tuleva.onboarding.savings.fund.redemption.RedemptionRequest.Status.IN_REVIEW;
+import static ee.tuleva.onboarding.savings.fund.redemption.RedemptionRequest.Status.VERIFIED;
+import static ee.tuleva.onboarding.savings.fund.redemption.RedemptionRequestFixture.redemptionRequestFixture;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import ee.tuleva.onboarding.time.ClockHolder;
+import ee.tuleva.onboarding.time.TestClockHolder;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class RedemptionReviewServiceTest {
+
+  @Mock private RedemptionRequestRepository repository;
+  @Mock private RedemptionStatusService redemptionStatusService;
+
+  @InjectMocks private RedemptionReviewService service;
+
+  @BeforeEach
+  void setUp() {
+    ClockHolder.setClock(TestClockHolder.clock);
+  }
+
+  @AfterEach
+  void tearDown() {
+    ClockHolder.setDefaultClock();
+  }
+
+  @Test
+  void approve_recordsApproverAndVerifiesRedemptionInReview() {
+    var requestId = UUID.randomUUID();
+    var request = redemptionRequestFixture().id(requestId).status(IN_REVIEW).build();
+    given(repository.findByIdForUpdate(requestId)).willReturn(Optional.of(request));
+
+    service.approve(requestId, "AML Specialist", "Reviewed transactions, source of funds clear");
+
+    assertThat(request.getReviewedBy()).isEqualTo("AML Specialist");
+    assertThat(request.getReviewReason()).isEqualTo("Reviewed transactions, source of funds clear");
+    assertThat(request.getReviewedAt()).isEqualTo(TestClockHolder.now);
+    verify(repository).save(request);
+    verify(redemptionStatusService).changeStatus(requestId, VERIFIED);
+  }
+
+  @Test
+  void approve_rejectsRedemptionThatIsNotInReview() {
+    var requestId = UUID.randomUUID();
+    var request = redemptionRequestFixture().id(requestId).status(VERIFIED).build();
+    given(repository.findByIdForUpdate(requestId)).willReturn(Optional.of(request));
+
+    assertThatThrownBy(() -> service.approve(requestId, "AML Specialist", "reason"))
+        .isInstanceOf(IllegalStateException.class);
+
+    verify(repository, never()).save(request);
+    verify(redemptionStatusService, never()).changeStatus(requestId, VERIFIED);
+  }
+
+  @Test
+  void approve_throwsWhenRedemptionNotFound() {
+    var requestId = UUID.randomUUID();
+    given(repository.findByIdForUpdate(requestId)).willReturn(Optional.empty());
+
+    assertThatThrownBy(() -> service.approve(requestId, "AML Specialist", "reason"))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+}

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/redemption/RedemptionVerificationServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/redemption/RedemptionVerificationServiceTest.java
@@ -12,9 +12,8 @@ import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
-import ee.tuleva.onboarding.aml.AmlCheck;
-import ee.tuleva.onboarding.aml.AmlCheckType;
 import ee.tuleva.onboarding.aml.AmlService;
+import ee.tuleva.onboarding.aml.risklevel.RiskLevelService;
 import ee.tuleva.onboarding.country.Country;
 import ee.tuleva.onboarding.kyb.LegalEntityScreener;
 import ee.tuleva.onboarding.kyc.survey.KycSurveyService;
@@ -22,7 +21,6 @@ import ee.tuleva.onboarding.party.PartyId;
 import ee.tuleva.onboarding.savings.fund.SavingsFundOnboardingRepository;
 import ee.tuleva.onboarding.savings.fund.SavingsFundOnboardingStatus;
 import ee.tuleva.onboarding.user.UserService;
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
@@ -38,13 +36,14 @@ class RedemptionVerificationServiceTest {
   @Mock private UserService userService;
   @Mock private KycSurveyService kycSurveyService;
   @Mock private AmlService amlService;
+  @Mock private RiskLevelService riskLevelService;
   @Mock private SavingsFundOnboardingRepository savingsFundOnboardingRepository;
   @Mock private LegalEntityScreener legalEntityScreener;
 
   @InjectMocks private RedemptionVerificationService service;
 
   @Test
-  void process_personRequest_transitionsToVerifiedWhenAllAmlChecksPass() {
+  void process_personRequest_transitionsToVerifiedWhenScreeningClearAndNotHighRisk() {
     var userId = 1L;
     var requestId = UUID.randomUUID();
     var request =
@@ -55,16 +54,11 @@ class RedemptionVerificationServiceTest {
             .build();
     var user = sampleUser().id(userId).build();
     var country = new Country("EE");
-    var passing =
-        AmlCheck.builder()
-            .personalCode(user.getPersonalCode())
-            .type(AmlCheckType.SANCTION)
-            .success(true)
-            .build();
 
     given(userService.findByPersonalCode("38812121215")).willReturn(Optional.of(user));
     given(kycSurveyService.getCountry(userId)).willReturn(Optional.of(country));
-    given(amlService.addSanctionAndPepCheckIfMissing(user, country)).willReturn(List.of(passing));
+    given(amlService.isSanctionAndPepClear(user, country)).willReturn(true);
+    given(riskLevelService.isHighRisk(user.getPersonalCode())).willReturn(false);
 
     service.process(request);
 
@@ -73,7 +67,7 @@ class RedemptionVerificationServiceTest {
   }
 
   @Test
-  void process_personRequest_transitionsToVerifiedWhenNoNewChecksNeeded() {
+  void process_personRequest_transitionsToInReviewWhenScreeningNotClear() {
     var userId = 1L;
     var requestId = UUID.randomUUID();
     var request =
@@ -87,15 +81,16 @@ class RedemptionVerificationServiceTest {
 
     given(userService.findByPersonalCode("38812121215")).willReturn(Optional.of(user));
     given(kycSurveyService.getCountry(userId)).willReturn(Optional.of(country));
-    given(amlService.addSanctionAndPepCheckIfMissing(user, country)).willReturn(List.of());
+    given(amlService.isSanctionAndPepClear(user, country)).willReturn(false);
 
     service.process(request);
 
-    verify(redemptionStatusService).changeStatus(requestId, VERIFIED);
+    verify(redemptionStatusService).changeStatus(requestId, IN_REVIEW);
+    verify(redemptionStatusService, never()).changeStatus(requestId, VERIFIED);
   }
 
   @Test
-  void process_personRequest_transitionsToInReviewWhenAnyAmlCheckFails() {
+  void process_personRequest_transitionsToInReviewWhenPartyIsHighRisk() {
     var userId = 1L;
     var requestId = UUID.randomUUID();
     var request =
@@ -106,16 +101,11 @@ class RedemptionVerificationServiceTest {
             .build();
     var user = sampleUser().id(userId).build();
     var country = new Country("EE");
-    var failing =
-        AmlCheck.builder()
-            .personalCode(user.getPersonalCode())
-            .type(AmlCheckType.SANCTION)
-            .success(false)
-            .build();
 
     given(userService.findByPersonalCode("38812121215")).willReturn(Optional.of(user));
     given(kycSurveyService.getCountry(userId)).willReturn(Optional.of(country));
-    given(amlService.addSanctionAndPepCheckIfMissing(user, country)).willReturn(List.of(failing));
+    given(amlService.isSanctionAndPepClear(user, country)).willReturn(true);
+    given(riskLevelService.isHighRisk(user.getPersonalCode())).willReturn(true);
 
     service.process(request);
 
@@ -136,16 +126,11 @@ class RedemptionVerificationServiceTest {
             .build();
     var child = sampleUser().id(2L).personalCode(childCode).build();
     var country = new Country("EE");
-    var passing =
-        AmlCheck.builder()
-            .personalCode(childCode)
-            .type(AmlCheckType.SANCTION)
-            .success(true)
-            .build();
 
     given(userService.findByPersonalCode(childCode)).willReturn(Optional.of(child));
     given(kycSurveyService.getCountry(child.getId())).willReturn(Optional.of(country));
-    given(amlService.addSanctionAndPepCheckIfMissing(child, country)).willReturn(List.of(passing));
+    given(amlService.isSanctionAndPepClear(child, country)).willReturn(true);
+    given(riskLevelService.isHighRisk(childCode)).willReturn(false);
 
     service.process(request);
 

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/redemption/RedemptionVerificationServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/redemption/RedemptionVerificationServiceTest.java
@@ -1,6 +1,7 @@
 package ee.tuleva.onboarding.savings.fund.redemption;
 
 import static ee.tuleva.onboarding.auth.UserFixture.sampleUser;
+import static ee.tuleva.onboarding.notification.OperationsNotificationService.Channel.AML;
 import static ee.tuleva.onboarding.party.PartyId.Type.LEGAL_ENTITY;
 import static ee.tuleva.onboarding.party.PartyId.Type.PERSON;
 import static ee.tuleva.onboarding.savings.fund.redemption.RedemptionRequest.Status.IN_REVIEW;
@@ -17,6 +18,7 @@ import ee.tuleva.onboarding.aml.risklevel.RiskLevelService;
 import ee.tuleva.onboarding.country.Country;
 import ee.tuleva.onboarding.kyb.LegalEntityScreener;
 import ee.tuleva.onboarding.kyc.survey.KycSurveyService;
+import ee.tuleva.onboarding.notification.OperationsNotificationService;
 import ee.tuleva.onboarding.party.PartyId;
 import ee.tuleva.onboarding.savings.fund.SavingsFundOnboardingRepository;
 import ee.tuleva.onboarding.savings.fund.SavingsFundOnboardingStatus;
@@ -39,6 +41,7 @@ class RedemptionVerificationServiceTest {
   @Mock private RiskLevelService riskLevelService;
   @Mock private SavingsFundOnboardingRepository savingsFundOnboardingRepository;
   @Mock private LegalEntityScreener legalEntityScreener;
+  @Mock private OperationsNotificationService notificationService;
 
   @InjectMocks private RedemptionVerificationService service;
 
@@ -87,6 +90,9 @@ class RedemptionVerificationServiceTest {
 
     verify(redemptionStatusService).changeStatus(requestId, IN_REVIEW);
     verify(redemptionStatusService, never()).changeStatus(requestId, VERIFIED);
+    verify(notificationService)
+        .sendMessage(
+            "AML: redemption held for review: id=" + requestId + ", amount=10.00 EUR", AML);
   }
 
   @Test

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/redemption/RedemptionVerificationServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/redemption/RedemptionVerificationServiceTest.java
@@ -8,6 +8,8 @@ import static ee.tuleva.onboarding.savings.fund.redemption.RedemptionRequest.Sta
 import static ee.tuleva.onboarding.savings.fund.redemption.RedemptionRequest.Status.VERIFIED;
 import static ee.tuleva.onboarding.savings.fund.redemption.RedemptionRequestFixture.redemptionRequestFixture;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.never;
@@ -93,6 +95,32 @@ class RedemptionVerificationServiceTest {
     verify(notificationService)
         .sendMessage(
             "AML: redemption held for review: id=" + requestId + ", amount=10.00 EUR", AML);
+  }
+
+  @Test
+  void process_personRequest_holdsRedemptionEvenWhenNotificationFails() {
+    var userId = 1L;
+    var requestId = UUID.randomUUID();
+    var request =
+        redemptionRequestFixture()
+            .id(requestId)
+            .userId(userId)
+            .partyId(new PartyId(PERSON, "38812121215"))
+            .build();
+    var user = sampleUser().id(userId).build();
+    var country = new Country("EE");
+
+    given(userService.findByPersonalCode("38812121215")).willReturn(Optional.of(user));
+    given(kycSurveyService.getCountry(userId)).willReturn(Optional.of(country));
+    given(amlService.isSanctionAndPepClear(user, country)).willReturn(false);
+    willThrow(new IllegalStateException("Slack unavailable"))
+        .given(notificationService)
+        .sendMessage(anyString(), any());
+
+    service.process(request);
+
+    verify(redemptionStatusService).changeStatus(requestId, IN_REVIEW);
+    verify(redemptionStatusService, never()).changeStatus(requestId, VERIFIED);
   }
 
   @Test


### PR DESCRIPTION
## Why

Two gaps found in an AML review against the internal procedure ("Klientide skriinimine ja monitoorimine", sisekord 19 / 13):

1. **Payout screening failed open.** `RedemptionVerificationService.runPersonChecks` passed when `addSanctionAndPepCheckIfMissing` returned an empty list. That happens both when OpenSanctions/yente is unavailable (screening error → empty list) **and** when the person has a standing failed sanction/PEP check whose re-screen outcome is unchanged (no new row written → empty list). In both cases the payout went straight to `VERIFIED`. Sisekord 13 p 10.5.6 requires refusing the transaction when sanctions status cannot be verified.

2. **High-risk clients' payouts were never held for approval.** The procedure requires AML specialist confirmation of payouts for high overall-risk clients ("väljamakse kinnitamine AML spetsialisti poolt"), but `RISK_LEVEL`/`TKF_RISK_LEVEL` were not consulted anywhere in the redemption path — and there was no code path for `IN_REVIEW → VERIFIED` at all, so releasing a held payout meant a direct DB update with no record of who approved it.

## What

- **`AmlService.isSanctionAndPepClear(person, country)`** — runs the screening, fails closed on screening error, then requires the *latest persisted* `SANCTION` and `POLITICALLY_EXPOSED_PERSON_AUTO` checks to be successful (absent record = not clear). Existing overrides keep working: they already flip the persisted check's `success` at write time.
- **`RiskLevelService.isHighRisk(personalCode)`** — latest of (`RISK_LEVEL`, `RISK_LEVEL_OVERRIDE`) or (`TKF_RISK_LEVEL`, `TKF_RISK_LEVEL_OVERRIDE`) with metadata `level = 1`. An override row without a `level` counts as a specialist confirmation (same interpretation the Metabase dashboard uses) and does not hold the payout.
- **`RedemptionVerificationService`** — person redemptions now go to `IN_REVIEW` when screening is not clear **or** the party is high-risk.
- **`POST /admin/redemptions/{id}/approve-review?approvedBy=&reason=`** (ops token) — the missing `IN_REVIEW → VERIFIED` path. When a redemption goes to `IN_REVIEW`, a message is posted to the AML Slack channel with the redemption id and amount (no personal data in Slack), so the specialist has an active signal to start the review. Records `reviewed_by`, `review_reason`, `reviewed_at` on `redemption_request` (migration `V1_237`) before verifying, so the approval is auditable.

## Notes for review

- Legal-entity redemptions are unchanged: company risk lives only in `analytics.v_company_risk_metadata` (never written to `aml_check`), so a company high-risk hold needs the company-risk plumbing first — follow-up.
- `RedemptionReviewService` throws `IllegalArgumentException`/`IllegalStateException` like the neighbouring `RedemptionStatusService`; the admin endpoint validates blank params with `ResponseStatusException` like the other admin endpoints.
- The `approvedBy` param is free text because admin auth is a shared token — same limitation as the Metabase actions. Personalized admin identity is a separate problem.
- ⚡ Performance: verification runs per redemption request (single-digit daily volume); the new lookups are 4 point queries on `aml_check` served by `aml_check_personal_code_index`. The admin endpoint is manual. No new hot paths, no caching needed.

## Tests

- `RedemptionVerificationServiceTest` — screening-not-clear → `IN_REVIEW`, high-risk → `IN_REVIEW`, clear+not-high → `VERIFIED`
- `AmlServiceTest` — fail-closed on screening exception; latest-check semantics (incl. standing failed check with unchanged outcome)
- `RiskLevelServiceTest` — high snapshot, high string-level override, non-high, override-without-level
- `RedemptionReviewServiceTest` + `AdminControllerTest` — approve path, blank reason 400, invalid token 401
- `RedemptionIntegrationTest`, `RedemptionVerificationJobTest` green; `spotlessCheck` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)