### PR TITLE
Expose the bank account behind each savings fund transaction

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/account/transaction/Transaction.java
+++ b/src/main/java/ee/tuleva/onboarding/account/transaction/Transaction.java
@@ -20,7 +20,8 @@ public record Transaction(
     String isin,
     CashFlow.Type type,
     BigDecimal units,
-    BigDecimal nav)
+    BigDecimal nav,
+    String counterpartyIban)
     implements Comparable<Transaction> {
 
   public static Transaction from(CashFlow cashFlow) {

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/SavingFundPaymentRepository.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/SavingFundPaymentRepository.java
@@ -24,6 +24,22 @@ import org.springframework.stereotype.Repository;
 public class SavingFundPaymentRepository {
   private final NamedParameterJdbcTemplate jdbcTemplate;
 
+  public Map<UUID, String> findRemitterIbansByIds(Collection<UUID> ids) {
+    if (ids.isEmpty()) {
+      return Map.of();
+    }
+    return jdbcTemplate.query(
+        "select id, remitter_iban from saving_fund_payment where id in (:ids)",
+        new MapSqlParameterSource("ids", ids),
+        (ResultSet rs) -> {
+          Map<UUID, String> ibans = new HashMap<>();
+          while (rs.next()) {
+            ibans.put(rs.getObject("id", UUID.class), rs.getString("remitter_iban"));
+          }
+          return ibans;
+        });
+  }
+
   public Optional<SavingFundPayment> findById(UUID id) {
     var result =
         jdbcTemplate.query(

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/SavingsFundTransactionService.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/SavingsFundTransactionService.java
@@ -17,8 +17,14 @@ import ee.tuleva.onboarding.ledger.LedgerParty.PartyType;
 import ee.tuleva.onboarding.ledger.LedgerService;
 import ee.tuleva.onboarding.ledger.LedgerTransaction;
 import ee.tuleva.onboarding.ledger.UserAccount;
+import ee.tuleva.onboarding.savings.fund.redemption.RedemptionRequestRepository;
 import java.math.BigDecimal;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -31,6 +37,8 @@ public class SavingsFundTransactionService {
   private final LedgerService ledgerService;
   private final SavingsFundOnboardingService savingsFundOnboardingService;
   private final SavingsFundConfiguration savingsFundConfiguration;
+  private final SavingFundPaymentRepository savingFundPaymentRepository;
+  private final RedemptionRequestRepository redemptionRequestRepository;
 
   @Transactional
   public List<Transaction> getTransactions(AuthenticatedPerson person) {
@@ -43,31 +51,67 @@ public class SavingsFundTransactionService {
 
     String isin = savingsFundConfiguration.getIsin();
 
+    List<LedgerEntry> subscriptionEntries = entriesOf(ownerCode, partyType, SUBSCRIPTIONS);
+    List<LedgerEntry> redemptionEntries = entriesOf(ownerCode, partyType, REDEMPTIONS);
+
     List<Transaction> subscriptions =
-        mapEntries(ownerCode, partyType, SUBSCRIPTIONS, CONTRIBUTION_CASH, isin);
+        mapEntries(
+            subscriptionEntries,
+            CONTRIBUTION_CASH,
+            isin,
+            remitterIbans(referencesOf(subscriptionEntries)));
     List<Transaction> redemptions =
-        mapEntries(ownerCode, partyType, REDEMPTIONS, SUBTRACTION, isin);
+        mapEntries(
+            redemptionEntries, SUBTRACTION, isin, customerIbans(referencesOf(redemptionEntries)));
 
     return Stream.concat(subscriptions.stream(), redemptions.stream())
         .sorted(reverseOrder())
         .toList();
   }
 
-  private List<Transaction> mapEntries(
-      String ownerCode,
-      PartyType partyType,
-      UserAccount userAccount,
-      CashFlow.Type type,
-      String isin) {
-    return ledgerService.getPartyAccount(ownerCode, partyType, userAccount).getEntries().stream()
-        .map(entry -> toTransaction(entry, type, isin))
-        .toList();
+  private List<LedgerEntry> entriesOf(
+      String ownerCode, PartyType partyType, UserAccount userAccount) {
+    return List.copyOf(
+        ledgerService.getPartyAccount(ownerCode, partyType, userAccount).getEntries());
   }
 
-  private Transaction toTransaction(LedgerEntry entry, CashFlow.Type type, String isin) {
+  private Set<UUID> referencesOf(List<LedgerEntry> entries) {
+    return entries.stream()
+        .map(entry -> entry.getTransaction().getExternalReference())
+        .filter(java.util.Objects::nonNull)
+        .collect(Collectors.toSet());
+  }
+
+  private Map<UUID, String> remitterIbans(Set<UUID> paymentIds) {
+    if (paymentIds.isEmpty()) {
+      return Map.of();
+    }
+    return savingFundPaymentRepository.findRemitterIbansByIds(paymentIds);
+  }
+
+  private Map<UUID, String> customerIbans(Set<UUID> requestIds) {
+    if (requestIds.isEmpty()) {
+      return Map.of();
+    }
+    Map<UUID, String> ibans = new HashMap<>();
+    redemptionRequestRepository
+        .findAllById(requestIds)
+        .forEach(request -> ibans.put(request.getId(), request.getCustomerIban()));
+    return ibans;
+  }
+
+  private List<Transaction> mapEntries(
+      List<LedgerEntry> entries, CashFlow.Type type, String isin, Map<UUID, String> ibans) {
+    return entries.stream().map(entry -> toTransaction(entry, type, isin, ibans)).toList();
+  }
+
+  private Transaction toTransaction(
+      LedgerEntry entry, CashFlow.Type type, String isin, Map<UUID, String> ibans) {
     LedgerTransaction ledgerTransaction = entry.getTransaction();
+    UUID externalReference = ledgerTransaction.getExternalReference();
 
     return Transaction.builder()
+        .counterpartyIban(externalReference == null ? null : ibans.get(externalReference))
         .id(ledgerTransaction.getId())
         .amount(entry.getAmount().negate())
         .currency(EUR)

--- a/src/test/groovy/ee/tuleva/onboarding/ledger/LedgerAccountFixture.java
+++ b/src/test/groovy/ee/tuleva/onboarding/ledger/LedgerAccountFixture.java
@@ -288,9 +288,14 @@ public class LedgerAccountFixture {
         List.of(new EntryFixture(balance, Instant.parse("2025-01-01T00:00:00Z"))));
   }
 
-  public record EntryFixture(BigDecimal amount, Instant transactionDate, BigDecimal navPerUnit) {
+  public record EntryFixture(
+      BigDecimal amount, Instant transactionDate, BigDecimal navPerUnit, UUID externalReference) {
     public EntryFixture(BigDecimal amount, Instant transactionDate) {
-      this(amount, transactionDate, new BigDecimal("10.0"));
+      this(amount, transactionDate, new BigDecimal("10.0"), null);
+    }
+
+    public EntryFixture(BigDecimal amount, Instant transactionDate, BigDecimal navPerUnit) {
+      this(amount, transactionDate, navPerUnit, null);
     }
   }
 
@@ -320,6 +325,7 @@ public class LedgerAccountFixture {
                   .id(UUID.randomUUID())
                   .transactionType(FUND_SUBSCRIPTION)
                   .transactionDate(entry.transactionDate())
+                  .externalReference(entry.externalReference())
                   .metadata(Map.of("navPerUnit", navPerUnit))
                   .build();
           transaction.addEntry(account, entry.amount().negate());
@@ -355,6 +361,7 @@ public class LedgerAccountFixture {
                   .id(UUID.randomUUID())
                   .transactionType(REDEMPTION_PAYOUT)
                   .transactionDate(entry.transactionDate())
+                  .externalReference(entry.externalReference())
                   .metadata(Map.of("navPerUnit", navPerUnit))
                   .build();
           transaction.addEntry(account, entry.amount());

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/SavingFundPaymentRepositoryTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/SavingFundPaymentRepositoryTest.java
@@ -12,6 +12,7 @@ import static java.time.temporal.ChronoUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.entry;
 import static org.assertj.core.api.Assertions.within;
 import static org.junit.jupiter.params.provider.EnumSource.Mode.EXCLUDE;
 
@@ -578,5 +579,32 @@ class SavingFundPaymentRepositoryTest {
     var unmatchedReturns = repository.findUnmatchedOutgoingReturns(depositIban);
 
     assertThat(unmatchedReturns).extracting("id").containsExactly(depositReturn);
+  }
+
+  @Test
+  void findsRemitterIbansForTheGivenPayments() {
+    var fromInvestmentAccount =
+        repository.savePaymentData(
+            createPayment().externalId("iia").remitterIban("EE888888888888888888").build());
+    var fromOrdinaryAccount =
+        repository.savePaymentData(
+            createPayment().externalId("ordinary").remitterIban("EE777777777777777777").build());
+    var notAsked =
+        repository.savePaymentData(
+            createPayment().externalId("other").remitterIban("EE666666666666666666").build());
+
+    var ibans =
+        repository.findRemitterIbansByIds(List.of(fromInvestmentAccount, fromOrdinaryAccount));
+
+    assertThat(ibans)
+        .containsOnly(
+            entry(fromInvestmentAccount, "EE888888888888888888"),
+            entry(fromOrdinaryAccount, "EE777777777777777777"));
+    assertThat(ibans).doesNotContainKey(notAsked);
+  }
+
+  @Test
+  void findsNoRemitterIbansWithoutPayments() {
+    assertThat(repository.findRemitterIbansByIds(List.of())).isEmpty();
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/SavingsFundTransactionServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/SavingsFundTransactionServiceTest.java
@@ -13,6 +13,7 @@ import static ee.tuleva.onboarding.ledger.UserAccount.SUBSCRIPTIONS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.when;
 
 import ee.tuleva.onboarding.account.transaction.Transaction;
@@ -21,9 +22,14 @@ import ee.tuleva.onboarding.ledger.LedgerAccount;
 import ee.tuleva.onboarding.ledger.LedgerAccountFixture.EntryFixture;
 import ee.tuleva.onboarding.ledger.LedgerService;
 import ee.tuleva.onboarding.party.PartyId;
+import ee.tuleva.onboarding.savings.fund.redemption.RedemptionRequest;
+import ee.tuleva.onboarding.savings.fund.redemption.RedemptionRequestRepository;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -36,6 +42,8 @@ class SavingsFundTransactionServiceTest {
   @Mock private LedgerService ledgerService;
   @Mock private SavingsFundOnboardingService savingsFundOnboardingService;
   @Mock private SavingsFundConfiguration savingsFundConfiguration;
+  @Mock private SavingFundPaymentRepository savingFundPaymentRepository;
+  @Mock private RedemptionRequestRepository redemptionRequestRepository;
 
   @InjectMocks private SavingsFundTransactionService service;
 
@@ -150,5 +158,66 @@ class SavingsFundTransactionServiceTest {
 
     assertThat(transactions).hasSize(1);
     assertThat(transactions.get(0).amount()).isEqualTo(new BigDecimal("100.00"));
+  }
+
+  @Test
+  void reportsTheBankAccountEachTransactionWentThroughSoTaxRegimeCanBeTold() {
+    String isin = "EE0000003283";
+    UUID paymentId = UUID.randomUUID();
+    UUID redemptionId = UUID.randomUUID();
+    Instant date = Instant.parse("2025-03-10T10:00:00Z");
+
+    given(savingsFundOnboardingService.isOnboardingCompleted(any(PartyId.class))).willReturn(true);
+    given(savingsFundConfiguration.getIsin()).willReturn(isin);
+
+    given(ledgerService.getPartyAccount(personalCode, PERSON, SUBSCRIPTIONS))
+        .willReturn(
+            subscriptionsAccountWithEntries(
+                List.of(
+                    new EntryFixture(
+                        new BigDecimal("100.00"), date, new BigDecimal("10.0"), paymentId))));
+    given(ledgerService.getPartyAccount(personalCode, PERSON, REDEMPTIONS))
+        .willReturn(
+            redemptionsAccountWithEntries(
+                List.of(
+                    new EntryFixture(
+                        new BigDecimal("25.00"), date, new BigDecimal("10.0"), redemptionId))));
+
+    given(savingFundPaymentRepository.findRemitterIbansByIds(Set.of(paymentId)))
+        .willReturn(Map.of(paymentId, "EE471000001020145685"));
+    RedemptionRequest redemptionRequest = new RedemptionRequest();
+    redemptionRequest.setId(redemptionId);
+    redemptionRequest.setCustomerIban("EE902200221020145685");
+    given(redemptionRequestRepository.findAllById(Set.of(redemptionId)))
+        .willReturn(List.of(redemptionRequest));
+
+    List<Transaction> transactions = service.getTransactions(person);
+
+    assertThat(transactions)
+        .extracting(Transaction::type, Transaction::counterpartyIban)
+        .containsExactlyInAnyOrder(
+            tuple(CONTRIBUTION_CASH, "EE471000001020145685"),
+            tuple(SUBTRACTION, "EE902200221020145685"));
+  }
+
+  @Test
+  void leavesTheBankAccountEmptyWhenTheTransactionHasNoPaymentBehindIt() {
+    String isin = "EE0000003283";
+    Instant date = Instant.parse("2025-03-10T10:00:00Z");
+
+    given(savingsFundOnboardingService.isOnboardingCompleted(any(PartyId.class))).willReturn(true);
+    given(savingsFundConfiguration.getIsin()).willReturn(isin);
+    given(ledgerService.getPartyAccount(personalCode, PERSON, SUBSCRIPTIONS))
+        .willReturn(
+            subscriptionsAccountWithEntries(
+                List.of(new EntryFixture(new BigDecimal("100.00"), date))));
+    given(ledgerService.getPartyAccount(personalCode, PERSON, REDEMPTIONS))
+        .willReturn(redemptionsAccountWithEntries(List.of()));
+
+    List<Transaction> transactions = service.getTransactions(person);
+
+    assertThat(transactions)
+        .singleElement()
+        .satisfies(transaction -> assertThat(transaction.counterpartyIban()).isNull());
   }
 }


### PR DESCRIPTION
## Why

How a savings fund holding is taxed depends on which bank account the money came from. Units bought from an **investeerimiskonto** are taxed on that account's cash flow (declared as payments in/out); everything else is taxed on the gain at redemption. `/v1/transactions` did not say which account was involved, so the client had no way to tell the two apart and could only ever show the ordinary-route calculation.

## What

`Transaction` gains a `counterpartyIban`:

- **Subscription** → the payment's `remitterIban` (where the money came from)
- **Redemption** → the redemption request's `customerIban` (where it was paid out)

Both resolved with one batched lookup per account type, not per transaction. `SavingFundPaymentRepository.findRemitterIbansByIds` is new; redemptions use the existing `CrudRepository.findAllById`.

Transactions with no external reference (and pension transactions, which build `Transaction` from a `CashFlow`) get `null`.

## Notes

- **Frontend depends on this** — see onboarding-client `tkf-statement-ui`. **Merge this first.**
- Tests caught a real NPE on the way in: `Map.of().get(null)` throws, so any ledger transaction without an external reference would have blown up. Guarded and covered.
- `LedgerAccountFixture.EntryFixture` gained an optional `externalReference`; the existing 2- and 3-arg constructors are unchanged, so no existing test moved.
- ⚡ **Performance:** two extra queries per `getTransactions` call, both keyed on primary keys, no N+1. No new indexes needed. This is an authenticated per-user endpoint, not a public one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)