### PR TITLE
Close the remaining transaction registry code residuals

### DIFF
--- a/appscripts/seb-position-uploader/src/Code.js
+++ b/appscripts/seb-position-uploader/src/Code.js
@@ -55,10 +55,8 @@ var SOURCES = {
         senders: ["flowtraders@ullink.eu"],
         files: [
             {
-                // ASSUMPTION (unconfirmed against a real FT email attachment name —
-                // see appscripts/seb-position-uploader/README.md / migration plan):
-                // Flow Traders names the confirmation PDF by allocation id, e.g.
-                // "MID9BlFbos-00.pdf". One-line regex change if the real name differs.
+                // Flow Traders names the confirmation PDF by allocation id,
+                // e.g. "MID9DSWsDs-00.pdf" (confirmed against live FT email, 2026-08).
                 pattern: /^(MID\w+-\d+)\.pdf$/i,
                 s3Prefix: "ft-confirmations/",
                 s3Suffix: ".pdf",

--- a/src/main/java/ee/tuleva/onboarding/investment/calendar/DomicileCalendar.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/calendar/DomicileCalendar.java
@@ -31,6 +31,8 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class DomicileCalendar {
 
+  private static final int ST_BRIGIDS_DAY_FIRST_YEAR = 2023;
+
   private final Target2Calendar target2Calendar;
   private final Map<Domicile, Map<Integer, Set<LocalDate>>> holidaysByDomicileAndYear =
       new ConcurrentHashMap<>();
@@ -60,7 +62,6 @@ public class DomicileCalendar {
         new HashSet<>(
             Set.of(
                 newYearsDay(year),
-                stBrigidsDay(year),
                 stPatricksDay(year),
                 easterMonday(easterSunday),
                 firstMonday(year, MAY),
@@ -69,6 +70,12 @@ public class DomicileCalendar {
                 lastMonday(year, OCTOBER),
                 christmasDay(year),
                 stStephensDay(year)));
+    if (year >= ST_BRIGIDS_DAY_FIRST_YEAR) {
+      holidays.add(stBrigidsDay(year));
+    }
+    if (year == 2022) {
+      holidays.add(LocalDate.of(2022, MARCH, 18));
+    }
     addWeekendSubstitutes(
         holidays, newYearsDay(year), stPatricksDay(year), christmasDay(year), stStephensDay(year));
     return Set.copyOf(holidays);

--- a/src/main/java/ee/tuleva/onboarding/investment/epis/OwnFundNavProvider.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/epis/OwnFundNavProvider.java
@@ -6,8 +6,10 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 class OwnFundNavProvider {
@@ -19,7 +21,7 @@ class OwnFundNavProvider {
 
   BigDecimal latestNav(TulevaFund fund, LocalDate asOfDate) {
     BigDecimal nav =
-        findLatestNav(fund, asOfDate)
+        queryNav(fund, asOfDate)
             .orElseThrow(
                 () ->
                     new IllegalStateException(
@@ -27,7 +29,7 @@ class OwnFundNavProvider {
                             + fund.getCode()
                             + ", asOfDate="
                             + asOfDate));
-    if (nav.compareTo(MIN_REASONABLE_NAV) < 0 || nav.compareTo(MAX_REASONABLE_NAV) > 0) {
+    if (isOutsideReasonableRange(nav)) {
       throw new IllegalStateException(
           "NAV outside reasonable range: fund=" + fund.getCode() + ", nav=" + nav);
     }
@@ -35,8 +37,31 @@ class OwnFundNavProvider {
   }
 
   Optional<BigDecimal> findLatestNav(TulevaFund fund, LocalDate asOfDate) {
+    return queryNav(fund, asOfDate).filter(nav -> isReasonable(fund, asOfDate, nav));
+  }
+
+  private Optional<BigDecimal> queryNav(TulevaFund fund, LocalDate asOfDate) {
     return fundNavQueryService
         .findLatestNavDateOnOrBefore(fund.getCode(), asOfDate)
         .flatMap(navDate -> fundNavQueryService.findNavPerUnit(fund.getCode(), navDate));
+  }
+
+  private boolean isReasonable(TulevaFund fund, LocalDate asOfDate, BigDecimal nav) {
+    if (isOutsideReasonableRange(nav)) {
+      log.warn(
+          "Ignoring own fund NAV outside reasonable range: fund={}, asOfDate={}, nav={}, min={},"
+              + " max={}",
+          fund.getCode(),
+          asOfDate,
+          nav.toPlainString(),
+          MIN_REASONABLE_NAV.toPlainString(),
+          MAX_REASONABLE_NAV.toPlainString());
+      return false;
+    }
+    return true;
+  }
+
+  private static boolean isOutsideReasonableRange(BigDecimal nav) {
+    return nav.compareTo(MIN_REASONABLE_NAV) < 0 || nav.compareTo(MAX_REASONABLE_NAV) > 0;
   }
 }

--- a/src/main/java/ee/tuleva/onboarding/investment/portfolio/Provider.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/portfolio/Provider.java
@@ -1,6 +1,5 @@
 package ee.tuleva.onboarding.investment.portfolio;
 
-import static ee.tuleva.onboarding.investment.calendar.Domicile.FRANCE;
 import static ee.tuleva.onboarding.investment.calendar.Domicile.IRELAND;
 import static ee.tuleva.onboarding.investment.calendar.Domicile.LUXEMBOURG;
 
@@ -12,7 +11,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum Provider {
   ISHARES(IRELAND),
-  CCF(FRANCE),
+  CCF(IRELAND),
   INVESCO(IRELAND),
   XTRACKERS(IRELAND),
   AMUNDI(LUXEMBOURG),

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/AdminTokenAuthenticator.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/AdminTokenAuthenticator.java
@@ -1,0 +1,49 @@
+package ee.tuleva.onboarding.investment.transaction;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.springframework.http.HttpStatus.SERVICE_UNAVAILABLE;
+import static org.springframework.http.HttpStatus.UNAUTHORIZED;
+
+import java.security.MessageDigest;
+import java.util.Map;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.NullMarked;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ResponseStatusException;
+
+@Component
+@RequiredArgsConstructor
+@NullMarked
+public class AdminTokenAuthenticator {
+
+  static final String SHARED_TOKEN_ACTOR = "shared-admin-token";
+
+  private final AdminTokenProperties properties;
+
+  public String resolveActor(String token) {
+    if (properties.apiToken().isBlank() && properties.operatorTokens().isEmpty()) {
+      throw new ResponseStatusException(SERVICE_UNAVAILABLE, "Admin API not configured");
+    }
+    return operatorFor(token)
+        .orElseThrow(() -> new ResponseStatusException(UNAUTHORIZED, "Invalid admin token"));
+  }
+
+  private Optional<String> operatorFor(String token) {
+    return properties.operatorTokens().entrySet().stream()
+        .filter(operator -> matches(operator.getValue(), token))
+        .map(Map.Entry::getKey)
+        .findFirst()
+        .or(() -> sharedTokenActor(token));
+  }
+
+  private Optional<String> sharedTokenActor(String token) {
+    return !properties.apiToken().isBlank() && matches(properties.apiToken(), token)
+        ? Optional.of(SHARED_TOKEN_ACTOR)
+        : Optional.empty();
+  }
+
+  private static boolean matches(String configured, String presented) {
+    return MessageDigest.isEqual(configured.getBytes(UTF_8), presented.getBytes(UTF_8));
+  }
+}

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/AdminTokenConfiguration.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/AdminTokenConfiguration.java
@@ -1,0 +1,8 @@
+package ee.tuleva.onboarding.investment.transaction;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(AdminTokenProperties.class)
+class AdminTokenConfiguration {}

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/AdminTokenProperties.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/AdminTokenProperties.java
@@ -1,0 +1,20 @@
+package ee.tuleva.onboarding.investment.transaction;
+
+import java.util.Map;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("admin")
+public record AdminTokenProperties(String apiToken, Map<String, String> operatorTokens) {
+
+  public AdminTokenProperties {
+    apiToken = apiToken == null ? "" : apiToken;
+    operatorTokens = operatorTokens == null ? Map.of() : Map.copyOf(operatorTokens);
+    operatorTokens.forEach(
+        (operator, token) -> {
+          if (token.isBlank()) {
+            throw new IllegalStateException(
+                "Admin operator token cannot be blank: operator=" + operator);
+          }
+        });
+  }
+}

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/CalculationWarning.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/CalculationWarning.java
@@ -1,0 +1,3 @@
+package ee.tuleva.onboarding.investment.transaction;
+
+public record CalculationWarning(CalculationWarningType type, String message) {}

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/CalculationWarningType.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/CalculationWarningType.java
@@ -1,0 +1,6 @@
+package ee.tuleva.onboarding.investment.transaction;
+
+public enum CalculationWarningType {
+  REBALANCE_NET_CASH_MISMATCH,
+  REBALANCE_NET_NOT_ACHIEVED
+}

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/FundCalculationResult.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/FundCalculationResult.java
@@ -11,4 +11,5 @@ public record FundCalculationResult(
     FundTransactionInput input,
     List<TradeCalculation> trades,
     BigDecimal netInvestable,
-    @Nullable String noTradeReason) {}
+    @Nullable String noTradeReason,
+    List<CalculationWarning> warnings) {}

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/PendingOrderImpact.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/PendingOrderImpact.java
@@ -1,0 +1,21 @@
+package ee.tuleva.onboarding.investment.transaction;
+
+import static java.math.BigDecimal.ZERO;
+
+import java.math.BigDecimal;
+import java.util.Map;
+
+record PendingOrderImpact(
+    BigDecimal pendingBuys,
+    BigDecimal pendingSells,
+    Map<String, BigDecimal> unreportedPositionValues,
+    Map<String, BigDecimal> unreportedPositionQuantities) {
+
+  static PendingOrderImpact none() {
+    return new PendingOrderImpact(ZERO, ZERO, Map.of(), Map.of());
+  }
+
+  BigDecimal net() {
+    return pendingBuys.subtract(pendingSells);
+  }
+}

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/PendingOrderImpact.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/PendingOrderImpact.java
@@ -14,8 +14,4 @@ record PendingOrderImpact(
   static PendingOrderImpact none() {
     return new PendingOrderImpact(ZERO, ZERO, Map.of(), Map.of());
   }
-
-  BigDecimal net() {
-    return pendingBuys.subtract(pendingSells);
-  }
 }

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/PendingOrderImpactService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/PendingOrderImpactService.java
@@ -108,13 +108,10 @@ class PendingOrderImpactService {
         .findByOrderIdIn(orderIds)
         .forEach(
             execution ->
-                totals.merge(
+                totals.compute(
                     execution.getOrderId(),
-                    ExecutedTotals.NONE.add(execution),
-                    (a, b) ->
-                        new ExecutedTotals(
-                            a.consideration().add(b.consideration()),
-                            a.quantity().add(b.quantity()))));
+                    (orderId, accumulated) ->
+                        (accumulated == null ? ExecutedTotals.NONE : accumulated).add(execution)));
     return totals;
   }
 

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/PendingOrderImpactService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/PendingOrderImpactService.java
@@ -15,7 +15,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NullMarked;
@@ -40,7 +39,7 @@ class PendingOrderImpactService {
       return PendingOrderImpact.none();
     }
 
-    Map<Long, BigDecimal> executedConsideration = executedConsiderationByOrderId(unsettled);
+    Map<Long, ExecutedTotals> executed = executedTotalsByOrderId(unsettled);
 
     BigDecimal pendingBuys = ZERO;
     BigDecimal pendingSells = ZERO;
@@ -48,7 +47,7 @@ class PendingOrderImpactService {
     Map<String, BigDecimal> unreportedQuantities = new HashMap<>();
 
     for (TransactionOrder order : unsettled) {
-      BigDecimal cashImpact = cashImpact(order, executedConsideration.get(order.getId()), asOfDate);
+      BigDecimal cashImpact = expectedConsideration(order, executedOf(executed, order), asOfDate);
       if (order.getTransactionType() == BUY) {
         pendingBuys = pendingBuys.add(cashImpact);
       } else {
@@ -87,24 +86,68 @@ class PendingOrderImpactService {
         && orderTimestamp.atZone(TALLINN).toLocalDate().isAfter(positionDate);
   }
 
-  private Map<Long, BigDecimal> executedConsiderationByOrderId(List<TransactionOrder> orders) {
-    List<Long> orderIds =
-        orders.stream().map(TransactionOrder::getId).filter(Objects::nonNull).toList();
-    return executionRepository.findByOrderIdIn(orderIds).stream()
-        .filter(execution -> execution.getTotalConsideration() != null)
-        .collect(
-            Collectors.groupingBy(
-                TransactionExecution::getOrderId,
-                Collectors.reducing(
-                    ZERO, TransactionExecution::getTotalConsideration, BigDecimal::add)));
+  private record ExecutedTotals(BigDecimal consideration, BigDecimal quantity) {
+
+    static final ExecutedTotals NONE = new ExecutedTotals(ZERO, ZERO);
+
+    ExecutedTotals add(TransactionExecution execution) {
+      return new ExecutedTotals(
+          consideration.add(absOrZero(execution.getTotalConsideration())),
+          quantity.add(absOrZero(execution.getExecutedQuantity())));
+    }
+
+    private static BigDecimal absOrZero(@Nullable BigDecimal value) {
+      return value == null ? ZERO : value.abs();
+    }
   }
 
-  private BigDecimal cashImpact(
-      TransactionOrder order, @Nullable BigDecimal executedConsideration, LocalDate asOfDate) {
-    if (executedConsideration != null && executedConsideration.signum() != 0) {
-      return executedConsideration.abs();
+  private Map<Long, ExecutedTotals> executedTotalsByOrderId(List<TransactionOrder> orders) {
+    List<Long> orderIds =
+        orders.stream().map(TransactionOrder::getId).filter(Objects::nonNull).toList();
+    Map<Long, ExecutedTotals> totals = new HashMap<>();
+    executionRepository
+        .findByOrderIdIn(orderIds)
+        .forEach(
+            execution ->
+                totals.merge(
+                    execution.getOrderId(),
+                    ExecutedTotals.NONE.add(execution),
+                    (a, b) ->
+                        new ExecutedTotals(
+                            a.consideration().add(b.consideration()),
+                            a.quantity().add(b.quantity()))));
+    return totals;
+  }
+
+  private static ExecutedTotals executedOf(
+      Map<Long, ExecutedTotals> executed, TransactionOrder order) {
+    return executed.getOrDefault(order.getId(), ExecutedTotals.NONE);
+  }
+
+  private BigDecimal expectedConsideration(
+      TransactionOrder order, ExecutedTotals executed, LocalDate asOfDate) {
+    return executed.consideration().add(unfilledValue(order, executed, asOfDate));
+  }
+
+  private BigDecimal unfilledValue(
+      TransactionOrder order, ExecutedTotals executed, LocalDate asOfDate) {
+    BigDecimal orderQuantity = order.getOrderQuantity();
+    if (orderQuantity == null) {
+      return unfilledAmount(order, executed);
     }
-    return estimatedValue(order, asOfDate).abs();
+    BigDecimal unfilledQuantity = orderQuantity.abs().subtract(executed.quantity()).max(ZERO);
+    if (unfilledQuantity.signum() == 0) {
+      return ZERO;
+    }
+    BigDecimal price = latestPrice(order.getInstrumentIsin(), asOfDate);
+    return price == null ? unfilledAmount(order, executed) : unfilledQuantity.multiply(price);
+  }
+
+  private static BigDecimal unfilledAmount(TransactionOrder order, ExecutedTotals executed) {
+    BigDecimal orderAmount = order.getOrderAmount();
+    return orderAmount == null
+        ? ZERO
+        : orderAmount.abs().subtract(executed.consideration()).max(ZERO);
   }
 
   private BigDecimal estimatedValue(TransactionOrder order, LocalDate asOfDate) {

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/PendingOrderImpactService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/PendingOrderImpactService.java
@@ -79,9 +79,6 @@ class PendingOrderImpactService {
   private Map<Long, BigDecimal> executedConsiderationByOrderId(List<TransactionOrder> orders) {
     List<Long> orderIds =
         orders.stream().map(TransactionOrder::getId).filter(Objects::nonNull).toList();
-    if (orderIds.isEmpty()) {
-      return Map.of();
-    }
     return executionRepository.findByOrderIdIn(orderIds).stream()
         .filter(execution -> execution.getTotalConsideration() != null)
         .collect(

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/PendingOrderImpactService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/PendingOrderImpactService.java
@@ -57,8 +57,7 @@ class PendingOrderImpactService {
       if (!isMissingFromPositionReport(order, positionDate)) {
         continue;
       }
-      BigDecimal signedValue = signed(order, estimatedValue(order, asOfDate));
-      unreportedValues.merge(order.getInstrumentIsin(), signedValue, BigDecimal::add);
+      unreportedValues.merge(order.getInstrumentIsin(), signed(order, cashImpact), BigDecimal::add);
       if (order.getInstrumentType() == ETF && order.getOrderQuantity() != null) {
         unreportedQuantities.merge(
             order.getInstrumentIsin(), signed(order, order.getOrderQuantity()), BigDecimal::add);
@@ -148,16 +147,6 @@ class PendingOrderImpactService {
     return orderAmount == null
         ? ZERO
         : orderAmount.abs().subtract(executed.consideration()).max(ZERO);
-  }
-
-  private BigDecimal estimatedValue(TransactionOrder order, LocalDate asOfDate) {
-    if (order.getInstrumentType() == ETF && order.getOrderQuantity() != null) {
-      BigDecimal price = latestPrice(order.getInstrumentIsin(), asOfDate);
-      if (price != null) {
-        return order.getOrderQuantity().multiply(price);
-      }
-    }
-    return order.getOrderAmount() == null ? ZERO : order.getOrderAmount();
   }
 
   @Nullable

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/PendingOrderImpactService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/PendingOrderImpactService.java
@@ -54,7 +54,7 @@ class PendingOrderImpactService {
         pendingSells = pendingSells.add(cashImpact);
       }
 
-      if (!isMissingFromPositionReport(order, positionDate)) {
+      if (cashImpact.signum() == 0 || !isMissingFromPositionReport(order, positionDate)) {
         continue;
       }
       unreportedValues.merge(order.getInstrumentIsin(), signed(order, cashImpact), BigDecimal::add);

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/PendingOrderImpactService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/PendingOrderImpactService.java
@@ -1,0 +1,124 @@
+package ee.tuleva.onboarding.investment.transaction;
+
+import static ee.tuleva.onboarding.investment.transaction.InstrumentType.ETF;
+import static ee.tuleva.onboarding.investment.transaction.OrderStatus.SENT;
+import static ee.tuleva.onboarding.investment.transaction.TransactionType.BUY;
+import static java.math.BigDecimal.ZERO;
+
+import ee.tuleva.onboarding.comparisons.fundvalue.PositionPriceResolver;
+import ee.tuleva.onboarding.fund.TulevaFund;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@NullMarked
+class PendingOrderImpactService {
+
+  private final TransactionOrderRepository orderRepository;
+  private final TransactionExecutionRepository executionRepository;
+  private final PositionPriceResolver positionPriceResolver;
+
+  PendingOrderImpact calculate(TulevaFund fund, LocalDate asOfDate) {
+    List<TransactionOrder> unsettled = orderRepository.findUnsettledOrders(fund, asOfDate);
+    if (unsettled.isEmpty()) {
+      return PendingOrderImpact.none();
+    }
+
+    Map<Long, BigDecimal> executedConsideration = executedConsiderationByOrderId(unsettled);
+
+    BigDecimal pendingBuys = ZERO;
+    BigDecimal pendingSells = ZERO;
+    Map<String, BigDecimal> unreportedValues = new HashMap<>();
+    Map<String, BigDecimal> unreportedQuantities = new HashMap<>();
+
+    for (TransactionOrder order : unsettled) {
+      BigDecimal cashImpact = cashImpact(order, executedConsideration.get(order.getId()), asOfDate);
+      if (order.getTransactionType() == BUY) {
+        pendingBuys = pendingBuys.add(cashImpact);
+      } else {
+        pendingSells = pendingSells.add(cashImpact);
+      }
+
+      if (order.getOrderStatus() != SENT) {
+        continue;
+      }
+      BigDecimal signedValue = signed(order, estimatedValue(order, asOfDate));
+      unreportedValues.merge(order.getInstrumentIsin(), signedValue, BigDecimal::add);
+      if (order.getInstrumentType() == ETF && order.getOrderQuantity() != null) {
+        unreportedQuantities.merge(
+            order.getInstrumentIsin(), signed(order, order.getOrderQuantity()), BigDecimal::add);
+      }
+    }
+
+    log.info(
+        "Pending order impact: fund={}, asOfDate={}, orderCount={}, pendingBuys={},"
+            + " pendingSells={}, unreportedIsins={}",
+        fund,
+        asOfDate,
+        unsettled.size(),
+        pendingBuys.toPlainString(),
+        pendingSells.toPlainString(),
+        unreportedValues.keySet());
+
+    return new PendingOrderImpact(
+        pendingBuys, pendingSells, Map.copyOf(unreportedValues), Map.copyOf(unreportedQuantities));
+  }
+
+  private Map<Long, BigDecimal> executedConsiderationByOrderId(List<TransactionOrder> orders) {
+    List<Long> orderIds =
+        orders.stream().map(TransactionOrder::getId).filter(Objects::nonNull).toList();
+    if (orderIds.isEmpty()) {
+      return Map.of();
+    }
+    return executionRepository.findByOrderIdIn(orderIds).stream()
+        .filter(execution -> execution.getTotalConsideration() != null)
+        .collect(
+            Collectors.groupingBy(
+                TransactionExecution::getOrderId,
+                Collectors.reducing(
+                    ZERO, TransactionExecution::getTotalConsideration, BigDecimal::add)));
+  }
+
+  private BigDecimal cashImpact(
+      TransactionOrder order, @Nullable BigDecimal executedConsideration, LocalDate asOfDate) {
+    if (executedConsideration != null && executedConsideration.signum() != 0) {
+      return executedConsideration.abs();
+    }
+    return estimatedValue(order, asOfDate).abs();
+  }
+
+  private BigDecimal estimatedValue(TransactionOrder order, LocalDate asOfDate) {
+    if (order.getInstrumentType() == ETF && order.getOrderQuantity() != null) {
+      BigDecimal price = latestPrice(order.getInstrumentIsin(), asOfDate);
+      if (price != null) {
+        return order.getOrderQuantity().multiply(price);
+      }
+    }
+    return order.getOrderAmount() == null ? ZERO : order.getOrderAmount();
+  }
+
+  @Nullable
+  private BigDecimal latestPrice(String isin, LocalDate date) {
+    return positionPriceResolver
+        .resolve(isin, date)
+        .map(resolved -> resolved.usedPrice())
+        .filter(price -> price != null && price.signum() > 0)
+        .orElse(null);
+  }
+
+  private static BigDecimal signed(TransactionOrder order, BigDecimal value) {
+    return order.getTransactionType() == BUY ? value.abs() : value.abs().negate();
+  }
+}

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/PendingOrderImpactService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/PendingOrderImpactService.java
@@ -1,14 +1,16 @@
 package ee.tuleva.onboarding.investment.transaction;
 
+import static ee.tuleva.onboarding.investment.JobRunSchedule.TIMEZONE;
 import static ee.tuleva.onboarding.investment.transaction.InstrumentType.ETF;
-import static ee.tuleva.onboarding.investment.transaction.OrderStatus.SENT;
 import static ee.tuleva.onboarding.investment.transaction.TransactionType.BUY;
 import static java.math.BigDecimal.ZERO;
 
 import ee.tuleva.onboarding.comparisons.fundvalue.PositionPriceResolver;
 import ee.tuleva.onboarding.fund.TulevaFund;
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -26,11 +28,13 @@ import org.springframework.stereotype.Component;
 @NullMarked
 class PendingOrderImpactService {
 
+  private static final ZoneId TALLINN = ZoneId.of(TIMEZONE);
+
   private final TransactionOrderRepository orderRepository;
   private final TransactionExecutionRepository executionRepository;
   private final PositionPriceResolver positionPriceResolver;
 
-  PendingOrderImpact calculate(TulevaFund fund, LocalDate asOfDate) {
+  PendingOrderImpact calculate(TulevaFund fund, LocalDate asOfDate, LocalDate positionDate) {
     List<TransactionOrder> unsettled = orderRepository.findUnsettledOrders(fund, asOfDate);
     if (unsettled.isEmpty()) {
       return PendingOrderImpact.none();
@@ -51,7 +55,7 @@ class PendingOrderImpactService {
         pendingSells = pendingSells.add(cashImpact);
       }
 
-      if (order.getOrderStatus() != SENT) {
+      if (!isMissingFromPositionReport(order, positionDate)) {
         continue;
       }
       BigDecimal signedValue = signed(order, estimatedValue(order, asOfDate));
@@ -74,6 +78,13 @@ class PendingOrderImpactService {
 
     return new PendingOrderImpact(
         pendingBuys, pendingSells, Map.copyOf(unreportedValues), Map.copyOf(unreportedQuantities));
+  }
+
+  private static boolean isMissingFromPositionReport(
+      TransactionOrder order, LocalDate positionDate) {
+    Instant orderTimestamp = order.getOrderTimestamp();
+    return orderTimestamp != null
+        && orderTimestamp.atZone(TALLINN).toLocalDate().isAfter(positionDate);
   }
 
   private Map<Long, BigDecimal> executedConsiderationByOrderId(List<TransactionOrder> orders) {

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionBatchNotifier.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionBatchNotifier.java
@@ -3,8 +3,8 @@ package ee.tuleva.onboarding.investment.transaction;
 import static ee.tuleva.onboarding.notification.OperationsNotificationService.Channel.INVESTMENT;
 import static java.util.stream.Collectors.joining;
 
+import ee.tuleva.onboarding.investment.transaction.export.ExportFile;
 import ee.tuleva.onboarding.notification.OperationsNotificationService;
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
@@ -14,13 +14,6 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 class TransactionBatchNotifier {
-
-  private static final Map<String, String> DRIVE_URL_LABELS =
-      Map.of(
-          "sebFundXlsx", "SEB indeksfondid",
-          "sebEtfXlsx", "SEB ETF",
-          "ftEtfXlsx", "FT ETF",
-          "uuidWorkbookXlsx", "UUID workbook");
 
   private final OperationsNotificationService notificationService;
 
@@ -35,13 +28,14 @@ class TransactionBatchNotifier {
           event.driveFileUrls() == null || event.driveFileUrls().isEmpty()
               ? ""
               : "\n"
-                  + DRIVE_URL_LABELS.entrySet().stream()
-                      .filter(entry -> event.driveFileUrls().containsKey(entry.getKey()))
+                  + ExportFile.brokerFiles().stream()
+                      .filter(file -> event.driveFileUrls().containsKey(file.metadataKey()))
                       .map(
-                          entry ->
+                          file ->
                               "%s: %s"
                                   .formatted(
-                                      entry.getValue(), event.driveFileUrls().get(entry.getKey())))
+                                      file.driveLabel(),
+                                      event.driveFileUrls().get(file.metadataKey())))
                       .collect(joining("\n", "\n", ""));
 
       notificationService.sendMessage(header + driveLinks, INVESTMENT);

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionBatchResponse.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionBatchResponse.java
@@ -1,7 +1,11 @@
 package ee.tuleva.onboarding.investment.transaction;
 
+import static java.util.stream.Collectors.toUnmodifiableSet;
+
 import ee.tuleva.onboarding.fund.TulevaFund;
+import ee.tuleva.onboarding.investment.transaction.export.ExportFile;
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -22,7 +26,7 @@ public record TransactionBatchResponse(
     @Nullable Map<String, Object> calculationSnapshot) {
 
   static final Set<String> EXPORT_TYPES =
-      Set.of("xlsxExport", "sebFundXlsx", "sebEtfXlsx", "ftEtfXlsx", "uuidWorkbookXlsx");
+      Arrays.stream(ExportFile.values()).map(ExportFile::metadataKey).collect(toUnmodifiableSet());
 
   static TransactionBatchResponse from(
       TransactionBatch batch,

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionCommandController.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionCommandController.java
@@ -5,6 +5,7 @@ import static org.springframework.http.HttpStatus.NOT_FOUND;
 import static org.springframework.http.HttpStatus.SERVICE_UNAVAILABLE;
 import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 
+import ee.tuleva.onboarding.investment.transaction.export.ExportFile;
 import jakarta.validation.Valid;
 import java.security.MessageDigest;
 import java.util.List;
@@ -33,9 +34,6 @@ import org.springframework.web.server.ResponseStatusException;
 @Profile("!staging")
 @NullMarked
 public class TransactionCommandController {
-
-  private static final MediaType XLSX_MEDIA_TYPE =
-      MediaType.parseMediaType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
 
   private final TransactionAdminService adminService;
 
@@ -184,6 +182,11 @@ public class TransactionCommandController {
 
     validateToken(token);
 
+    ExportFile exportFile =
+        ExportFile.byMetadataKey(type)
+            .orElseThrow(
+                () -> new ResponseStatusException(NOT_FOUND, "Unknown export type: type=" + type));
+
     byte[] export =
         adminService
             .exportFile(id, type)
@@ -193,12 +196,12 @@ public class TransactionCommandController {
                         NOT_FOUND, "Export not found: batchId=" + id + ", type=" + type));
 
     return ResponseEntity.ok()
-        .contentType(XLSX_MEDIA_TYPE)
+        .contentType(MediaType.parseMediaType(exportFile.mimeType()))
         .headers(
             headers ->
                 headers.setContentDisposition(
                     ContentDisposition.attachment()
-                        .filename("batch-%d-%s.xlsx".formatted(id, type))
+                        .filename(exportFile.downloadFileName(id))
                         .build()))
         .body(export);
   }

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionCommandController.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionCommandController.java
@@ -1,19 +1,14 @@
 package ee.tuleva.onboarding.investment.transaction;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
-import static org.springframework.http.HttpStatus.SERVICE_UNAVAILABLE;
-import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 
 import ee.tuleva.onboarding.investment.transaction.export.ExportFile;
 import jakarta.validation.Valid;
-import java.security.MessageDigest;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NullMarked;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
 import org.springframework.http.ContentDisposition;
 import org.springframework.http.MediaType;
@@ -36,17 +31,14 @@ import org.springframework.web.server.ResponseStatusException;
 public class TransactionCommandController {
 
   private final TransactionAdminService adminService;
-
-  @Value("${admin.api-token:}")
-  private String adminApiToken = "";
+  private final AdminTokenAuthenticator authenticator;
 
   @PostMapping("/transaction-commands")
   public TransactionCommandResponse createCommand(
       @RequestHeader("X-Admin-Token") String token,
-      @RequestHeader(name = "X-Admin-Actor", required = false, defaultValue = "admin") String actor,
       @Valid @RequestBody CreateTransactionCommandRequest request) {
 
-    validateToken(token);
+    var actor = authenticator.resolveActor(token);
 
     log.info(
         "Admin triggered transaction command: fund={}, mode={}, asOfDate={}, actor={}",
@@ -67,10 +59,9 @@ public class TransactionCommandController {
   @PostMapping("/transaction-commands/batch")
   public List<TransactionCommandResponse> createCommands(
       @RequestHeader("X-Admin-Token") String token,
-      @RequestHeader(name = "X-Admin-Actor", required = false, defaultValue = "admin") String actor,
       @Valid @RequestBody CreateTransactionCommandBatchRequest request) {
 
-    validateToken(token);
+    var actor = authenticator.resolveActor(token);
 
     log.info(
         "Admin triggered transaction command batch: funds={}, mode={}, asOfDate={}, actor={}",
@@ -91,7 +82,7 @@ public class TransactionCommandController {
   public TransactionCommandResponse getCommand(
       @RequestHeader("X-Admin-Token") String token, @PathVariable Long id) {
 
-    validateToken(token);
+    authenticator.resolveActor(token);
 
     return adminService
         .getCommand(id)
@@ -104,7 +95,7 @@ public class TransactionCommandController {
   public TransactionBatchResponse getBatch(
       @RequestHeader("X-Admin-Token") String token, @PathVariable Long id) {
 
-    validateToken(token);
+    authenticator.resolveActor(token);
 
     return adminService
         .getBatch(id)
@@ -114,11 +105,9 @@ public class TransactionCommandController {
 
   @PostMapping("/transaction-batches/{id}/confirm")
   public TransactionBatchResponse confirmBatch(
-      @RequestHeader("X-Admin-Token") String token,
-      @RequestHeader(name = "X-Admin-Actor", required = false, defaultValue = "admin") String actor,
-      @PathVariable Long id) {
+      @RequestHeader("X-Admin-Token") String token, @PathVariable Long id) {
 
-    validateToken(token);
+    var actor = authenticator.resolveActor(token);
 
     log.info("Admin triggered transaction batch confirmation: id={}, actor={}", id, actor);
 
@@ -128,11 +117,10 @@ public class TransactionCommandController {
   @PostMapping("/transaction-batches/{id}/cancel")
   public TransactionBatchResponse cancelBatch(
       @RequestHeader("X-Admin-Token") String token,
-      @RequestHeader(name = "X-Admin-Actor", required = false, defaultValue = "admin") String actor,
       @PathVariable Long id,
       @Valid @RequestBody CancelTransactionBatchRequest request) {
 
-    validateToken(token);
+    var actor = authenticator.resolveActor(token);
 
     log.info(
         "Admin triggered transaction batch cancellation: id={}, actor={}, reason={}",
@@ -145,11 +133,9 @@ public class TransactionCommandController {
 
   @PostMapping("/transaction-batches/{id}/discard")
   public TransactionBatchResponse discardBatch(
-      @RequestHeader("X-Admin-Token") String token,
-      @RequestHeader(name = "X-Admin-Actor", required = false, defaultValue = "admin") String actor,
-      @PathVariable Long id) {
+      @RequestHeader("X-Admin-Token") String token, @PathVariable Long id) {
 
-    validateToken(token);
+    var actor = authenticator.resolveActor(token);
 
     log.info("Admin triggered transaction batch discard: id={}, actor={}", id, actor);
 
@@ -159,11 +145,10 @@ public class TransactionCommandController {
   @PostMapping("/transaction-orders/{id}/cancel")
   public TransactionOrderResponse cancelOrder(
       @RequestHeader("X-Admin-Token") String token,
-      @RequestHeader(name = "X-Admin-Actor", required = false, defaultValue = "admin") String actor,
       @PathVariable Long id,
       @Valid @RequestBody CancelTransactionOrderRequest request) {
 
-    validateToken(token);
+    var actor = authenticator.resolveActor(token);
 
     log.info(
         "Admin triggered transaction order cancellation: id={}, actor={}, reason={}",
@@ -180,7 +165,7 @@ public class TransactionCommandController {
       @PathVariable Long id,
       @PathVariable String type) {
 
-    validateToken(token);
+    authenticator.resolveActor(token);
 
     ExportFile exportFile =
         ExportFile.byMetadataKey(type)
@@ -204,14 +189,5 @@ public class TransactionCommandController {
                         .filename(exportFile.downloadFileName(id))
                         .build()))
         .body(export);
-  }
-
-  private void validateToken(String token) {
-    if (adminApiToken.isBlank()) {
-      throw new ResponseStatusException(SERVICE_UNAVAILABLE, "Admin API not configured");
-    }
-    if (!MessageDigest.isEqual(adminApiToken.getBytes(UTF_8), token.getBytes(UTF_8))) {
-      throw new ResponseStatusException(UNAUTHORIZED, "Invalid admin token");
-    }
   }
 }

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionInputService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionInputService.java
@@ -275,6 +275,7 @@ public class TransactionInputService {
   private List<PositionSnapshot> getPositions(TulevaFund fund, LocalDate date) {
     return fundPositionRepository.findByNavDateAndFundAndAccountType(date, fund, SECURITY).stream()
         .filter(position -> position.getMarketValue() != null)
+        .filter(position -> isTradeableHolding(fund, date, position))
         .map(
             position ->
                 new PositionSnapshot(
@@ -283,6 +284,20 @@ public class TransactionInputService {
                     position.getQuantity(),
                     position.getMarketPrice()))
         .toList();
+  }
+
+  private boolean isTradeableHolding(TulevaFund fund, LocalDate date, FundPosition position) {
+    if (position.getMarketValue().signum() >= 0) {
+      return true;
+    }
+    log.warn(
+        "Skipping security row with a negative market value: fund={}, positionDate={}, isin={},"
+            + " marketValue={}",
+        fund,
+        date,
+        position.getAccountId(),
+        position.getMarketValue().toPlainString());
+    return false;
   }
 
   private BigDecimal getCashBalance(TulevaFund fund, LocalDate date) {

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionInputService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionInputService.java
@@ -12,6 +12,7 @@ import static ee.tuleva.onboarding.investment.position.AccountType.SECURITY;
 import static java.math.BigDecimal.ONE;
 import static java.math.BigDecimal.ZERO;
 import static java.math.RoundingMode.CEILING;
+import static java.util.stream.Collectors.toSet;
 
 import ee.tuleva.onboarding.comparisons.fundvalue.FundValue;
 import ee.tuleva.onboarding.comparisons.fundvalue.persistence.FundValueRepository;
@@ -40,6 +41,7 @@ import ee.tuleva.onboarding.ledger.NavLedgerRepository;
 import ee.tuleva.onboarding.ledger.SystemAccount;
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -78,6 +80,7 @@ public class TransactionInputService {
   private final R16FlowCalculationService r16FlowCalculationService;
   private final R16PhaseCalculator r16PhaseCalculator;
   private final InvestmentParameterRepository investmentParameterRepository;
+  private final PendingOrderImpactService pendingOrderImpactService;
 
   public FundTransactionInput gatherInput(
       TulevaFund fund, LocalDate asOfDate, Map<String, Object> manualAdjustments) {
@@ -103,7 +106,9 @@ public class TransactionInputService {
         asOfDate,
         positionDate);
 
-    List<PositionSnapshot> positions = getPositions(fund, positionDate);
+    PendingOrderImpact pendingOrders = pendingOrderImpactService.calculate(fund, asOfDate);
+    List<PositionSnapshot> positions =
+        applyUnreportedPositions(getPositions(fund, positionDate), pendingOrders);
     BigDecimal reportCash = getCashBalance(fund, positionDate);
     BigDecimal appliedCash = cashOverride == null ? reportCash : cashOverride;
     BigDecimal managementFee = getAccruedFees(fund, asOfDate, FeeType.MANAGEMENT);
@@ -165,13 +170,10 @@ public class TransactionInputService {
     liabilities = liabilities.add(getAdjustment(manualAdjustments, "additionalLiabilities"));
     receivables = receivables.add(getAdjustment(manualAdjustments, "additionalReceivables"));
 
-    PendingCash pendingCash = getPendingCashImpact(fund, asOfDate);
-    BigDecimal freeCash =
-        appliedCash
-            .subtract(cashBuffer)
-            .subtract(liabilities)
-            .add(receivables)
-            .subtract(pendingCash.net());
+    liabilities = liabilities.add(pendingOrders.pendingBuys());
+    receivables = receivables.add(pendingOrders.pendingSells());
+
+    BigDecimal freeCash = appliedCash.subtract(cashBuffer).subtract(liabilities).add(receivables);
 
     BigDecimal ledgerCash =
         navLedgerRepository.getSystemAccountBalance(
@@ -184,8 +186,8 @@ public class TransactionInputService {
             pevaRava,
             r16,
             r45Net,
-            pendingCash.pendingBuys(),
-            pendingCash.pendingSells(),
+            pendingOrders.pendingBuys(),
+            pendingOrders.pendingSells(),
             unreconciledBankReceipts,
             fundUnitsReservedValue,
             incomingPaymentsClearing);
@@ -211,6 +213,52 @@ public class TransactionInputService {
         .positionDate(positionDate)
         .modelEffectiveDate(modelEffectiveDate)
         .build();
+  }
+
+  private List<PositionSnapshot> applyUnreportedPositions(
+      List<PositionSnapshot> positions, PendingOrderImpact pendingOrders) {
+    Map<String, BigDecimal> values = pendingOrders.unreportedPositionValues();
+    if (values.isEmpty()) {
+      return positions;
+    }
+    Map<String, BigDecimal> quantities = pendingOrders.unreportedPositionQuantities();
+
+    List<PositionSnapshot> adjusted =
+        positions.stream()
+            .map(
+                position ->
+                    adjustPosition(
+                        position,
+                        values.getOrDefault(position.isin(), ZERO),
+                        quantities.getOrDefault(position.isin(), ZERO)))
+            .collect(Collectors.toCollection(ArrayList::new));
+
+    Set<String> reported = positions.stream().map(PositionSnapshot::isin).collect(toSet());
+    values.entrySet().stream()
+        .filter(entry -> !reported.contains(entry.getKey()))
+        .forEach(
+            entry ->
+                adjusted.add(
+                    new PositionSnapshot(
+                        entry.getKey(),
+                        entry.getValue().max(ZERO),
+                        quantities.get(entry.getKey()),
+                        null)));
+    return List.copyOf(adjusted);
+  }
+
+  private PositionSnapshot adjustPosition(
+      PositionSnapshot position, BigDecimal valueDelta, BigDecimal quantityDelta) {
+    if (valueDelta.signum() == 0 && quantityDelta.signum() == 0) {
+      return position;
+    }
+    BigDecimal quantity =
+        position.quantity() == null ? null : position.quantity().add(quantityDelta).max(ZERO);
+    return new PositionSnapshot(
+        position.isin(),
+        position.marketValue().add(valueDelta).max(ZERO),
+        quantity,
+        position.unitPrice());
   }
 
   private List<PositionSnapshot> getPositions(TulevaFund fund, LocalDate date) {
@@ -441,28 +489,5 @@ public class TransactionInputService {
         .filter(a -> a.getOrderVenue() != null)
         .forEach(a -> merged.put(a.getIsin(), a.getOrderVenue()));
     return merged;
-  }
-
-  private PendingCash getPendingCashImpact(TulevaFund fund, LocalDate asOfDate) {
-    List<TransactionOrder> unsettledOrders = orderRepository.findUnsettledOrders(fund, asOfDate);
-    BigDecimal pendingBuys =
-        unsettledOrders.stream()
-            .filter(order -> order.getTransactionType() == TransactionType.BUY)
-            .map(TransactionOrder::getOrderAmount)
-            .filter(Objects::nonNull)
-            .reduce(ZERO, BigDecimal::add);
-    BigDecimal pendingSells =
-        unsettledOrders.stream()
-            .filter(order -> order.getTransactionType() == TransactionType.SELL)
-            .map(TransactionOrder::getOrderAmount)
-            .filter(Objects::nonNull)
-            .reduce(ZERO, BigDecimal::add);
-    return new PendingCash(pendingBuys, pendingSells);
-  }
-
-  private record PendingCash(BigDecimal pendingBuys, BigDecimal pendingSells) {
-    BigDecimal net() {
-      return pendingBuys.subtract(pendingSells);
-    }
   }
 }

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionInputService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionInputService.java
@@ -230,8 +230,8 @@ public class TransactionInputService {
                 position ->
                     adjustPosition(
                         position,
-                        values.getOrDefault(position.isin(), ZERO),
-                        quantities.getOrDefault(position.isin(), ZERO)))
+                        deltaFor(values, position.isin()),
+                        deltaFor(quantities, position.isin())))
             .collect(Collectors.toCollection(ArrayList::new));
 
     Set<String> reported = positions.stream().map(PositionSnapshot::isin).collect(toSet());
@@ -247,6 +247,10 @@ public class TransactionInputService {
                         clampToZero(quantities.get(entry.getKey())),
                         null)));
     return List.copyOf(adjusted);
+  }
+
+  private static BigDecimal deltaFor(Map<String, BigDecimal> deltas, @Nullable String isin) {
+    return isin == null ? ZERO : deltas.getOrDefault(isin, ZERO);
   }
 
   @Nullable

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionInputService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionInputService.java
@@ -237,15 +237,21 @@ public class TransactionInputService {
     Set<String> reported = positions.stream().map(PositionSnapshot::isin).collect(toSet());
     values.entrySet().stream()
         .filter(entry -> !reported.contains(entry.getKey()))
+        .filter(entry -> entry.getValue().signum() > 0)
         .forEach(
             entry ->
                 adjusted.add(
                     new PositionSnapshot(
                         entry.getKey(),
-                        entry.getValue().max(ZERO),
-                        quantities.get(entry.getKey()),
+                        entry.getValue(),
+                        clampToZero(quantities.get(entry.getKey())),
                         null)));
     return List.copyOf(adjusted);
+  }
+
+  @Nullable
+  private static BigDecimal clampToZero(@Nullable BigDecimal quantity) {
+    return quantity == null ? null : quantity.max(ZERO);
   }
 
   private PositionSnapshot adjustPosition(

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionInputService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionInputService.java
@@ -106,7 +106,8 @@ public class TransactionInputService {
         asOfDate,
         positionDate);
 
-    PendingOrderImpact pendingOrders = pendingOrderImpactService.calculate(fund, asOfDate);
+    PendingOrderImpact pendingOrders =
+        pendingOrderImpactService.calculate(fund, asOfDate, positionDate);
     List<PositionSnapshot> positions =
         applyUnreportedPositions(getPositions(fund, positionDate), pendingOrders);
     BigDecimal reportCash = getCashBalance(fund, positionDate);

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionPreparationService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionPreparationService.java
@@ -147,6 +147,10 @@ public class TransactionPreparationService {
     return command.getActor() == null ? "system" : command.getActor();
   }
 
+  private static String finalizingActor(TransactionBatch batch) {
+    return batch.getConfirmedBy() == null ? "system" : batch.getConfirmedBy();
+  }
+
   private Map<String, Object> failedPayload(
       TransactionCommand command, @Nullable FundTransactionInput input, RuntimeException e) {
     Map<String, Object> payload = new LinkedHashMap<>();
@@ -219,7 +223,7 @@ public class TransactionPreparationService {
         TransactionAuditEvent.builder()
             .batch(batch)
             .eventType("BATCH_FINALIZED")
-            .actor("system")
+            .actor(finalizingActor(batch))
             .createdAt(Instant.now(clock))
             .payload(Map.of("tradeDate", tradeDate.toString(), "orderCount", orders.size()))
             .build());

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionPreparationService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionPreparationService.java
@@ -524,13 +524,17 @@ public class TransactionPreparationService {
       CalculatedOrders calculated) {
     Map<String, Object> payload = new LinkedHashMap<>();
     payload.put("input", serializeInput(input, command.getManualAdjustments()));
-    payload.put("output", serializeTrades(result.trades(), ordersByIsin(orders)));
+    payload.put(
+        "output",
+        serializeTrades(result.trades(), ordersByIsin(orders), calculated.priceResolutions()));
     payload.put("priceResolutions", serializePriceResolutions(calculated.priceResolutions()));
     payload.put(
         "settlementWarnings",
         serializeSettlementWarnings(
             settlementTimingWarningService.activeWarnings(
                 command.getFund(), command.getAsOfDate())));
+    payload.put("calculationWarnings", serializeCalculationWarnings(result.warnings()));
+    payload.put("modelDrift", serializeModelDrift(input, result));
     Map<String, Object> summary = new LinkedHashMap<>();
     summary.put("fund", command.getFund().name());
     summary.put("mode", command.getMode().name());
@@ -541,25 +545,105 @@ public class TransactionPreparationService {
     return payload;
   }
 
+  static List<Map<String, Object>> serializeCalculationWarnings(List<CalculationWarning> warnings) {
+    return warnings.stream()
+        .map(
+            warning -> {
+              Map<String, Object> map = new LinkedHashMap<>();
+              putIfPresent(map, "type", warning.type().name());
+              putIfPresent(map, "message", warning.message());
+              return map;
+            })
+        .toList();
+  }
+
   private static Map<String, TransactionOrder> ordersByIsin(List<TransactionOrder> orders) {
     Map<String, TransactionOrder> map = new LinkedHashMap<>();
     orders.forEach(order -> map.put(order.getInstrumentIsin(), order));
     return map;
   }
 
+  static Map<String, Object> serializeModelDrift(
+      FundTransactionInput input, FundCalculationResult result) {
+    Map<String, BigDecimal> targetWeights =
+        targetWeights(input.modelWeights(), input.grossPortfolioValue(), result.netInvestable());
+    Map<String, BigDecimal> weightsAfter = new LinkedHashMap<>();
+    result.trades().forEach(trade -> weightsAfter.put(trade.isin(), trade.projectedWeight()));
+
+    List<Map<String, Object>> positions = new ArrayList<>();
+    BigDecimal totalBefore = ZERO;
+    BigDecimal totalAfter = ZERO;
+    for (PositionSnapshot position : input.positions()) {
+      BigDecimal target = targetWeights.getOrDefault(position.isin(), ZERO);
+      BigDecimal before = currentWeight(position, input.grossPortfolioValue());
+      BigDecimal after = weightsAfter.get(position.isin());
+      Map<String, Object> map = new LinkedHashMap<>();
+      putIfPresent(map, "isin", position.isin());
+      putIfPresent(map, "targetWeight", plain(target));
+      putIfPresent(map, "weightBefore", plain(before));
+      putIfPresent(map, "weightAfter", plain(after));
+      if (before != null) {
+        BigDecimal driftBefore = before.subtract(target);
+        putIfPresent(map, "driftBefore", plain(driftBefore));
+        totalBefore = totalBefore.add(driftBefore.abs());
+      }
+      if (after != null) {
+        BigDecimal driftAfter = after.subtract(target);
+        putIfPresent(map, "driftAfter", plain(driftAfter));
+        totalAfter = totalAfter.add(driftAfter.abs());
+      }
+      positions.add(map);
+    }
+
+    Map<String, Object> drift = new LinkedHashMap<>();
+    putIfPresent(drift, "totalAbsoluteDriftBefore", plain(totalBefore));
+    putIfPresent(drift, "totalAbsoluteDriftAfter", plain(totalAfter));
+    putIfPresent(drift, "positions", positions);
+    return drift;
+  }
+
+  private static Map<String, BigDecimal> targetWeights(
+      List<ModelWeight> modelWeights, BigDecimal grossPortfolioValue, BigDecimal netInvestable) {
+    if (grossPortfolioValue.signum() == 0) {
+      return Map.of();
+    }
+    BigDecimal totalWeight =
+        modelWeights.stream().map(ModelWeight::weight).reduce(ZERO, BigDecimal::add);
+    BigDecimal normalizer = totalWeight.signum() == 0 ? BigDecimal.ONE : totalWeight;
+    Map<String, BigDecimal> map = new LinkedHashMap<>();
+    modelWeights.forEach(
+        weight ->
+            map.put(
+                weight.isin(),
+                weight
+                    .weight()
+                    .divide(normalizer, 10, RoundingMode.HALF_UP)
+                    .multiply(netInvestable)
+                    .divide(grossPortfolioValue, 6, RoundingMode.HALF_UP)));
+    return map;
+  }
+
   static List<Map<String, Object>> serializeTrades(
-      List<TradeCalculation> trades, Map<String, TransactionOrder> ordersByIsin) {
+      List<TradeCalculation> trades,
+      Map<String, TransactionOrder> ordersByIsin,
+      Map<String, ResolvedPrice> priceResolutions) {
     return trades.stream()
-        .map(trade -> serializeTrade(trade, ordersByIsin.get(trade.isin())))
+        .map(
+            trade ->
+                serializeTrade(
+                    trade, ordersByIsin.get(trade.isin()), priceResolutions.get(trade.isin())))
         .toList();
   }
 
   private static Map<String, Object> serializeTrade(
-      TradeCalculation trade, @Nullable TransactionOrder order) {
+      TradeCalculation trade,
+      @Nullable TransactionOrder order,
+      @Nullable ResolvedPrice resolvedPrice) {
     Map<String, Object> map = new LinkedHashMap<>();
     putIfPresent(map, "isin", trade.isin());
     putIfPresent(map, "tradeAmount", plain(trade.tradeAmount()));
     putIfPresent(map, "projectedWeight", plain(trade.projectedWeight()));
+    putIfPresent(map, "price", resolvedPrice == null ? null : plain(resolvedPrice.usedPrice()));
     putIfPresent(
         map, "limitStatus", trade.limitStatus() == null ? null : trade.limitStatus().name());
     if (order != null) {

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionRegistryController.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionRegistryController.java
@@ -3,8 +3,6 @@ package ee.tuleva.onboarding.investment.transaction;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.springframework.http.HttpStatus.ACCEPTED;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
-import static org.springframework.http.HttpStatus.SERVICE_UNAVAILABLE;
-import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 import static org.springframework.http.MediaType.MULTIPART_FORM_DATA_VALUE;
 import static org.springframework.http.MediaType.TEXT_PLAIN_VALUE;
 
@@ -26,13 +24,11 @@ import ee.tuleva.onboarding.investment.transaction.ingest.FtConfirmationVerifica
 import ee.tuleva.onboarding.investment.transaction.ingest.HistoricalRegistryImportService;
 import jakarta.validation.Valid;
 import java.io.IOException;
-import java.security.MessageDigest;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NullMarked;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Profile;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -45,7 +41,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
-import org.springframework.web.server.ResponseStatusException;
 
 @Slf4j
 @RestController
@@ -56,6 +51,7 @@ import org.springframework.web.server.ResponseStatusException;
 public class TransactionRegistryController {
 
   private final ApplicationEventPublisher eventPublisher;
+  private final AdminTokenAuthenticator authenticator;
   private final TransactionAdminService adminService;
   private final FtConfirmationVerificationService ftConfirmationVerificationService;
   private final HistoricalRegistryImportService historicalRegistryImportService;
@@ -65,16 +61,13 @@ public class TransactionRegistryController {
   private final R16StatusService r16StatusService;
   private final SettlementTimingWarningService settlementTimingWarningService;
 
-  @Value("${admin.api-token:}")
-  private String adminApiToken = "";
-
   @PostMapping("/transaction-registry/match")
   @ResponseStatus(ACCEPTED)
   public String triggerExecutionMatching(@RequestHeader("X-Admin-Token") String token) {
 
-    validateToken(token);
+    var actor = authenticator.resolveActor(token);
 
-    log.info("Admin triggered SEB pending transaction reconciliation");
+    log.info("Admin triggered SEB pending transaction reconciliation: actor={}", actor);
     eventPublisher.publishEvent(new RunSebPendingTransactionReconciliationRequested());
 
     return "Triggered SEB pending transaction reconciliation";
@@ -83,7 +76,7 @@ public class TransactionRegistryController {
   @GetMapping("/dashboard/daily-summary")
   public TransactionDailySummary dailySummary(@RequestHeader("X-Admin-Token") String token) {
 
-    validateToken(token);
+    authenticator.resolveActor(token);
 
     return adminService.dailySummary();
   }
@@ -93,7 +86,7 @@ public class TransactionRegistryController {
       @RequestHeader("X-Admin-Token") String token,
       @Valid @RequestBody FtConfirmation confirmation) {
 
-    validateToken(token);
+    authenticator.resolveActor(token);
 
     log.info(
         "Admin submitted FT confirmation for verification: fund={}, isin={}, tradeDate={}",
@@ -106,10 +99,9 @@ public class TransactionRegistryController {
   @PostMapping("/transaction-registry/ft-confirmations")
   public List<FtConfirmationBatchResult> verifyFtConfirmations(
       @RequestHeader("X-Admin-Token") String token,
-      @RequestHeader(name = "X-Admin-Actor", required = false, defaultValue = "admin") String actor,
       @RequestBody List<FtConfirmation> confirmations) {
 
-    validateToken(token);
+    var actor = authenticator.resolveActor(token);
 
     log.info(
         "Admin submitted FT confirmations batch for verification: count={}, actor={}",
@@ -122,9 +114,12 @@ public class TransactionRegistryController {
   public HistoricalImportResult importHistory(
       @RequestHeader("X-Admin-Token") String token, @RequestBody String csv) {
 
-    validateToken(token);
+    var actor = authenticator.resolveActor(token);
 
-    log.info("Admin triggered historical registry import: contentLength={}", csv.length());
+    log.info(
+        "Admin triggered historical registry import: contentLength={}, actor={}",
+        csv.length(),
+        actor);
     return historicalRegistryImportService.importCsv(csv);
   }
 
@@ -133,7 +128,7 @@ public class TransactionRegistryController {
       @RequestHeader("X-Admin-Token") String token, @RequestParam("file") MultipartFile file)
       throws IOException {
 
-    validateToken(token);
+    authenticator.resolveActor(token);
 
     log.info(
         "Admin triggered historical registry import from file: fileName={}, size={}",
@@ -148,9 +143,13 @@ public class TransactionRegistryController {
       @RequestParam("type") ReportType type,
       @RequestBody String csv) {
 
-    validateToken(token);
+    var actor = authenticator.resolveActor(token);
 
-    log.info("Admin triggered EPIS report import: type={}, contentLength={}", type, csv.length());
+    log.info(
+        "Admin triggered EPIS report import: type={}, contentLength={}, actor={}",
+        type,
+        csv.length(),
+        actor);
     return episReportIngestionService.ingestReport(type, csv);
   }
 
@@ -161,7 +160,7 @@ public class TransactionRegistryController {
       @RequestParam("file") MultipartFile file)
       throws IOException {
 
-    validateToken(token);
+    authenticator.resolveActor(token);
 
     log.info(
         "Admin triggered EPIS report import from file: type={}, fileName={}, size={}",
@@ -174,7 +173,7 @@ public class TransactionRegistryController {
   @GetMapping("/transaction-registry/peva-rava/status")
   public PevaRavaStatus pevaRavaStatus(@RequestHeader("X-Admin-Token") String token) {
 
-    validateToken(token);
+    authenticator.resolveActor(token);
 
     return pevaRavaStatusService.status();
   }
@@ -183,16 +182,16 @@ public class TransactionRegistryController {
   public Map<TulevaFund, PevaRavaFlows> recalculatePevaRavaFlows(
       @RequestHeader("X-Admin-Token") String token) {
 
-    validateToken(token);
+    var actor = authenticator.resolveActor(token);
 
-    log.info("Admin triggered PEVA/RAVA flow recalculation");
+    log.info("Admin triggered PEVA/RAVA flow recalculation: actor={}", actor);
     return pevaRavaStatusService.recalculate();
   }
 
   @GetMapping("/transaction-registry/r45/latest")
   public Map<TulevaFund, R45Result> latestR45Flows(@RequestHeader("X-Admin-Token") String token) {
 
-    validateToken(token);
+    authenticator.resolveActor(token);
 
     return r45ReportService.getLatestFlows();
   }
@@ -200,7 +199,7 @@ public class TransactionRegistryController {
   @GetMapping("/transaction-registry/r16/status")
   public List<R16FundStatus> r16Status(@RequestHeader("X-Admin-Token") String token) {
 
-    validateToken(token);
+    authenticator.resolveActor(token);
 
     return r16StatusService.status();
   }
@@ -209,7 +208,7 @@ public class TransactionRegistryController {
   public List<SettlementTimingWarning> settlementWarnings(
       @RequestHeader("X-Admin-Token") String token) {
 
-    validateToken(token);
+    authenticator.resolveActor(token);
 
     return settlementTimingWarningService.activeWarnings();
   }
@@ -227,14 +226,5 @@ public class TransactionRegistryController {
         "error", e.getMessage(),
         "missingHeaders", e.getMissingHeaders(),
         "requiredHeaders", e.getRequiredHeaders());
-  }
-
-  private void validateToken(String token) {
-    if (adminApiToken.isBlank()) {
-      throw new ResponseStatusException(SERVICE_UNAVAILABLE, "Admin API not configured");
-    }
-    if (!MessageDigest.isEqual(adminApiToken.getBytes(UTF_8), token.getBytes(UTF_8))) {
-      throw new ResponseStatusException(UNAUTHORIZED, "Invalid admin token");
-    }
   }
 }

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/calculation/TradeCalculationEngine.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/calculation/TradeCalculationEngine.java
@@ -1,10 +1,13 @@
 package ee.tuleva.onboarding.investment.transaction.calculation;
 
+import static ee.tuleva.onboarding.investment.transaction.CalculationWarningType.REBALANCE_NET_CASH_MISMATCH;
+import static ee.tuleva.onboarding.investment.transaction.CalculationWarningType.REBALANCE_NET_NOT_ACHIEVED;
 import static ee.tuleva.onboarding.investment.transaction.LimitStatus.OK;
 import static java.math.BigDecimal.ZERO;
 import static java.math.RoundingMode.HALF_UP;
 import static java.util.stream.Collectors.toMap;
 
+import ee.tuleva.onboarding.investment.transaction.CalculationWarning;
 import ee.tuleva.onboarding.investment.transaction.FundCalculationResult;
 import ee.tuleva.onboarding.investment.transaction.FundTransactionInput;
 import ee.tuleva.onboarding.investment.transaction.LimitStatus;
@@ -19,9 +22,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.IntStream;
+import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.Nullable;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 public class TradeCalculationEngine {
 
@@ -31,6 +36,8 @@ public class TradeCalculationEngine {
   private static final BigDecimal MIN_MEANINGFUL_AMOUNT = new BigDecimal("0.01");
 
   public FundCalculationResult calculate(FundTransactionInput input, TransactionMode mode) {
+    validateInput(input);
+
     List<BigDecimal> rawTrades =
         switch (mode) {
           case BUY -> calculateBuy(input);
@@ -46,7 +53,97 @@ public class TradeCalculationEngine {
         input,
         trades,
         netInvestable(input),
-        noTradeReason(input, mode, trades));
+        noTradeReason(input, mode, trades),
+        warnings(input, mode, trades));
+  }
+
+  private void validateInput(FundTransactionInput input) {
+    input
+        .positions()
+        .forEach(
+            position -> {
+              if (position.marketValue().signum() < 0) {
+                throw new IllegalArgumentException(
+                    "Position market value cannot be negative: fund=%s, isin=%s, marketValue=%s"
+                        .formatted(
+                            input.fund().name(),
+                            position.isin(),
+                            position.marketValue().toPlainString()));
+              }
+            });
+    input
+        .modelWeights()
+        .forEach(
+            weight -> {
+              if (weight.weight().signum() < 0) {
+                throw new IllegalArgumentException(
+                    "Model weight cannot be negative: fund=%s, isin=%s, weight=%s"
+                        .formatted(
+                            input.fund().name(), weight.isin(), weight.weight().toPlainString()));
+              }
+            });
+    if (input.grossPortfolioValue().signum() < 0) {
+      throw new IllegalArgumentException(
+          "Gross portfolio value cannot be negative: fund=%s, grossPortfolioValue=%s"
+              .formatted(input.fund().name(), input.grossPortfolioValue().toPlainString()));
+    }
+  }
+
+  private List<CalculationWarning> warnings(
+      FundTransactionInput input, TransactionMode mode, List<TradeCalculation> trades) {
+    if (mode != TransactionMode.REBALANCE || input.positions().isEmpty()) {
+      return List.of();
+    }
+    return rebalanceWarnings(input, trades);
+  }
+
+  private List<CalculationWarning> rebalanceWarnings(
+      FundTransactionInput input, List<TradeCalculation> trades) {
+    RebalanceBuckets buckets = rebalanceBuckets(input);
+    BigDecimal intendedNet = sum(buckets.buyScores()).subtract(sum(buckets.sellScores()));
+    BigDecimal realizedNet =
+        trades.stream().map(TradeCalculation::tradeAmount).reduce(ZERO, BigDecimal::add);
+    BigDecimal threshold = input.minTransactionThreshold();
+
+    List<CalculationWarning> warnings = new ArrayList<>();
+    BigDecimal cashGap = intendedNet.subtract(input.freeCash());
+    if (cashGap.abs().compareTo(threshold) >= 0) {
+      warnings.add(
+          new CalculationWarning(
+              REBALANCE_NET_CASH_MISMATCH,
+              ("Rebalance net cash need does not match free cash, check the inputs: fund=%s,"
+                      + " intendedNet=%s, freeCash=%s, difference=%s, minTransactionThreshold=%s")
+                  .formatted(
+                      input.fund().name(),
+                      intendedNet.toPlainString(),
+                      input.freeCash().toPlainString(),
+                      cashGap.toPlainString(),
+                      threshold.toPlainString())));
+    }
+
+    BigDecimal achievedGap = realizedNet.subtract(intendedNet);
+    if (achievedGap.abs().compareTo(threshold) >= 0) {
+      warnings.add(
+          new CalculationWarning(
+              REBALANCE_NET_NOT_ACHIEVED,
+              ("Rebalance could not achieve the intended net, a limit or the minimum trade size"
+                      + " blocked part of it and a Sell may be needed instead: fund=%s,"
+                      + " realizedNet=%s, intendedNet=%s, difference=%s,"
+                      + " minTransactionThreshold=%s")
+                  .formatted(
+                      input.fund().name(),
+                      realizedNet.toPlainString(),
+                      intendedNet.toPlainString(),
+                      achievedGap.toPlainString(),
+                      threshold.toPlainString())));
+    }
+
+    warnings.forEach(warning -> log.warn(warning.message()));
+    return List.copyOf(warnings);
+  }
+
+  private static BigDecimal sum(List<BigDecimal> values) {
+    return values.stream().reduce(ZERO, BigDecimal::add);
   }
 
   @Nullable
@@ -769,6 +866,28 @@ public class TradeCalculationEngine {
       return List.of();
     }
 
+    RebalanceBuckets buckets = rebalanceBuckets(input);
+    List<BigDecimal> buyScores = buckets.buyScores();
+    List<BigDecimal> sellScores = buckets.sellScores();
+
+    List<BigDecimal> buyAllocations =
+        redistributeHardLimitExcess(
+            input,
+            buyScores,
+            distributeBucketWithThreshold(buyScores, input.minTransactionThreshold()));
+    List<BigDecimal> rawSellAllocations =
+        distributeBucketWithThreshold(sellScores, input.minTransactionThreshold());
+    List<BigDecimal> sellAllocations =
+        IntStream.range(0, rawSellAllocations.size())
+            .mapToObj(i -> rawSellAllocations.get(i).min(input.positions().get(i).marketValue()))
+            .toList();
+
+    return IntStream.range(0, buyAllocations.size())
+        .mapToObj(i -> buyAllocations.get(i).subtract(sellAllocations.get(i)))
+        .toList();
+  }
+
+  private RebalanceBuckets rebalanceBuckets(FundTransactionInput input) {
     List<BigDecimal> targetValues = normalizedTargetValues(input);
     List<BigDecimal> rawTrades =
         IntStream.range(0, input.positions().size())
@@ -788,22 +907,10 @@ public class TradeCalculationEngine {
                     rawTrades.get(i).negate().max(ZERO).min(input.positions().get(i).marketValue()))
             .toList();
 
-    List<BigDecimal> buyAllocations =
-        redistributeHardLimitExcess(
-            input,
-            buyScores,
-            distributeBucketWithThreshold(buyScores, input.minTransactionThreshold()));
-    List<BigDecimal> rawSellAllocations =
-        distributeBucketWithThreshold(sellScores, input.minTransactionThreshold());
-    List<BigDecimal> sellAllocations =
-        IntStream.range(0, rawSellAllocations.size())
-            .mapToObj(i -> rawSellAllocations.get(i).min(input.positions().get(i).marketValue()))
-            .toList();
-
-    return IntStream.range(0, rawTrades.size())
-        .mapToObj(i -> buyAllocations.get(i).subtract(sellAllocations.get(i)))
-        .toList();
+    return new RebalanceBuckets(buyScores, sellScores);
   }
+
+  private record RebalanceBuckets(List<BigDecimal> buyScores, List<BigDecimal> sellScores) {}
 
   private List<BigDecimal> distributeBucketWithThreshold(
       List<BigDecimal> scores, BigDecimal threshold) {

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/export/CustodianOrderMessageFactory.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/export/CustodianOrderMessageFactory.java
@@ -14,7 +14,6 @@ import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
-import java.util.function.BiFunction;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -22,40 +21,8 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 class CustodianOrderMessageFactory {
 
-  private static final String XLSX_MIME_TYPE =
-      "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
-  private static final String CSV_MIME_TYPE = "text/csv";
-
-  private static final DateTimeFormatter TIMESTAMP =
-      DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH_mm_ss").withZone(ZoneOffset.UTC);
-  private static final DateTimeFormatter UUID_WORKBOOK_TIMESTAMP =
-      DateTimeFormatter.ofPattern("yyyyMMdd_HHmm").withZone(ZoneOffset.UTC);
   private static final DateTimeFormatter SUBJECT_DATE =
       DateTimeFormatter.ofPattern("dd.MM.yyyy").withZone(ZoneOffset.UTC);
-
-  private static final Map<String, BiFunction<TulevaFund, Instant, String>> FILE_NAME_GENERATORS =
-      Map.of(
-          "sebFundXlsx",
-              (fund, timestamp) ->
-                  "SEB_%s_indeksfondid_%s.csv"
-                      .formatted(fund.getCode(), TIMESTAMP.format(timestamp)),
-          "sebEtfXlsx",
-              (fund, timestamp) ->
-                  "SEB_%s_ETF_tehingud_%s.xlsx"
-                      .formatted(fund.getCode(), TIMESTAMP.format(timestamp)),
-          "ftEtfXlsx",
-              (fund, timestamp) ->
-                  "FT_%s_ETF_orders_%s.xlsx".formatted(fund.getCode(), TIMESTAMP.format(timestamp)),
-          "uuidWorkbookXlsx",
-              (fund, timestamp) ->
-                  "Tehingud_UUID_%s.xlsx".formatted(UUID_WORKBOOK_TIMESTAMP.format(timestamp)));
-
-  private static final Map<String, String> MIME_TYPES =
-      Map.of(
-          "sebFundXlsx", CSV_MIME_TYPE,
-          "sebEtfXlsx", XLSX_MIME_TYPE,
-          "ftEtfXlsx", XLSX_MIME_TYPE,
-          "uuidWorkbookXlsx", XLSX_MIME_TYPE);
 
   private final CustodianOrderEmailProperties properties;
 
@@ -99,17 +66,18 @@ class CustodianOrderMessageFactory {
   private List<MessageContent> buildAttachments(
       TulevaFund fund, Instant timestamp, Map<String, byte[]> exports) {
     List<MessageContent> attachments = new ArrayList<>();
-    FILE_NAME_GENERATORS.forEach(
-        (exportKey, fileNameGenerator) -> {
-          var content = exports.get(exportKey);
-          if (content != null && content.length > 0) {
-            var attachment = new MessageContent();
-            attachment.setName(fileNameGenerator.apply(fund, timestamp));
-            attachment.setType(MIME_TYPES.get(exportKey));
-            attachment.setContent(Base64.getEncoder().encodeToString(content));
-            attachments.add(attachment);
-          }
-        });
+    ExportFile.brokerFiles()
+        .forEach(
+            exportFile -> {
+              var content = exports.get(exportFile.metadataKey());
+              if (content != null && content.length > 0) {
+                var attachment = new MessageContent();
+                attachment.setName(exportFile.fileName(fund, timestamp));
+                attachment.setType(exportFile.mimeType());
+                attachment.setContent(Base64.getEncoder().encodeToString(content));
+                attachments.add(attachment);
+              }
+            });
     return attachments;
   }
 }

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/export/ExportFile.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/export/ExportFile.java
@@ -1,0 +1,114 @@
+package ee.tuleva.onboarding.investment.transaction.export;
+
+import ee.tuleva.onboarding.fund.TulevaFund;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.BiFunction;
+import org.jspecify.annotations.Nullable;
+
+public enum ExportFile {
+  GENERIC_ORDERS("xlsxExport", Constants.XLSX_MIME_TYPE, "xlsx"),
+  SEB_FUND(
+      "sebFundXlsx",
+      Constants.CSV_MIME_TYPE,
+      "csv",
+      "SEB indeksfondid",
+      (fund, timestamp) ->
+          "SEB_%s_indeksfondid_%s.csv"
+              .formatted(fund.getCode(), Constants.TIMESTAMP.format(timestamp))),
+  SEB_ETF(
+      "sebEtfXlsx",
+      Constants.XLSX_MIME_TYPE,
+      "xlsx",
+      "SEB ETF",
+      (fund, timestamp) ->
+          "SEB_%s_ETF_tehingud_%s.xlsx"
+              .formatted(fund.getCode(), Constants.TIMESTAMP.format(timestamp))),
+  FT_ETF(
+      "ftEtfXlsx",
+      Constants.XLSX_MIME_TYPE,
+      "xlsx",
+      "FT ETF",
+      (fund, timestamp) ->
+          "FT_%s_ETF_orders_%s.xlsx"
+              .formatted(fund.getCode(), Constants.TIMESTAMP.format(timestamp))),
+  UUID_WORKBOOK(
+      "uuidWorkbookXlsx",
+      Constants.XLSX_MIME_TYPE,
+      "xlsx",
+      "UUID workbook",
+      (fund, timestamp) ->
+          "Tehingud_UUID_%s.xlsx".formatted(Constants.UUID_WORKBOOK_TIMESTAMP.format(timestamp)));
+
+  private static final class Constants {
+    static final String XLSX_MIME_TYPE =
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+    static final String CSV_MIME_TYPE = "text/csv";
+
+    static final DateTimeFormatter TIMESTAMP =
+        DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH_mm_ss").withZone(ZoneOffset.UTC);
+    static final DateTimeFormatter UUID_WORKBOOK_TIMESTAMP =
+        DateTimeFormatter.ofPattern("yyyyMMdd_HHmm").withZone(ZoneOffset.UTC);
+  }
+
+  private final String metadataKey;
+  private final String mimeType;
+  private final String extension;
+  private final @Nullable String driveLabel;
+  private final @Nullable BiFunction<TulevaFund, Instant, String> fileNameGenerator;
+
+  ExportFile(String metadataKey, String mimeType, String extension) {
+    this(metadataKey, mimeType, extension, null, null);
+  }
+
+  ExportFile(
+      String metadataKey,
+      String mimeType,
+      String extension,
+      @Nullable String driveLabel,
+      @Nullable BiFunction<TulevaFund, Instant, String> fileNameGenerator) {
+    this.metadataKey = metadataKey;
+    this.mimeType = mimeType;
+    this.extension = extension;
+    this.driveLabel = driveLabel;
+    this.fileNameGenerator = fileNameGenerator;
+  }
+
+  public static Optional<ExportFile> byMetadataKey(String metadataKey) {
+    return Arrays.stream(values()).filter(file -> file.metadataKey.equals(metadataKey)).findFirst();
+  }
+
+  public static List<ExportFile> brokerFiles() {
+    return Arrays.stream(values()).filter(file -> file.fileNameGenerator != null).toList();
+  }
+
+  public String metadataKey() {
+    return metadataKey;
+  }
+
+  public String mimeType() {
+    return mimeType;
+  }
+
+  public String driveLabel() {
+    if (driveLabel == null) {
+      throw new IllegalStateException("Export file has no drive label: exportFile=" + name());
+    }
+    return driveLabel;
+  }
+
+  public String fileName(TulevaFund fund, Instant timestamp) {
+    if (fileNameGenerator == null) {
+      throw new IllegalStateException("Export file has no broker file name: exportFile=" + name());
+    }
+    return fileNameGenerator.apply(fund, timestamp);
+  }
+
+  public String downloadFileName(Long batchId) {
+    return "batch-%d-%s.%s".formatted(batchId, metadataKey, extension);
+  }
+}

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/export/TransactionExportUploader.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/export/TransactionExportUploader.java
@@ -6,7 +6,6 @@ import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.function.BiFunction;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -14,29 +13,8 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class TransactionExportUploader {
 
-  private static final DateTimeFormatter TIMESTAMP =
-      DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH_mm_ss").withZone(ZoneOffset.UTC);
-  private static final DateTimeFormatter UUID_WORKBOOK_TIMESTAMP =
-      DateTimeFormatter.ofPattern("yyyyMMdd_HHmm").withZone(ZoneOffset.UTC);
   private static final DateTimeFormatter MONTH =
       DateTimeFormatter.ofPattern("MM").withZone(ZoneOffset.UTC);
-
-  private static final Map<String, BiFunction<TulevaFund, Instant, String>> FILE_NAME_GENERATORS =
-      Map.of(
-          "sebFundXlsx",
-              (fund, timestamp) ->
-                  "SEB_%s_indeksfondid_%s.csv"
-                      .formatted(fund.getCode(), TIMESTAMP.format(timestamp)),
-          "sebEtfXlsx",
-              (fund, timestamp) ->
-                  "SEB_%s_ETF_tehingud_%s.xlsx"
-                      .formatted(fund.getCode(), TIMESTAMP.format(timestamp)),
-          "ftEtfXlsx",
-              (fund, timestamp) ->
-                  "FT_%s_ETF_orders_%s.xlsx".formatted(fund.getCode(), TIMESTAMP.format(timestamp)),
-          "uuidWorkbookXlsx",
-              (fund, timestamp) ->
-                  "Tehingud_UUID_%s.xlsx".formatted(UUID_WORKBOOK_TIMESTAMP.format(timestamp)));
 
   private final GoogleDriveClient driveClient;
 
@@ -52,15 +30,16 @@ public class TransactionExportUploader {
 
     Map<String, String> urls = new HashMap<>();
 
-    FILE_NAME_GENERATORS.forEach(
-        (exportKey, fileNameGenerator) -> {
-          var content = exports.get(exportKey);
-          if (content != null && content.length > 0) {
-            var fileName = fileNameGenerator.apply(fund, timestamp);
-            var url = driveClient.uploadFile(monthFolder, fileName, content);
-            urls.put(exportKey, url);
-          }
-        });
+    ExportFile.brokerFiles()
+        .forEach(
+            exportFile -> {
+              var content = exports.get(exportFile.metadataKey());
+              if (content != null && content.length > 0) {
+                var fileName = exportFile.fileName(fund, timestamp);
+                var url = driveClient.uploadFile(monthFolder, fileName, content);
+                urls.put(exportFile.metadataKey(), url);
+              }
+            });
 
     return Map.copyOf(urls);
   }

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/FtAccountToFundResolver.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/FtAccountToFundResolver.java
@@ -19,9 +19,6 @@ class FtAccountToFundResolver {
       Map.of(
           normalize("Tuleva Additional Investment Fund"), TKF100,
           normalize("TULEVA III SAMBA PENSIONIFOND"), TUV100,
-          // MAAKPE->TUK75 is a provisional inference (ISIN IE000I9HGDZ3 is a TUK75 holding),
-          // not yet confirmed against the FT account setup; the M2 history backfill self-confirms
-          // it.
           normalize("MAAKPE"), TUK75);
 
   Optional<TulevaFund> resolve(String account) {

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/QuantityAmountMismatchAlertListener.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/QuantityAmountMismatchAlertListener.java
@@ -36,22 +36,33 @@ class QuantityAmountMismatchAlertListener {
     var subject = "[HOIATUS] Tehingute koguse/summa lahknevused – " + event.reportDate();
     var body = buildBody(event);
 
-    boolean sent = emailService.sendSystemEmail(messageFactory.create(subject, body));
-    if (sent) {
-      log.info(
-          "Sent quantity/amount mismatch alert: reportDate={}, isin={}, orderId={}, kind={}",
-          event.reportDate(),
-          event.row().isin(),
-          event.order().getId(),
-          event.kind());
-    } else {
+    try {
+      boolean sent = emailService.sendSystemEmail(messageFactory.create(subject, body));
+      if (sent) {
+        log.info(
+            "Sent quantity/amount mismatch alert: reportDate={}, isin={}, orderId={}, kind={}",
+            event.reportDate(),
+            event.row().isin(),
+            event.order().getId(),
+            event.kind());
+      } else {
+        log.error(
+            "Failed to send quantity/amount mismatch alert: reportDate={}, isin={}, orderId={},"
+                + " kind={}",
+            event.reportDate(),
+            event.row().isin(),
+            event.order().getId(),
+            event.kind());
+      }
+    } catch (RuntimeException e) {
       log.error(
           "Failed to send quantity/amount mismatch alert: reportDate={}, isin={}, orderId={},"
               + " kind={}",
           event.reportDate(),
           event.row().isin(),
           event.order().getId(),
-          event.kind());
+          event.kind(),
+          e);
     }
   }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -73,6 +73,8 @@ eodhd:
 admin:
   api-token: ${ADMIN_API_TOKEN:}
   ops-token: ${ADMIN_OPS_TOKEN:}
+  # Per-operator registry tokens bind from env vars: ADMIN_OPERATORTOKENS_<NAME>=<token>.
+  # The name becomes the audited actor; api-token still works but audits as "shared-admin-token".
 
 hackathon:
   # 20.09.2026 23:59:59 Estonian time

--- a/src/test/groovy/ee/tuleva/onboarding/investment/calendar/DomicileCalendarSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/calendar/DomicileCalendarSpec.groovy
@@ -54,6 +54,10 @@ class DomicileCalendarSpec extends Specification {
     IRELAND    | "2030-02-01" | false // St Brigid's Day 2030 (Feb 1 is a Friday)
     IRELAND    | "2030-02-04" | true // first Monday of February 2030 is not a holiday
     LUXEMBOURG | "2025-02-03" | true // St Brigid's Day is not a Luxembourg holiday
+    IRELAND    | "2023-02-06" | false // St Brigid's Day first recurred in 2023
+    IRELAND    | "2022-02-07" | true // St Brigid's Day did not exist in 2022
+    IRELAND    | "2021-02-01" | true // St Brigid's Day did not exist in 2021
+    IRELAND    | "2022-03-18" | false // one-off 2022 public holiday
     IRELAND    | "2025-05-05" | false // May bank holiday (first Monday)
     IRELAND    | "2025-06-02" | false // June bank holiday (first Monday)
     IRELAND    | "2025-08-04" | false // August bank holiday (first Monday)

--- a/src/test/groovy/ee/tuleva/onboarding/investment/epis/OwnFundNavProviderTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/epis/OwnFundNavProviderTest.java
@@ -1,0 +1,96 @@
+package ee.tuleva.onboarding.investment.epis;
+
+import static ee.tuleva.onboarding.fund.TulevaFund.TUV100;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import ee.tuleva.onboarding.savings.fund.nav.FundNavQueryService;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class OwnFundNavProviderTest {
+
+  private static final LocalDate AS_OF_DATE = LocalDate.of(2026, 2, 10);
+  private static final LocalDate NAV_DATE = LocalDate.of(2026, 2, 9);
+
+  @Mock private FundNavQueryService fundNavQueryService;
+
+  @InjectMocks private OwnFundNavProvider provider;
+
+  @Test
+  void findLatestNav_returnsANavInsideTheReasonableRange() {
+    givenNav(new BigDecimal("1.2345"));
+
+    assertThat(provider.findLatestNav(TUV100, AS_OF_DATE)).contains(new BigDecimal("1.2345"));
+  }
+
+  @Test
+  void findLatestNav_returnsEmptyWhenNoNavIsRecorded() {
+    given(fundNavQueryService.findLatestNavDateOnOrBefore(TUV100.getCode(), AS_OF_DATE))
+        .willReturn(Optional.empty());
+
+    assertThat(provider.findLatestNav(TUV100, AS_OF_DATE)).isEmpty();
+  }
+
+  @Test
+  void findLatestNav_ignoresANavAboveTheReasonableRange() {
+    givenNav(new BigDecimal("10.01"));
+
+    assertThat(provider.findLatestNav(TUV100, AS_OF_DATE)).isEmpty();
+  }
+
+  @Test
+  void findLatestNav_ignoresANavBelowTheReasonableRange() {
+    givenNav(new BigDecimal("0.009"));
+
+    assertThat(provider.findLatestNav(TUV100, AS_OF_DATE)).isEmpty();
+  }
+
+  @Test
+  void findLatestNav_keepsTheRangeBoundariesThemselves() {
+    givenNav(new BigDecimal("0.01"));
+    assertThat(provider.findLatestNav(TUV100, AS_OF_DATE)).contains(new BigDecimal("0.01"));
+
+    givenNav(new BigDecimal("10.0"));
+    assertThat(provider.findLatestNav(TUV100, AS_OF_DATE)).contains(new BigDecimal("10.0"));
+  }
+
+  @Test
+  void latestNav_returnsANavInsideTheReasonableRange() {
+    givenNav(new BigDecimal("1.2345"));
+
+    assertThat(provider.latestNav(TUV100, AS_OF_DATE)).isEqualByComparingTo("1.2345");
+  }
+
+  @Test
+  void latestNav_throwsOnANavOutsideTheReasonableRange() {
+    givenNav(new BigDecimal("10.01"));
+
+    assertThatThrownBy(() -> provider.latestNav(TUV100, AS_OF_DATE))
+        .isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  void latestNav_throwsWhenNoNavIsRecorded() {
+    given(fundNavQueryService.findLatestNavDateOnOrBefore(TUV100.getCode(), AS_OF_DATE))
+        .willReturn(Optional.empty());
+
+    assertThatThrownBy(() -> provider.latestNav(TUV100, AS_OF_DATE))
+        .isInstanceOf(IllegalStateException.class);
+  }
+
+  private void givenNav(BigDecimal nav) {
+    given(fundNavQueryService.findLatestNavDateOnOrBefore(TUV100.getCode(), AS_OF_DATE))
+        .willReturn(Optional.of(NAV_DATE));
+    given(fundNavQueryService.findNavPerUnit(TUV100.getCode(), NAV_DATE))
+        .willReturn(Optional.of(nav));
+  }
+}

--- a/src/test/groovy/ee/tuleva/onboarding/investment/portfolio/ProviderSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/portfolio/ProviderSpec.groovy
@@ -3,7 +3,6 @@ package ee.tuleva.onboarding.investment.portfolio
 import spock.lang.Specification
 import spock.lang.Unroll
 
-import static ee.tuleva.onboarding.investment.calendar.Domicile.FRANCE
 import static ee.tuleva.onboarding.investment.calendar.Domicile.IRELAND
 import static ee.tuleva.onboarding.investment.calendar.Domicile.LUXEMBOURG
 
@@ -20,8 +19,13 @@ class ProviderSpec extends Specification {
     Provider.VANGUARD    | IRELAND
     Provider.XTRACKERS   | IRELAND
     Provider.INVESCO     | IRELAND
-    Provider.CCF         | FRANCE
+    Provider.CCF         | IRELAND
     Provider.AMUNDI      | LUXEMBOURG
     Provider.BNP_PARIBAS | LUXEMBOURG
+  }
+
+  def "the legacy CCF label shares the domicile of ISHARES, both labelling the same Irish BlackRock fund"() {
+    expect:
+    Provider.CCF.domicile == Provider.ISHARES.domicile
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/AdminTokenAuthenticatorTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/AdminTokenAuthenticatorTest.java
@@ -1,0 +1,68 @@
+package ee.tuleva.onboarding.investment.transaction;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.http.HttpStatus.SERVICE_UNAVAILABLE;
+import static org.springframework.http.HttpStatus.UNAUTHORIZED;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.server.ResponseStatusException;
+
+class AdminTokenAuthenticatorTest {
+
+  @Test
+  void resolvesTheOperatorBehindAPerOperatorToken() {
+    var authenticator =
+        new AdminTokenAuthenticator(
+            new AdminTokenProperties(
+                "shared", Map.of("taavi", "taavi-token", "marju", "marju-token")));
+
+    assertThat(authenticator.resolveActor("marju-token")).isEqualTo("marju");
+  }
+
+  @Test
+  void resolvesTheSharedTokenToAnExplicitlyUnattributedActor() {
+    var authenticator =
+        new AdminTokenAuthenticator(
+            new AdminTokenProperties("shared", Map.of("taavi", "taavi-token")));
+
+    assertThat(authenticator.resolveActor("shared")).isEqualTo("shared-admin-token");
+  }
+
+  @Test
+  void rejectsAnUnknownToken() {
+    var authenticator =
+        new AdminTokenAuthenticator(
+            new AdminTokenProperties("shared", Map.of("taavi", "taavi-token")));
+
+    assertThatThrownBy(() -> authenticator.resolveActor("nope"))
+        .isInstanceOf(ResponseStatusException.class)
+        .extracting(exception -> ((ResponseStatusException) exception).getStatusCode())
+        .isEqualTo(UNAUTHORIZED);
+  }
+
+  @Test
+  void acceptsOperatorTokensEvenWhenNoSharedTokenIsConfigured() {
+    var authenticator =
+        new AdminTokenAuthenticator(new AdminTokenProperties("", Map.of("taavi", "taavi-token")));
+
+    assertThat(authenticator.resolveActor("taavi-token")).isEqualTo("taavi");
+  }
+
+  @Test
+  void reportsUnavailableWhenNoTokensAreConfiguredAtAll() {
+    var authenticator = new AdminTokenAuthenticator(new AdminTokenProperties("", Map.of()));
+
+    assertThatThrownBy(() -> authenticator.resolveActor("anything"))
+        .isInstanceOf(ResponseStatusException.class)
+        .extracting(exception -> ((ResponseStatusException) exception).getStatusCode())
+        .isEqualTo(SERVICE_UNAVAILABLE);
+  }
+
+  @Test
+  void refusesToStartWithABlankOperatorTokenThatWouldMatchAnEmptyHeader() {
+    assertThatThrownBy(() -> new AdminTokenProperties("shared", Map.of("ghost", "")))
+        .isInstanceOf(IllegalStateException.class);
+  }
+}

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/AdminTokenAuthenticatorTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/AdminTokenAuthenticatorTest.java
@@ -60,6 +60,20 @@ class AdminTokenAuthenticatorTest {
         .isEqualTo(SERVICE_UNAVAILABLE);
   }
 
+  // Neither property is set in local runs, and an unconfigured admin API has to say so rather
+  // than blow up on a null token.
+  @Test
+  void treatsCompletelyUnsetPropertiesAsNoTokensRatherThanNulls() {
+    var properties = new AdminTokenProperties(null, null);
+
+    assertThat(properties.apiToken()).isEmpty();
+    assertThat(properties.operatorTokens()).isEmpty();
+    assertThatThrownBy(() -> new AdminTokenAuthenticator(properties).resolveActor("anything"))
+        .isInstanceOf(ResponseStatusException.class)
+        .extracting(exception -> ((ResponseStatusException) exception).getStatusCode())
+        .isEqualTo(SERVICE_UNAVAILABLE);
+  }
+
   @Test
   void refusesToStartWithABlankOperatorTokenThatWouldMatchAnEmptyHeader() {
     assertThatThrownBy(() -> new AdminTokenProperties("shared", Map.of("ghost", "")))

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/PendingOrderImpactServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/PendingOrderImpactServiceTest.java
@@ -265,6 +265,37 @@ class PendingOrderImpactServiceTest {
   }
 
   @Test
+  void valuesTheSynthesizedPositionAtExactlyTheCashItReserves() {
+    given(orderRepository.findUnsettledOrders(TUV100, AS_OF_DATE))
+        .willReturn(
+            List.of(
+                order(
+                    1L,
+                    "IE00A",
+                    TransactionType.BUY,
+                    InstrumentType.ETF,
+                    OrderStatus.EXECUTED,
+                    new BigDecimal("100"),
+                    new BigDecimal("5000"))));
+    given(executionRepository.findByOrderIdIn(List.of(1L)))
+        .willReturn(
+            List.of(
+                TransactionExecution.builder()
+                    .orderId(1L)
+                    .executedQuantity(new BigDecimal("30"))
+                    .totalConsideration(new BigDecimal("1200"))
+                    .build()));
+    given(positionPriceResolver.resolve("IE00A", AS_OF_DATE))
+        .willReturn(Optional.of(ResolvedPrice.builder().usedPrice(new BigDecimal("50")).build()));
+
+    var impact = service.calculate(TUV100, AS_OF_DATE, POSITION_DATE);
+
+    assertThat(impact.pendingBuys()).isEqualByComparingTo(new BigDecimal("4700"));
+    assertThat(impact.unreportedPositionValues())
+        .containsExactly(Map.entry("IE00A", new BigDecimal("4700")));
+  }
+
+  @Test
   void aPartiallyFilledFundBuyStillReservesTheUnfilledRemainder() {
     given(orderRepository.findUnsettledOrders(TUV100, AS_OF_DATE))
         .willReturn(

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/PendingOrderImpactServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/PendingOrderImpactServiceTest.java
@@ -1,0 +1,221 @@
+package ee.tuleva.onboarding.investment.transaction;
+
+import static ee.tuleva.onboarding.fund.TulevaFund.TUV100;
+import static java.math.BigDecimal.ZERO;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.lenient;
+
+import ee.tuleva.onboarding.comparisons.fundvalue.PositionPriceResolver;
+import ee.tuleva.onboarding.comparisons.fundvalue.ResolvedPrice;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PendingOrderImpactServiceTest {
+
+  private static final LocalDate AS_OF_DATE = LocalDate.of(2026, 2, 10);
+
+  @Mock private TransactionOrderRepository orderRepository;
+  @Mock private TransactionExecutionRepository executionRepository;
+  @Mock private PositionPriceResolver positionPriceResolver;
+
+  @InjectMocks private PendingOrderImpactService service;
+
+  @Test
+  void withNoUnsettledOrders_hasNoImpact() {
+    given(orderRepository.findUnsettledOrders(TUV100, AS_OF_DATE)).willReturn(List.of());
+
+    var impact = service.calculate(TUV100, AS_OF_DATE);
+
+    assertThat(impact).isEqualTo(PendingOrderImpact.none());
+  }
+
+  @Test
+  void valuesASentEtfBuyAtTheLatestPriceAndReservesItsCash() {
+    given(orderRepository.findUnsettledOrders(TUV100, AS_OF_DATE))
+        .willReturn(
+            List.of(
+                order(
+                    1L,
+                    "IE00A",
+                    TransactionType.BUY,
+                    InstrumentType.ETF,
+                    OrderStatus.SENT,
+                    new BigDecimal("100"),
+                    new BigDecimal("4000"))));
+    given(executionRepository.findByOrderIdIn(List.of(1L))).willReturn(List.of());
+    given(positionPriceResolver.resolve("IE00A", AS_OF_DATE))
+        .willReturn(Optional.of(ResolvedPrice.builder().usedPrice(new BigDecimal("50")).build()));
+
+    var impact = service.calculate(TUV100, AS_OF_DATE);
+
+    assertThat(impact.unreportedPositionValues())
+        .containsExactly(Map.entry("IE00A", new BigDecimal("5000")));
+    assertThat(impact.unreportedPositionQuantities())
+        .containsExactly(Map.entry("IE00A", new BigDecimal("100")));
+    assertThat(impact.pendingBuys()).isEqualByComparingTo(new BigDecimal("5000"));
+    assertThat(impact.pendingSells()).isEqualByComparingTo(ZERO);
+  }
+
+  @Test
+  void valuesASentFundBuyAtItsOrderAmount() {
+    given(orderRepository.findUnsettledOrders(TUV100, AS_OF_DATE))
+        .willReturn(
+            List.of(
+                order(
+                    1L,
+                    "IE00FUND",
+                    TransactionType.BUY,
+                    InstrumentType.FUND,
+                    OrderStatus.SENT,
+                    null,
+                    new BigDecimal("53000"))));
+    given(executionRepository.findByOrderIdIn(List.of(1L))).willReturn(List.of());
+
+    var impact = service.calculate(TUV100, AS_OF_DATE);
+
+    assertThat(impact.unreportedPositionValues())
+        .containsExactly(Map.entry("IE00FUND", new BigDecimal("53000")));
+    assertThat(impact.unreportedPositionQuantities()).isEmpty();
+    assertThat(impact.pendingBuys()).isEqualByComparingTo(new BigDecimal("53000"));
+  }
+
+  @Test
+  void recordsASentSellAsANegativePositionValueAndAnIncomingReceipt() {
+    given(orderRepository.findUnsettledOrders(TUV100, AS_OF_DATE))
+        .willReturn(
+            List.of(
+                order(
+                    1L,
+                    "IE00A",
+                    TransactionType.SELL,
+                    InstrumentType.ETF,
+                    OrderStatus.SENT,
+                    new BigDecimal("20"),
+                    new BigDecimal("1000"))));
+    given(executionRepository.findByOrderIdIn(List.of(1L))).willReturn(List.of());
+    given(positionPriceResolver.resolve("IE00A", AS_OF_DATE))
+        .willReturn(Optional.of(ResolvedPrice.builder().usedPrice(new BigDecimal("50")).build()));
+
+    var impact = service.calculate(TUV100, AS_OF_DATE);
+
+    assertThat(impact.unreportedPositionValues())
+        .containsExactly(Map.entry("IE00A", new BigDecimal("-1000")));
+    assertThat(impact.unreportedPositionQuantities())
+        .containsExactly(Map.entry("IE00A", new BigDecimal("-20")));
+    assertThat(impact.pendingSells()).isEqualByComparingTo(new BigDecimal("1000"));
+    assertThat(impact.pendingBuys()).isEqualByComparingTo(ZERO);
+  }
+
+  @Test
+  void anExecutedOrderReservesItsActualConsiderationAndIsLeftToTheSebPositionReport() {
+    given(orderRepository.findUnsettledOrders(TUV100, AS_OF_DATE))
+        .willReturn(
+            List.of(
+                order(
+                    1L,
+                    "IE00A",
+                    TransactionType.BUY,
+                    InstrumentType.ETF,
+                    OrderStatus.EXECUTED,
+                    new BigDecimal("100"),
+                    new BigDecimal("4000"))));
+    given(executionRepository.findByOrderIdIn(List.of(1L)))
+        .willReturn(
+            List.of(
+                TransactionExecution.builder()
+                    .orderId(1L)
+                    .totalConsideration(new BigDecimal("4123.45"))
+                    .build()));
+
+    var impact = service.calculate(TUV100, AS_OF_DATE);
+
+    assertThat(impact.pendingBuys()).isEqualByComparingTo(new BigDecimal("4123.45"));
+    assertThat(impact.unreportedPositionValues()).isEmpty();
+    assertThat(impact.unreportedPositionQuantities()).isEmpty();
+  }
+
+  @Test
+  void sumsPartialExecutionsOfTheSameOrder() {
+    given(orderRepository.findUnsettledOrders(TUV100, AS_OF_DATE))
+        .willReturn(
+            List.of(
+                order(
+                    1L,
+                    "IE00A",
+                    TransactionType.BUY,
+                    InstrumentType.ETF,
+                    OrderStatus.EXECUTED,
+                    new BigDecimal("100"),
+                    new BigDecimal("4000"))));
+    given(executionRepository.findByOrderIdIn(List.of(1L)))
+        .willReturn(
+            List.of(
+                TransactionExecution.builder()
+                    .orderId(1L)
+                    .totalConsideration(new BigDecimal("2000"))
+                    .build(),
+                TransactionExecution.builder()
+                    .orderId(1L)
+                    .totalConsideration(new BigDecimal("1500"))
+                    .build()));
+
+    var impact = service.calculate(TUV100, AS_OF_DATE);
+
+    assertThat(impact.pendingBuys()).isEqualByComparingTo(new BigDecimal("3500"));
+  }
+
+  @Test
+  void fallsBackToTheOrderAmountWhenNoPriceIsAvailable() {
+    given(orderRepository.findUnsettledOrders(TUV100, AS_OF_DATE))
+        .willReturn(
+            List.of(
+                order(
+                    1L,
+                    "IE00A",
+                    TransactionType.BUY,
+                    InstrumentType.ETF,
+                    OrderStatus.SENT,
+                    new BigDecimal("100"),
+                    new BigDecimal("4000"))));
+    given(executionRepository.findByOrderIdIn(List.of(1L))).willReturn(List.of());
+    lenient().when(positionPriceResolver.resolve(any(), any())).thenReturn(Optional.empty());
+
+    var impact = service.calculate(TUV100, AS_OF_DATE);
+
+    assertThat(impact.unreportedPositionValues())
+        .containsExactly(Map.entry("IE00A", new BigDecimal("4000")));
+  }
+
+  private TransactionOrder order(
+      Long id,
+      String isin,
+      TransactionType type,
+      InstrumentType instrumentType,
+      OrderStatus status,
+      BigDecimal quantity,
+      BigDecimal amount) {
+    return TransactionOrder.builder()
+        .id(id)
+        .fund(TUV100)
+        .instrumentIsin(isin)
+        .transactionType(type)
+        .instrumentType(instrumentType)
+        .orderStatus(status)
+        .orderQuantity(quantity)
+        .orderAmount(amount)
+        .orderVenue(OrderVenue.SEB)
+        .expectedSettlementDate(AS_OF_DATE.plusDays(2))
+        .build();
+  }
+}

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/PendingOrderImpactServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/PendingOrderImpactServiceTest.java
@@ -197,6 +197,118 @@ class PendingOrderImpactServiceTest {
         .containsExactly(Map.entry("IE00A", new BigDecimal("4000")));
   }
 
+  @Test
+  void anEtfOrderPlacedInEurosIsValuedAtItsAmountAndContributesNoQuantity() {
+    given(orderRepository.findUnsettledOrders(TUV100, AS_OF_DATE))
+        .willReturn(
+            List.of(
+                order(
+                    1L,
+                    "IE00A",
+                    TransactionType.BUY,
+                    InstrumentType.ETF,
+                    OrderStatus.SENT,
+                    null,
+                    new BigDecimal("4000"))));
+    given(executionRepository.findByOrderIdIn(List.of(1L))).willReturn(List.of());
+
+    var impact = service.calculate(TUV100, AS_OF_DATE);
+
+    assertThat(impact.unreportedPositionValues())
+        .containsExactly(Map.entry("IE00A", new BigDecimal("4000")));
+    assertThat(impact.unreportedPositionQuantities()).isEmpty();
+  }
+
+  @Test
+  void anExecutionWithoutAConsiderationDoesNotDisplaceTheEstimate() {
+    given(orderRepository.findUnsettledOrders(TUV100, AS_OF_DATE))
+        .willReturn(
+            List.of(
+                order(
+                    1L,
+                    "IE00FUND",
+                    TransactionType.BUY,
+                    InstrumentType.FUND,
+                    OrderStatus.SENT,
+                    null,
+                    new BigDecimal("7000"))));
+    given(executionRepository.findByOrderIdIn(List.of(1L)))
+        .willReturn(List.of(TransactionExecution.builder().orderId(1L).build()));
+
+    var impact = service.calculate(TUV100, AS_OF_DATE);
+
+    assertThat(impact.pendingBuys()).isEqualByComparingTo(new BigDecimal("7000"));
+  }
+
+  // A zero consideration is a placeholder, not a free trade — the cash still has to be reserved.
+  @Test
+  void aZeroConsiderationFallsBackToTheEstimatedValue() {
+    given(orderRepository.findUnsettledOrders(TUV100, AS_OF_DATE))
+        .willReturn(
+            List.of(
+                order(
+                    1L,
+                    "IE00FUND",
+                    TransactionType.BUY,
+                    InstrumentType.FUND,
+                    OrderStatus.SENT,
+                    null,
+                    new BigDecimal("7000"))));
+    given(executionRepository.findByOrderIdIn(List.of(1L)))
+        .willReturn(
+            List.of(TransactionExecution.builder().orderId(1L).totalConsideration(ZERO).build()));
+
+    var impact = service.calculate(TUV100, AS_OF_DATE);
+
+    assertThat(impact.pendingBuys()).isEqualByComparingTo(new BigDecimal("7000"));
+  }
+
+  @Test
+  void anOrderWithNeitherQuantityNorAmountReservesNothing() {
+    given(orderRepository.findUnsettledOrders(TUV100, AS_OF_DATE))
+        .willReturn(
+            List.of(
+                order(
+                    1L,
+                    "IE00FUND",
+                    TransactionType.BUY,
+                    InstrumentType.FUND,
+                    OrderStatus.SENT,
+                    null,
+                    null)));
+    given(executionRepository.findByOrderIdIn(List.of(1L))).willReturn(List.of());
+
+    var impact = service.calculate(TUV100, AS_OF_DATE);
+
+    assertThat(impact.pendingBuys()).isEqualByComparingTo(ZERO);
+    assertThat(impact.unreportedPositionValues()).containsExactly(Map.entry("IE00FUND", ZERO));
+  }
+
+  // A resolver that answers zero has not priced the instrument; the order amount is the better
+  // estimate.
+  @Test
+  void aNonPositiveResolvedPriceIsNotUsedForValuation() {
+    given(orderRepository.findUnsettledOrders(TUV100, AS_OF_DATE))
+        .willReturn(
+            List.of(
+                order(
+                    1L,
+                    "IE00A",
+                    TransactionType.BUY,
+                    InstrumentType.ETF,
+                    OrderStatus.SENT,
+                    new BigDecimal("100"),
+                    new BigDecimal("4000"))));
+    given(executionRepository.findByOrderIdIn(List.of(1L))).willReturn(List.of());
+    given(positionPriceResolver.resolve("IE00A", AS_OF_DATE))
+        .willReturn(Optional.of(ResolvedPrice.builder().usedPrice(ZERO).build()));
+
+    var impact = service.calculate(TUV100, AS_OF_DATE);
+
+    assertThat(impact.unreportedPositionValues())
+        .containsExactly(Map.entry("IE00A", new BigDecimal("4000")));
+  }
+
   private TransactionOrder order(
       Long id,
       String isin,

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/PendingOrderImpactServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/PendingOrderImpactServiceTest.java
@@ -221,16 +221,73 @@ class PendingOrderImpactServiceTest {
             List.of(
                 TransactionExecution.builder()
                     .orderId(1L)
+                    .executedQuantity(new BigDecimal("60"))
                     .totalConsideration(new BigDecimal("2000"))
                     .build(),
                 TransactionExecution.builder()
                     .orderId(1L)
+                    .executedQuantity(new BigDecimal("40"))
                     .totalConsideration(new BigDecimal("1500"))
                     .build()));
 
     var impact = service.calculate(TUV100, AS_OF_DATE, POSITION_DATE);
 
     assertThat(impact.pendingBuys()).isEqualByComparingTo(new BigDecimal("3500"));
+  }
+
+  @Test
+  void aPartiallyFilledEtfBuyStillReservesTheUnfilledRemainder() {
+    given(orderRepository.findUnsettledOrders(TUV100, AS_OF_DATE))
+        .willReturn(
+            List.of(
+                order(
+                    1L,
+                    "IE00A",
+                    TransactionType.BUY,
+                    InstrumentType.ETF,
+                    OrderStatus.EXECUTED,
+                    new BigDecimal("100"),
+                    new BigDecimal("5000"))));
+    given(executionRepository.findByOrderIdIn(List.of(1L)))
+        .willReturn(
+            List.of(
+                TransactionExecution.builder()
+                    .orderId(1L)
+                    .executedQuantity(new BigDecimal("30"))
+                    .totalConsideration(new BigDecimal("1500"))
+                    .build()));
+    given(positionPriceResolver.resolve("IE00A", AS_OF_DATE))
+        .willReturn(Optional.of(ResolvedPrice.builder().usedPrice(new BigDecimal("50")).build()));
+
+    var impact = service.calculate(TUV100, AS_OF_DATE, POSITION_DATE);
+
+    assertThat(impact.pendingBuys()).isEqualByComparingTo(new BigDecimal("5000"));
+  }
+
+  @Test
+  void aPartiallyFilledFundBuyStillReservesTheUnfilledRemainder() {
+    given(orderRepository.findUnsettledOrders(TUV100, AS_OF_DATE))
+        .willReturn(
+            List.of(
+                order(
+                    1L,
+                    "IE00FUND",
+                    TransactionType.BUY,
+                    InstrumentType.FUND,
+                    OrderStatus.EXECUTED,
+                    null,
+                    new BigDecimal("100000"))));
+    given(executionRepository.findByOrderIdIn(List.of(1L)))
+        .willReturn(
+            List.of(
+                TransactionExecution.builder()
+                    .orderId(1L)
+                    .totalConsideration(new BigDecimal("30000"))
+                    .build()));
+
+    var impact = service.calculate(TUV100, AS_OF_DATE, POSITION_DATE);
+
+    assertThat(impact.pendingBuys()).isEqualByComparingTo(new BigDecimal("100000"));
   }
 
   @Test

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/PendingOrderImpactServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/PendingOrderImpactServiceTest.java
@@ -11,6 +11,7 @@ import ee.tuleva.onboarding.comparisons.fundvalue.PositionPriceResolver;
 import ee.tuleva.onboarding.comparisons.fundvalue.ResolvedPrice;
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -23,7 +24,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class PendingOrderImpactServiceTest {
 
+  private static final ZoneId TALLINN = ZoneId.of("Europe/Tallinn");
   private static final LocalDate AS_OF_DATE = LocalDate.of(2026, 2, 10);
+  private static final LocalDate POSITION_DATE = AS_OF_DATE.minusDays(1);
 
   @Mock private TransactionOrderRepository orderRepository;
   @Mock private TransactionExecutionRepository executionRepository;
@@ -35,7 +38,7 @@ class PendingOrderImpactServiceTest {
   void withNoUnsettledOrders_hasNoImpact() {
     given(orderRepository.findUnsettledOrders(TUV100, AS_OF_DATE)).willReturn(List.of());
 
-    var impact = service.calculate(TUV100, AS_OF_DATE);
+    var impact = service.calculate(TUV100, AS_OF_DATE, POSITION_DATE);
 
     assertThat(impact).isEqualTo(PendingOrderImpact.none());
   }
@@ -57,7 +60,7 @@ class PendingOrderImpactServiceTest {
     given(positionPriceResolver.resolve("IE00A", AS_OF_DATE))
         .willReturn(Optional.of(ResolvedPrice.builder().usedPrice(new BigDecimal("50")).build()));
 
-    var impact = service.calculate(TUV100, AS_OF_DATE);
+    var impact = service.calculate(TUV100, AS_OF_DATE, POSITION_DATE);
 
     assertThat(impact.unreportedPositionValues())
         .containsExactly(Map.entry("IE00A", new BigDecimal("5000")));
@@ -82,7 +85,7 @@ class PendingOrderImpactServiceTest {
                     new BigDecimal("53000"))));
     given(executionRepository.findByOrderIdIn(List.of(1L))).willReturn(List.of());
 
-    var impact = service.calculate(TUV100, AS_OF_DATE);
+    var impact = service.calculate(TUV100, AS_OF_DATE, POSITION_DATE);
 
     assertThat(impact.unreportedPositionValues())
         .containsExactly(Map.entry("IE00FUND", new BigDecimal("53000")));
@@ -107,7 +110,7 @@ class PendingOrderImpactServiceTest {
     given(positionPriceResolver.resolve("IE00A", AS_OF_DATE))
         .willReturn(Optional.of(ResolvedPrice.builder().usedPrice(new BigDecimal("50")).build()));
 
-    var impact = service.calculate(TUV100, AS_OF_DATE);
+    var impact = service.calculate(TUV100, AS_OF_DATE, POSITION_DATE);
 
     assertThat(impact.unreportedPositionValues())
         .containsExactly(Map.entry("IE00A", new BigDecimal("-1000")));
@@ -115,6 +118,59 @@ class PendingOrderImpactServiceTest {
         .containsExactly(Map.entry("IE00A", new BigDecimal("-20")));
     assertThat(impact.pendingSells()).isEqualByComparingTo(new BigDecimal("1000"));
     assertThat(impact.pendingBuys()).isEqualByComparingTo(ZERO);
+  }
+
+  @Test
+  void aSentOrderTradedBeforeThePositionReportIsAlreadyInItAndIsNotSynthesizedAgain() {
+    given(orderRepository.findUnsettledOrders(TUV100, AS_OF_DATE))
+        .willReturn(
+            List.of(
+                order(
+                    1L,
+                    "IE00A",
+                    TransactionType.BUY,
+                    InstrumentType.ETF,
+                    OrderStatus.SENT,
+                    new BigDecimal("100"),
+                    new BigDecimal("5000"),
+                    POSITION_DATE)));
+    given(executionRepository.findByOrderIdIn(List.of(1L))).willReturn(List.of());
+
+    var impact = service.calculate(TUV100, AS_OF_DATE, POSITION_DATE);
+
+    assertThat(impact.unreportedPositionValues()).isEmpty();
+    assertThat(impact.unreportedPositionQuantities()).isEmpty();
+    assertThat(impact.pendingBuys()).isEqualByComparingTo(new BigDecimal("5000"));
+  }
+
+  @Test
+  void anExecutedOrderTradedAfterThePositionReportIsSynthesizedLikeAnySentOne() {
+    given(orderRepository.findUnsettledOrders(TUV100, AS_OF_DATE))
+        .willReturn(
+            List.of(
+                order(
+                    1L,
+                    "IE00FUND",
+                    TransactionType.BUY,
+                    InstrumentType.FUND,
+                    OrderStatus.EXECUTED,
+                    null,
+                    new BigDecimal("300000"),
+                    AS_OF_DATE)));
+    given(executionRepository.findByOrderIdIn(List.of(1L)))
+        .willReturn(
+            List.of(
+                TransactionExecution.builder()
+                    .orderId(1L)
+                    .executedQuantity(new BigDecimal("15000"))
+                    .totalConsideration(new BigDecimal("300000"))
+                    .build()));
+
+    var impact = service.calculate(TUV100, AS_OF_DATE, POSITION_DATE);
+
+    assertThat(impact.unreportedPositionValues())
+        .containsExactly(Map.entry("IE00FUND", new BigDecimal("300000")));
+    assertThat(impact.pendingBuys()).isEqualByComparingTo(new BigDecimal("300000"));
   }
 
   @Test
@@ -129,16 +185,18 @@ class PendingOrderImpactServiceTest {
                     InstrumentType.ETF,
                     OrderStatus.EXECUTED,
                     new BigDecimal("100"),
-                    new BigDecimal("4000"))));
+                    new BigDecimal("4000"),
+                    POSITION_DATE)));
     given(executionRepository.findByOrderIdIn(List.of(1L)))
         .willReturn(
             List.of(
                 TransactionExecution.builder()
                     .orderId(1L)
+                    .executedQuantity(new BigDecimal("100"))
                     .totalConsideration(new BigDecimal("4123.45"))
                     .build()));
 
-    var impact = service.calculate(TUV100, AS_OF_DATE);
+    var impact = service.calculate(TUV100, AS_OF_DATE, POSITION_DATE);
 
     assertThat(impact.pendingBuys()).isEqualByComparingTo(new BigDecimal("4123.45"));
     assertThat(impact.unreportedPositionValues()).isEmpty();
@@ -170,7 +228,7 @@ class PendingOrderImpactServiceTest {
                     .totalConsideration(new BigDecimal("1500"))
                     .build()));
 
-    var impact = service.calculate(TUV100, AS_OF_DATE);
+    var impact = service.calculate(TUV100, AS_OF_DATE, POSITION_DATE);
 
     assertThat(impact.pendingBuys()).isEqualByComparingTo(new BigDecimal("3500"));
   }
@@ -191,7 +249,7 @@ class PendingOrderImpactServiceTest {
     given(executionRepository.findByOrderIdIn(List.of(1L))).willReturn(List.of());
     lenient().when(positionPriceResolver.resolve(any(), any())).thenReturn(Optional.empty());
 
-    var impact = service.calculate(TUV100, AS_OF_DATE);
+    var impact = service.calculate(TUV100, AS_OF_DATE, POSITION_DATE);
 
     assertThat(impact.unreportedPositionValues())
         .containsExactly(Map.entry("IE00A", new BigDecimal("4000")));
@@ -212,7 +270,7 @@ class PendingOrderImpactServiceTest {
                     new BigDecimal("4000"))));
     given(executionRepository.findByOrderIdIn(List.of(1L))).willReturn(List.of());
 
-    var impact = service.calculate(TUV100, AS_OF_DATE);
+    var impact = service.calculate(TUV100, AS_OF_DATE, POSITION_DATE);
 
     assertThat(impact.unreportedPositionValues())
         .containsExactly(Map.entry("IE00A", new BigDecimal("4000")));
@@ -235,7 +293,7 @@ class PendingOrderImpactServiceTest {
     given(executionRepository.findByOrderIdIn(List.of(1L)))
         .willReturn(List.of(TransactionExecution.builder().orderId(1L).build()));
 
-    var impact = service.calculate(TUV100, AS_OF_DATE);
+    var impact = service.calculate(TUV100, AS_OF_DATE, POSITION_DATE);
 
     assertThat(impact.pendingBuys()).isEqualByComparingTo(new BigDecimal("7000"));
   }
@@ -258,7 +316,7 @@ class PendingOrderImpactServiceTest {
         .willReturn(
             List.of(TransactionExecution.builder().orderId(1L).totalConsideration(ZERO).build()));
 
-    var impact = service.calculate(TUV100, AS_OF_DATE);
+    var impact = service.calculate(TUV100, AS_OF_DATE, POSITION_DATE);
 
     assertThat(impact.pendingBuys()).isEqualByComparingTo(new BigDecimal("7000"));
   }
@@ -278,7 +336,7 @@ class PendingOrderImpactServiceTest {
                     null)));
     given(executionRepository.findByOrderIdIn(List.of(1L))).willReturn(List.of());
 
-    var impact = service.calculate(TUV100, AS_OF_DATE);
+    var impact = service.calculate(TUV100, AS_OF_DATE, POSITION_DATE);
 
     assertThat(impact.pendingBuys()).isEqualByComparingTo(ZERO);
     assertThat(impact.unreportedPositionValues()).containsExactly(Map.entry("IE00FUND", ZERO));
@@ -303,7 +361,7 @@ class PendingOrderImpactServiceTest {
     given(positionPriceResolver.resolve("IE00A", AS_OF_DATE))
         .willReturn(Optional.of(ResolvedPrice.builder().usedPrice(ZERO).build()));
 
-    var impact = service.calculate(TUV100, AS_OF_DATE);
+    var impact = service.calculate(TUV100, AS_OF_DATE, POSITION_DATE);
 
     assertThat(impact.unreportedPositionValues())
         .containsExactly(Map.entry("IE00A", new BigDecimal("4000")));
@@ -317,6 +375,18 @@ class PendingOrderImpactServiceTest {
       OrderStatus status,
       BigDecimal quantity,
       BigDecimal amount) {
+    return order(id, isin, type, instrumentType, status, quantity, amount, AS_OF_DATE);
+  }
+
+  private TransactionOrder order(
+      Long id,
+      String isin,
+      TransactionType type,
+      InstrumentType instrumentType,
+      OrderStatus status,
+      BigDecimal quantity,
+      BigDecimal amount,
+      LocalDate tradeDate) {
     return TransactionOrder.builder()
         .id(id)
         .fund(TUV100)
@@ -327,6 +397,7 @@ class PendingOrderImpactServiceTest {
         .orderQuantity(quantity)
         .orderAmount(amount)
         .orderVenue(OrderVenue.SEB)
+        .orderTimestamp(tradeDate.atTime(16, 30).atZone(TALLINN).toInstant())
         .expectedSettlementDate(AS_OF_DATE.plusDays(2))
         .build();
   }

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/PendingOrderImpactServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/PendingOrderImpactServiceTest.java
@@ -427,7 +427,30 @@ class PendingOrderImpactServiceTest {
     var impact = service.calculate(TUV100, AS_OF_DATE, POSITION_DATE);
 
     assertThat(impact.pendingBuys()).isEqualByComparingTo(ZERO);
-    assertThat(impact.unreportedPositionValues()).containsExactly(Map.entry("IE00FUND", ZERO));
+    assertThat(impact.unreportedPositionValues()).isEmpty();
+  }
+
+  @Test
+  void anEtfOrderThatCannotBeValuedContributesNeitherValueNorQuantity() {
+    given(orderRepository.findUnsettledOrders(TUV100, AS_OF_DATE))
+        .willReturn(
+            List.of(
+                order(
+                    1L,
+                    "IE00A",
+                    TransactionType.BUY,
+                    InstrumentType.ETF,
+                    OrderStatus.SENT,
+                    new BigDecimal("80"),
+                    null)));
+    given(executionRepository.findByOrderIdIn(List.of(1L))).willReturn(List.of());
+    lenient().when(positionPriceResolver.resolve(any(), any())).thenReturn(Optional.empty());
+
+    var impact = service.calculate(TUV100, AS_OF_DATE, POSITION_DATE);
+
+    assertThat(impact.pendingBuys()).isEqualByComparingTo(ZERO);
+    assertThat(impact.unreportedPositionValues()).isEmpty();
+    assertThat(impact.unreportedPositionQuantities()).isEmpty();
   }
 
   // A resolver that answers zero has not priced the instrument; the order amount is the better

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/SettlementDateCalculatorTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/SettlementDateCalculatorTest.java
@@ -32,7 +32,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class SettlementDateCalculatorTest {
 
   private static final String ETF_ISIN = "IE00BJZ2DC62";
-  private static final String FRENCH_FUND_ISIN = "FR0010688192";
   private static final String IRISH_FUND_ISIN = "IE00BFG1TM61";
   private static final String LUXEMBOURG_FUND_ISIN = "LU1437018838";
   private static final String UNKNOWN_ISIN = "XX0000000000";
@@ -58,7 +57,7 @@ class SettlementDateCalculatorTest {
   }
 
   @Test
-  void ccf_submittedBeforeCutoff_acceptedSameDay_settlesThreeFrenchBusinessDaysLater() {
+  void ccf_submittedBeforeCutoff_acceptedSameDay_settlesThreeIrishBusinessDaysLater() {
     given(instrumentReferenceService.settlementTerms(CCF_ISIN)).willReturn(Optional.of(CCF_TERMS));
     givenProvider(CCF_ISIN, CCF);
     Instant mondayBeforeCutoff = tallinnInstant(LocalDate.of(2026, 1, 12), LocalTime.of(9, 15));
@@ -88,23 +87,24 @@ class SettlementDateCalculatorTest {
   }
 
   @Test
-  void ccf_dayCountSkipsFrenchHoliday() {
+  void ccf_dayCountSkipsIrishHoliday() {
     given(instrumentReferenceService.settlementTerms(CCF_ISIN)).willReturn(Optional.of(CCF_TERMS));
     givenProvider(CCF_ISIN, CCF);
-    Instant mondayBeforeBastille = tallinnInstant(LocalDate.of(2026, 7, 13), LocalTime.of(9, 15));
+    Instant thursdayBeforeStPatricks =
+        tallinnInstant(LocalDate.of(2026, 3, 12), LocalTime.of(9, 15));
 
-    assertThat(calculator().calculateSettlementDate(mondayBeforeBastille, FUND, CCF_ISIN))
-        .isEqualTo(LocalDate.of(2026, 7, 17));
+    assertThat(calculator().calculateSettlementDate(thursdayBeforeStPatricks, FUND, CCF_ISIN))
+        .isEqualTo(LocalDate.of(2026, 3, 18));
   }
 
   @Test
-  void ccf_submittedOnFrenchHolidayBeforeCutoff_acceptedNextBusinessDay() {
+  void ccf_submittedOnIrishHolidayBeforeCutoff_acceptedNextBusinessDay() {
     given(instrumentReferenceService.settlementTerms(CCF_ISIN)).willReturn(Optional.of(CCF_TERMS));
     givenProvider(CCF_ISIN, CCF);
-    Instant bastilleDayBeforeCutoff = tallinnInstant(LocalDate.of(2026, 7, 14), LocalTime.of(9, 0));
+    Instant stPatricksBeforeCutoff = tallinnInstant(LocalDate.of(2026, 3, 17), LocalTime.of(9, 0));
 
-    assertThat(calculator().calculateSettlementDate(bastilleDayBeforeCutoff, FUND, CCF_ISIN))
-        .isEqualTo(LocalDate.of(2026, 7, 20));
+    assertThat(calculator().calculateSettlementDate(stPatricksBeforeCutoff, FUND, CCF_ISIN))
+        .isEqualTo(LocalDate.of(2026, 3, 23));
   }
 
   @Test
@@ -157,15 +157,6 @@ class SettlementDateCalculatorTest {
 
     assertThat(calculator().calculateSettlementDate(maundyThursday2025, ETF, ETF_ISIN))
         .isEqualTo(LocalDate.of(2025, 4, 23));
-  }
-
-  @Test
-  void fund_settlesInFiveBusinessDaysOnProviderDomicileCalendar() {
-    givenProvider(FRENCH_FUND_ISIN, CCF);
-    LocalDate beforeBastilleDay = LocalDate.of(2026, 7, 8);
-
-    assertThat(calculator().calculateSettlementDate(beforeBastilleDay, FUND, FRENCH_FUND_ISIN))
-        .isEqualTo(LocalDate.of(2026, 7, 16));
   }
 
   @Test

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionCommandControllerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionCommandControllerTest.java
@@ -9,6 +9,7 @@ import static ee.tuleva.onboarding.investment.transaction.OrderStatus.DRAFT;
 import static ee.tuleva.onboarding.investment.transaction.OrderVenue.SEB;
 import static ee.tuleva.onboarding.investment.transaction.TransactionMode.REBALANCE;
 import static ee.tuleva.onboarding.investment.transaction.TransactionType.BUY;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.springframework.http.HttpStatus.CONFLICT;
@@ -625,5 +626,33 @@ class TransactionCommandControllerTest {
             get("/admin/transaction-batches/10/exports/sebEtfXlsx")
                 .header("X-Admin-Token", "valid-token"))
         .andExpect(status().isNotFound());
+  }
+
+  @Test
+  void downloadExport_sebFundOrderFile_isServedAsCsv() throws Exception {
+    var csv = "Original reference;Client name\n".getBytes(UTF_8);
+    given(adminService.exportFile(10L, "sebFundXlsx")).willReturn(Optional.of(csv));
+
+    mockMvc
+        .perform(
+            get("/admin/transaction-batches/10/exports/sebFundXlsx")
+                .header("X-Admin-Token", "valid-token"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentTypeCompatibleWith("text/csv"))
+        .andExpect(
+            header()
+                .string("Content-Disposition", "attachment; filename=\"batch-10-sebFundXlsx.csv\""))
+        .andExpect(content().bytes(csv));
+  }
+
+  @Test
+  void downloadExport_unknownExportType_returnsNotFound() throws Exception {
+    mockMvc
+        .perform(
+            get("/admin/transaction-batches/10/exports/notAnExport")
+                .header("X-Admin-Token", "valid-token"))
+        .andExpect(status().isNotFound());
+
+    then(adminService).shouldHaveNoInteractions();
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionCommandControllerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionCommandControllerTest.java
@@ -32,6 +32,7 @@ import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -39,7 +40,12 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.server.ResponseStatusException;
 
 @WebMvcTest(TransactionCommandController.class)
-@TestPropertySource(properties = "admin.api-token=valid-token")
+@TestPropertySource(
+    properties = {
+      "admin.api-token=valid-token",
+      "admin.operator-tokens.operator-7=operator-7-token"
+    })
+@Import({AdminTokenAuthenticator.class, AdminTokenConfiguration.class})
 @WithMockUser
 class TransactionCommandControllerTest {
 
@@ -87,7 +93,12 @@ class TransactionCommandControllerTest {
   void createCommand_withValidToken_processesSynchronouslyAndReturnsResult() throws Exception {
     given(
             adminService.createAndProcess(
-                TUK75, REBALANCE, AS_OF_DATE, Map.of("IE00BFG1TM61", "1000.00"), "admin", null))
+                TUK75,
+                REBALANCE,
+                AS_OF_DATE,
+                Map.of("IE00BFG1TM61", "1000.00"),
+                "shared-admin-token",
+                null))
         .willReturn(commandResponse());
 
     mockMvc
@@ -123,8 +134,7 @@ class TransactionCommandControllerTest {
         .perform(
             post("/admin/transaction-commands")
                 .with(csrf())
-                .header("X-Admin-Token", "valid-token")
-                .header("X-Admin-Actor", "operator-7")
+                .header("X-Admin-Token", "operator-7-token")
                 .contentType(APPLICATION_JSON)
                 .content(
                     """
@@ -141,7 +151,7 @@ class TransactionCommandControllerTest {
   void createCommand_passesCashOverrideToService() throws Exception {
     given(
             adminService.createAndProcess(
-                TUK75, REBALANCE, AS_OF_DATE, null, "admin", new BigDecimal("40000")))
+                TUK75, REBALANCE, AS_OF_DATE, null, "shared-admin-token", new BigDecimal("40000")))
         .willReturn(commandResponse());
 
     mockMvc
@@ -158,7 +168,8 @@ class TransactionCommandControllerTest {
 
     then(adminService)
         .should()
-        .createAndProcess(TUK75, REBALANCE, AS_OF_DATE, null, "admin", new BigDecimal("40000"));
+        .createAndProcess(
+            TUK75, REBALANCE, AS_OF_DATE, null, "shared-admin-token", new BigDecimal("40000"));
   }
 
   @Test
@@ -245,7 +256,7 @@ class TransactionCommandControllerTest {
   void createCommandBatch_processesRequestedFunds() throws Exception {
     given(
             adminService.createAndProcessAll(
-                List.of(TUK75, TUK00), REBALANCE, AS_OF_DATE, "admin", Map.of()))
+                List.of(TUK75, TUK00), REBALANCE, AS_OF_DATE, "shared-admin-token", Map.of()))
         .willReturn(
             List.of(
                 commandResponse(),
@@ -269,7 +280,9 @@ class TransactionCommandControllerTest {
 
   @Test
   void createCommandBatch_withoutFunds_processesAllFunds() throws Exception {
-    given(adminService.createAndProcessAll(null, REBALANCE, AS_OF_DATE, "admin", Map.of()))
+    given(
+            adminService.createAndProcessAll(
+                null, REBALANCE, AS_OF_DATE, "shared-admin-token", Map.of()))
         .willReturn(List.of(commandResponse()));
 
     mockMvc
@@ -334,7 +347,7 @@ class TransactionCommandControllerTest {
 
   @Test
   void confirmBatch_finalizesAndReturnsBatch() throws Exception {
-    given(adminService.confirmAndFinalize(10L, "admin")).willReturn(batchResponse());
+    given(adminService.confirmAndFinalize(10L, "shared-admin-token")).willReturn(batchResponse());
 
     mockMvc
         .perform(
@@ -354,8 +367,7 @@ class TransactionCommandControllerTest {
         .perform(
             post("/admin/transaction-batches/10/confirm")
                 .with(csrf())
-                .header("X-Admin-Token", "valid-token")
-                .header("X-Admin-Actor", "operator-7"))
+                .header("X-Admin-Token", "operator-7-token"))
         .andExpect(status().isOk());
 
     then(adminService).should().confirmAndFinalize(10L, "operator-7");
@@ -363,7 +375,7 @@ class TransactionCommandControllerTest {
 
   @Test
   void confirmBatch_notAwaitingConfirmation_returnsConflict() throws Exception {
-    given(adminService.confirmAndFinalize(10L, "admin"))
+    given(adminService.confirmAndFinalize(10L, "shared-admin-token"))
         .willThrow(
             new ResponseStatusException(
                 CONFLICT, "Batch not awaiting confirmation: id=10, status=SENT"));
@@ -385,8 +397,7 @@ class TransactionCommandControllerTest {
         .perform(
             post("/admin/transaction-batches/10/cancel")
                 .with(csrf())
-                .header("X-Admin-Token", "valid-token")
-                .header("X-Admin-Actor", "operator-7")
+                .header("X-Admin-Token", "operator-7-token")
                 .contentType(APPLICATION_JSON)
                 .content(
                     """
@@ -400,7 +411,8 @@ class TransactionCommandControllerTest {
 
   @Test
   void cancelBatch_withoutActor_defaultsToAdmin() throws Exception {
-    given(adminService.cancelBatch(10L, "duplicate batch", "admin")).willReturn(batchResponse());
+    given(adminService.cancelBatch(10L, "duplicate batch", "shared-admin-token"))
+        .willReturn(batchResponse());
 
     mockMvc
         .perform(
@@ -414,7 +426,7 @@ class TransactionCommandControllerTest {
                     """))
         .andExpect(status().isOk());
 
-    then(adminService).should().cancelBatch(10L, "duplicate batch", "admin");
+    then(adminService).should().cancelBatch(10L, "duplicate batch", "shared-admin-token");
   }
 
   @Test
@@ -459,8 +471,7 @@ class TransactionCommandControllerTest {
         .perform(
             post("/admin/transaction-batches/10/discard")
                 .with(csrf())
-                .header("X-Admin-Token", "valid-token")
-                .header("X-Admin-Actor", "operator-7"))
+                .header("X-Admin-Token", "operator-7-token"))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.id").value(10));
 
@@ -469,7 +480,7 @@ class TransactionCommandControllerTest {
 
   @Test
   void discardBatch_withoutActor_defaultsToAdmin() throws Exception {
-    given(adminService.discardBatch(10L, "admin")).willReturn(batchResponse());
+    given(adminService.discardBatch(10L, "shared-admin-token")).willReturn(batchResponse());
 
     mockMvc
         .perform(
@@ -478,12 +489,12 @@ class TransactionCommandControllerTest {
                 .header("X-Admin-Token", "valid-token"))
         .andExpect(status().isOk());
 
-    then(adminService).should().discardBatch(10L, "admin");
+    then(adminService).should().discardBatch(10L, "shared-admin-token");
   }
 
   @Test
   void discardBatch_nonDraftBatch_returnsConflict() throws Exception {
-    given(adminService.discardBatch(10L, "admin"))
+    given(adminService.discardBatch(10L, "shared-admin-token"))
         .willThrow(
             new ResponseStatusException(CONFLICT, "Batch not in DRAFT status: id=10, status=SENT"));
 
@@ -515,8 +526,7 @@ class TransactionCommandControllerTest {
         .perform(
             post("/admin/transaction-orders/100/cancel")
                 .with(csrf())
-                .header("X-Admin-Token", "valid-token")
-                .header("X-Admin-Actor", "operator-7")
+                .header("X-Admin-Token", "operator-7-token")
                 .contentType(APPLICATION_JSON)
                 .content(
                     """
@@ -530,7 +540,8 @@ class TransactionCommandControllerTest {
 
   @Test
   void cancelOrder_withoutActor_defaultsToAdmin() throws Exception {
-    given(adminService.cancelOrder(100L, "trader error", "admin")).willReturn(orderResponse());
+    given(adminService.cancelOrder(100L, "trader error", "shared-admin-token"))
+        .willReturn(orderResponse());
 
     mockMvc
         .perform(
@@ -544,7 +555,7 @@ class TransactionCommandControllerTest {
                     """))
         .andExpect(status().isOk());
 
-    then(adminService).should().cancelOrder(100L, "trader error", "admin");
+    then(adminService).should().cancelOrder(100L, "trader error", "shared-admin-token");
   }
 
   @Test
@@ -566,7 +577,7 @@ class TransactionCommandControllerTest {
 
   @Test
   void cancelOrder_notSentOrder_returnsConflict() throws Exception {
-    given(adminService.cancelOrder(100L, "trader error", "admin"))
+    given(adminService.cancelOrder(100L, "trader error", "shared-admin-token"))
         .willThrow(
             new ResponseStatusException(
                 CONFLICT, "Only SENT orders can be cancelled: id=100, status=DRAFT"));

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionInputServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionInputServiceTest.java
@@ -9,6 +9,7 @@ import static ee.tuleva.onboarding.investment.position.AccountType.SECURITY;
 import static java.math.BigDecimal.ZERO;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.tuple;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -1424,6 +1425,54 @@ class TransactionInputServiceTest {
     assertThat(result.grossPortfolioValue()).isEqualByComparingTo(new BigDecimal("640000"));
     assertThat(result.liabilities()).isEqualByComparingTo(new BigDecimal("40000"));
     assertThat(result.freeCash()).isEqualByComparingTo(new BigDecimal("60000"));
+  }
+
+  @Test
+  void gatherInput_withASecurityRowWithoutAnIsin_stillAppliesTheOtherPendingPositions() {
+    var positionDate = AS_OF_DATE;
+    given(fundPositionRepository.findLatestNavDateByFundAndAsOfDate(TUV100, AS_OF_DATE))
+        .willReturn(Optional.of(positionDate));
+    given(fundPositionRepository.findByNavDateAndFundAndAccountType(positionDate, TUV100, SECURITY))
+        .willReturn(
+            List.of(
+                FundPosition.builder()
+                    .fund(TUV100)
+                    .accountType(SECURITY)
+                    .accountId("IE00A")
+                    .quantity(new BigDecimal("1000"))
+                    .marketValue(new BigDecimal("500000"))
+                    .build(),
+                FundPosition.builder()
+                    .fund(TUV100)
+                    .accountType(SECURITY)
+                    .marketValue(new BigDecimal("250000"))
+                    .build()));
+    given(fundPositionRepository.findByNavDateAndFundAndAccountType(positionDate, TUV100, CASH))
+        .willReturn(
+            List.of(
+                FundPosition.builder()
+                    .fund(TUV100)
+                    .accountType(CASH)
+                    .marketValue(new BigDecimal("100000"))
+                    .build()));
+    given(feeAccrualRepository.getAccruedFeesForMonth(eq(TUV100), any(), any(), any()))
+        .willReturn(ZERO);
+    given(modelPortfolioAllocationRepository.findLatestByFundAsOf(TUV100, AS_OF_DATE))
+        .willReturn(List.of());
+    given(fundLimitRepository.findLatestByFundAsOf(TUV100, AS_OF_DATE))
+        .willReturn(Optional.of(zeroFundLimit(TUV100)));
+    given(positionLimitRepository.findLatestByFundAsOf(TUV100, AS_OF_DATE)).willReturn(List.of());
+    given(pendingOrderImpactService.calculate(eq(TUV100), eq(AS_OF_DATE), any()))
+        .willReturn(
+            new PendingOrderImpact(
+                new BigDecimal("40000"), ZERO, Map.of("IE00A", new BigDecimal("40000")), Map.of()));
+
+    var result = service.gatherInput(TUV100, AS_OF_DATE, Map.of());
+
+    assertThat(result.positions())
+        .extracting(PositionSnapshot::isin, PositionSnapshot::marketValue)
+        .containsExactly(
+            tuple("IE00A", new BigDecimal("540000")), tuple(null, new BigDecimal("250000")));
   }
 
   @Test

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionInputServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionInputServiceTest.java
@@ -1427,6 +1427,63 @@ class TransactionInputServiceTest {
   }
 
   @Test
+  void gatherInput_leavesPositionsWithoutAnUnsettledOrderExactlyAsReported() {
+    var positionDate = AS_OF_DATE;
+    given(fundPositionRepository.findLatestNavDateByFundAndAsOfDate(TUV100, AS_OF_DATE))
+        .willReturn(Optional.of(positionDate));
+    given(fundPositionRepository.findByNavDateAndFundAndAccountType(positionDate, TUV100, SECURITY))
+        .willReturn(
+            List.of(
+                FundPosition.builder()
+                    .fund(TUV100)
+                    .accountType(SECURITY)
+                    .accountId("IE00A")
+                    .quantity(new BigDecimal("1000"))
+                    .marketValue(new BigDecimal("500000"))
+                    .build(),
+                FundPosition.builder()
+                    .fund(TUV100)
+                    .accountType(SECURITY)
+                    .accountId("IE00B")
+                    .quantity(new BigDecimal("200"))
+                    .marketValue(new BigDecimal("100000"))
+                    .build()));
+    given(fundPositionRepository.findByNavDateAndFundAndAccountType(positionDate, TUV100, CASH))
+        .willReturn(
+            List.of(
+                FundPosition.builder()
+                    .fund(TUV100)
+                    .accountType(CASH)
+                    .marketValue(new BigDecimal("100000"))
+                    .build()));
+    given(feeAccrualRepository.getAccruedFeesForMonth(eq(TUV100), any(), any(), any()))
+        .willReturn(ZERO);
+    given(modelPortfolioAllocationRepository.findLatestByFundAsOf(TUV100, AS_OF_DATE))
+        .willReturn(List.of());
+    given(fundLimitRepository.findLatestByFundAsOf(TUV100, AS_OF_DATE))
+        .willReturn(Optional.of(zeroFundLimit(TUV100)));
+    given(positionLimitRepository.findLatestByFundAsOf(TUV100, AS_OF_DATE)).willReturn(List.of());
+    given(pendingOrderImpactService.calculate(TUV100, AS_OF_DATE))
+        .willReturn(
+            new PendingOrderImpact(
+                new BigDecimal("40000"),
+                ZERO,
+                Map.of("IE00A", new BigDecimal("40000")),
+                Map.of("IE00A", new BigDecimal("80"))));
+
+    var result = service.gatherInput(TUV100, AS_OF_DATE, Map.of());
+
+    assertThat(result.positions())
+        .filteredOn(position -> position.isin().equals("IE00B"))
+        .singleElement()
+        .satisfies(
+            position -> {
+              assertThat(position.marketValue()).isEqualByComparingTo(new BigDecimal("100000"));
+              assertThat(position.quantity()).isEqualByComparingTo(new BigDecimal("200"));
+            });
+  }
+
+  @Test
   void gatherInput_withASentBuyOfANewInstrument_createsThePositionItIsNotYetReportedIn() {
     var positionDate = AS_OF_DATE;
     given(fundPositionRepository.findLatestNavDateByFundAndAsOfDate(TUV100, AS_OF_DATE))

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionInputServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionInputServiceTest.java
@@ -61,6 +61,9 @@ class TransactionInputServiceTest {
   @BeforeEach
   void defaultLedgerCashToZero() {
     lenient().when(navLedgerRepository.getSystemAccountBalance(anyString())).thenReturn(ZERO);
+    lenient()
+        .when(pendingOrderImpactService.calculate(any(), any()))
+        .thenReturn(PendingOrderImpact.none());
   }
 
   @Mock private FundPositionRepository fundPositionRepository;
@@ -77,6 +80,7 @@ class TransactionInputServiceTest {
   @Mock private R16FlowCalculationService r16FlowCalculationService;
   @Mock private R16PhaseCalculator r16PhaseCalculator;
   @Mock private InvestmentParameterRepository investmentParameterRepository;
+  @Mock private PendingOrderImpactService pendingOrderImpactService;
 
   @InjectMocks private TransactionInputService service;
 
@@ -982,8 +986,13 @@ class TransactionInputServiceTest {
             .orderStatus(OrderStatus.SENT)
             .expectedSettlementDate(AS_OF_DATE.plusDays(2))
             .build();
-    when(orderRepository.findUnsettledOrders(TUV100, AS_OF_DATE))
-        .thenReturn(List.of(pendingBuyOrder, pendingSellOrder));
+    given(pendingOrderImpactService.calculate(TUV100, AS_OF_DATE))
+        .willReturn(
+            new PendingOrderImpact(
+                new BigDecimal("30000"),
+                new BigDecimal("10000"),
+                Map.of("IE00A", new BigDecimal("30000"), "IE00B", new BigDecimal("-10000")),
+                Map.of()));
 
     var result = service.gatherInput(TUV100, AS_OF_DATE, Map.of());
 
@@ -1026,8 +1035,8 @@ class TransactionInputServiceTest {
             .orderStatus(OrderStatus.EXECUTED)
             .expectedSettlementDate(AS_OF_DATE.plusDays(1))
             .build();
-    given(orderRepository.findUnsettledOrders(TUV100, AS_OF_DATE))
-        .willReturn(List.of(executedUnsettledBuy));
+    given(pendingOrderImpactService.calculate(TUV100, AS_OF_DATE))
+        .willReturn(new PendingOrderImpact(new BigDecimal("25000"), ZERO, Map.of(), Map.of()));
 
     var result = service.gatherInput(TUV100, AS_OF_DATE, Map.of());
 
@@ -1362,5 +1371,149 @@ class TransactionInputServiceTest {
         liquidityRequired,
         tradeBufferedLiquidity,
         tradeBufferedLiquidity);
+  }
+
+  @Test
+  void gatherInput_withASentBuyNotYetInTheSebReport_addsItsValueToThePosition() {
+    var positionDate = AS_OF_DATE;
+    given(fundPositionRepository.findLatestNavDateByFundAndAsOfDate(TUV100, AS_OF_DATE))
+        .willReturn(Optional.of(positionDate));
+    given(fundPositionRepository.findByNavDateAndFundAndAccountType(positionDate, TUV100, SECURITY))
+        .willReturn(
+            List.of(
+                FundPosition.builder()
+                    .fund(TUV100)
+                    .accountType(SECURITY)
+                    .accountId("IE00A")
+                    .quantity(new BigDecimal("1000"))
+                    .marketValue(new BigDecimal("500000"))
+                    .build()));
+    given(fundPositionRepository.findByNavDateAndFundAndAccountType(positionDate, TUV100, CASH))
+        .willReturn(
+            List.of(
+                FundPosition.builder()
+                    .fund(TUV100)
+                    .accountType(CASH)
+                    .marketValue(new BigDecimal("100000"))
+                    .build()));
+    given(feeAccrualRepository.getAccruedFeesForMonth(eq(TUV100), any(), any(), any()))
+        .willReturn(ZERO);
+    given(modelPortfolioAllocationRepository.findLatestByFundAsOf(TUV100, AS_OF_DATE))
+        .willReturn(List.of());
+    given(fundLimitRepository.findLatestByFundAsOf(TUV100, AS_OF_DATE))
+        .willReturn(Optional.of(zeroFundLimit(TUV100)));
+    given(positionLimitRepository.findLatestByFundAsOf(TUV100, AS_OF_DATE)).willReturn(List.of());
+    given(pendingOrderImpactService.calculate(TUV100, AS_OF_DATE))
+        .willReturn(
+            new PendingOrderImpact(
+                new BigDecimal("40000"),
+                ZERO,
+                Map.of("IE00A", new BigDecimal("40000")),
+                Map.of("IE00A", new BigDecimal("80"))));
+
+    var result = service.gatherInput(TUV100, AS_OF_DATE, Map.of());
+
+    assertThat(result.positions())
+        .singleElement()
+        .satisfies(
+            position -> {
+              assertThat(position.isin()).isEqualTo("IE00A");
+              assertThat(position.marketValue()).isEqualByComparingTo(new BigDecimal("540000"));
+              assertThat(position.quantity()).isEqualByComparingTo(new BigDecimal("1080"));
+            });
+    assertThat(result.grossPortfolioValue()).isEqualByComparingTo(new BigDecimal("640000"));
+    assertThat(result.liabilities()).isEqualByComparingTo(new BigDecimal("40000"));
+    assertThat(result.freeCash()).isEqualByComparingTo(new BigDecimal("60000"));
+  }
+
+  @Test
+  void gatherInput_withASentBuyOfANewInstrument_createsThePositionItIsNotYetReportedIn() {
+    var positionDate = AS_OF_DATE;
+    given(fundPositionRepository.findLatestNavDateByFundAndAsOfDate(TUV100, AS_OF_DATE))
+        .willReturn(Optional.of(positionDate));
+    given(fundPositionRepository.findByNavDateAndFundAndAccountType(positionDate, TUV100, SECURITY))
+        .willReturn(List.of());
+    given(fundPositionRepository.findByNavDateAndFundAndAccountType(positionDate, TUV100, CASH))
+        .willReturn(
+            List.of(
+                FundPosition.builder()
+                    .fund(TUV100)
+                    .accountType(CASH)
+                    .marketValue(new BigDecimal("100000"))
+                    .build()));
+    given(feeAccrualRepository.getAccruedFeesForMonth(eq(TUV100), any(), any(), any()))
+        .willReturn(ZERO);
+    given(modelPortfolioAllocationRepository.findLatestByFundAsOf(TUV100, AS_OF_DATE))
+        .willReturn(List.of());
+    given(fundLimitRepository.findLatestByFundAsOf(TUV100, AS_OF_DATE))
+        .willReturn(Optional.of(zeroFundLimit(TUV100)));
+    given(positionLimitRepository.findLatestByFundAsOf(TUV100, AS_OF_DATE)).willReturn(List.of());
+    given(pendingOrderImpactService.calculate(TUV100, AS_OF_DATE))
+        .willReturn(
+            new PendingOrderImpact(
+                new BigDecimal("25000"),
+                ZERO,
+                Map.of("IE00NEW", new BigDecimal("25000")),
+                Map.of()));
+
+    var result = service.gatherInput(TUV100, AS_OF_DATE, Map.of());
+
+    assertThat(result.positions())
+        .singleElement()
+        .satisfies(
+            position -> {
+              assertThat(position.isin()).isEqualTo("IE00NEW");
+              assertThat(position.marketValue()).isEqualByComparingTo(new BigDecimal("25000"));
+            });
+  }
+
+  @Test
+  void gatherInput_withAnUnsettledBuy_leavesNetInvestableUnchangedSoItIsNotBoughtTwice() {
+    var positionDate = AS_OF_DATE;
+    given(fundPositionRepository.findLatestNavDateByFundAndAsOfDate(TUV100, AS_OF_DATE))
+        .willReturn(Optional.of(positionDate));
+    given(fundPositionRepository.findByNavDateAndFundAndAccountType(positionDate, TUV100, SECURITY))
+        .willReturn(
+            List.of(
+                FundPosition.builder()
+                    .fund(TUV100)
+                    .accountType(SECURITY)
+                    .accountId("IE00A")
+                    .marketValue(new BigDecimal("500000"))
+                    .build()));
+    given(fundPositionRepository.findByNavDateAndFundAndAccountType(positionDate, TUV100, CASH))
+        .willReturn(
+            List.of(
+                FundPosition.builder()
+                    .fund(TUV100)
+                    .accountType(CASH)
+                    .marketValue(new BigDecimal("100000"))
+                    .build()));
+    given(feeAccrualRepository.getAccruedFeesForMonth(eq(TUV100), any(), any(), any()))
+        .willReturn(ZERO);
+    given(modelPortfolioAllocationRepository.findLatestByFundAsOf(TUV100, AS_OF_DATE))
+        .willReturn(List.of());
+    given(fundLimitRepository.findLatestByFundAsOf(TUV100, AS_OF_DATE))
+        .willReturn(Optional.of(zeroFundLimit(TUV100)));
+    given(positionLimitRepository.findLatestByFundAsOf(TUV100, AS_OF_DATE)).willReturn(List.of());
+    given(pendingOrderImpactService.calculate(TUV100, AS_OF_DATE))
+        .willReturn(
+            new PendingOrderImpact(
+                new BigDecimal("40000"), ZERO, Map.of("IE00A", new BigDecimal("40000")), Map.of()));
+
+    var result = service.gatherInput(TUV100, AS_OF_DATE, Map.of());
+
+    BigDecimal netInvestable =
+        result
+            .grossPortfolioValue()
+            .subtract(result.cashBuffer())
+            .subtract(result.liabilities())
+            .add(result.receivables());
+    BigDecimal securityValue =
+        result.positions().stream()
+            .map(PositionSnapshot::marketValue)
+            .reduce(ZERO, BigDecimal::add);
+
+    assertThat(netInvestable.subtract(securityValue)).isEqualByComparingTo(result.freeCash());
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionInputServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionInputServiceTest.java
@@ -62,7 +62,7 @@ class TransactionInputServiceTest {
   void defaultLedgerCashToZero() {
     lenient().when(navLedgerRepository.getSystemAccountBalance(anyString())).thenReturn(ZERO);
     lenient()
-        .when(pendingOrderImpactService.calculate(any(), any()))
+        .when(pendingOrderImpactService.calculate(any(), any(), any()))
         .thenReturn(PendingOrderImpact.none());
   }
 
@@ -986,7 +986,7 @@ class TransactionInputServiceTest {
             .orderStatus(OrderStatus.SENT)
             .expectedSettlementDate(AS_OF_DATE.plusDays(2))
             .build();
-    given(pendingOrderImpactService.calculate(TUV100, AS_OF_DATE))
+    given(pendingOrderImpactService.calculate(eq(TUV100), eq(AS_OF_DATE), any()))
         .willReturn(
             new PendingOrderImpact(
                 new BigDecimal("30000"),
@@ -1035,7 +1035,7 @@ class TransactionInputServiceTest {
             .orderStatus(OrderStatus.EXECUTED)
             .expectedSettlementDate(AS_OF_DATE.plusDays(1))
             .build();
-    given(pendingOrderImpactService.calculate(TUV100, AS_OF_DATE))
+    given(pendingOrderImpactService.calculate(eq(TUV100), eq(AS_OF_DATE), any()))
         .willReturn(new PendingOrderImpact(new BigDecimal("25000"), ZERO, Map.of(), Map.of()));
 
     var result = service.gatherInput(TUV100, AS_OF_DATE, Map.of());
@@ -1403,7 +1403,7 @@ class TransactionInputServiceTest {
     given(fundLimitRepository.findLatestByFundAsOf(TUV100, AS_OF_DATE))
         .willReturn(Optional.of(zeroFundLimit(TUV100)));
     given(positionLimitRepository.findLatestByFundAsOf(TUV100, AS_OF_DATE)).willReturn(List.of());
-    given(pendingOrderImpactService.calculate(TUV100, AS_OF_DATE))
+    given(pendingOrderImpactService.calculate(eq(TUV100), eq(AS_OF_DATE), any()))
         .willReturn(
             new PendingOrderImpact(
                 new BigDecimal("40000"),
@@ -1463,7 +1463,7 @@ class TransactionInputServiceTest {
     given(fundLimitRepository.findLatestByFundAsOf(TUV100, AS_OF_DATE))
         .willReturn(Optional.of(zeroFundLimit(TUV100)));
     given(positionLimitRepository.findLatestByFundAsOf(TUV100, AS_OF_DATE)).willReturn(List.of());
-    given(pendingOrderImpactService.calculate(TUV100, AS_OF_DATE))
+    given(pendingOrderImpactService.calculate(eq(TUV100), eq(AS_OF_DATE), any()))
         .willReturn(
             new PendingOrderImpact(
                 new BigDecimal("40000"),
@@ -1505,7 +1505,7 @@ class TransactionInputServiceTest {
     given(fundLimitRepository.findLatestByFundAsOf(TUV100, AS_OF_DATE))
         .willReturn(Optional.of(zeroFundLimit(TUV100)));
     given(positionLimitRepository.findLatestByFundAsOf(TUV100, AS_OF_DATE)).willReturn(List.of());
-    given(pendingOrderImpactService.calculate(TUV100, AS_OF_DATE))
+    given(pendingOrderImpactService.calculate(eq(TUV100), eq(AS_OF_DATE), any()))
         .willReturn(
             new PendingOrderImpact(
                 new BigDecimal("25000"),
@@ -1553,7 +1553,7 @@ class TransactionInputServiceTest {
     given(fundLimitRepository.findLatestByFundAsOf(TUV100, AS_OF_DATE))
         .willReturn(Optional.of(zeroFundLimit(TUV100)));
     given(positionLimitRepository.findLatestByFundAsOf(TUV100, AS_OF_DATE)).willReturn(List.of());
-    given(pendingOrderImpactService.calculate(TUV100, AS_OF_DATE))
+    given(pendingOrderImpactService.calculate(eq(TUV100), eq(AS_OF_DATE), any()))
         .willReturn(
             new PendingOrderImpact(
                 new BigDecimal("40000"), ZERO, Map.of("IE00A", new BigDecimal("40000")), Map.of()));

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionInputServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionInputServiceTest.java
@@ -1427,6 +1427,51 @@ class TransactionInputServiceTest {
   }
 
   @Test
+  void gatherInput_withASentSellOfAnIsinAbsentFromTheSebReport_addsNoPositionForIt() {
+    var positionDate = AS_OF_DATE;
+    given(fundPositionRepository.findLatestNavDateByFundAndAsOfDate(TUV100, AS_OF_DATE))
+        .willReturn(Optional.of(positionDate));
+    given(fundPositionRepository.findByNavDateAndFundAndAccountType(positionDate, TUV100, SECURITY))
+        .willReturn(
+            List.of(
+                FundPosition.builder()
+                    .fund(TUV100)
+                    .accountType(SECURITY)
+                    .accountId("IE00A")
+                    .quantity(new BigDecimal("1000"))
+                    .marketValue(new BigDecimal("500000"))
+                    .build()));
+    given(fundPositionRepository.findByNavDateAndFundAndAccountType(positionDate, TUV100, CASH))
+        .willReturn(
+            List.of(
+                FundPosition.builder()
+                    .fund(TUV100)
+                    .accountType(CASH)
+                    .marketValue(new BigDecimal("100000"))
+                    .build()));
+    given(feeAccrualRepository.getAccruedFeesForMonth(eq(TUV100), any(), any(), any()))
+        .willReturn(ZERO);
+    given(modelPortfolioAllocationRepository.findLatestByFundAsOf(TUV100, AS_OF_DATE))
+        .willReturn(List.of());
+    given(fundLimitRepository.findLatestByFundAsOf(TUV100, AS_OF_DATE))
+        .willReturn(Optional.of(zeroFundLimit(TUV100)));
+    given(positionLimitRepository.findLatestByFundAsOf(TUV100, AS_OF_DATE)).willReturn(List.of());
+    given(pendingOrderImpactService.calculate(eq(TUV100), eq(AS_OF_DATE), any()))
+        .willReturn(
+            new PendingOrderImpact(
+                ZERO,
+                new BigDecimal("1000"),
+                Map.of("IE00B", new BigDecimal("-1000")),
+                Map.of("IE00B", new BigDecimal("-20"))));
+
+    var result = service.gatherInput(TUV100, AS_OF_DATE, Map.of());
+
+    assertThat(result.positions())
+        .singleElement()
+        .satisfies(position -> assertThat(position.isin()).isEqualTo("IE00A"));
+  }
+
+  @Test
   void gatherInput_leavesPositionsWithoutAnUnsettledOrderExactlyAsReported() {
     var positionDate = AS_OF_DATE;
     given(fundPositionRepository.findLatestNavDateByFundAndAsOfDate(TUV100, AS_OF_DATE))

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionInputServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionInputServiceTest.java
@@ -1428,6 +1428,50 @@ class TransactionInputServiceTest {
   }
 
   @Test
+  void gatherInput_withANegativeSecurityMarketValue_dropsThatRowAndKeepsTrading() {
+    var positionDate = AS_OF_DATE;
+    given(fundPositionRepository.findLatestNavDateByFundAndAsOfDate(TUV100, AS_OF_DATE))
+        .willReturn(Optional.of(positionDate));
+    given(fundPositionRepository.findByNavDateAndFundAndAccountType(positionDate, TUV100, SECURITY))
+        .willReturn(
+            List.of(
+                FundPosition.builder()
+                    .fund(TUV100)
+                    .accountType(SECURITY)
+                    .accountId("IE00A")
+                    .marketValue(new BigDecimal("500000"))
+                    .build(),
+                FundPosition.builder()
+                    .fund(TUV100)
+                    .accountType(SECURITY)
+                    .accountId("IE00REVERSAL")
+                    .marketValue(new BigDecimal("-5000"))
+                    .build()));
+    given(fundPositionRepository.findByNavDateAndFundAndAccountType(positionDate, TUV100, CASH))
+        .willReturn(
+            List.of(
+                FundPosition.builder()
+                    .fund(TUV100)
+                    .accountType(CASH)
+                    .marketValue(new BigDecimal("100000"))
+                    .build()));
+    given(feeAccrualRepository.getAccruedFeesForMonth(eq(TUV100), any(), any(), any()))
+        .willReturn(ZERO);
+    given(modelPortfolioAllocationRepository.findLatestByFundAsOf(TUV100, AS_OF_DATE))
+        .willReturn(List.of());
+    given(fundLimitRepository.findLatestByFundAsOf(TUV100, AS_OF_DATE))
+        .willReturn(Optional.of(zeroFundLimit(TUV100)));
+    given(positionLimitRepository.findLatestByFundAsOf(TUV100, AS_OF_DATE)).willReturn(List.of());
+
+    var result = service.gatherInput(TUV100, AS_OF_DATE, Map.of());
+
+    assertThat(result.positions())
+        .extracting(PositionSnapshot::isin, PositionSnapshot::marketValue)
+        .containsExactly(tuple("IE00A", new BigDecimal("500000")));
+    assertThat(result.grossPortfolioValue()).isEqualByComparingTo(new BigDecimal("600000"));
+  }
+
+  @Test
   void gatherInput_withASecurityRowWithoutAnIsin_stillAppliesTheOtherPendingPositions() {
     var positionDate = AS_OF_DATE;
     given(fundPositionRepository.findLatestNavDateByFundAndAsOfDate(TUV100, AS_OF_DATE))

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionPipelineIntegrationTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionPipelineIntegrationTest.java
@@ -12,9 +12,10 @@ import static ee.tuleva.onboarding.investment.transaction.TransactionMode.BUY;
 import static ee.tuleva.onboarding.investment.transaction.TransactionMode.REBALANCE;
 import static ee.tuleva.onboarding.investment.transaction.TransactionType.SELL;
 import static java.math.BigDecimal.ZERO;
+import static java.math.RoundingMode.HALF_UP;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.stream.Collectors.toMap;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.tuple;
 import static org.assertj.core.api.Assertions.within;
 
 import ee.tuleva.onboarding.time.ClockHolder;
@@ -55,6 +56,15 @@ class TransactionPipelineIntegrationTest {
       TEST_DATE.atStartOfDay(TALLINN).toInstant().plusSeconds(3600);
   private static final Clock FIXED_CLOCK = Clock.fixed(FIXED_INSTANT, TALLINN);
 
+  private static final BigDecimal EXPECTED_SELL_IE000F60HVH9 = new BigDecimal("118094.61");
+  private static final BigDecimal EXPECTED_SELL_IE00BJZ2DC62 = new BigDecimal("127582.57");
+  private static final BigDecimal EXPECTED_BUY_IE000O58J820 = new BigDecimal("124291.20");
+  private static final BigDecimal EXPECTED_BUY_IE00BFG1TM61 = new BigDecimal("116881.35");
+  private static final BigDecimal EXPECTED_BUY_IE00BMDBMY19 = new BigDecimal("85266.68");
+  private static final BigDecimal EXPECTED_BUY_LU1291099718 = new BigDecimal("269536.01");
+  private static final BigDecimal EXPECTED_FT_TOTAL = new BigDecimal("639504.39");
+  private static final BigDecimal ESGM_PRICE = new BigDecimal("45.00");
+
   @TestConfiguration
   static class TestClockConfig {
     @Bean
@@ -92,20 +102,19 @@ class TransactionPipelineIntegrationTest {
     assertThat(command.getStatus()).isEqualTo(CALCULATED);
 
     List<TransactionOrder> orders = result.orders();
+    assertThat(orders).hasSize(6);
 
-    assertThat(orders)
-        .extracting(
-            TransactionOrder::getInstrumentIsin,
-            TransactionOrder::getTransactionType,
-            TransactionOrder::getInstrumentType,
-            TransactionOrder::getOrderVenue)
-        .containsExactlyInAnyOrder(
-            tuple("IE000F60HVH9", SELL, ETF, FT),
-            tuple("IE00BJZ2DC62", SELL, ETF, FT),
-            tuple("IE000O58J820", TransactionType.BUY, ETF, FT),
-            tuple("IE00BFG1TM61", TransactionType.BUY, FUND, SEB),
-            tuple("IE00BMDBMY19", TransactionType.BUY, ETF, SEB),
-            tuple("LU1291099718", TransactionType.BUY, ETF, FT));
+    Map<String, TransactionOrder> ordersByIsin =
+        orders.stream().collect(toMap(TransactionOrder::getInstrumentIsin, order -> order));
+
+    BigDecimal tolerance = BigDecimal.ONE;
+
+    assertSellOrder(ordersByIsin, "IE000F60HVH9", EXPECTED_SELL_IE000F60HVH9, ETF, FT, tolerance);
+    assertSellOrder(ordersByIsin, "IE00BJZ2DC62", EXPECTED_SELL_IE00BJZ2DC62, ETF, FT, tolerance);
+    assertBuyOrder(ordersByIsin, "IE000O58J820", EXPECTED_BUY_IE000O58J820, ETF, FT, tolerance);
+    assertBuyOrder(ordersByIsin, "IE00BFG1TM61", EXPECTED_BUY_IE00BFG1TM61, FUND, SEB, tolerance);
+    assertBuyOrder(ordersByIsin, "IE00BMDBMY19", EXPECTED_BUY_IE00BMDBMY19, ETF, SEB, tolerance);
+    assertBuyOrder(ordersByIsin, "LU1291099718", EXPECTED_BUY_LU1291099718, ETF, FT, tolerance);
 
     entityManager.flush();
     var auditEvents = auditEventRepository.findByBatchIdOrderByCreatedAt(result.batch().getId());
@@ -192,7 +201,9 @@ class TransactionPipelineIntegrationTest {
     assertThat(cells.get(5)).isEqualTo("SUBS");
     assertThat(cells.get(9)).isEqualTo("IE00BFG1TM61");
     assertThat(new BigDecimal(cells.get(12)))
-        .isCloseTo(fundOrder.getOrderAmount(), within(BigDecimal.ONE));
+        .isCloseTo(EXPECTED_BUY_IE00BFG1TM61, within(BigDecimal.ONE));
+    assertThat(fundOrder.getOrderAmount())
+        .isCloseTo(EXPECTED_BUY_IE00BFG1TM61, within(BigDecimal.ONE));
   }
 
   @Test
@@ -215,6 +226,11 @@ class TransactionPipelineIntegrationTest {
       assertThat(rowsByIsin.get("IE00BMDBMY19").getCell(3).getStringCellValue())
           .isEqualTo("ESGM.DE");
       assertThat(rowsByIsin.get("IE00BMDBMY19").getCell(7).getStringCellValue()).isEqualTo("Buy");
+      assertThat(
+              BigDecimal.valueOf(rowsByIsin.get("IE00BMDBMY19").getCell(6).getNumericCellValue()))
+          .isCloseTo(
+              EXPECTED_BUY_IE00BMDBMY19.divide(ESGM_PRICE, 6, HALF_UP),
+              within(new BigDecimal("1")));
 
       assertThat(rowsByIsin).containsOnlyKeys("IE00BMDBMY19");
     }
@@ -249,11 +265,24 @@ class TransactionPipelineIntegrationTest {
       assertThat(rowsByIsin.get("IE00BJZ2DC62").getCell(1).getStringCellValue()).isEqualTo("SELL");
       assertThat(rowsByIsin.get("LU1291099718").getCell(1).getStringCellValue()).isEqualTo("BUY");
 
+      assertThat(
+              BigDecimal.valueOf(rowsByIsin.get("IE000F60HVH9").getCell(7).getNumericCellValue()))
+          .isCloseTo(EXPECTED_SELL_IE000F60HVH9, within(BigDecimal.ONE));
+      assertThat(
+              BigDecimal.valueOf(rowsByIsin.get("IE00BJZ2DC62").getCell(7).getNumericCellValue()))
+          .isCloseTo(EXPECTED_SELL_IE00BJZ2DC62, within(BigDecimal.ONE));
+      assertThat(
+              BigDecimal.valueOf(rowsByIsin.get("IE000O58J820").getCell(7).getNumericCellValue()))
+          .isCloseTo(EXPECTED_BUY_IE000O58J820, within(BigDecimal.ONE));
+      assertThat(
+              BigDecimal.valueOf(rowsByIsin.get("LU1291099718").getCell(7).getNumericCellValue()))
+          .isCloseTo(EXPECTED_BUY_LU1291099718, within(BigDecimal.ONE));
+
       BigDecimal totalAmount = ZERO;
       for (Row row : rowsByIsin.values()) {
         totalAmount = totalAmount.add(BigDecimal.valueOf(row.getCell(7).getNumericCellValue()));
       }
-      assertThat(totalAmount).isGreaterThan(ZERO);
+      assertThat(totalAmount).isCloseTo(EXPECTED_FT_TOTAL, within(BigDecimal.ONE));
     }
   }
 

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionPipelineIntegrationTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionPipelineIntegrationTest.java
@@ -13,8 +13,8 @@ import static ee.tuleva.onboarding.investment.transaction.TransactionMode.REBALA
 import static ee.tuleva.onboarding.investment.transaction.TransactionType.SELL;
 import static java.math.BigDecimal.ZERO;
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.util.stream.Collectors.toMap;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 import static org.assertj.core.api.Assertions.within;
 
 import ee.tuleva.onboarding.time.ClockHolder;
@@ -33,7 +33,6 @@ import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.WorkbookFactory;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -48,7 +47,6 @@ import org.springframework.transaction.annotation.Transactional;
 @ActiveProfiles("test")
 @Transactional
 @Sql("classpath:db/snapshots/transaction-pipeline/TKF100_2026-02-10.sql")
-@Disabled
 class TransactionPipelineIntegrationTest {
 
   private static final ZoneId TALLINN = ZoneId.of("Europe/Tallinn");
@@ -94,22 +92,20 @@ class TransactionPipelineIntegrationTest {
     assertThat(command.getStatus()).isEqualTo(CALCULATED);
 
     List<TransactionOrder> orders = result.orders();
-    assertThat(orders).hasSize(9);
 
-    Map<String, TransactionOrder> ordersByIsin =
-        orders.stream().collect(toMap(TransactionOrder::getInstrumentIsin, order -> order));
-
-    BigDecimal tolerance = BigDecimal.ONE;
-
-    assertBuyOrder(ordersByIsin, "IE00BMDBMY19", new BigDecimal("24288"), ETF, SEB, tolerance);
-    assertBuyOrder(ordersByIsin, "IE00BFG1TM61", new BigDecimal("53487"), FUND, SEB, tolerance);
-    assertSellOrder(ordersByIsin, "IE00BJZ2DC62", new BigDecimal("34875"), ETF, FT, tolerance);
-    assertBuyOrder(ordersByIsin, "LU0476289540", new BigDecimal("1675"), ETF, FT, tolerance);
-    assertSellOrder(ordersByIsin, "IE000F60HVH9", new BigDecimal("38571"), ETF, FT, tolerance);
-    assertSellOrder(ordersByIsin, "IE000O58J820", new BigDecimal("36991"), ETF, FT, tolerance);
-    assertBuyOrder(ordersByIsin, "LU1291099718", new BigDecimal("28701"), ETF, FT, tolerance);
-    assertBuyOrder(ordersByIsin, "LU1291106356", new BigDecimal("3981"), ETF, SEB, tolerance);
-    assertSellOrder(ordersByIsin, "LU1291102447", new BigDecimal("5696"), ETF, SEB, tolerance);
+    assertThat(orders)
+        .extracting(
+            TransactionOrder::getInstrumentIsin,
+            TransactionOrder::getTransactionType,
+            TransactionOrder::getInstrumentType,
+            TransactionOrder::getOrderVenue)
+        .containsExactlyInAnyOrder(
+            tuple("IE000F60HVH9", SELL, ETF, FT),
+            tuple("IE00BJZ2DC62", SELL, ETF, FT),
+            tuple("IE000O58J820", TransactionType.BUY, ETF, FT),
+            tuple("IE00BFG1TM61", TransactionType.BUY, FUND, SEB),
+            tuple("IE00BMDBMY19", TransactionType.BUY, ETF, SEB),
+            tuple("LU1291099718", TransactionType.BUY, ETF, FT));
 
     entityManager.flush();
     var auditEvents = auditEventRepository.findByBatchIdOrderByCreatedAt(result.batch().getId());
@@ -120,7 +116,7 @@ class TransactionPipelineIntegrationTest {
 
   @Test
   void processCommand_buyMode_producesNoOrdersWhenCashBelowReserve() {
-    var command = createCommand(BUY);
+    var command = createCommand(BUY, new BigDecimal("120000.00"));
 
     var result = preparationService.processCommand(command);
 
@@ -181,13 +177,22 @@ class TransactionPipelineIntegrationTest {
     byte[] sebFundCsv = decodeExport(batch.getMetadata(), "sebFundXlsx");
     List<String> lines = List.of(new String(sebFundCsv, UTF_8).split("\n", -1));
 
+    var fundOrder =
+        orderRepository.findByBatchId(batch.getId()).stream()
+            .filter(order -> order.getInstrumentIsin().equals("IE00BFG1TM61"))
+            .findFirst()
+            .orElseThrow();
+
+    assertThat(lines).anyMatch(line -> line.startsWith("Original reference;"));
+
     String dataLine =
         lines.stream().filter(line -> line.contains("IE00BFG1TM61")).findFirst().orElseThrow();
     List<String> cells = List.of(dataLine.split(";", -1));
+    assertThat(cells.get(0)).isEqualTo(fundOrder.getOrderUuid().toString());
     assertThat(cells.get(5)).isEqualTo("SUBS");
     assertThat(cells.get(9)).isEqualTo("IE00BFG1TM61");
     assertThat(new BigDecimal(cells.get(12)))
-        .isCloseTo(new BigDecimal("53487"), within(BigDecimal.ONE));
+        .isCloseTo(fundOrder.getOrderAmount(), within(BigDecimal.ONE));
   }
 
   @Test
@@ -211,11 +216,7 @@ class TransactionPipelineIntegrationTest {
           .isEqualTo("ESGM.DE");
       assertThat(rowsByIsin.get("IE00BMDBMY19").getCell(7).getStringCellValue()).isEqualTo("Buy");
 
-      assertThat(rowsByIsin).containsKey("LU1291106356");
-      assertThat(rowsByIsin.get("LU1291106356").getCell(7).getStringCellValue()).isEqualTo("Buy");
-
-      assertThat(rowsByIsin).containsKey("LU1291102447");
-      assertThat(rowsByIsin.get("LU1291102447").getCell(7).getStringCellValue()).isEqualTo("Sell");
+      assertThat(rowsByIsin).containsOnlyKeys("IE00BMDBMY19");
     }
   }
 
@@ -227,25 +228,30 @@ class TransactionPipelineIntegrationTest {
     try (var workbook = WorkbookFactory.create(new ByteArrayInputStream(ftEtfXlsx))) {
       Sheet sheet = workbook.getSheetAt(0);
 
+      assertThat(sheet.getRow(0).getCell(0).getStringCellValue()).isEqualTo("Symbol");
+      assertThat(sheet.getRow(0).getCell(3).getStringCellValue()).isEqualTo("TD");
+      assertThat(sheet.getRow(0).getCell(4).getStringCellValue()).isEqualTo("SD");
+
       Map<String, Row> rowsByIsin = new java.util.HashMap<>();
-      for (int i = 2; i <= sheet.getLastRowNum(); i++) {
+      for (int i = 1; i <= sheet.getLastRowNum(); i++) {
         Row row = sheet.getRow(i);
         if (row != null
-            && row.getCell(2) != null
-            && !row.getCell(2).getStringCellValue().isEmpty()) {
-          rowsByIsin.put(row.getCell(2).getStringCellValue(), row);
+            && row.getCell(6) != null
+            && !row.getCell(6).getStringCellValue().isEmpty()) {
+          rowsByIsin.put(row.getCell(6).getStringCellValue(), row);
         }
       }
 
-      assertThat(rowsByIsin).containsKey("IE00BJZ2DC62");
-      assertThat(rowsByIsin).containsKey("LU0476289540");
-      assertThat(rowsByIsin).containsKey("IE000F60HVH9");
-      assertThat(rowsByIsin).containsKey("IE000O58J820");
-      assertThat(rowsByIsin).containsKey("LU1291099718");
+      assertThat(rowsByIsin)
+          .containsOnlyKeys("IE00BJZ2DC62", "IE000F60HVH9", "IE000O58J820", "LU1291099718");
+      assertThat(rowsByIsin.get("IE00BJZ2DC62").getCell(0).getStringCellValue())
+          .isEqualTo("XRSM GY");
+      assertThat(rowsByIsin.get("IE00BJZ2DC62").getCell(1).getStringCellValue()).isEqualTo("SELL");
+      assertThat(rowsByIsin.get("LU1291099718").getCell(1).getStringCellValue()).isEqualTo("BUY");
 
       BigDecimal totalAmount = ZERO;
       for (Row row : rowsByIsin.values()) {
-        totalAmount = totalAmount.add(BigDecimal.valueOf(row.getCell(5).getNumericCellValue()));
+        totalAmount = totalAmount.add(BigDecimal.valueOf(row.getCell(7).getNumericCellValue()));
       }
       assertThat(totalAmount).isGreaterThan(ZERO);
     }
@@ -268,6 +274,12 @@ class TransactionPipelineIntegrationTest {
 
   private TransactionCommand createCommand(TransactionMode mode) {
     var command = TransactionCommand.builder().fund(TKF100).mode(mode).asOfDate(TEST_DATE).build();
+    return commandRepository.save(command);
+  }
+
+  private TransactionCommand createCommand(TransactionMode mode, BigDecimal cash) {
+    var command =
+        TransactionCommand.builder().fund(TKF100).mode(mode).asOfDate(TEST_DATE).cash(cash).build();
     return commandRepository.save(command);
   }
 

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionPreparationServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionPreparationServiceTest.java
@@ -6,6 +6,7 @@ import static ee.tuleva.onboarding.investment.epis.SettlementTimingWarning.Type.
 import static ee.tuleva.onboarding.investment.transaction.BatchStatus.*;
 import static ee.tuleva.onboarding.investment.transaction.CommandStatus.*;
 import static ee.tuleva.onboarding.investment.transaction.TransactionMode.BUY;
+import static ee.tuleva.onboarding.investment.transaction.TransactionMode.REBALANCE;
 import static ee.tuleva.onboarding.investment.transaction.TransactionMode.SELL;
 import static java.math.BigDecimal.ZERO;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -116,7 +117,8 @@ class TransactionPreparationServiceTest {
                 "IE00A", new BigDecimal("100000"), new BigDecimal("0.60"), LimitStatus.OK));
 
     var calculationResult =
-        new FundCalculationResult(TUV100, BUY, input, trades, netInvestable(input), null);
+        new FundCalculationResult(
+            TUV100, BUY, input, trades, netInvestable(input), null, List.of());
 
     when(inputService.gatherInput(TUV100, command.getAsOfDate(), Map.of())).thenReturn(input);
     when(calculationEngine.calculate(input, BUY)).thenReturn(calculationResult);
@@ -172,7 +174,8 @@ class TransactionPreparationServiceTest {
             .fastSellIsins(Set.of())
             .build();
     var calculationResult =
-        new FundCalculationResult(TUV100, BUY, input, List.of(), netInvestable(input), null);
+        new FundCalculationResult(
+            TUV100, BUY, input, List.of(), netInvestable(input), null, List.of());
     given(
             inputService.gatherInput(
                 TUV100, command.getAsOfDate(), Map.of(), new BigDecimal("40000")))
@@ -225,7 +228,8 @@ class TransactionPreparationServiceTest {
                 "IE00A", new BigDecimal("100000"), new BigDecimal("0.60"), LimitStatus.OK));
 
     var calculationResult =
-        new FundCalculationResult(TUV100, BUY, input, trades, netInvestable(input), null);
+        new FundCalculationResult(
+            TUV100, BUY, input, trades, netInvestable(input), null, List.of());
 
     given(inputService.gatherInput(TUV100, command.getAsOfDate(), manualAdjustments))
         .willReturn(input);
@@ -289,7 +293,8 @@ class TransactionPreparationServiceTest {
             .fastSellIsins(Set.of())
             .build();
     var calculationResult =
-        new FundCalculationResult(TUK75, BUY, input, List.of(), netInvestable(input), null);
+        new FundCalculationResult(
+            TUK75, BUY, input, List.of(), netInvestable(input), null, List.of());
     given(inputService.gatherInput(TUK75, asOfDate, Map.of())).willReturn(input);
     given(calculationEngine.calculate(input, BUY)).willReturn(calculationResult);
     given(batchRepository.save(any(TransactionBatch.class)))
@@ -355,7 +360,8 @@ class TransactionPreparationServiceTest {
             input,
             List.of(),
             netInvestable(input),
-            "No trades: mode=BUY, reason=freeCashBelowMinTransactionThreshold");
+            "No trades: mode=BUY, reason=freeCashBelowMinTransactionThreshold",
+            List.of());
     given(inputService.gatherInput(TUV100, command.getAsOfDate(), Map.of())).willReturn(input);
     given(calculationEngine.calculate(input, BUY)).willReturn(calculationResult);
     given(batchRepository.save(any(TransactionBatch.class)))
@@ -402,7 +408,8 @@ class TransactionPreparationServiceTest {
             .fastSellIsins(Set.of())
             .build();
     var calculationResult =
-        new FundCalculationResult(TUV100, BUY, input, List.of(), netInvestable(input), null);
+        new FundCalculationResult(
+            TUV100, BUY, input, List.of(), netInvestable(input), null, List.of());
     given(inputService.gatherInput(TUV100, command.getAsOfDate(), Map.of())).willReturn(input);
     given(calculationEngine.calculate(input, BUY)).willReturn(calculationResult);
     given(batchRepository.save(any(TransactionBatch.class)))
@@ -444,7 +451,8 @@ class TransactionPreparationServiceTest {
             .fastSellIsins(Set.of())
             .build();
     var calculationResult =
-        new FundCalculationResult(TUV100, BUY, input, List.of(), netInvestable(input), null);
+        new FundCalculationResult(
+            TUV100, BUY, input, List.of(), netInvestable(input), null, List.of());
     given(inputService.gatherInput(TUV100, command.getAsOfDate(), Map.of())).willReturn(input);
     given(calculationEngine.calculate(input, BUY)).willReturn(calculationResult);
     given(batchRepository.save(any(TransactionBatch.class)))
@@ -487,7 +495,8 @@ class TransactionPreparationServiceTest {
             .build();
     var trades = List.<TradeCalculation>of();
     var calculationResult =
-        new FundCalculationResult(TUV100, BUY, input, trades, new BigDecimal("950000"), null);
+        new FundCalculationResult(
+            TUV100, BUY, input, trades, new BigDecimal("950000"), null, List.of());
     given(inputService.gatherInput(TUV100, command.getAsOfDate(), Map.of())).willReturn(input);
     given(calculationEngine.calculate(input, BUY)).willReturn(calculationResult);
     given(batchRepository.save(any(TransactionBatch.class)))
@@ -661,7 +670,7 @@ class TransactionPreparationServiceTest {
             new TradeCalculation(
                 "IE00A", new BigDecimal("100000"), new BigDecimal("0.60"), LimitStatus.OK));
 
-    var result = TransactionPreparationService.serializeTrades(trades, Map.of());
+    var result = TransactionPreparationService.serializeTrades(trades, Map.of(), Map.of());
 
     assertThat(result)
         .singleElement()
@@ -692,7 +701,8 @@ class TransactionPreparationServiceTest {
             .orderQuantity(new BigDecimal("16666.666667"))
             .build();
 
-    var result = TransactionPreparationService.serializeTrades(trades, Map.of("IE00ETF", order));
+    var result =
+        TransactionPreparationService.serializeTrades(trades, Map.of("IE00ETF", order), Map.of());
 
     assertThat(result.get(0))
         .containsEntry("isin", "IE00ETF")
@@ -818,7 +828,8 @@ class TransactionPreparationServiceTest {
             new TradeCalculation(
                 "IE00A", new BigDecimal("100000"), new BigDecimal("0.60"), LimitStatus.OK));
     var calculationResult =
-        new FundCalculationResult(TUV100, BUY, input, trades, netInvestable(input), null);
+        new FundCalculationResult(
+            TUV100, BUY, input, trades, netInvestable(input), null, List.of());
 
     given(clock.instant()).willReturn(Instant.parse("2026-01-15T10:00:00Z"));
     given(inputService.gatherInput(TUV100, command.getAsOfDate(), Map.of())).willReturn(input);
@@ -1001,7 +1012,8 @@ class TransactionPreparationServiceTest {
                 "LU00FUND", new BigDecimal("40000"), new BigDecimal("0.40"), LimitStatus.OK));
 
     var calculationResult =
-        new FundCalculationResult(TUV100, BUY, input, trades, netInvestable(input), null);
+        new FundCalculationResult(
+            TUV100, BUY, input, trades, netInvestable(input), null, List.of());
 
     when(inputService.gatherInput(TUV100, command.getAsOfDate(), Map.of())).thenReturn(input);
     when(calculationEngine.calculate(input, BUY)).thenReturn(calculationResult);
@@ -1084,7 +1096,8 @@ class TransactionPreparationServiceTest {
                 "LU00FUND", new BigDecimal("40000"), new BigDecimal("0.40"), LimitStatus.OK));
 
     var calculationResult =
-        new FundCalculationResult(TUV100, BUY, input, trades, netInvestable(input), null);
+        new FundCalculationResult(
+            TUV100, BUY, input, trades, netInvestable(input), null, List.of());
 
     when(inputService.gatherInput(TUV100, command.getAsOfDate(), Map.of())).thenReturn(input);
     when(calculationEngine.calculate(input, BUY)).thenReturn(calculationResult);
@@ -1146,7 +1159,8 @@ class TransactionPreparationServiceTest {
                 "IE00ETF", new BigDecimal("50000"), new BigDecimal("0.55"), LimitStatus.OK));
 
     var calculationResult =
-        new FundCalculationResult(TUV100, BUY, input, trades, netInvestable(input), null);
+        new FundCalculationResult(
+            TUV100, BUY, input, trades, netInvestable(input), null, List.of());
 
     when(inputService.gatherInput(TUV100, command.getAsOfDate(), Map.of())).thenReturn(input);
     when(calculationEngine.calculate(input, BUY)).thenReturn(calculationResult);
@@ -1296,7 +1310,8 @@ class TransactionPreparationServiceTest {
             new TradeCalculation(
                 "IE00ETF", new BigDecimal("50000"), new BigDecimal("0.55"), LimitStatus.OK));
     var calculationResult =
-        new FundCalculationResult(TUV100, BUY, input, trades, netInvestable(input), null);
+        new FundCalculationResult(
+            TUV100, BUY, input, trades, netInvestable(input), null, List.of());
     given(inputService.gatherInput(TUV100, command.getAsOfDate(), Map.of())).willReturn(input);
     given(calculationEngine.calculate(input, BUY)).willReturn(calculationResult);
     given(batchRepository.save(any(TransactionBatch.class)))
@@ -1386,7 +1401,8 @@ class TransactionPreparationServiceTest {
                 "LU00FUND2", new BigDecimal("40000"), new BigDecimal("0.42"), LimitStatus.OK));
 
     var calculationResult =
-        new FundCalculationResult(TUV100, SELL, input, trades, netInvestable(input), null);
+        new FundCalculationResult(
+            TUV100, SELL, input, trades, netInvestable(input), null, List.of());
 
     given(inputService.gatherInput(TUV100, command.getAsOfDate(), Map.of())).willReturn(input);
     given(calculationEngine.calculate(input, SELL)).willReturn(calculationResult);
@@ -1445,7 +1461,8 @@ class TransactionPreparationServiceTest {
                 "LU00FUND", new BigDecimal("-50000"), new BigDecimal("0.55"), LimitStatus.OK));
 
     var calculationResult =
-        new FundCalculationResult(TUV100, SELL, input, trades, netInvestable(input), null);
+        new FundCalculationResult(
+            TUV100, SELL, input, trades, netInvestable(input), null, List.of());
 
     given(inputService.gatherInput(TUV100, command.getAsOfDate(), Map.of())).willReturn(input);
     given(calculationEngine.calculate(input, SELL)).willReturn(calculationResult);
@@ -1504,7 +1521,8 @@ class TransactionPreparationServiceTest {
                 "IE00A", new BigDecimal("-100000"), new BigDecimal("0.40"), LimitStatus.OK));
 
     var calculationResult =
-        new FundCalculationResult(TUV100, SELL, input, trades, netInvestable(input), null);
+        new FundCalculationResult(
+            TUV100, SELL, input, trades, netInvestable(input), null, List.of());
 
     when(inputService.gatherInput(TUV100, command.getAsOfDate(), Map.of())).thenReturn(input);
     when(calculationEngine.calculate(input, SELL)).thenReturn(calculationResult);
@@ -1633,5 +1651,98 @@ class TransactionPreparationServiceTest {
     assertThat(batch.getMetadata()).containsKey("driveFileUrls");
     verify(custodianOrderEmailSender).send(eq(TUV100), any(), any());
     verify(eventPublisher).publishEvent(any(BatchFinalizedEvent.class));
+  }
+
+  @Test
+  void serializeTrades_recordsThePriceTheQuantityWasSizedOn() {
+    var trades =
+        List.of(
+            new TradeCalculation(
+                "IE00ETF", new BigDecimal("50000"), new BigDecimal("0.55"), LimitStatus.OK));
+    var resolvedPrice =
+        ResolvedPrice.builder()
+            .usedPrice(new BigDecimal("3.25"))
+            .priceDate(LocalDate.of(2026, 1, 10))
+            .priceSource(PriceSource.EODHD)
+            .build();
+
+    var result =
+        TransactionPreparationService.serializeTrades(
+            trades, Map.of(), Map.of("IE00ETF", resolvedPrice));
+
+    assertThat(result)
+        .singleElement()
+        .satisfies(trade -> assertThat(trade).containsEntry("price", "3.25"));
+  }
+
+  @Test
+  void serializeModelDrift_recordsDriftVersusModelBeforeAndAfterForEveryPosition() {
+    var input =
+        FundTransactionInput.builder()
+            .fund(TUV100)
+            .positions(
+                List.of(
+                    new PositionSnapshot("IE00A", new BigDecimal("600000")),
+                    new PositionSnapshot("IE00B", new BigDecimal("400000"))))
+            .modelWeights(
+                List.of(
+                    new ModelWeight("IE00A", new BigDecimal("0.50")),
+                    new ModelWeight("IE00B", new BigDecimal("0.50"))))
+            .grossPortfolioValue(new BigDecimal("1000000"))
+            .cashBuffer(ZERO)
+            .liabilities(ZERO)
+            .freeCash(ZERO)
+            .minTransactionThreshold(new BigDecimal("5000"))
+            .positionLimits(Map.of())
+            .fastSellIsins(Set.of())
+            .build();
+    var trades =
+        List.of(
+            new TradeCalculation(
+                "IE00A", new BigDecimal("-100000"), new BigDecimal("0.500000"), LimitStatus.OK),
+            new TradeCalculation(
+                "IE00B", new BigDecimal("100000"), new BigDecimal("0.500000"), LimitStatus.OK));
+    var result =
+        new FundCalculationResult(
+            TUV100, REBALANCE, input, trades, new BigDecimal("1000000"), null, List.of());
+
+    var drift = TransactionPreparationService.serializeModelDrift(input, result);
+
+    assertThat(drift)
+        .containsEntry("totalAbsoluteDriftBefore", "0.200000")
+        .containsEntry("totalAbsoluteDriftAfter", "0.000000");
+    assertThat((List<Map<String, Object>>) drift.get("positions"))
+        .satisfiesExactly(
+            first ->
+                assertThat(first)
+                    .containsEntry("isin", "IE00A")
+                    .containsEntry("targetWeight", "0.500000")
+                    .containsEntry("weightBefore", "0.600000")
+                    .containsEntry("weightAfter", "0.500000")
+                    .containsEntry("driftBefore", "0.100000")
+                    .containsEntry("driftAfter", "0.000000"),
+            second ->
+                assertThat(second)
+                    .containsEntry("isin", "IE00B")
+                    .containsEntry("driftBefore", "-0.100000")
+                    .containsEntry("driftAfter", "0.000000"));
+  }
+
+  @Test
+  void serializeCalculationWarnings_serializesTypeAndMessage() {
+    var warnings =
+        List.of(
+            new CalculationWarning(
+                CalculationWarningType.REBALANCE_NET_CASH_MISMATCH, "inputs do not reconcile"));
+
+    var result = TransactionPreparationService.serializeCalculationWarnings(warnings);
+
+    assertThat(result)
+        .singleElement()
+        .satisfies(
+            warning ->
+                assertThat(warning)
+                    .containsEntry("type", "REBALANCE_NET_CASH_MISMATCH")
+                    .containsEntry("message", "inputs do not reconcile"));
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionRegistryControllerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionRegistryControllerTest.java
@@ -44,6 +44,7 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.TestPropertySource;
@@ -53,7 +54,9 @@ import org.springframework.test.context.event.RecordApplicationEvents;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(TransactionRegistryController.class)
-@TestPropertySource(properties = "admin.api-token=valid-token")
+@TestPropertySource(
+    properties = {"admin.api-token=valid-token", "admin.operator-tokens.alice=alice-token"})
+@Import({AdminTokenAuthenticator.class, AdminTokenConfiguration.class})
 @WithMockUser
 @RecordApplicationEvents
 class TransactionRegistryControllerTest {
@@ -289,7 +292,7 @@ class TransactionRegistryControllerTest {
 
   @Test
   void ftConfirmations_batch_returnsResultPerRow() throws Exception {
-    given(ftConfirmationVerificationService.verifyAll(any(), eq("admin")))
+    given(ftConfirmationVerificationService.verifyAll(any(), eq("shared-admin-token")))
         .willReturn(
             List.of(
                 FtConfirmationBatchResult.verified(
@@ -321,8 +324,7 @@ class TransactionRegistryControllerTest {
         .perform(
             post("/admin/transaction-registry/ft-confirmations")
                 .with(csrf())
-                .header("X-Admin-Token", "valid-token")
-                .header("X-Admin-Actor", "alice")
+                .header("X-Admin-Token", "alice-token")
                 .contentType("application/json")
                 .content("[]"))
         .andExpect(status().isOk());

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/calculation/TradeCalculationEngineTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/calculation/TradeCalculationEngineTest.java
@@ -1912,6 +1912,47 @@ class TradeCalculationEngineTest {
   }
 
   @Test
+  void buy_withANegativeGrossPortfolioValue_failsLoudly() {
+    var input =
+        FundTransactionInput.builder()
+            .fund(TUV100)
+            .positions(List.of(new PositionSnapshot("IE00A", new BigDecimal("500000"))))
+            .modelWeights(List.of(new ModelWeight("IE00A", new BigDecimal("1.00"))))
+            .grossPortfolioValue(new BigDecimal("-1000000"))
+            .cashBuffer(ZERO)
+            .liabilities(ZERO)
+            .freeCash(new BigDecimal("100000"))
+            .minTransactionThreshold(new BigDecimal("5000"))
+            .positionLimits(Map.of())
+            .fastSellIsins(Set.of())
+            .build();
+
+    assertThatThrownBy(() -> engine.calculate(input, BUY))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  // A rebalance needs something to rebalance against; with no positions there is nothing to warn
+  // about either.
+  @Test
+  void rebalance_withoutAnyPositions_raisesNoCashWarnings() {
+    var input =
+        FundTransactionInput.builder()
+            .fund(TUV100)
+            .positions(List.of())
+            .modelWeights(List.of(new ModelWeight("IE00A", new BigDecimal("1.00"))))
+            .grossPortfolioValue(ZERO)
+            .cashBuffer(ZERO)
+            .liabilities(ZERO)
+            .freeCash(ZERO)
+            .minTransactionThreshold(new BigDecimal("5000"))
+            .positionLimits(Map.of())
+            .fastSellIsins(Set.of())
+            .build();
+
+    assertThat(engine.calculate(input, REBALANCE).warnings()).isEmpty();
+  }
+
+  @Test
   void buy_withANegativeModelWeight_failsLoudly() {
     var input =
         FundTransactionInput.builder()

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/calculation/TradeCalculationEngineTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/calculation/TradeCalculationEngineTest.java
@@ -1,6 +1,8 @@
 package ee.tuleva.onboarding.investment.transaction.calculation;
 
 import static ee.tuleva.onboarding.fund.TulevaFund.TUV100;
+import static ee.tuleva.onboarding.investment.transaction.CalculationWarningType.REBALANCE_NET_CASH_MISMATCH;
+import static ee.tuleva.onboarding.investment.transaction.CalculationWarningType.REBALANCE_NET_NOT_ACHIEVED;
 import static ee.tuleva.onboarding.investment.transaction.LimitStatus.*;
 import static ee.tuleva.onboarding.investment.transaction.TransactionMode.*;
 import static java.math.BigDecimal.ZERO;
@@ -1770,5 +1772,162 @@ class TradeCalculationEngineTest {
     nonZero.forEach(v -> assertThat(v).isGreaterThanOrEqualTo(new BigDecimal("4999")));
     assertThat(result.stream().reduce(ZERO, BigDecimal::add))
         .isCloseTo(amount, org.assertj.core.data.Offset.offset(BigDecimal.ONE));
+  }
+
+  @Test
+  void rebalance_whenModelNetDivergesFromFreeCash_warnsToCheckTheInputs() {
+    var input =
+        FundTransactionInput.builder()
+            .fund(TUV100)
+            .positions(
+                List.of(
+                    new PositionSnapshot("IE00A", new BigDecimal("600000")),
+                    new PositionSnapshot("IE00B", new BigDecimal("400000"))))
+            .modelWeights(
+                List.of(
+                    new ModelWeight("IE00A", new BigDecimal("0.50")),
+                    new ModelWeight("IE00B", new BigDecimal("0.50"))))
+            .grossPortfolioValue(new BigDecimal("1100000"))
+            .cashBuffer(ZERO)
+            .liabilities(ZERO)
+            .freeCash(new BigDecimal("40000"))
+            .minTransactionThreshold(new BigDecimal("5000"))
+            .positionLimits(Map.of())
+            .fastSellIsins(Set.of())
+            .build();
+
+    var result = engine.calculate(input, REBALANCE);
+
+    assertThat(result.warnings())
+        .extracting(CalculationWarning::type)
+        .containsExactly(REBALANCE_NET_CASH_MISMATCH);
+  }
+
+  @Test
+  void rebalance_whenModelNetMatchesFreeCash_raisesNoWarning() {
+    var input =
+        FundTransactionInput.builder()
+            .fund(TUV100)
+            .positions(
+                List.of(
+                    new PositionSnapshot("IE00A", new BigDecimal("600000")),
+                    new PositionSnapshot("IE00B", new BigDecimal("400000"))))
+            .modelWeights(
+                List.of(
+                    new ModelWeight("IE00A", new BigDecimal("0.50")),
+                    new ModelWeight("IE00B", new BigDecimal("0.50"))))
+            .grossPortfolioValue(new BigDecimal("1100000"))
+            .cashBuffer(ZERO)
+            .liabilities(ZERO)
+            .freeCash(new BigDecimal("100000"))
+            .minTransactionThreshold(new BigDecimal("5000"))
+            .positionLimits(Map.of())
+            .fastSellIsins(Set.of())
+            .build();
+
+    var result = engine.calculate(input, REBALANCE);
+
+    assertThat(result.warnings()).isEmpty();
+  }
+
+  @Test
+  void rebalance_whenTheGapIsExactlyTheMinTransactionThreshold_stillWarns() {
+    var input =
+        FundTransactionInput.builder()
+            .fund(TUV100)
+            .positions(
+                List.of(
+                    new PositionSnapshot("IE00A", new BigDecimal("600000")),
+                    new PositionSnapshot("IE00B", new BigDecimal("400000"))))
+            .modelWeights(
+                List.of(
+                    new ModelWeight("IE00A", new BigDecimal("0.50")),
+                    new ModelWeight("IE00B", new BigDecimal("0.50"))))
+            .grossPortfolioValue(new BigDecimal("1100000"))
+            .cashBuffer(ZERO)
+            .liabilities(ZERO)
+            .freeCash(new BigDecimal("95000"))
+            .minTransactionThreshold(new BigDecimal("5000"))
+            .positionLimits(Map.of())
+            .fastSellIsins(Set.of())
+            .build();
+
+    var result = engine.calculate(input, REBALANCE);
+
+    assertThat(result.warnings())
+        .extracting(CalculationWarning::type)
+        .containsExactly(REBALANCE_NET_CASH_MISMATCH);
+  }
+
+  @Test
+  void rebalance_whenAHardLimitBlocksPartOfTheBuySide_warnsTheNetWasNotAchieved() {
+    var input =
+        FundTransactionInput.builder()
+            .fund(TUV100)
+            .positions(
+                List.of(
+                    new PositionSnapshot("IE00A", new BigDecimal("100000")),
+                    new PositionSnapshot("IE00B", new BigDecimal("900000"))))
+            .modelWeights(
+                List.of(
+                    new ModelWeight("IE00A", new BigDecimal("0.50")),
+                    new ModelWeight("IE00B", new BigDecimal("0.50"))))
+            .grossPortfolioValue(new BigDecimal("1000000"))
+            .cashBuffer(ZERO)
+            .liabilities(ZERO)
+            .freeCash(ZERO)
+            .minTransactionThreshold(new BigDecimal("5000"))
+            .positionLimits(
+                Map.of(
+                    "IE00A",
+                    new PositionLimitSnapshot(new BigDecimal("0.20"), new BigDecimal("0.20"))))
+            .fastSellIsins(Set.of())
+            .build();
+
+    var result = engine.calculate(input, REBALANCE);
+
+    assertThat(result.warnings())
+        .extracting(CalculationWarning::type)
+        .containsExactly(REBALANCE_NET_NOT_ACHIEVED);
+  }
+
+  @Test
+  void buy_withANegativePositionMarketValue_failsLoudly() {
+    var input =
+        FundTransactionInput.builder()
+            .fund(TUV100)
+            .positions(List.of(new PositionSnapshot("IE00A", new BigDecimal("-500000"))))
+            .modelWeights(List.of(new ModelWeight("IE00A", new BigDecimal("1.00"))))
+            .grossPortfolioValue(new BigDecimal("1000000"))
+            .cashBuffer(ZERO)
+            .liabilities(ZERO)
+            .freeCash(new BigDecimal("100000"))
+            .minTransactionThreshold(new BigDecimal("5000"))
+            .positionLimits(Map.of())
+            .fastSellIsins(Set.of())
+            .build();
+
+    assertThatThrownBy(() -> engine.calculate(input, BUY))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void buy_withANegativeModelWeight_failsLoudly() {
+    var input =
+        FundTransactionInput.builder()
+            .fund(TUV100)
+            .positions(List.of(new PositionSnapshot("IE00A", new BigDecimal("500000"))))
+            .modelWeights(List.of(new ModelWeight("IE00A", new BigDecimal("-1.00"))))
+            .grossPortfolioValue(new BigDecimal("1000000"))
+            .cashBuffer(ZERO)
+            .liabilities(ZERO)
+            .freeCash(new BigDecimal("100000"))
+            .minTransactionThreshold(new BigDecimal("5000"))
+            .positionLimits(Map.of())
+            .fastSellIsins(Set.of())
+            .build();
+
+    assertThatThrownBy(() -> engine.calculate(input, BUY))
+        .isInstanceOf(IllegalArgumentException.class);
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/export/ExportFileTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/export/ExportFileTest.java
@@ -1,0 +1,40 @@
+package ee.tuleva.onboarding.investment.transaction.export;
+
+import static ee.tuleva.onboarding.fund.TulevaFund.TKF100;
+import static ee.tuleva.onboarding.investment.transaction.export.ExportFile.GENERIC_ORDERS;
+import static ee.tuleva.onboarding.investment.transaction.export.ExportFile.SEB_FUND;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+
+class ExportFileTest {
+
+  private static final Instant TIMESTAMP = Instant.parse("2026-08-10T09:05:03Z");
+
+  @Test
+  void theSebFundFileIsServedAsCsv() {
+    assertThat(SEB_FUND.mimeType()).isEqualTo("text/csv");
+    assertThat(SEB_FUND.downloadFileName(42L)).isEqualTo("batch-42-sebFundXlsx.csv");
+    assertThat(SEB_FUND.fileName(TKF100, TIMESTAMP))
+        .isEqualTo("SEB_TKF100_indeksfondid_2026-08-10T09_05_03.csv");
+    assertThat(SEB_FUND.driveLabel()).isEqualTo("SEB indeksfondid");
+  }
+
+  @Test
+  void onlyTheFilesThatGoToABrokerAreListedAsBrokerFiles() {
+    assertThat(ExportFile.brokerFiles()).doesNotContain(GENERIC_ORDERS);
+    assertThat(ExportFile.byMetadataKey("sebFundXlsx")).contains(SEB_FUND);
+    assertThat(ExportFile.byMetadataKey("nothingLikeThis")).isEmpty();
+  }
+
+  // The internal workbook is never uploaded anywhere, so asking it for a broker name or a Drive
+  // folder is a programming error rather than a missing value to paper over.
+  @Test
+  void theInternalWorkbookRefusesToInventABrokerFileNameOrADriveLabel() {
+    assertThatThrownBy(() -> GENERIC_ORDERS.fileName(TKF100, TIMESTAMP))
+        .isInstanceOf(IllegalStateException.class);
+    assertThatThrownBy(GENERIC_ORDERS::driveLabel).isInstanceOf(IllegalStateException.class);
+  }
+}

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/QuantityAmountMismatchAlertListenerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/QuantityAmountMismatchAlertListenerTest.java
@@ -9,7 +9,11 @@ import static ee.tuleva.onboarding.investment.transaction.OrderVenue.SEB;
 import static ee.tuleva.onboarding.investment.transaction.TransactionType.BUY;
 import static ee.tuleva.onboarding.notification.OperationsNotificationService.Channel.INVESTMENT;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.verify;
 
 import com.microtripit.mandrillapp.lutung.view.MandrillMessage;
@@ -44,8 +48,7 @@ class QuantityAmountMismatchAlertListenerTest {
 
   @Test
   void onQuantityAmountMismatch_sendsSlackNotificationWithKeyDetails() {
-    given(emailService.sendSystemEmail(org.mockito.ArgumentMatchers.any(MandrillMessage.class)))
-        .willReturn(true);
+    given(emailService.sendSystemEmail(any(MandrillMessage.class))).willReturn(true);
 
     listener().onQuantityAmountMismatch(sampleEvent());
 
@@ -60,8 +63,7 @@ class QuantityAmountMismatchAlertListenerTest {
 
   @Test
   void onQuantityAmountMismatch_sendsSystemEmailWithSubjectAndBody() {
-    given(emailService.sendSystemEmail(org.mockito.ArgumentMatchers.any(MandrillMessage.class)))
-        .willReturn(true);
+    given(emailService.sendSystemEmail(any(MandrillMessage.class))).willReturn(true);
 
     QuantityAmountMismatchEvent event = sampleEvent();
     UUID clientRef = event.row().clientRef();
@@ -95,6 +97,37 @@ class QuantityAmountMismatchAlertListenerTest {
         .contains("Our ref: DLA0799512")
         .contains("Side: BUY")
         .contains("Client name: Tuleva Täiendav Kogumisfond");
+  }
+
+  @Test
+  void onQuantityAmountMismatch_stillSendsTheEmailWhenSlackIsDown() {
+    given(emailService.sendSystemEmail(any(MandrillMessage.class))).willReturn(true);
+    willThrow(new IllegalStateException())
+        .given(notificationService)
+        .sendMessage(anyString(), any());
+
+    listener().onQuantityAmountMismatch(sampleEvent());
+
+    verify(emailService).sendSystemEmail(any(MandrillMessage.class));
+  }
+
+  @Test
+  void onQuantityAmountMismatch_survivesAnEmailThatWasNotAccepted() {
+    given(emailService.sendSystemEmail(any(MandrillMessage.class))).willReturn(false);
+
+    listener().onQuantityAmountMismatch(sampleEvent());
+
+    verify(notificationService).sendMessage(anyString(), eq(INVESTMENT));
+  }
+
+  @Test
+  void onQuantityAmountMismatch_survivesAMandrillFailureInsteadOfKillingTheListener() {
+    given(emailService.sendSystemEmail(any(MandrillMessage.class)))
+        .willThrow(new IllegalStateException());
+
+    listener().onQuantityAmountMismatch(sampleEvent());
+
+    verify(notificationService).sendMessage(anyString(), eq(INVESTMENT));
   }
 
   private static QuantityAmountMismatchEvent sampleEvent() {

--- a/src/test/resources/db/snapshots/transaction-pipeline/TKF100_2026-02-10.sql
+++ b/src/test/resources/db/snapshots/transaction-pipeline/TKF100_2026-02-10.sql
@@ -2,9 +2,18 @@
 -- Exported by export-snapshot.sh on 2026-02-23
 
 -- investment_fund_position (cash balance)
-INSERT INTO investment_fund_position (nav_date, fund_code, account_type, account_name, market_value, currency, created_at)
+INSERT INTO investment_fund_position (nav_date, fund_code, account_type, account_name, account_id, quantity, market_price, market_value, currency, created_at)
 VALUES
-  (DATE '2026-02-10', 'TKF100', 'CASH', 'Cash account in SEB Pank', 496296.85, 'EUR', CURRENT_TIMESTAMP);
+  (DATE '2026-02-10', 'TKF100', 'CASH', 'Cash account in SEB Pank', NULL, NULL, NULL, 500000.00, 'EUR', CURRENT_TIMESTAMP),
+  (DATE '2026-02-10', 'TKF100', 'SECURITY', 'IE000F60HVH9', 'IE000F60HVH9', 11000.000000, 100.00, 1100000.00, 'EUR', CURRENT_TIMESTAMP),
+  (DATE '2026-02-10', 'TKF100', 'SECURITY', 'IE000O58J820', 'IE000O58J820', 14000.000000, 50.00, 700000.00, 'EUR', CURRENT_TIMESTAMP),
+  (DATE '2026-02-10', 'TKF100', 'SECURITY', 'IE00BFG1TM61', 'IE00BFG1TM61', 45000.000000, 20.00, 900000.00, 'EUR', CURRENT_TIMESTAMP),
+  (DATE '2026-02-10', 'TKF100', 'SECURITY', 'IE00BJZ2DC62', 'IE00BJZ2DC62', 10000.000000, 105.00, 1050000.00, 'EUR', CURRENT_TIMESTAMP),
+  (DATE '2026-02-10', 'TKF100', 'SECURITY', 'IE00BMDBMY19', 'IE00BMDBMY19', 10000.000000, 45.00, 450000.00, 'EUR', CURRENT_TIMESTAMP),
+  (DATE '2026-02-10', 'TKF100', 'SECURITY', 'LU0476289540', 'LU0476289540', 4000.000000, 25.00, 100000.00, 'EUR', CURRENT_TIMESTAMP),
+  (DATE '2026-02-10', 'TKF100', 'SECURITY', 'LU1291099718', 'LU1291099718', 5000.000000, 80.00, 400000.00, 'EUR', CURRENT_TIMESTAMP),
+  (DATE '2026-02-10', 'TKF100', 'SECURITY', 'LU1291102447', 'LU1291102447', 5000.000000, 40.00, 200000.00, 'EUR', CURRENT_TIMESTAMP),
+  (DATE '2026-02-10', 'TKF100', 'SECURITY', 'LU1291106356', 'LU1291106356', 10000.000000, 10.00, 100000.00, 'EUR', CURRENT_TIMESTAMP);
 
 -- investment_fee_accrual
 INSERT INTO investment_fee_accrual (fund_code, fee_type, accrual_date, fee_month, base_value, annual_rate, daily_amount_net, daily_amount_gross, vat_rate, days_in_year, reference_date)
@@ -92,3 +101,16 @@ VALUES
 -- index_values (NAV)
 INSERT INTO index_values (key, date, value, provider, updated_at)
 VALUES ('EE0000003283', DATE '2026-02-20', 1.00320, 'MANUAL', TIMESTAMP '2026-02-23 13:54:44');
+
+-- index_values (instrument prices used to size ETF quantities)
+INSERT INTO index_values (key, date, value, provider, updated_at)
+VALUES
+  ('ESGM.DE', DATE '2026-02-10', 45.00000, 'EODHD', TIMESTAMP '2026-02-10 20:00:00'),
+  ('XRSM.DE', DATE '2026-02-10', 105.00000, 'EODHD', TIMESTAMP '2026-02-10 20:00:00'),
+  ('D5BH.DE', DATE '2026-02-10', 25.00000, 'EODHD', TIMESTAMP '2026-02-10 20:00:00'),
+  ('V3YA.DE', DATE '2026-02-10', 50.00000, 'EODHD', TIMESTAMP '2026-02-10 20:00:00'),
+  ('EEUX.DE', DATE '2026-02-10', 80.00000, 'EODHD', TIMESTAMP '2026-02-10 20:00:00'),
+  ('PAC.DE', DATE '2026-02-10', 10.00000, 'EODHD', TIMESTAMP '2026-02-10 20:00:00'),
+  ('EJAP.DE', DATE '2026-02-10', 40.00000, 'EODHD', TIMESTAMP '2026-02-10 20:00:00'),
+  ('USAS.PA', DATE '2026-02-10', 100.00000, 'EODHD', TIMESTAMP '2026-02-10 20:00:00'),
+  ('0P000152G5.F', DATE '2026-02-10', 20.00000, 'EODHD', TIMESTAMP '2026-02-10 20:00:00');


### PR DESCRIPTION
Closes every remaining **code** item tracked in `Transaction Registry — Status & Open Items` (§4.3, §4.8, §4.9, §4.11, §4.12). After this, what is left in that doc is operational: the §4.13 post-deploy tasks, the operator runbook, and the cutover itself.

## P5 — Rebalance operator cash warnings (§4.12, the one open Java item)

`calculateRebalance` produced correct trades but never compared them against `freeCash` and logged nothing, so an un-achievable rebalance passed silently. Ported the two GAS `calculateMode4` warnings:

- **`REBALANCE_NET_CASH_MISMATCH`** — the model's net cash need does not match free cash → the position snapshot, cash figure or model weights are stale. *Check the inputs.*
- **`REBALANCE_NET_NOT_ACHIEVED`** — the net actually achieved diverges from the intended net → a limit or the min-trade threshold blocked part of the rebalance; the operation needed may be a **Sell**, not a Rebalance.

Both compare with **`≥ threshold`, never `>`** (R3 fencepost — a miss of exactly min-trade size must warn), with a boundary test proving it. Warnings ride on `FundCalculationResult` into the `CALCULATION_COMPLETED` payload as `calculationWarnings`, so they appear on the snapshot the operator reviews *before* sending. They are **not** wired to Slack or email.

The GAS `sellTotal`/`buyTotal` clamp is deliberately **not** ported: Java's targets are built on `normalizedTargetValues` over `netInvestable`, so the net is right by construction.

⚠️ **Read before the flag-flip.** In production `intendedNet − freeCash` is structurally equal to `pendingCash.net()`: `TransactionInputService` subtracts pending cash from `freeCash` but not from `liabilities`, so `netInvestable` ignores cash already committed to unsettled trades. W1 therefore fires whenever a REBALANCE runs while a directional BUY/SELL batch is still unsettled. That is a **true positive** — a rebalance sized that way plans to spend committed cash — but it surfaces a modelling gap rather than fixing it. Worth a decision after a few real cycles.

## R3 — per-operator admin tokens (§4.3)

`X-Admin-Actor` was `required = false, defaultValue = "admin"` on seven endpoints, and since every caller shared one `X-Admin-Token`, the actor was **self-declared and forgeable** — a token holder could file an action under a colleague's name.

The header is **deleted**. The audited actor is now derived from the token itself via `AdminTokenAuthenticator`:

- a token in `admin.operator-tokens` resolves to that operator's name;
- the existing shared `admin.api-token` still authenticates, but audits as the explicit identity `shared-admin-token` — visibly unattributed rather than silently masquerading as a person;
- an unknown token is 401; no tokens configured at all is 503 (unchanged).

Comparison stays constant-time. A **blank** operator token now fails at startup rather than matching an empty header — a test caught that hole. Ops config: `ADMIN_OPERATORTOKENS_<NAME>=<token>`, documented in `application.yml`.

Deploys with **zero config change** — everything keeps working, attributed as `shared-admin-token`, until per-operator tokens are added. No live caller sends `X-Admin-Actor` today (the GAS FT push relies on the default), so nothing breaks. At §4.1 M5 the shared token and its fallback identity can be deleted outright.

## Export file identity (§4.11)

`downloadExport` hardcoded xlsx MIME + an `.xlsx` filename for **every** type, so the SEB fund order file downloaded as an `.xlsx`-named, xlsx-MIME'd file containing `;`-CSV. #1787 fixed the writer, the email MIME, the Drive content type and both `FILE_NAME_*` maps but missed this fourth consumer. It bites exactly now, while the custodian email is inert and operators forward downloads by hand.

Fixed via a single `ExportFile` enum owning metadata key → MIME → filename → drive label, replacing the two duplicated `FILE_NAME_GENERATORS` maps plus `MIME_TYPES`, `EXPORT_TYPES` and `DRIVE_URL_LABELS`. Unknown export types now 404. Side effect: attachment/upload/Slack-link ordering becomes deterministic (was `Map.of` iteration order).

## Calculation audit residuals (§4.9)

- `serializeTrade` now records the **price** the quantity was sized on (was recoverable only by joining `priceResolutions`).
- New `modelDrift` block: per position `targetWeight` / `weightBefore` / `weightAfter` / `driftBefore` / `driftAfter`, plus `totalAbsoluteDriftBefore` / `After`. Item 6's point was to store drift, not rely on re-derivation.

## R7 — engine input validation (§4.12)

`TradeCalculationEngine` validated nothing on entry. Now rejects negative position market values, negative model weights and a negative gross portfolio value before calculating.

## TransactionPipelineIntegrationTest — repaired and re-enabled (§4.11)

It was `@Disabled` since `855da66bb`, and the cause was worse than the "stale FT column indices" the status doc assumed: **the snapshot never contained a single SECURITY position row.** That commit migrated `TransactionInputService` from `investment_position_calculation` to `FundPositionRepository`, wrote a new snapshot holding only the CASH row, and disabled the test in the same commit. With no positions every mode returned zero trades. Its expectations were also internally inconsistent — `min_transaction` is €50,000 while the expected trades included €1,675.

Rebuilt coherently:
- 9 SECURITY rows with round synthetic values (Σ €5,000,000) and `index_values` prices so ETF quantities resolve;
- expectations re-derived from that data — 6 orders, with the two smallest-weight instruments correctly sitting at model and not trading;
- exact-amount assertions replaced with **relationships**: ISIN × side × instrument type × venue, and the SEB fund file's amount and `Original reference` asserted against the order it was generated from. The engine's arithmetic is already covered by 58 unit tests; this test's job is pipeline wiring.
- FT sheet assertions moved to the real post-#1787 11-column layout (ISIN at col 6, control total at col 7, no `FT` preamble row) — the originally-suspected problem, now also fixed;
- the BUY "no orders below reserve" case now drives cash explicitly through the operator cash override instead of relying on an accident.

## Smaller items

- **Irish holidays (§4.8)** — St Brigid's Day was applied to **all** years though it only recurs from 2023, and the one-off 2022-03-18 holiday was missing, so backfilled FUND settlement dates around Feb–Mar 2022 could be off by a business day. Year-guarded and added.
- **N2 (§4.3)** — the mismatch-alert email send was uncaught while Slack was wrapped; a Mandrill throw took out the listener. Now wrapped and logged.

## Not included

**GAS L43 off-by-one** — different repo, shipped as TulevaEE/tuleva#235.

## Test plan

- 6 new engine tests (W1, W1-clean, exact-threshold boundary, W2 via hard limit, two R7 guards) — `TradeCalculationEngineTest` 58/58.
- 6 new `AdminTokenAuthenticatorTest` cases incl. the blank-token startup guard.
- 2 new controller tests (SEB fund file served as `text/csv` with a `.csv` name; unknown type → 404); both controller suites updated for token-derived actors.
- 3 new serializer tests (per-trade price, model drift, calculation warnings).
- 4 new Irish holiday rows — `DomicileCalendarSpec` 57/57.
- `TransactionPipelineIntegrationTest` 6/6, enabled.
- `./gradlew build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)