### PR TITLE
Start an all-time portfolio at the person's first holding

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/account/portfolio/PortfolioController.java
+++ b/src/main/java/ee/tuleva/onboarding/account/portfolio/PortfolioController.java
@@ -22,8 +22,6 @@ import org.springframework.web.server.ResponseStatusException;
 @RequiredArgsConstructor
 public class PortfolioController {
 
-  private static final LocalDate BEGINNING_OF_TIMES = LocalDate.parse("2003-01-07");
-
   private final PortfolioService portfolioService;
   private final Clock clock;
 
@@ -33,12 +31,11 @@ public class PortfolioController {
       @AuthenticationPrincipal AuthenticatedPerson person,
       @RequestParam(required = false) @DateTimeFormat(iso = DATE) @Nullable LocalDate from,
       @RequestParam(required = false) @DateTimeFormat(iso = DATE) @Nullable LocalDate to) {
-    var startDate = from == null ? BEGINNING_OF_TIMES : from;
     var endDate = to == null ? LocalDate.now(clock) : to;
-    if (startDate.isAfter(endDate)) {
+    if (from != null && from.isAfter(endDate)) {
       throw new ResponseStatusException(
-          BAD_REQUEST, "Invalid portfolio period: from=" + startDate + ", to=" + endDate);
+          BAD_REQUEST, "Invalid portfolio period: from=" + from + ", to=" + endDate);
     }
-    return portfolioService.getPortfolio(person, startDate, endDate);
+    return portfolioService.getPortfolio(person, from, endDate);
   }
 }

--- a/src/main/java/ee/tuleva/onboarding/account/portfolio/PortfolioService.java
+++ b/src/main/java/ee/tuleva/onboarding/account/portfolio/PortfolioService.java
@@ -2,6 +2,7 @@ package ee.tuleva.onboarding.account.portfolio;
 
 import static ee.tuleva.onboarding.account.portfolio.PortfolioGroup.SECOND_PILLAR;
 import static ee.tuleva.onboarding.account.portfolio.PortfolioGroup.THIRD_PILLAR;
+import static java.util.Comparator.naturalOrder;
 import static java.util.stream.Collectors.toMap;
 
 import ee.tuleva.onboarding.account.transaction.Transaction;
@@ -24,6 +25,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.Nullable;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -44,22 +46,31 @@ public class PortfolioService {
   private final ReturnsService returnsService;
   private final FundNavProvider fundNavProvider;
 
-  public Portfolio getPortfolio(AuthenticatedPerson person, LocalDate from, LocalDate to) {
+  public Portfolio getPortfolio(
+      AuthenticatedPerson person, @Nullable LocalDate from, LocalDate to) {
     List<Transaction> transactions = transactionService.getTransactions(person);
+    LocalDate startDate = from == null ? firstHoldingDate(transactions, to) : from;
     Map<String, PortfolioGroup> groupByIsin = groupByIsin();
     Set<String> heldIsins = PortfolioValuation.heldIsins(transactions, groupByIsin);
 
     PortfolioValuation valuation =
-        new PortfolioValuation(transactions, groupByIsin, navHistory(heldIsins, from, to));
+        new PortfolioValuation(transactions, groupByIsin, navHistory(heldIsins, startDate, to));
     List<PortfolioGroup> groups = valuation.heldGroups();
-    Map<PortfolioGroup, BigDecimal> rates = annualReturnRates(person, groups, from, to);
+    Map<PortfolioGroup, BigDecimal> rates = annualReturnRates(person, groups, startDate, to);
 
     return Portfolio.builder()
-        .from(from)
+        .from(startDate)
         .to(to)
-        .groups(summaries(valuation, groups, rates, from, to))
-        .series(valuation.series(from, to))
+        .groups(summaries(valuation, groups, rates, startDate, to))
+        .series(valuation.series(startDate, to))
         .build();
+  }
+
+  private static LocalDate firstHoldingDate(List<Transaction> transactions, LocalDate to) {
+    return transactions.stream()
+        .map(PortfolioValuation::pricingDayOf)
+        .min(naturalOrder())
+        .orElse(to);
   }
 
   private static List<Portfolio.GroupSummary> summaries(

--- a/src/main/java/ee/tuleva/onboarding/account/portfolio/PortfolioValuation.java
+++ b/src/main/java/ee/tuleva/onboarding/account/portfolio/PortfolioValuation.java
@@ -81,7 +81,7 @@ public class PortfolioValuation {
     return byIsin;
   }
 
-  private static LocalDate pricingDayOf(Transaction transaction) {
+  static LocalDate pricingDayOf(Transaction transaction) {
     return transaction.priceTime().atZone(ESTONIAN_ZONE).toLocalDate();
   }
 

--- a/src/test/groovy/ee/tuleva/onboarding/account/portfolio/PortfolioControllerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/account/portfolio/PortfolioControllerTest.java
@@ -71,18 +71,18 @@ class PortfolioControllerTest {
   }
 
   @Test
-  void defaultsToTheBeginningOfTimesAndToday() throws Exception {
-    LocalDate from = LocalDate.parse("2003-01-07");
+  void leavesTheStartOfAnAllTimePeriodToTheServiceAndEndsItToday() throws Exception {
+    LocalDate firstHolding = LocalDate.parse("2019-03-05");
     LocalDate to = LocalDate.parse("2020-01-01");
 
     when(clock.instant()).thenReturn(TestClockHolder.now);
     when(clock.getZone()).thenReturn(UTC);
-    when(portfolioService.getPortfolio(eq(authPerson), eq(from), eq(to)))
-        .thenReturn(portfolio(from, to));
+    when(portfolioService.getPortfolio(eq(authPerson), eq(null), eq(to)))
+        .thenReturn(portfolio(firstHolding, to));
 
     mvc.perform(get("/v1/portfolio").with(authentication(authentication)))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$.from").value("2003-01-07"))
+        .andExpect(jsonPath("$.from").value("2019-03-05"))
         .andExpect(jsonPath("$.to").value("2020-01-01"));
   }
 

--- a/src/test/groovy/ee/tuleva/onboarding/account/portfolio/PortfolioServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/account/portfolio/PortfolioServiceTest.java
@@ -46,6 +46,7 @@ class PortfolioServiceTest {
   private static final LocalDate FROM = LocalDate.parse("2025-01-01");
   private static final LocalDate TO = LocalDate.parse("2025-12-31");
   private static final LocalDate FAR_FUTURE = LocalDate.parse("9999-12-31");
+  private static final LocalDate FIRST_HOLDING = LocalDate.parse("2019-03-05");
 
   @Mock private TransactionService transactionService;
   @Mock private FundRepository fundRepository;
@@ -101,6 +102,26 @@ class PortfolioServiceTest {
                     .to(TO)
                     .build()))
         .build();
+  }
+
+  @Test
+  void startsAnAllTimePeriodAtTheFirstDayAnythingWasHeld() {
+    given(transactionService.getTransactions(person))
+        .willReturn(List.of(buy(PILLAR_2, "2019-03-05T10:00:00Z", "100", "2")));
+    given(fundRepository.findAll())
+        .willReturn(List.of(Fund.builder().isin(PILLAR_2).pillar(2).build()));
+    given(fundValueRepository.getLatestValue(any(), any())).willReturn(Optional.empty());
+    given(fundValueRepository.findValuesBetweenDates(eq(PILLAR_2), eq(FIRST_HOLDING), eq(TO)))
+        .willReturn(
+            List.of(
+                fundValue(PILLAR_2, "2019-03-05", "2"), fundValue(PILLAR_2, "2025-12-31", "3")));
+    given(returnsService.get(eq(person), eq(FIRST_HOLDING), eq(TO), any()))
+        .willReturn(personalReturn(PersonalReturnProvider.SECOND_PILLAR, "0.0712"));
+
+    Portfolio portfolio = portfolioService.getPortfolio(person, null, TO);
+
+    assertThat(portfolio.from()).isEqualTo(FIRST_HOLDING);
+    assertThat(portfolio.series().getFirst().date()).isEqualTo(FIRST_HOLDING);
   }
 
   @Test


### PR DESCRIPTION
## What

An absent `from` on `GET /v1/portfolio` became `2003-01-07` — the start of the Estonian II pillar — regardless of when the person actually started saving. The chart therefore opened on a flat zero line running from years before they held anything.

All time is now the person's own history: with no start date given, the period begins on the first day they held something, and the resolved date is what the response reports back in `from`, so the client's date box shows where the history really begins.

## Why it drew a zero line rather than nothing

`pricingDates(from, to)` returns every day any ever-held ISIN has a published price, with no check that units were held yet, and `unitsAt` returns `ZERO` for those days. So an old fund's price history alone was enough to draw a decade of zeroes.

## Notes for review

- `PortfolioValuation.pricingDayOf` became package-private (not public) — `PortfolioService` is in the same package.
- Someone with no transactions at all has no history to start from, so the period collapses to `to` and the series is empty.
- The `from` after `to` check now only applies when a start date was actually given.

## Performance

No new queries. `firstHoldingDate` streams transactions already loaded for the valuation. The change makes the endpoint cheaper: `findValuesBetweenDates` now scans from the first holding instead of 2003, and the series JSON loses every zero-valued point before it.

## Merge order

Independent of the client PR, but the fix is only visible once this is deployed — the client sends no start date for "all time".

🤖 Generated with [Claude Code](https://claude.com/claude-code)