### PR TITLE
Restore unique enforcement for system ledger accounts

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/ledger/LedgerAccountService.java
+++ b/src/main/java/ee/tuleva/onboarding/ledger/LedgerAccountService.java
@@ -83,14 +83,27 @@ class LedgerAccountService {
   }
 
   LedgerAccount createSystemAccount(String name, AccountType accountType, AssetType assetType) {
-    var ledgerAccount =
-        LedgerAccount.builder()
-            .name(name)
-            .purpose(SYSTEM_ACCOUNT)
-            .assetType(assetType)
-            .accountType(accountType)
-            .build();
+    insertSystemAccountIfAbsent(name, accountType, assetType);
+    return findSystemAccountByName(name, accountType, assetType).orElseThrow();
+  }
 
-    return ledgerAccountRepository.save(ledgerAccount);
+  private void insertSystemAccountIfAbsent(
+      String name, AccountType accountType, AssetType assetType) {
+    jdbcClient
+        .sql(
+            """
+            INSERT INTO ledger.account (id, name, purpose, account_type, asset_type)
+            VALUES (:id, :name,
+                    CAST(:purpose AS ledger.account_purpose),
+                    CAST(:accountType AS ledger.account_type),
+                    CAST(:assetType AS ledger.asset_type))
+            ON CONFLICT DO NOTHING
+            """)
+        .param("id", UUID.randomUUID())
+        .param("name", name)
+        .param("purpose", SYSTEM_ACCOUNT.name())
+        .param("accountType", accountType.name())
+        .param("assetType", assetType.name())
+        .update();
   }
 }

--- a/src/main/resources/db/migration/V1_238__enforce_system_account_uniqueness.sql
+++ b/src/main/resources/db/migration/V1_238__enforce_system_account_uniqueness.sql
@@ -1,0 +1,5 @@
+DROP INDEX ledger.ux_account_owner_name;
+
+ALTER TABLE ledger.account
+  ADD CONSTRAINT ux_account_owner_name
+    UNIQUE NULLS NOT DISTINCT (owner_party_id, name, purpose, asset_type, account_type);

--- a/src/test/groovy/ee/tuleva/onboarding/ledger/LedgerAccountServiceIntegrationTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/ledger/LedgerAccountServiceIntegrationTest.java
@@ -1,5 +1,7 @@
 package ee.tuleva.onboarding.ledger;
 
+import static ee.tuleva.onboarding.ledger.LedgerAccount.AccountType.ASSET;
+import static ee.tuleva.onboarding.ledger.LedgerAccount.AssetType.EUR;
 import static ee.tuleva.onboarding.ledger.LedgerParty.PartyType.LEGAL_ENTITY;
 import static ee.tuleva.onboarding.ledger.UserAccount.SUBSCRIPTIONS;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -14,6 +16,8 @@ import org.springframework.jdbc.core.simple.JdbcClient;
 @DataJpaTest
 @Import({LedgerAccountService.class, LedgerPartyService.class})
 class LedgerAccountServiceIntegrationTest {
+
+  private static final String SYSTEM_ACCOUNT_NAME = "TEST_SYSTEM_ACCOUNT";
 
   @Autowired LedgerAccountService ledgerAccountService;
   @Autowired LedgerPartyService ledgerPartyService;
@@ -52,6 +56,19 @@ class LedgerAccountServiceIntegrationTest {
     assertThat(accountCount(party, SUBSCRIPTIONS)).isEqualTo(1);
   }
 
+  @Test
+  void createSystemAccount_returnsExistingAccountWithoutCreatingDuplicate() {
+    LedgerAccount first = ledgerAccountService.createSystemAccount(SYSTEM_ACCOUNT_NAME, ASSET, EUR);
+    LedgerAccount second =
+        ledgerAccountService.createSystemAccount(SYSTEM_ACCOUNT_NAME, ASSET, EUR);
+
+    assertThat(second.getId()).isEqualTo(first.getId());
+    assertThat(systemAccountCount(SYSTEM_ACCOUNT_NAME)).isEqualTo(1);
+    assertThat(ledgerAccountService.findSystemAccountByName(SYSTEM_ACCOUNT_NAME, ASSET, EUR))
+        .map(LedgerAccount::getId)
+        .contains(first.getId());
+  }
+
   private long accountCount(LedgerParty owner, UserAccount userAccount) {
     return jdbcClient
         .sql(
@@ -59,6 +76,14 @@ class LedgerAccountServiceIntegrationTest {
                 + " WHERE owner_party_id = :ownerPartyId AND name = :name")
         .param("ownerPartyId", owner.getId())
         .param("name", userAccount.name())
+        .query(Long.class)
+        .single();
+  }
+
+  private long systemAccountCount(String name) {
+    return jdbcClient
+        .sql("SELECT count(*) FROM ledger.account WHERE name = :name AND owner_party_id IS NULL")
+        .param("name", name)
         .query(Long.class)
         .single();
   }

--- a/src/test/groovy/ee/tuleva/onboarding/ledger/LedgerSystemAccountConcurrencyIntegrationTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/ledger/LedgerSystemAccountConcurrencyIntegrationTest.java
@@ -1,0 +1,103 @@
+package ee.tuleva.onboarding.ledger;
+
+import static ee.tuleva.onboarding.ledger.LedgerAccount.AccountType.ASSET;
+import static ee.tuleva.onboarding.ledger.LedgerAccount.AssetType.EUR;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.simple.JdbcClient;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@SpringBootTest
+@TestPropertySource(properties = "spring.datasource.hikari.maximum-pool-size=20")
+class LedgerSystemAccountConcurrencyIntegrationTest {
+
+  @Autowired LedgerAccountService ledgerAccountService;
+  @Autowired JdbcClient jdbcClient;
+  @Autowired DataSource dataSource;
+  @Autowired PlatformTransactionManager transactionManager;
+
+  @Test
+  void concurrentGetOrCreateOfSameSystemAccount_createsExactlyOneAccount() throws Exception {
+    assumeTrue(isPostgres(), "The get-or-create race only reproduces on PostgreSQL");
+
+    String name = "CONCURRENT_SYSTEM_ACCOUNT:" + UUID.randomUUID();
+    int threads = 16;
+    TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);
+    ExecutorService pool = Executors.newFixedThreadPool(threads);
+    CyclicBarrier barrier = new CyclicBarrier(threads);
+    List<Throwable> errors = new CopyOnWriteArrayList<>();
+    List<Future<?>> futures = new ArrayList<>();
+
+    long accounts;
+    try {
+      for (int i = 0; i < threads; i++) {
+        futures.add(
+            pool.submit(
+                () -> {
+                  try {
+                    barrier.await();
+                    transactionTemplate.executeWithoutResult(status -> getOrCreate(name));
+                  } catch (Throwable t) {
+                    errors.add(t);
+                  }
+                  return null;
+                }));
+      }
+      for (Future<?> future : futures) {
+        future.get(60, SECONDS);
+      }
+      accounts = systemAccountCount(name);
+    } finally {
+      pool.shutdownNow();
+      pool.awaitTermination(10, SECONDS);
+      deleteSystemAccounts(name);
+    }
+
+    assertThat(errors).isEmpty();
+    assertThat(accounts).isEqualTo(1);
+  }
+
+  private LedgerAccount getOrCreate(String name) {
+    return ledgerAccountService
+        .findSystemAccountByName(name, ASSET, EUR)
+        .orElseGet(() -> ledgerAccountService.createSystemAccount(name, ASSET, EUR));
+  }
+
+  private boolean isPostgres() throws SQLException {
+    try (var connection = dataSource.getConnection()) {
+      return connection.getMetaData().getDatabaseProductName().toLowerCase().contains("postgresql");
+    }
+  }
+
+  private long systemAccountCount(String name) {
+    return jdbcClient
+        .sql("SELECT count(*) FROM ledger.account WHERE name = :name AND owner_party_id IS NULL")
+        .param("name", name)
+        .query(Long.class)
+        .single();
+  }
+
+  private void deleteSystemAccounts(String name) {
+    jdbcClient
+        .sql("DELETE FROM ledger.account WHERE name = :name AND owner_party_id IS NULL")
+        .param("name", name)
+        .update();
+  }
+}

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/nav/NavCalculationIntegrationTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/nav/NavCalculationIntegrationTest.java
@@ -4,6 +4,7 @@ import static ee.tuleva.onboarding.auth.UserFixture.sampleUser;
 import static ee.tuleva.onboarding.fund.TulevaFund.TKF100;
 import static ee.tuleva.onboarding.fund.TulevaFund.TUK75;
 import static ee.tuleva.onboarding.investment.position.AccountType.NAV;
+import static ee.tuleva.onboarding.ledger.LedgerAccount.AccountPurpose.SYSTEM_ACCOUNT;
 import static ee.tuleva.onboarding.ledger.LedgerAccount.AssetType.EUR;
 import static ee.tuleva.onboarding.ledger.LedgerAccount.AssetType.FUND_UNIT;
 import static ee.tuleva.onboarding.ledger.LedgerParty.PartyType.PERSON;
@@ -402,23 +403,9 @@ class NavCalculationIntegrationTest {
 
   private void createSecuritiesUnitBalance(
       TulevaFund fund, String isin, BigDecimal units, Instant transactionDate) {
-    var securitiesUnitsAccount =
-        LedgerAccount.builder()
-            .name(SECURITIES_UNITS.getAccountName(fund, isin))
-            .purpose(LedgerAccount.AccountPurpose.SYSTEM_ACCOUNT)
-            .accountType(SECURITIES_UNITS.getAccountType())
-            .assetType(SECURITIES_UNITS.getAssetType())
-            .build();
-    entityManager.persist(securitiesUnitsAccount);
-
+    var securitiesUnitsAccount = getOrCreateInstrumentAccount(SECURITIES_UNITS, fund, isin);
     var securitiesUnitsEquityAccount =
-        LedgerAccount.builder()
-            .name(SECURITIES_UNITS_EQUITY.getAccountName(fund, isin))
-            .purpose(LedgerAccount.AccountPurpose.SYSTEM_ACCOUNT)
-            .accountType(SECURITIES_UNITS_EQUITY.getAccountType())
-            .assetType(SECURITIES_UNITS_EQUITY.getAssetType())
-            .build();
-    entityManager.persist(securitiesUnitsEquityAccount);
+        getOrCreateInstrumentAccount(SECURITIES_UNITS_EQUITY, fund, isin);
 
     var transaction =
         LedgerTransaction.builder()
@@ -445,6 +432,40 @@ class NavCalculationIntegrationTest {
     transaction.getEntries().add(entry);
     transaction.getEntries().add(counterEntry);
     entityManager.persist(transaction);
+  }
+
+  private LedgerAccount getOrCreateInstrumentAccount(
+      SystemAccount systemAccount, TulevaFund fund, String isin) {
+    String name = systemAccount.getAccountName(fund, isin);
+    return entityManager
+        .createQuery(
+            """
+            SELECT a FROM LedgerAccount a
+            WHERE a.name = :name
+              AND a.purpose = :purpose
+              AND a.accountType = :accountType
+              AND a.assetType = :assetType
+            """,
+            LedgerAccount.class)
+        .setParameter("name", name)
+        .setParameter("purpose", SYSTEM_ACCOUNT)
+        .setParameter("accountType", systemAccount.getAccountType())
+        .setParameter("assetType", systemAccount.getAssetType())
+        .getResultStream()
+        .findFirst()
+        .orElseGet(() -> persistSystemAccount(systemAccount, name));
+  }
+
+  private LedgerAccount persistSystemAccount(SystemAccount systemAccount, String name) {
+    var account =
+        LedgerAccount.builder()
+            .name(name)
+            .purpose(SYSTEM_ACCOUNT)
+            .accountType(systemAccount.getAccountType())
+            .assetType(systemAccount.getAssetType())
+            .build();
+    entityManager.persist(account);
+    return account;
   }
 
   private void createSystemAccountBalance(

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/report/TrusteeReportRepositoryTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/report/TrusteeReportRepositoryTest.java
@@ -109,7 +109,6 @@ class TrusteeReportRepositoryTest {
   }
 
   private UUID createSystemAccount(String name, String assetType) {
-    var id = UUID.randomUUID();
     jdbcClient
         .sql(
             """
@@ -118,12 +117,21 @@ class TrusteeReportRepositoryTest {
               CAST('SYSTEM_ACCOUNT' AS ledger.account_purpose),
               CAST('LIABILITY' AS ledger.account_type),
               CAST(:assetType AS ledger.asset_type))
+            ON CONFLICT DO NOTHING
             """)
-        .param("id", id)
+        .param("id", UUID.randomUUID())
         .param("name", name)
         .param("assetType", assetType)
         .update();
-    return id;
+    return jdbcClient
+        .sql(
+            """
+            SELECT id FROM ledger.account
+            WHERE name = :name AND owner_party_id IS NULL AND purpose = 'SYSTEM_ACCOUNT'
+            """)
+        .param("name", name)
+        .query(UUID.class)
+        .single();
   }
 
   private UUID createUserAccount(String name, String assetType) {


### PR DESCRIPTION
V1_124 replaced the system-account unique index with one including the nullable owner_party_id, and NULLs-are-distinct semantics left system accounts unenforced. Re-add enforcement with UNIQUE NULLS NOT DISTINCT and make createSystemAccount race-safe with ON CONFLICT DO NOTHING + re-select, mirroring the party/user-account fix.