### PR TITLE
Notify the payer when a savings fund payment is returned

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/savings/fund/PaymentVerificationService.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/PaymentVerificationService.java
@@ -16,10 +16,14 @@ import ee.tuleva.onboarding.party.PartyResolver;
 import ee.tuleva.onboarding.payment.event.SavingsPaymentFailedEvent;
 import ee.tuleva.onboarding.savings.fund.notification.UnattributedPaymentEvent;
 import ee.tuleva.onboarding.user.UserRepository;
+import ee.tuleva.onboarding.user.personalcode.PersonalCode;
 import ee.tuleva.onboarding.user.personalcode.PersonalCodeValidator;
+import java.time.Clock;
+import java.time.LocalDate;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -42,6 +46,7 @@ public class PaymentVerificationService {
   private final NameMatcher nameMatcher;
   private final PartyResolver partyResolver;
   private final ParentChildLinkService parentChildLinkService;
+  private final Clock clock;
 
   record VerificationMessages(
       String codeMismatch, String notClient, String nameMismatch, String notOnboarded) {
@@ -139,13 +144,34 @@ public class PaymentVerificationService {
     applicationEventPublisher.publishEvent(
         new UnattributedPaymentEvent(payment.getId(), payment.getAmount(), reason));
 
-    Optional.ofNullable(payment.getPartyId())
+    notifyAboutFailedPayment(payment);
+  }
+
+  private void notifyAboutFailedPayment(SavingFundPayment payment) {
+    try {
+      personalCodeToNotify(payment)
+          .flatMap(userRepository::findByPersonalCode)
+          .ifPresent(
+              user ->
+                  applicationEventPublisher.publishEvent(
+                      new SavingsPaymentFailedEvent(this, user, Locale.of("et"))));
+    } catch (Exception e) {
+      log.error("Failed to notify about returned payment: paymentId={}", payment.getId(), e);
+    }
+  }
+
+  private Optional<String> personalCodeToNotify(SavingFundPayment payment) {
+    Predicate<PartyId> isPerson = partyId -> partyId.type() == PERSON;
+    return parsePartyId(payment.getRemitterIdCode())
+        .filter(isPerson)
+        .or(() -> Optional.ofNullable(payment.getPartyId()).filter(isPerson))
         .map(PartyId::code)
-        .flatMap(userRepository::findByPersonalCode)
-        .ifPresent(
-            user ->
-                applicationEventPublisher.publishEvent(
-                    new SavingsPaymentFailedEvent(this, user, Locale.of("et"))));
+        .filter(this::canReceiveSelfServiceEmail);
+  }
+
+  private boolean canReceiveSelfServiceEmail(String personalCode) {
+    return personalCodeValidator.isValid(personalCode)
+        && !PersonalCode.isMinor(personalCode, LocalDate.now(clock));
   }
 
   private Optional<PartyId> extractPartyId(SavingFundPayment payment) {

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/PaymentVerificationServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/PaymentVerificationServiceTest.java
@@ -22,8 +22,10 @@ import ee.tuleva.onboarding.savings.fund.notification.UnattributedPaymentEvent;
 import ee.tuleva.onboarding.user.User;
 import ee.tuleva.onboarding.user.UserRepository;
 import java.math.BigDecimal;
+import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
@@ -41,6 +43,7 @@ class PaymentVerificationServiceTest {
   ApplicationEventPublisher applicationEventPublisher = mock(ApplicationEventPublisher.class);
   PartyResolver partyResolver = new PartyResolver(userRepository, companyRepository);
   ParentChildLinkService parentChildLinkService = mock(ParentChildLinkService.class);
+  Clock clock = Clock.fixed(Instant.parse("2025-10-01T12:00:00Z"), ZoneOffset.UTC);
 
   PaymentVerificationService service =
       new PaymentVerificationService(
@@ -51,7 +54,8 @@ class PaymentVerificationServiceTest {
           applicationEventPublisher,
           new NameMatcher(),
           partyResolver,
-          parentChildLinkService);
+          parentChildLinkService,
+          clock);
 
   @Test
   void process_returnsPaymentWhenNoCodeAnywhere() {
@@ -131,7 +135,7 @@ class PaymentVerificationServiceTest {
 
     service.process(payment);
 
-    verify(userRepository).findByPersonalCode("37508295796");
+    verify(userRepository, atLeastOnce()).findByPersonalCode("37508295796");
     verify(savingFundPaymentRepository).changeStatus(payment.getId(), TO_BE_RETURNED);
     verify(savingFundPaymentRepository)
         .addReturnReason(payment.getId(), "isik ei ole Tuleva klient");
@@ -154,7 +158,7 @@ class PaymentVerificationServiceTest {
 
     service.process(payment);
 
-    verify(userRepository).findByPersonalCode("37508295796");
+    verify(userRepository, atLeastOnce()).findByPersonalCode("37508295796");
     verify(savingsFundOnboardingService).isOnboardingCompleted(new PartyId(PERSON, "37508295796"));
     verify(savingFundPaymentRepository).changeStatus(payment.getId(), TO_BE_RETURNED);
     verify(savingFundPaymentRepository)
@@ -648,6 +652,104 @@ class PaymentVerificationServiceTest {
         .addReturnReason(payment.getId(), "selgituses olev isikukood ei klapi maksja isikukoodiga");
     verify(savingFundPaymentRepository, never()).attachParty(any(), any());
     verifyNoMoreInteractions(savingFundPaymentRepository);
+  }
+
+  @Test
+  void identityCheckFailure_notifiesPayerRatherThanIntendedBeneficiary() {
+    var parentCode = "38812121215";
+    var childCode = "61506150006";
+    var parent =
+        User.builder()
+            .id(789L)
+            .personalCode(parentCode)
+            .firstName("PÄRT")
+            .lastName("ÕLEKÕRS")
+            .build();
+    var payment = createPayment(parentCode, "for child " + childCode);
+    when(parentChildLinkService.isActiveRepresentation(parentCode, childCode)).thenReturn(false);
+    when(userRepository.findByPersonalCode(parentCode)).thenReturn(Optional.of(parent));
+
+    service.process(payment);
+
+    verify(applicationEventPublisher)
+        .publishEvent(
+            argThat(
+                (SavingsPaymentFailedEvent e) ->
+                    e.getUser().equals(parent) && e.getLocale().equals(Locale.of("et"))));
+  }
+
+  @Test
+  void identityCheckFailure_doesNotNotifyMinorBeneficiaryWhenRemitterIsUnidentified() {
+    var childCode = "61506150006";
+    var child =
+        User.builder()
+            .id(456L)
+            .personalCode(childCode)
+            .firstName("MARI")
+            .lastName("MAASIKAS")
+            .build();
+    var payment =
+        SavingFundPayment.builder()
+            .id(randomUUID())
+            .amount(new BigDecimal("100.00"))
+            .partyId(new PartyId(PERSON, childCode))
+            .remitterName("PÄRT ÕLEKÕRS")
+            .remitterIban("EE123456789012345678")
+            .description("no personal code here")
+            .receivedBefore(Instant.parse("2025-10-01T20:59:59.999999Z"))
+            .build();
+    lenient().when(userRepository.findByPersonalCode(childCode)).thenReturn(Optional.of(child));
+
+    service.process(payment);
+
+    verify(applicationEventPublisher, never()).publishEvent(any(SavingsPaymentFailedEvent.class));
+  }
+
+  @Test
+  void identityCheckFailure_recordsReturnAndLedgerEvenWhenNotificationFails() {
+    var payment = createPayment("37508295796", "to user 37508295796");
+    var user =
+        User.builder().personalCode("37508295796").firstName("PÄRT").lastName("ÕLEKÕRS").build();
+    when(userRepository.findByPersonalCode(any())).thenReturn(Optional.of(user));
+    when(savingsFundOnboardingService.isOnboardingCompleted(any(PartyId.class))).thenReturn(false);
+    doThrow(new RuntimeException("notification failed"))
+        .when(applicationEventPublisher)
+        .publishEvent(any(SavingsPaymentFailedEvent.class));
+
+    service.process(payment);
+
+    verify(savingFundPaymentRepository).changeStatus(payment.getId(), TO_BE_RETURNED);
+    verify(savingsFundLedger)
+        .recordUnattributedPayment(payment.getAmount(), payment.getId(), LocalDate.of(2025, 10, 1));
+  }
+
+  @Test
+  void identityCheckFailure_notifiesAttachedPersonWhenRemitterIsCompany() {
+    var personalCode = "37508295796";
+    var user =
+        User.builder()
+            .id(321L)
+            .personalCode(personalCode)
+            .firstName("PÄRT")
+            .lastName("ÕLEKÕRS")
+            .build();
+    var payment =
+        SavingFundPayment.builder()
+            .id(randomUUID())
+            .amount(new BigDecimal("100.00"))
+            .partyId(new PartyId(PERSON, personalCode))
+            .remitterName("TULEVA FONDID AS")
+            .remitterIdCode("14118923")
+            .remitterIban("EE123456789012345678")
+            .description("for user 45009144745")
+            .receivedBefore(Instant.parse("2025-10-01T20:59:59.999999Z"))
+            .build();
+    when(userRepository.findByPersonalCode(personalCode)).thenReturn(Optional.of(user));
+
+    service.process(payment);
+
+    verify(applicationEventPublisher)
+        .publishEvent(argThat((SavingsPaymentFailedEvent e) -> e.getUser().equals(user)));
   }
 
   private SavingFundPayment createPayment(String remitterIdCode, String description) {

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/SavingsFundPaymentIntegrationTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/SavingsFundPaymentIntegrationTest.java
@@ -2,6 +2,7 @@ package ee.tuleva.onboarding.savings.fund;
 
 import static ee.tuleva.onboarding.banking.BankAccountType.FUND_INVESTMENT_EUR;
 import static ee.tuleva.onboarding.banking.seb.Seb.SEB_GATEWAY_TIME_ZONE;
+import static ee.tuleva.onboarding.conversion.ConversionResponseFixture.notFullyConverted;
 import static ee.tuleva.onboarding.fund.TulevaFund.TKF100;
 import static ee.tuleva.onboarding.ledger.LedgerParty.PartyType.*;
 import static ee.tuleva.onboarding.ledger.LedgerTransaction.TransactionType.PAYMENT_BOUNCE_BACK;
@@ -9,10 +10,15 @@ import static ee.tuleva.onboarding.ledger.LedgerTransaction.TransactionType.PAYM
 import static ee.tuleva.onboarding.ledger.SystemAccount.*;
 import static ee.tuleva.onboarding.ledger.UserAccount.*;
 import static ee.tuleva.onboarding.party.PartyId.Type.PERSON;
+import static ee.tuleva.onboarding.paymentrate.PaymentRatesFixture.samplePaymentRates;
 import static ee.tuleva.onboarding.savings.fund.SavingFundPayment.Status.*;
 import static ee.tuleva.onboarding.savings.fund.SavingsFundOnboardingStatus.COMPLETED;
 import static java.math.BigDecimal.ZERO;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 
 import ee.tuleva.onboarding.banking.BankType;
 import ee.tuleva.onboarding.banking.event.BankMessageEvents.ProcessBankMessagesRequested;
@@ -21,12 +27,17 @@ import ee.tuleva.onboarding.banking.message.BankingMessageRepository;
 import ee.tuleva.onboarding.banking.seb.SebAccountConfiguration;
 import ee.tuleva.onboarding.comparisons.fundvalue.FundValue;
 import ee.tuleva.onboarding.comparisons.fundvalue.persistence.FundValueRepository;
+import ee.tuleva.onboarding.conversion.UserConversionService;
 import ee.tuleva.onboarding.currency.Currency;
+import ee.tuleva.onboarding.epis.contact.ContactDetails;
+import ee.tuleva.onboarding.epis.contact.ContactDetailsService;
 import ee.tuleva.onboarding.ledger.LedgerAccount;
 import ee.tuleva.onboarding.ledger.LedgerParty;
 import ee.tuleva.onboarding.ledger.LedgerService;
 import ee.tuleva.onboarding.ledger.SavingsFundLedger;
 import ee.tuleva.onboarding.party.PartyId;
+import ee.tuleva.onboarding.payment.email.PaymentEmailService;
+import ee.tuleva.onboarding.paymentrate.SecondPillarPaymentRateService;
 import ee.tuleva.onboarding.savings.fund.issuing.FundAccountPaymentJob;
 import ee.tuleva.onboarding.savings.fund.issuing.IssuingJob;
 import ee.tuleva.onboarding.time.ClockHolder;
@@ -46,6 +57,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.jdbc.core.simple.JdbcClient;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
@@ -56,6 +68,7 @@ class SavingsFundPaymentIntegrationTest {
   @Autowired private BankingMessageRepository bankingMessageRepository;
   @Autowired private ApplicationEventPublisher eventPublisher;
   @Autowired private PaymentVerificationJob paymentVerificationJob;
+  @Autowired private PaymentVerificationService paymentVerificationService;
   @Autowired private SavingsFundReservationJob savingsFundReservationJob;
   @Autowired private IssuingJob issuingJob;
   @Autowired private FundAccountPaymentJob fundAccountPaymentJob;
@@ -69,6 +82,11 @@ class SavingsFundPaymentIntegrationTest {
   @Autowired private SavingsFundLedger savingsFundLedger;
   @Autowired private UnattributedPaymentAttributionService attributionService;
 
+  @MockitoBean private ContactDetailsService contactDetailsService;
+  @MockitoBean private UserConversionService conversionService;
+  @MockitoBean private SecondPillarPaymentRateService paymentRateService;
+  @MockitoBean private PaymentEmailService paymentEmailService;
+
   // Monday 2025-09-29 17:00 EET (15:00 UTC) - after 16:00 cutoff
   private static final Instant NOW = Instant.parse("2025-09-29T15:00:00Z");
 
@@ -77,6 +95,10 @@ class SavingsFundPaymentIntegrationTest {
   @BeforeEach
   void setUp() {
     ClockHolder.setClock(Clock.fixed(NOW, ZoneId.of("UTC")));
+
+    given(contactDetailsService.getContactDetails(any())).willReturn(new ContactDetails());
+    given(conversionService.getConversion(any())).willReturn(notFullyConverted());
+    given(paymentRateService.getPaymentRates(any())).willReturn(samplePaymentRates());
 
     // Create user and complete savings fund onboarding
     testUser =
@@ -618,6 +640,51 @@ class SavingsFundPaymentIntegrationTest {
     // Assert final ledger: bounce back recorded, clearing accounts balanced
     assertThat(getUnreconciledBankReceiptsAccount().getBalance()).isEqualByComparingTo(ZERO);
     assertThat(getIncomingPaymentsClearingAccount().getBalance()).isEqualByComparingTo(ZERO);
+  }
+
+  @Test
+  void paymentTargetingMinorWithoutActiveRepresentation_isReturnedAndRecordedAsUnattributed() {
+    var minorPersonalCode = "61506150006";
+    userRepository.save(
+        User.builder()
+            .firstName("Mari")
+            .lastName("Maasikas")
+            .personalCode(minorPersonalCode)
+            .build());
+    savingsFundOnboardingRepository.saveOnboardingStatus(minorPersonalCode, PERSON, COMPLETED);
+
+    var paymentAmount = new BigDecimal("50.00");
+    var paymentId =
+        paymentRepository.savePaymentData(
+            SavingFundPayment.builder()
+                .amount(paymentAmount)
+                .currency(Currency.EUR)
+                .description("Payment for " + minorPersonalCode)
+                .remitterName("Jüri Tamm")
+                .remitterIdCode(testUser.getPersonalCode())
+                .remitterIban("EE982200221234567890")
+                .beneficiaryIban("EE442200221092874625")
+                .externalId("test-minor-payment-1")
+                .receivedBefore(NOW)
+                .build());
+    paymentRepository.attachParty(paymentId, new PartyId(PERSON, minorPersonalCode));
+    paymentRepository.changeStatus(paymentId, RECEIVED);
+
+    paymentVerificationService.process(paymentRepository.findById(paymentId).orElseThrow());
+
+    var payment = paymentRepository.findById(paymentId).orElseThrow();
+    assertThat(payment.getStatus()).isEqualTo(TO_BE_RETURNED);
+    assertThat(payment.getReturnReason())
+        .isEqualTo("selgituses olev isikukood ei klapi maksja isikukoodiga");
+
+    assertThat(getIncomingPaymentsClearingAccount().getBalance())
+        .isEqualByComparingTo(paymentAmount);
+    assertThat(getUnreconciledBankReceiptsAccount().getBalance())
+        .isEqualByComparingTo(paymentAmount.negate());
+
+    verify(contactDetailsService)
+        .getContactDetails(
+            argThat(notified -> testUser.getPersonalCode().equals(notified.getPersonalCode())));
   }
 
   private String createUnverifiablePaymentXml() {


### PR DESCRIPTION
A parent paid for their child, so the payment was addressed to the child while the parent remitted it. The failure notification targeted the child, and PrincipalService blocks under-18s from self-authenticating, so building the email security context threw and rolled back the whole verification transaction. The TO_BE_RETURNED status change and the UNATTRIBUTED_PAYMENT ledger entry were both discarded, the Slack notification had already gone out, and the one minute job retried forever. The ledger stayed short by the payment amount, so bank reconciliation failed every night.

The success path already notifies the payer rather than the recipient. Do the same on the failure path: the payer is the one whose money is being returned, and a payer is never a minor.

Also stop notification failures from rolling back verification. Any listener exception, an EPIS timeout for example, could otherwise discard committed payment state and restart the retry loop. The integration test stubbed only its own collaborators, so three sibling tests were silently throwing inside the same swallowed path while the build stayed green.