### PR TITLE
Open the portfolio on the person's first day, not the system's

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/account/portfolio/PortfolioController.java
+++ b/src/main/java/ee/tuleva/onboarding/account/portfolio/PortfolioController.java
@@ -22,8 +22,6 @@ import org.springframework.web.server.ResponseStatusException;
 @RequiredArgsConstructor
 public class PortfolioController {
 
-  private static final LocalDate BEGINNING_OF_TIMES = LocalDate.parse("2003-01-07");
-
   private final PortfolioService portfolioService;
   private final Clock clock;
 
@@ -33,12 +31,11 @@ public class PortfolioController {
       @AuthenticationPrincipal AuthenticatedPerson person,
       @RequestParam(required = false) @DateTimeFormat(iso = DATE) @Nullable LocalDate from,
       @RequestParam(required = false) @DateTimeFormat(iso = DATE) @Nullable LocalDate to) {
-    var startDate = from == null ? BEGINNING_OF_TIMES : from;
     var endDate = to == null ? LocalDate.now(clock) : to;
-    if (startDate.isAfter(endDate)) {
+    if (from != null && from.isAfter(endDate)) {
       throw new ResponseStatusException(
-          BAD_REQUEST, "Invalid portfolio period: from=" + startDate + ", to=" + endDate);
+          BAD_REQUEST, "Invalid portfolio period: from=" + from + ", to=" + endDate);
     }
-    return portfolioService.getPortfolio(person, startDate, endDate);
+    return portfolioService.getPortfolio(person, from, endDate);
   }
 }

--- a/src/main/java/ee/tuleva/onboarding/account/portfolio/PortfolioService.java
+++ b/src/main/java/ee/tuleva/onboarding/account/portfolio/PortfolioService.java
@@ -24,6 +24,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.Nullable;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -44,10 +45,13 @@ public class PortfolioService {
   private final ReturnsService returnsService;
   private final FundNavProvider fundNavProvider;
 
-  public Portfolio getPortfolio(AuthenticatedPerson person, LocalDate from, LocalDate to) {
+  public Portfolio getPortfolio(
+      AuthenticatedPerson person, @Nullable LocalDate requestedFrom, LocalDate to) {
     List<Transaction> transactions = transactionService.getTransactions(person);
     Map<String, PortfolioGroup> groupByIsin = groupByIsin();
     Set<String> heldIsins = PortfolioValuation.heldIsins(transactions, groupByIsin);
+    LocalDate from =
+        requestedFrom != null ? requestedFrom : firstHeldDay(transactions, heldIsins, to);
 
     PortfolioValuation valuation =
         new PortfolioValuation(transactions, groupByIsin, navHistory(heldIsins, from, to));
@@ -60,6 +64,11 @@ public class PortfolioService {
         .groups(summaries(valuation, groups, rates, from, to))
         .series(valuation.series(from, to))
         .build();
+  }
+
+  private static LocalDate firstHeldDay(
+      List<Transaction> transactions, Set<String> heldIsins, LocalDate to) {
+    return PortfolioValuation.earliestPricingDay(transactions, heldIsins).orElse(to);
   }
 
   private static List<Portfolio.GroupSummary> summaries(

--- a/src/main/java/ee/tuleva/onboarding/account/portfolio/PortfolioValuation.java
+++ b/src/main/java/ee/tuleva/onboarding/account/portfolio/PortfolioValuation.java
@@ -2,6 +2,7 @@ package ee.tuleva.onboarding.account.portfolio;
 
 import static java.math.RoundingMode.HALF_UP;
 import static java.util.Comparator.comparing;
+import static java.util.Comparator.naturalOrder;
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.mapping;
 import static java.util.stream.Collectors.toCollection;
@@ -16,6 +17,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
+import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
@@ -190,6 +192,14 @@ public class PortfolioValuation {
     return Arrays.stream(PortfolioGroup.values())
         .filter(group -> held.stream().anyMatch(isin -> group == groupByIsin.get(isin)))
         .toList();
+  }
+
+  public static Optional<LocalDate> earliestPricingDay(
+      List<Transaction> transactions, Set<String> isins) {
+    return transactions.stream()
+        .filter(transaction -> isins.contains(transaction.isin()))
+        .map(PortfolioValuation::pricingDayOf)
+        .min(naturalOrder());
   }
 
   public static Set<String> heldIsins(

--- a/src/test/groovy/ee/tuleva/onboarding/account/portfolio/PortfolioControllerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/account/portfolio/PortfolioControllerTest.java
@@ -6,6 +6,7 @@ import static ee.tuleva.onboarding.auth.AuthenticatedPersonFixture.sampleAuthent
 import static ee.tuleva.onboarding.auth.authority.Authority.USER;
 import static java.time.ZoneOffset.UTC;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
@@ -71,18 +72,18 @@ class PortfolioControllerTest {
   }
 
   @Test
-  void defaultsToTheBeginningOfTimesAndToday() throws Exception {
-    LocalDate from = LocalDate.parse("2003-01-07");
+  void leavesTheStartToTheServiceAndDefaultsTheEndToToday() throws Exception {
+    LocalDate firstHeldDay = LocalDate.parse("2021-03-15");
     LocalDate to = LocalDate.parse("2020-01-01");
 
     when(clock.instant()).thenReturn(TestClockHolder.now);
     when(clock.getZone()).thenReturn(UTC);
-    when(portfolioService.getPortfolio(eq(authPerson), eq(from), eq(to)))
-        .thenReturn(portfolio(from, to));
+    when(portfolioService.getPortfolio(eq(authPerson), isNull(), eq(to)))
+        .thenReturn(portfolio(firstHeldDay, to));
 
     mvc.perform(get("/v1/portfolio").with(authentication(authentication)))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$.from").value("2003-01-07"))
+        .andExpect(jsonPath("$.from").value("2021-03-15"))
         .andExpect(jsonPath("$.to").value("2020-01-01"));
   }
 

--- a/src/test/groovy/ee/tuleva/onboarding/account/portfolio/PortfolioServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/account/portfolio/PortfolioServiceTest.java
@@ -251,4 +251,45 @@ class PortfolioServiceTest {
 
     assertThat(portfolio.groups().getFirst().endValue()).isEqualByComparingTo("600.00");
   }
+
+  @Test
+  void opensOnTheFirstDayThePersonHeldAnythingWhenNoStartIsGiven() {
+    given(fundNavProvider.safeMaxNavDate()).willReturn(FAR_FUTURE);
+    given(transactionService.getTransactions(person))
+        .willReturn(List.of(buy(TKF, "2021-03-15T10:00:00Z", "100", "10")));
+    given(fundRepository.findAll()).willReturn(List.of(Fund.builder().isin(TKF).build()));
+    given(fundValueRepository.getLatestValue(any(), any())).willReturn(Optional.empty());
+    given(fundValueRepository.findValuesBetweenDates(eq(TKF), any(), eq(TO)))
+        .willReturn(List.of(fundValue(TKF, "2025-12-31", "12")));
+
+    Portfolio portfolio = portfolioService.getPortfolio(person, null, TO);
+
+    assertThat(portfolio.from()).isEqualTo(LocalDate.parse("2021-03-15"));
+  }
+
+  @Test
+  void opensOnTheEndOfThePeriodWhenThePersonHoldsNothing() {
+    given(transactionService.getTransactions(person)).willReturn(List.of());
+    given(fundRepository.findAll()).willReturn(List.of(Fund.builder().isin(TKF).build()));
+
+    Portfolio portfolio = portfolioService.getPortfolio(person, null, TO);
+
+    assertThat(portfolio.from()).isEqualTo(TO);
+    assertThat(portfolio.groups()).isEmpty();
+  }
+
+  @Test
+  void keepsAnExplicitStartDate() {
+    given(fundNavProvider.safeMaxNavDate()).willReturn(FAR_FUTURE);
+    given(transactionService.getTransactions(person))
+        .willReturn(List.of(buy(TKF, "2021-03-15T10:00:00Z", "100", "10")));
+    given(fundRepository.findAll()).willReturn(List.of(Fund.builder().isin(TKF).build()));
+    given(fundValueRepository.getLatestValue(any(), any())).willReturn(Optional.empty());
+    given(fundValueRepository.findValuesBetweenDates(eq(TKF), eq(FROM), eq(TO)))
+        .willReturn(List.of(fundValue(TKF, "2025-12-31", "12")));
+
+    Portfolio portfolio = portfolioService.getPortfolio(person, FROM, TO);
+
+    assertThat(portfolio.from()).isEqualTo(FROM);
+  }
 }


### PR DESCRIPTION
## Why

The **All time** preset was starting at `2003-01-07` — the day the second pillar itself began, hardcoded in the controller as `BEGINNING_OF_TIMES`.

For anyone who joined later that is wrong twice: the chart draws a flat empty run-up before their money appears, and the date box reads a year they had nothing to do with.

## What

An omitted `from` now resolves to **the first day the person actually held something**. Only the backend can work that out — the client stopped fetching the transaction list when the valuation moved here, so it has nothing to derive it from.

The response echoes the resolved date, so the client's date box shows the person's real start rather than a placeholder.

- Holding nothing → `from` comes back as the end of the period, with no groups
- An explicit `from` → honoured exactly as given
- `BEGINNING_OF_TIMES` is gone

`PortfolioValuation` gained `earliestPricingDay`, so the Europe/Tallinn conversion stays in the one class that already owns it rather than being re-derived in the service.

## Note on the date used

It resolves off `priceTime`, matching how the valuation dates unit counts and cash flows since #1826. Booking day would put the opening edge one day off from the first point the chart can actually draw.

## Verification

- 3 new service tests: first held day when no start is given, end of period when nothing is held, explicit start honoured
- The controller test that pinned the old epoch default now pins the new contract — the controller passes the start through untouched and only defaults the end to today
- Full `account.*` and `savings.fund.*` suites green

## Pairs with

onboarding-client#1611, which also reorders the stacked bands to II pillar, III pillar, savings fund on top. That one is frontend-only and does not depend on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
