### PR TITLE
Price savings fund orders at the NAV of the dealing day they were selected for

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/savings/fund/issuing/IssuingJob.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/issuing/IssuingJob.java
@@ -42,7 +42,7 @@ public class IssuingJob {
       log.info("No payments to issue, skipping");
       return;
     }
-    var previousCutoff = getPreviousCutoff();
+    var previousCutoff = getPreviousCutoff(cutoff);
     payments.forEach(
         payment -> {
           if (payment.getReceivedBefore() != null
@@ -85,21 +85,8 @@ public class IssuingJob {
         .toList();
   }
 
-  private Instant getPreviousCutoff() {
-    var today = todayInTallinn();
-    var todaysCutoff = getCutoff(today);
-    var currentTime = clock.instant();
-    var publicHolidays = new PublicHolidays();
-    var isTodayWorkingDay = publicHolidays.isWorkingDay(today);
-    if (currentTime.isBefore(todaysCutoff) || !isTodayWorkingDay) {
-      var thirdToLastWorkingDay =
-          publicHolidays.previousWorkingDay(
-              publicHolidays.previousWorkingDay(publicHolidays.previousWorkingDay(today)));
-      return getCutoff(thirdToLastWorkingDay);
-    }
-    var secondToLastWorkingDay =
-        publicHolidays.previousWorkingDay(publicHolidays.previousWorkingDay(today));
-    return getCutoff(secondToLastWorkingDay);
+  private Instant getPreviousCutoff(Instant cutoff) {
+    return getCutoff(new PublicHolidays().previousWorkingDay(dealingDate(cutoff)));
   }
 
   private LocalDate todayInTallinn() {

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/issuing/IssuingJob.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/issuing/IssuingJob.java
@@ -9,7 +9,6 @@ import ee.tuleva.onboarding.savings.fund.SavingFundPayment;
 import ee.tuleva.onboarding.savings.fund.SavingFundPaymentRepository;
 import ee.tuleva.onboarding.savings.fund.nav.FundNavProvider;
 import ee.tuleva.onboarding.savings.fund.notification.IssuingCompletedEvent;
-import java.math.BigDecimal;
 import java.time.*;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -37,7 +36,8 @@ public class IssuingJob {
   @SchedulerLock(name = "IssuingJob_runJob", lockAtMostFor = "50s", lockAtLeastFor = "10s")
   @Transactional
   public void runJob() {
-    var payments = getReservedPaymentsDependingOnCurrentTime();
+    var cutoff = getCutoffForProcessing();
+    var payments = getReservedPaymentsReceivedBefore(cutoff);
     if (payments.isEmpty()) {
       log.info("No payments to issue, skipping");
       return;
@@ -55,7 +55,7 @@ public class IssuingJob {
           }
         });
     log.info("Running issuing job for {} payments", payments.size());
-    var nav = getNAV();
+    var nav = navProvider.getVerifiedNavForIssuingAndRedeeming(TKF100, dealingDate(cutoff));
     log.info("Running issuing job for {} payments with nav {}", payments.size(), nav);
     var totalAmount = ZERO;
     var totalFundUnits = ZERO;
@@ -69,41 +69,19 @@ public class IssuingJob {
         new IssuingCompletedEvent(payments.size(), totalAmount, totalFundUnits, nav));
   }
 
-  private List<SavingFundPayment> getReservedPaymentsDependingOnCurrentTime() {
+  private Instant getCutoffForProcessing() {
     var today = todayInTallinn();
-    var todaysCutoff = getCutoff(today);
-    var currentTime = clock.instant();
-    var isTodayWorkingDay = new PublicHolidays().isWorkingDay(today);
-    if (currentTime.isBefore(todaysCutoff) || !isTodayWorkingDay) {
-      return getReservedPaymentsFromBeforeSecondToLastWorkingDay();
-    }
-
-    return getReservedPaymentsFromBeforeLastWorkingDay();
-  }
-
-  private List<SavingFundPayment> getReservedPaymentsFromBeforeSecondToLastWorkingDay() {
-    var reservedPayments = savingFundPaymentRepository.findPaymentsWithStatus(RESERVED);
-
     var publicHolidays = new PublicHolidays();
-    var secondToLastWorkingDay =
-        publicHolidays.previousWorkingDay(publicHolidays.previousWorkingDay(todayInTallinn()));
-
-    var reservedTransactionCutoff = getCutoff(secondToLastWorkingDay);
-
-    return reservedPayments.stream()
-        .filter(payment -> payment.getReceivedBefore().isBefore(reservedTransactionCutoff))
-        .toList();
+    var lastWorkingDay = publicHolidays.previousWorkingDay(today);
+    if (clock.instant().isBefore(getCutoff(today)) || !publicHolidays.isWorkingDay(today)) {
+      return getCutoff(publicHolidays.previousWorkingDay(lastWorkingDay));
+    }
+    return getCutoff(lastWorkingDay);
   }
 
-  private List<SavingFundPayment> getReservedPaymentsFromBeforeLastWorkingDay() {
-    var reservedPayments = savingFundPaymentRepository.findPaymentsWithStatus(RESERVED);
-
-    var lastWorkingDay = new PublicHolidays().previousWorkingDay(todayInTallinn());
-
-    var reservedTransactionCutoff = getCutoff(lastWorkingDay);
-
-    return reservedPayments.stream()
-        .filter(payment -> payment.getReceivedBefore().isBefore(reservedTransactionCutoff))
+  private List<SavingFundPayment> getReservedPaymentsReceivedBefore(Instant cutoff) {
+    return savingFundPaymentRepository.findPaymentsWithStatus(RESERVED).stream()
+        .filter(payment -> payment.getReceivedBefore().isBefore(cutoff))
         .toList();
   }
 
@@ -128,11 +106,11 @@ public class IssuingJob {
     return clock.instant().atZone(CUTOFF_TIMEZONE).toLocalDate();
   }
 
-  private Instant getCutoff(LocalDate date) {
-    return ZonedDateTime.of(date, CUTOFF_TIME, CUTOFF_TIMEZONE).toInstant();
+  private LocalDate dealingDate(Instant cutoff) {
+    return cutoff.atZone(CUTOFF_TIMEZONE).toLocalDate();
   }
 
-  private BigDecimal getNAV() {
-    return navProvider.getVerifiedNavForIssuingAndRedeeming(TKF100);
+  private Instant getCutoff(LocalDate date) {
+    return ZonedDateTime.of(date, CUTOFF_TIME, CUTOFF_TIMEZONE).toInstant();
   }
 }

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/nav/FundNavProvider.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/nav/FundNavProvider.java
@@ -44,23 +44,25 @@ public class FundNavProvider {
     return nav.stripTrailingZeros().setScale(fund.getNavScale(), UNNECESSARY);
   }
 
-  public BigDecimal getVerifiedNavForIssuingAndRedeeming(TulevaFund fund) {
+  public BigDecimal getVerifiedNavForIssuingAndRedeeming(TulevaFund fund, LocalDate dealingDate) {
     String isin = fund.getIsin();
     FundValue fundValue =
         fundValueRepository
-            .findLastValueForFund(isin)
+            .getLatestValue(isin, dealingDate)
             .orElseThrow(
-                () -> new IllegalStateException("NAV not found for savings fund: isin=" + isin));
+                () ->
+                    new IllegalStateException(
+                        "NAV not found for savings fund: isin="
+                            + isin
+                            + ", expectedDate="
+                            + dealingDate));
 
-    LocalDate today = clock.instant().atZone(ESTONIAN_ZONE).toLocalDate();
-    LocalDate expectedDate = publicHolidays.previousWorkingDay(today);
-
-    if (!fundValue.date().equals(expectedDate)) {
+    if (!fundValue.date().equals(dealingDate)) {
       throw new IllegalStateException(
           "Stale NAV for savings fund: isin="
               + isin
               + ", expectedDate="
-              + expectedDate
+              + dealingDate
               + ", actualDate="
               + fundValue.date());
     }
@@ -78,7 +80,7 @@ public class FundNavProvider {
 
     nav = nav.stripTrailingZeros().setScale(fund.getNavScale(), UNNECESSARY);
 
-    validateReasonableChange(isin, nav, expectedDate);
+    validateReasonableChange(isin, nav, dealingDate);
 
     return nav;
   }

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/nav/NavTransactionImpactAlertJob.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/nav/NavTransactionImpactAlertJob.java
@@ -106,7 +106,7 @@ public class NavTransactionImpactAlertJob {
           reservedPayments.stream().map(SavingFundPayment::getAmount).reduce(ZERO, BigDecimal::add);
 
       List<RedemptionRequest> redemptions =
-          redemptionRequestRepository.findByStatusAndRequestedAtBefore(VERIFIED, cutoff);
+          redemptionRequestRepository.findAcceptedBefore(VERIFIED, cutoff);
       BigDecimal redemptionEur = estimateRedemptionEur(redemptions);
 
       BigDecimal totalVolume = subscriptionEur.add(redemptionEur);

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/redemption/RedemptionAlertJob.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/redemption/RedemptionAlertJob.java
@@ -48,7 +48,7 @@ public class RedemptionAlertJob {
 
     Instant cutoff = RedemptionCutoff.cutoffInstant(today);
     List<RedemptionRequest> requests =
-        redemptionRequestRepository.findByStatusAndRequestedAtBefore(VERIFIED, cutoff);
+        redemptionRequestRepository.findAcceptedBefore(VERIFIED, cutoff);
 
     if (requests.isEmpty()) {
       return;

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/redemption/RedemptionBatchJob.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/redemption/RedemptionBatchJob.java
@@ -67,7 +67,7 @@ public class RedemptionBatchJob {
   public void runJob() {
     Instant cutoff = getCutoffForProcessing();
     List<RedemptionRequest> toProcess =
-        redemptionRequestRepository.findByStatusAndRequestedAtBefore(VERIFIED, cutoff);
+        redemptionRequestRepository.findAcceptedBefore(VERIFIED, cutoff);
 
     if (toProcess.isEmpty()) {
       return;
@@ -77,7 +77,7 @@ public class RedemptionBatchJob {
         "Running redemption job for {} verified requests submitted before {}",
         toProcess.size(),
         cutoff);
-    processVerifiedRequests(toProcess);
+    processVerifiedRequests(toProcess, dealingDate(cutoff));
   }
 
   private Instant getCutoffForProcessing() {
@@ -107,12 +107,16 @@ public class RedemptionBatchJob {
     return clock.instant().atZone(CUTOFF_TIMEZONE).toLocalDate();
   }
 
+  private LocalDate dealingDate(Instant cutoff) {
+    return cutoff.atZone(CUTOFF_TIMEZONE).toLocalDate();
+  }
+
   private Instant getCutoff(LocalDate date) {
     return RedemptionCutoff.cutoffInstant(date);
   }
 
-  private void processVerifiedRequests(List<RedemptionRequest> toProcess) {
-    BigDecimal nav = getNAV();
+  private void processVerifiedRequests(List<RedemptionRequest> toProcess, LocalDate dealingDate) {
+    BigDecimal nav = getNAV(dealingDate);
     BigDecimal totalCashAmount = ZERO;
 
     for (RedemptionRequest request : toProcess) {
@@ -310,7 +314,7 @@ public class RedemptionBatchJob {
     }
   }
 
-  private BigDecimal getNAV() {
-    return navProvider.getVerifiedNavForIssuingAndRedeeming(TKF100);
+  private BigDecimal getNAV(LocalDate dealingDate) {
+    return navProvider.getVerifiedNavForIssuingAndRedeeming(TKF100, dealingDate);
   }
 }

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/redemption/RedemptionRequestRepository.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/redemption/RedemptionRequestRepository.java
@@ -26,7 +26,14 @@ public interface RedemptionRequestRepository extends CrudRepository<RedemptionRe
   List<RedemptionRequest> findByStatusAndRequestedAtBeforeAndCancelledAtIsNull(
       Status status, Instant cutoff);
 
-  List<RedemptionRequest> findByStatusAndRequestedAtBefore(Status status, Instant cutoff);
+  @Query(
+      """
+      SELECT r FROM RedemptionRequest r
+      WHERE r.status = :status
+        AND COALESCE(r.reviewedAt, r.requestedAt) < :cutoff
+      """)
+  List<RedemptionRequest> findAcceptedBefore(
+      @Param("status") Status status, @Param("cutoff") Instant cutoff);
 
   @Lock(LockModeType.PESSIMISTIC_WRITE)
   @Query("SELECT r FROM RedemptionRequest r WHERE r.id = :id")

--- a/src/test/groovy/ee/tuleva/onboarding/banking/seb/SebRedemptionIntegrationTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/banking/seb/SebRedemptionIntegrationTest.java
@@ -66,7 +66,7 @@ class SebRedemptionIntegrationTest {
   void setUp() {
     ClockHolder.setClock(Clock.fixed(FRIDAY, UTC));
     when(navProvider.getDisplayNav(any())).thenReturn(ONE);
-    when(navProvider.getVerifiedNavForIssuingAndRedeeming(any())).thenReturn(ONE);
+    when(navProvider.getVerifiedNavForIssuingAndRedeeming(any(), any())).thenReturn(ONE);
 
     testUser =
         userRepository.save(sampleUser().id(null).member(null).personalCode("39901019992").build());

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/issuing/IssuingJobTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/issuing/IssuingJobTest.java
@@ -1,5 +1,6 @@
 package ee.tuleva.onboarding.savings.fund.issuing;
 
+import static ee.tuleva.onboarding.fund.TulevaFund.TKF100;
 import static ee.tuleva.onboarding.savings.fund.SavingFundPayment.Status.RESERVED;
 import static ee.tuleva.onboarding.savings.fund.SavingFundPaymentFixture.aPayment;
 import static java.math.BigDecimal.ONE;
@@ -45,7 +46,7 @@ class IssuingJobTest {
     issuerService = mock(IssuerService.class);
     navProvider = mock(FundNavProvider.class);
     eventPublisher = mock(ApplicationEventPublisher.class);
-    lenient().when(navProvider.getVerifiedNavForIssuingAndRedeeming(any())).thenReturn(nav);
+    lenient().when(navProvider.getVerifiedNavForIssuingAndRedeeming(any(), any())).thenReturn(nav);
     lenient()
         .when(issuerService.processPayment(any(), any()))
         .thenReturn(new IssuingResult(ZERO, ZERO));
@@ -300,8 +301,44 @@ class IssuingJobTest {
 
     issuingJob.runJob();
 
-    verify(navProvider, never()).getVerifiedNavForIssuingAndRedeeming(any());
+    verify(navProvider, never()).getVerifiedNavForIssuingAndRedeeming(any(), any());
     verifyNoInteractions(issuerService);
+  }
+
+  @Test
+  void beforeCutoff_issuesAtTheNavOfTheSecondToLastWorkingDay() {
+    var now = Instant.parse("2025-01-15T12:00:00Z"); // 14:00 Tallinn time (before cutoff)
+    var issuingJob = createIssuingJob(now);
+
+    when(paymentRepository.findPaymentsWithStatus(RESERVED))
+        .thenReturn(
+            List.of(
+                aPayment()
+                    .receivedBefore(Instant.parse("2025-01-13T10:00:00Z"))
+                    .status(RESERVED)
+                    .build()));
+
+    issuingJob.runJob();
+
+    verify(navProvider).getVerifiedNavForIssuingAndRedeeming(TKF100, LocalDate.of(2025, 1, 13));
+  }
+
+  @Test
+  void afterCutoff_issuesAtTheNavOfTheLastWorkingDay() {
+    var now = Instant.parse("2025-01-15T15:00:00Z"); // 17:00 Tallinn time (after cutoff)
+    var issuingJob = createIssuingJob(now);
+
+    when(paymentRepository.findPaymentsWithStatus(RESERVED))
+        .thenReturn(
+            List.of(
+                aPayment()
+                    .receivedBefore(Instant.parse("2025-01-14T10:00:00Z"))
+                    .status(RESERVED)
+                    .build()));
+
+    issuingJob.runJob();
+
+    verify(navProvider).getVerifiedNavForIssuingAndRedeeming(TKF100, LocalDate.of(2025, 1, 14));
   }
 
   @Test
@@ -309,7 +346,7 @@ class IssuingJobTest {
     var issuingJob = createIssuingJob(Instant.parse("2025-01-03T14:00:00Z"));
 
     var nav = new BigDecimal("9.9918");
-    when(navProvider.getVerifiedNavForIssuingAndRedeeming(any())).thenReturn(nav);
+    when(navProvider.getVerifiedNavForIssuingAndRedeeming(any(), any())).thenReturn(nav);
 
     var payment1 =
         aPayment()

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/nav/FundNavProviderTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/nav/FundNavProviderTest.java
@@ -146,7 +146,7 @@ class FundNavProviderTest {
   }
 
   @Test
-  void getVerifiedNav_ignoresNavPublishedAfterTheDealingDate() {
+  void getVerifiedNav_comparesAgainstThePreviousWorkingDayAcrossAWeekend() {
     var provider = provider("2025-01-15T15:30:00");
     LocalDate dealingDate = LocalDate.of(2025, 1, 13);
     LocalDate previousDealingDate = LocalDate.of(2025, 1, 10);

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/nav/FundNavProviderTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/nav/FundNavProviderTest.java
@@ -106,68 +106,95 @@ class FundNavProviderTest {
   }
 
   @Test
-  void getCurrentNavForIssuing_returnsNavWhenDateMatches() {
+  void getVerifiedNav_returnsNavDatedOnTheDealingDate() {
     var provider = provider("2025-01-15T17:00:00");
-    LocalDate today = LocalDate.of(2025, 1, 15);
-    LocalDate yesterday = LocalDate.of(2025, 1, 14);
-    LocalDate dayBefore = LocalDate.of(2025, 1, 13);
+    LocalDate dealingDate = LocalDate.of(2025, 1, 14);
+    LocalDate previousDealingDate = LocalDate.of(2025, 1, 13);
     var fundValue =
-        new FundValue(ISIN, yesterday, new BigDecimal("9.6994"), "TULEVA", Instant.now());
+        new FundValue(ISIN, dealingDate, new BigDecimal("9.6994"), "TULEVA", Instant.now());
     var previousValue =
-        new FundValue(ISIN, dayBefore, new BigDecimal("9.6500"), "TULEVA", Instant.now());
-    when(fundValueRepository.findLastValueForFund(ISIN)).thenReturn(Optional.of(fundValue));
-    when(fundValueRepository.getLatestValue(ISIN, dayBefore))
+        new FundValue(ISIN, previousDealingDate, new BigDecimal("9.6500"), "TULEVA", Instant.now());
+    when(fundValueRepository.getLatestValue(ISIN, dealingDate)).thenReturn(Optional.of(fundValue));
+    when(fundValueRepository.getLatestValue(ISIN, previousDealingDate))
         .thenReturn(Optional.of(previousValue));
 
-    assertThat(provider.getVerifiedNavForIssuingAndRedeeming(TKF100))
+    assertThat(provider.getVerifiedNavForIssuingAndRedeeming(TKF100, dealingDate))
         .isEqualByComparingTo("9.6994");
   }
 
   @Test
-  void getCurrentNavForIssuing_throwsWhenDateDoesNotMatch() {
+  void getVerifiedNav_throwsWhenNewestNavPredatesTheDealingDate() {
     var provider = provider("2025-01-15T17:00:00");
-    LocalDate today = LocalDate.of(2025, 1, 15);
-    LocalDate yesterday = LocalDate.of(2025, 1, 14);
+    LocalDate dealingDate = LocalDate.of(2025, 1, 14);
     var staleValue =
         new FundValue(
             ISIN, LocalDate.of(2025, 1, 10), new BigDecimal("9.6994"), "TULEVA", Instant.now());
-    when(fundValueRepository.findLastValueForFund(ISIN)).thenReturn(Optional.of(staleValue));
+    when(fundValueRepository.getLatestValue(ISIN, dealingDate)).thenReturn(Optional.of(staleValue));
 
-    assertThatThrownBy(() -> provider.getVerifiedNavForIssuingAndRedeeming(TKF100))
+    assertThatThrownBy(() -> provider.getVerifiedNavForIssuingAndRedeeming(TKF100, dealingDate))
         .isInstanceOf(IllegalStateException.class);
   }
 
   @Test
-  void getCurrentNavForIssuing_throwsWhenNavDeviatesMoreThan20Percent() {
+  void getVerifiedNav_throwsWhenNoNavExistsOnOrBeforeTheDealingDate() {
     var provider = provider("2025-01-15T17:00:00");
-    LocalDate today = LocalDate.of(2025, 1, 15);
-    LocalDate yesterday = LocalDate.of(2025, 1, 14);
-    LocalDate dayBefore = LocalDate.of(2025, 1, 13);
-    var currentNav =
-        new FundValue(ISIN, yesterday, new BigDecimal("500.0000"), "TULEVA", Instant.now());
-    var previousNav =
-        new FundValue(ISIN, dayBefore, new BigDecimal("10.0000"), "TULEVA", Instant.now());
-    when(fundValueRepository.findLastValueForFund(ISIN)).thenReturn(Optional.of(currentNav));
-    when(fundValueRepository.getLatestValue(ISIN, dayBefore)).thenReturn(Optional.of(previousNav));
+    LocalDate dealingDate = LocalDate.of(2025, 1, 14);
+    when(fundValueRepository.getLatestValue(ISIN, dealingDate)).thenReturn(Optional.empty());
 
-    assertThatThrownBy(() -> provider.getVerifiedNavForIssuingAndRedeeming(TKF100))
+    assertThatThrownBy(() -> provider.getVerifiedNavForIssuingAndRedeeming(TKF100, dealingDate))
         .isInstanceOf(IllegalStateException.class);
   }
 
   @Test
-  void getCurrentNavForIssuing_allowsNavChangeWithin20Percent() {
-    var provider = provider("2025-01-15T17:00:00");
-    LocalDate today = LocalDate.of(2025, 1, 15);
-    LocalDate yesterday = LocalDate.of(2025, 1, 14);
-    LocalDate dayBefore = LocalDate.of(2025, 1, 13);
-    var currentNav =
-        new FundValue(ISIN, yesterday, new BigDecimal("10.5000"), "TULEVA", Instant.now());
-    var previousNav =
-        new FundValue(ISIN, dayBefore, new BigDecimal("10.0000"), "TULEVA", Instant.now());
-    when(fundValueRepository.findLastValueForFund(ISIN)).thenReturn(Optional.of(currentNav));
-    when(fundValueRepository.getLatestValue(ISIN, dayBefore)).thenReturn(Optional.of(previousNav));
+  void getVerifiedNav_ignoresNavPublishedAfterTheDealingDate() {
+    var provider = provider("2025-01-15T15:30:00");
+    LocalDate dealingDate = LocalDate.of(2025, 1, 13);
+    LocalDate previousDealingDate = LocalDate.of(2025, 1, 10);
+    var fundValue =
+        new FundValue(ISIN, dealingDate, new BigDecimal("9.6500"), "TULEVA", Instant.now());
+    var previousValue =
+        new FundValue(ISIN, previousDealingDate, new BigDecimal("9.6000"), "TULEVA", Instant.now());
+    when(fundValueRepository.getLatestValue(ISIN, dealingDate)).thenReturn(Optional.of(fundValue));
+    when(fundValueRepository.getLatestValue(ISIN, previousDealingDate))
+        .thenReturn(Optional.of(previousValue));
 
-    assertThat(provider.getVerifiedNavForIssuingAndRedeeming(TKF100))
+    assertThat(provider.getVerifiedNavForIssuingAndRedeeming(TKF100, dealingDate))
+        .isEqualByComparingTo("9.6500");
+  }
+
+  @Test
+  void getVerifiedNav_throwsWhenNavDeviatesMoreThan20Percent() {
+    var provider = provider("2025-01-15T17:00:00");
+    LocalDate dealingDate = LocalDate.of(2025, 1, 14);
+    LocalDate previousDealingDate = LocalDate.of(2025, 1, 13);
+    var currentNav =
+        new FundValue(ISIN, dealingDate, new BigDecimal("500.0000"), "TULEVA", Instant.now());
+    var previousNav =
+        new FundValue(
+            ISIN, previousDealingDate, new BigDecimal("10.0000"), "TULEVA", Instant.now());
+    when(fundValueRepository.getLatestValue(ISIN, dealingDate)).thenReturn(Optional.of(currentNav));
+    when(fundValueRepository.getLatestValue(ISIN, previousDealingDate))
+        .thenReturn(Optional.of(previousNav));
+
+    assertThatThrownBy(() -> provider.getVerifiedNavForIssuingAndRedeeming(TKF100, dealingDate))
+        .isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  void getVerifiedNav_allowsNavChangeWithin20Percent() {
+    var provider = provider("2025-01-15T17:00:00");
+    LocalDate dealingDate = LocalDate.of(2025, 1, 14);
+    LocalDate previousDealingDate = LocalDate.of(2025, 1, 13);
+    var currentNav =
+        new FundValue(ISIN, dealingDate, new BigDecimal("10.5000"), "TULEVA", Instant.now());
+    var previousNav =
+        new FundValue(
+            ISIN, previousDealingDate, new BigDecimal("10.0000"), "TULEVA", Instant.now());
+    when(fundValueRepository.getLatestValue(ISIN, dealingDate)).thenReturn(Optional.of(currentNav));
+    when(fundValueRepository.getLatestValue(ISIN, previousDealingDate))
+        .thenReturn(Optional.of(previousNav));
+
+    assertThat(provider.getVerifiedNavForIssuingAndRedeeming(TKF100, dealingDate))
         .isEqualByComparingTo("10.5000");
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/nav/NavTransactionImpactAlertJobTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/nav/NavTransactionImpactAlertJobTest.java
@@ -409,17 +409,13 @@ class NavTransactionImpactAlertJobTest {
   }
 
   private void stubTkf100Redemptions(List<RedemptionRequest> redemptions) {
-    given(
-            redemptionRequestRepository.findByStatusAndRequestedAtBefore(
-                eq(VERIFIED), any(Instant.class)))
+    given(redemptionRequestRepository.findAcceptedBefore(eq(VERIFIED), any(Instant.class)))
         .willReturn(redemptions);
   }
 
   private void stubTkf100RedemptionsLenient(List<RedemptionRequest> redemptions) {
     lenient()
-        .when(
-            redemptionRequestRepository.findByStatusAndRequestedAtBefore(
-                eq(VERIFIED), any(Instant.class)))
+        .when(redemptionRequestRepository.findAcceptedBefore(eq(VERIFIED), any(Instant.class)))
         .thenReturn(redemptions);
   }
 

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/redemption/RedemptionAlertJobTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/redemption/RedemptionAlertJobTest.java
@@ -48,7 +48,7 @@ class RedemptionAlertJobTest {
     var job = jobOn(WED_1605_UTC);
     given(publicHolidays.isWorkingDay(LocalDate.of(2025, 1, 15))).willReturn(true);
 
-    given(redemptionRequestRepository.findByStatusAndRequestedAtBefore(VERIFIED, WED_CUTOFF))
+    given(redemptionRequestRepository.findAcceptedBefore(VERIFIED, WED_CUTOFF))
         .willReturn(
             List.of(
                 requestWithAmount(new BigDecimal("25000.00")),
@@ -68,7 +68,7 @@ class RedemptionAlertJobTest {
     var job = jobOn(WED_1605_UTC);
     given(publicHolidays.isWorkingDay(LocalDate.of(2025, 1, 15))).willReturn(true);
 
-    given(redemptionRequestRepository.findByStatusAndRequestedAtBefore(VERIFIED, WED_CUTOFF))
+    given(redemptionRequestRepository.findAcceptedBefore(VERIFIED, WED_CUTOFF))
         .willReturn(
             List.of(
                 requestWithAmount(new BigDecimal("3000.00")),
@@ -88,7 +88,7 @@ class RedemptionAlertJobTest {
     var job = jobOn(WED_1605_UTC);
     given(publicHolidays.isWorkingDay(LocalDate.of(2025, 1, 15))).willReturn(true);
 
-    given(redemptionRequestRepository.findByStatusAndRequestedAtBefore(VERIFIED, WED_CUTOFF))
+    given(redemptionRequestRepository.findAcceptedBefore(VERIFIED, WED_CUTOFF))
         .willReturn(
             List.of(
                 requestWithAmount(new BigDecimal("25000.00")),
@@ -108,7 +108,7 @@ class RedemptionAlertJobTest {
     var job = jobOn(WED_1605_UTC);
     given(publicHolidays.isWorkingDay(LocalDate.of(2025, 1, 15))).willReturn(true);
 
-    given(redemptionRequestRepository.findByStatusAndRequestedAtBefore(VERIFIED, WED_CUTOFF))
+    given(redemptionRequestRepository.findAcceptedBefore(VERIFIED, WED_CUTOFF))
         .willReturn(
             List.of(
                 requestWithAmount(new BigDecimal("2000.00")),
@@ -127,7 +127,7 @@ class RedemptionAlertJobTest {
     var job = jobOn(WED_1605_UTC);
     given(publicHolidays.isWorkingDay(LocalDate.of(2025, 1, 15))).willReturn(true);
 
-    given(redemptionRequestRepository.findByStatusAndRequestedAtBefore(VERIFIED, WED_CUTOFF))
+    given(redemptionRequestRepository.findAcceptedBefore(VERIFIED, WED_CUTOFF))
         .willReturn(List.of(requestWithAmount(new BigDecimal("40000.00"))));
 
     given(fundValueRepository.findLastValueForFund(TKF100.getAumKey()))
@@ -154,7 +154,7 @@ class RedemptionAlertJobTest {
     var job = jobOn(WED_1605_UTC);
     given(publicHolidays.isWorkingDay(LocalDate.of(2025, 1, 15))).willReturn(true);
 
-    given(redemptionRequestRepository.findByStatusAndRequestedAtBefore(VERIFIED, WED_CUTOFF))
+    given(redemptionRequestRepository.findAcceptedBefore(VERIFIED, WED_CUTOFF))
         .willReturn(List.of());
 
     job.checkRedemptionAlerts();
@@ -168,7 +168,7 @@ class RedemptionAlertJobTest {
     var job = jobOn(WED_1605_UTC);
     given(publicHolidays.isWorkingDay(LocalDate.of(2025, 1, 15))).willReturn(true);
 
-    given(redemptionRequestRepository.findByStatusAndRequestedAtBefore(VERIFIED, WED_CUTOFF))
+    given(redemptionRequestRepository.findAcceptedBefore(VERIFIED, WED_CUTOFF))
         .willReturn(
             List.of(
                 requestWithAmount(new BigDecimal("25000.00")),
@@ -188,7 +188,7 @@ class RedemptionAlertJobTest {
     var job = jobOn(WED_1605_UTC);
     given(publicHolidays.isWorkingDay(LocalDate.of(2025, 1, 15))).willReturn(true);
 
-    given(redemptionRequestRepository.findByStatusAndRequestedAtBefore(VERIFIED, WED_CUTOFF))
+    given(redemptionRequestRepository.findAcceptedBefore(VERIFIED, WED_CUTOFF))
         .willReturn(
             List.of(
                 requestWithAmount(new BigDecimal("25000.00")),

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/redemption/RedemptionBatchJobTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/redemption/RedemptionBatchJobTest.java
@@ -3,6 +3,7 @@ package ee.tuleva.onboarding.savings.fund.redemption;
 import static ee.tuleva.onboarding.auth.UserFixture.sampleUser;
 import static ee.tuleva.onboarding.banking.BankAccountType.FUND_INVESTMENT_EUR;
 import static ee.tuleva.onboarding.banking.BankAccountType.WITHDRAWAL_EUR;
+import static ee.tuleva.onboarding.fund.TulevaFund.TKF100;
 import static ee.tuleva.onboarding.savings.fund.redemption.RedemptionRequest.Status.*;
 import static ee.tuleva.onboarding.savings.fund.redemption.RedemptionRequestFixture.redemptionRequestFixture;
 import static java.time.ZoneOffset.UTC;
@@ -59,7 +60,7 @@ class RedemptionBatchJobTest {
   @BeforeEach
   void setUp() {
     lenient()
-        .when(navProvider.getVerifiedNavForIssuingAndRedeeming(any()))
+        .when(navProvider.getVerifiedNavForIssuingAndRedeeming(any(), any()))
         .thenReturn(BigDecimal.ONE);
   }
 
@@ -86,13 +87,49 @@ class RedemptionBatchJobTest {
     var now = Instant.parse("2025-01-15T15:00:00Z");
     var batchJob = createBatchJob(now);
 
-    when(redemptionRequestRepository.findByStatusAndRequestedAtBefore(eq(VERIFIED), any()))
-        .thenReturn(List.of());
+    when(redemptionRequestRepository.findAcceptedBefore(eq(VERIFIED), any())).thenReturn(List.of());
 
     batchJob.runJob();
 
-    verify(redemptionRequestRepository).findByStatusAndRequestedAtBefore(eq(VERIFIED), any());
+    verify(redemptionRequestRepository).findAcceptedBefore(eq(VERIFIED), any());
     verify(eventPublisher, never()).publishEvent(any(RequestPaymentEvent.class));
+  }
+
+  @Test
+  void runJob_beforeCutoff_pricesAtTheNavOfTheSecondToLastWorkingDay() {
+    var now = Instant.parse("2025-01-15T12:00:00Z"); // 14:00 Tallinn time (before cutoff)
+
+    runJobWithSinglePendingRequest(now);
+
+    verify(navProvider).getVerifiedNavForIssuingAndRedeeming(TKF100, LocalDate.of(2025, 1, 13));
+  }
+
+  @Test
+  void runJob_afterCutoff_pricesAtTheNavOfTheLastWorkingDay() {
+    var now = Instant.parse("2025-01-15T15:00:00Z"); // 17:00 Tallinn time (after cutoff)
+
+    runJobWithSinglePendingRequest(now);
+
+    verify(navProvider).getVerifiedNavForIssuingAndRedeeming(TKF100, LocalDate.of(2025, 1, 14));
+  }
+
+  private void runJobWithSinglePendingRequest(Instant now) {
+    var requestId = UUID.randomUUID();
+    var request = redemptionRequestFixture().id(requestId).status(VERIFIED).build();
+
+    when(redemptionRequestRepository.findAcceptedBefore(eq(VERIFIED), any()))
+        .thenReturn(List.of(request));
+    when(redemptionRequestRepository.findById(requestId)).thenReturn(Optional.of(request));
+    when(savingsFundLedger.hasPricingEntry(requestId)).thenReturn(true);
+    doAnswer(
+            invocation -> {
+              TransactionCallback<?> callback = invocation.getArgument(0);
+              return callback.doInTransaction(null);
+            })
+        .when(transactionTemplate)
+        .execute(any());
+
+    createBatchJob(now).runJob();
   }
 
   @Test
@@ -113,7 +150,7 @@ class RedemptionBatchJobTest {
             .requestedAt(now.minus(1, DAYS)) // yesterday
             .build();
 
-    when(redemptionRequestRepository.findByStatusAndRequestedAtBefore(eq(VERIFIED), any()))
+    when(redemptionRequestRepository.findAcceptedBefore(eq(VERIFIED), any()))
         .thenReturn(List.of(request));
     when(redemptionRequestRepository.findById(requestId)).thenReturn(Optional.of(request));
     when(bankAccountConfiguration.getAccountIban(FUND_INVESTMENT_EUR))
@@ -156,8 +193,7 @@ class RedemptionBatchJobTest {
     var batchJob = createBatchJob(now);
 
     var cutoffCaptor = ArgumentCaptor.forClass(Instant.class);
-    when(redemptionRequestRepository.findByStatusAndRequestedAtBefore(
-            eq(VERIFIED), cutoffCaptor.capture()))
+    when(redemptionRequestRepository.findAcceptedBefore(eq(VERIFIED), cutoffCaptor.capture()))
         .thenReturn(List.of());
 
     batchJob.runJob();
@@ -176,8 +212,7 @@ class RedemptionBatchJobTest {
     var batchJob = createBatchJob(now);
 
     var cutoffCaptor = ArgumentCaptor.forClass(Instant.class);
-    when(redemptionRequestRepository.findByStatusAndRequestedAtBefore(
-            eq(VERIFIED), cutoffCaptor.capture()))
+    when(redemptionRequestRepository.findAcceptedBefore(eq(VERIFIED), cutoffCaptor.capture()))
         .thenReturn(List.of());
 
     batchJob.runJob();
@@ -195,8 +230,7 @@ class RedemptionBatchJobTest {
     var batchJob = createBatchJob(sundayNightUtc);
 
     var cutoffCaptor = ArgumentCaptor.forClass(Instant.class);
-    when(redemptionRequestRepository.findByStatusAndRequestedAtBefore(
-            eq(VERIFIED), cutoffCaptor.capture()))
+    when(redemptionRequestRepository.findAcceptedBefore(eq(VERIFIED), cutoffCaptor.capture()))
         .thenReturn(List.of());
 
     batchJob.runJob();
@@ -212,8 +246,7 @@ class RedemptionBatchJobTest {
     var batchJob = createBatchJob(sundayNightUtc);
 
     var cutoffCaptor = ArgumentCaptor.forClass(Instant.class);
-    when(redemptionRequestRepository.findByStatusAndRequestedAtBefore(
-            eq(VERIFIED), cutoffCaptor.capture()))
+    when(redemptionRequestRepository.findAcceptedBefore(eq(VERIFIED), cutoffCaptor.capture()))
         .thenReturn(List.of());
 
     batchJob.runJob();
@@ -229,8 +262,7 @@ class RedemptionBatchJobTest {
     var batchJob = createBatchJob(fridayNightUtc);
 
     var cutoffCaptor = ArgumentCaptor.forClass(Instant.class);
-    when(redemptionRequestRepository.findByStatusAndRequestedAtBefore(
-            eq(VERIFIED), cutoffCaptor.capture()))
+    when(redemptionRequestRepository.findAcceptedBefore(eq(VERIFIED), cutoffCaptor.capture()))
         .thenReturn(List.of());
 
     batchJob.runJob();
@@ -257,7 +289,7 @@ class RedemptionBatchJobTest {
             .cashAmount(new BigDecimal("10.00"))
             .build();
 
-    when(redemptionRequestRepository.findByStatusAndRequestedAtBefore(eq(VERIFIED), any()))
+    when(redemptionRequestRepository.findAcceptedBefore(eq(VERIFIED), any()))
         .thenReturn(List.of(request));
     when(redemptionRequestRepository.findById(requestId)).thenReturn(Optional.of(request));
     when(bankAccountConfiguration.getAccountIban(FUND_INVESTMENT_EUR))
@@ -298,7 +330,7 @@ class RedemptionBatchJobTest {
     var requestId = UUID.randomUUID();
     var request = redemptionRequestFixture().id(requestId).status(VERIFIED).build();
 
-    when(redemptionRequestRepository.findByStatusAndRequestedAtBefore(eq(VERIFIED), any()))
+    when(redemptionRequestRepository.findAcceptedBefore(eq(VERIFIED), any()))
         .thenReturn(List.of(request));
     when(redemptionRequestRepository.findById(requestId)).thenReturn(Optional.of(request));
 
@@ -331,7 +363,7 @@ class RedemptionBatchJobTest {
             .requestedAt(now.minus(1, DAYS))
             .build();
 
-    when(redemptionRequestRepository.findByStatusAndRequestedAtBefore(eq(VERIFIED), any()))
+    when(redemptionRequestRepository.findAcceptedBefore(eq(VERIFIED), any()))
         .thenReturn(List.of(request));
     when(redemptionRequestRepository.findById(requestId)).thenReturn(Optional.of(request));
     when(bankAccountConfiguration.getAccountIban(FUND_INVESTMENT_EUR))
@@ -373,7 +405,7 @@ class RedemptionBatchJobTest {
             .requestedAt(now.minus(1, DAYS))
             .build();
 
-    when(redemptionRequestRepository.findByStatusAndRequestedAtBefore(eq(VERIFIED), any()))
+    when(redemptionRequestRepository.findAcceptedBefore(eq(VERIFIED), any()))
         .thenReturn(List.of(request));
     when(redemptionRequestRepository.findById(requestId)).thenReturn(Optional.of(request));
     when(bankAccountConfiguration.getAccountIban(FUND_INVESTMENT_EUR))
@@ -419,7 +451,7 @@ class RedemptionBatchJobTest {
             .requestedAt(now.minus(1, DAYS))
             .build();
 
-    when(redemptionRequestRepository.findByStatusAndRequestedAtBefore(eq(VERIFIED), any()))
+    when(redemptionRequestRepository.findAcceptedBefore(eq(VERIFIED), any()))
         .thenReturn(List.of(request))
         .thenReturn(List.of()); // Second run finds no VERIFIED requests
     when(redemptionRequestRepository.findById(requestId)).thenReturn(Optional.of(request));
@@ -464,7 +496,7 @@ class RedemptionBatchJobTest {
             .requestedAt(now.minus(1, DAYS))
             .build();
 
-    when(redemptionRequestRepository.findByStatusAndRequestedAtBefore(eq(VERIFIED), any()))
+    when(redemptionRequestRepository.findAcceptedBefore(eq(VERIFIED), any()))
         .thenReturn(List.of(request));
     when(redemptionRequestRepository.findById(requestId)).thenReturn(Optional.of(request));
     when(savingsFundLedger.hasPricingEntry(requestId)).thenReturn(true);
@@ -500,7 +532,7 @@ class RedemptionBatchJobTest {
             .requestedAt(now.minus(1, DAYS))
             .build();
 
-    when(redemptionRequestRepository.findByStatusAndRequestedAtBefore(eq(VERIFIED), any()))
+    when(redemptionRequestRepository.findAcceptedBefore(eq(VERIFIED), any()))
         .thenReturn(List.of(request));
     when(redemptionRequestRepository.findById(requestId)).thenReturn(Optional.of(request));
     when(bankAccountConfiguration.getAccountIban(FUND_INVESTMENT_EUR))
@@ -640,7 +672,7 @@ class RedemptionBatchJobTest {
             .requestedAt(now.minus(1, DAYS))
             .build();
 
-    when(redemptionRequestRepository.findByStatusAndRequestedAtBefore(eq(VERIFIED), any()))
+    when(redemptionRequestRepository.findAcceptedBefore(eq(VERIFIED), any()))
         .thenReturn(List.of(request));
     when(redemptionRequestRepository.findById(requestId)).thenReturn(Optional.of(request));
     when(bankAccountConfiguration.getAccountIban(FUND_INVESTMENT_EUR))
@@ -694,7 +726,7 @@ class RedemptionBatchJobTest {
             .requestedAt(now.minus(1, DAYS))
             .build();
 
-    when(redemptionRequestRepository.findByStatusAndRequestedAtBefore(eq(VERIFIED), any()))
+    when(redemptionRequestRepository.findAcceptedBefore(eq(VERIFIED), any()))
         .thenReturn(List.of(request));
     when(redemptionRequestRepository.findById(requestId)).thenReturn(Optional.of(request));
     when(bankAccountConfiguration.getAccountIban(FUND_INVESTMENT_EUR))
@@ -745,7 +777,7 @@ class RedemptionBatchJobTest {
             .cashAmount(new BigDecimal("10.00"))
             .build();
 
-    when(redemptionRequestRepository.findByStatusAndRequestedAtBefore(eq(VERIFIED), any()))
+    when(redemptionRequestRepository.findAcceptedBefore(eq(VERIFIED), any()))
         .thenReturn(List.of(request));
     when(redemptionRequestRepository.findById(requestId)).thenReturn(Optional.of(request));
     when(bankAccountConfiguration.getAccountIban(FUND_INVESTMENT_EUR))
@@ -787,7 +819,7 @@ class RedemptionBatchJobTest {
             .cashAmount(new BigDecimal("10.00"))
             .build();
 
-    when(redemptionRequestRepository.findByStatusAndRequestedAtBefore(eq(VERIFIED), any()))
+    when(redemptionRequestRepository.findAcceptedBefore(eq(VERIFIED), any()))
         .thenReturn(List.of(request));
     when(redemptionRequestRepository.findById(requestId)).thenReturn(Optional.of(request));
     when(bankAccountConfiguration.getAccountIban(FUND_INVESTMENT_EUR))

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/redemption/RedemptionIntegrationTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/redemption/RedemptionIntegrationTest.java
@@ -99,7 +99,7 @@ class RedemptionIntegrationTest {
     doReturn("").when(sebGatewayClient).submitPaymentFile(any(), any());
     lenient().when(navProvider.getDisplayNav(any())).thenReturn(BigDecimal.ONE);
     lenient()
-        .when(navProvider.getVerifiedNavForIssuingAndRedeeming(any()))
+        .when(navProvider.getVerifiedNavForIssuingAndRedeeming(any(), any()))
         .thenReturn(BigDecimal.ONE);
 
     testUser =

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/redemption/RedemptionRequestRepositoryTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/redemption/RedemptionRequestRepositoryTest.java
@@ -1,0 +1,95 @@
+package ee.tuleva.onboarding.savings.fund.redemption;
+
+import static ee.tuleva.onboarding.auth.UserFixture.sampleUserNonMember;
+import static ee.tuleva.onboarding.savings.fund.redemption.RedemptionRequest.Status.VERIFIED;
+import static ee.tuleva.onboarding.savings.fund.redemption.RedemptionRequestFixture.redemptionRequestFixture;
+import static java.time.temporal.ChronoUnit.DAYS;
+import static java.time.temporal.ChronoUnit.HOURS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jpa.test.autoconfigure.TestEntityManager;
+
+@DataJpaTest
+class RedemptionRequestRepositoryTest {
+
+  private static final Instant CUTOFF = Instant.parse("2026-08-11T13:00:00Z");
+
+  @Autowired RedemptionRequestRepository repository;
+  @Autowired TestEntityManager entityManager;
+
+  private Long userId;
+
+  @BeforeEach
+  void persistUser() {
+    userId = entityManager.persistFlushFind(sampleUserNonMember().id(null).build()).getId();
+  }
+
+  @Test
+  void findsRequestRequestedBeforeTheCutoff() {
+    var request =
+        repository.save(
+            redemptionRequestFixture()
+                .userId(userId)
+                .status(VERIFIED)
+                .requestedAt(CUTOFF.minus(1, DAYS))
+                .build());
+
+    assertThat(repository.findAcceptedBefore(VERIFIED, CUTOFF)).containsExactly(request);
+  }
+
+  @Test
+  void excludesRequestRequestedAfterTheCutoff() {
+    repository.save(
+        redemptionRequestFixture()
+            .userId(userId)
+            .status(VERIFIED)
+            .requestedAt(CUTOFF.plus(1, HOURS))
+            .build());
+
+    assertThat(repository.findAcceptedBefore(VERIFIED, CUTOFF)).isEmpty();
+  }
+
+  @Test
+  void excludesRequestReleasedFromReviewAfterTheCutoff() {
+    repository.save(
+        redemptionRequestFixture()
+            .userId(userId)
+            .status(VERIFIED)
+            .requestedAt(CUTOFF.minus(7, DAYS))
+            .reviewedAt(CUTOFF.plus(1, HOURS))
+            .build());
+
+    assertThat(repository.findAcceptedBefore(VERIFIED, CUTOFF)).isEmpty();
+  }
+
+  @Test
+  void includesRequestReleasedFromReviewBeforeTheCutoff() {
+    var request =
+        repository.save(
+            redemptionRequestFixture()
+                .userId(userId)
+                .status(VERIFIED)
+                .requestedAt(CUTOFF.minus(7, DAYS))
+                .reviewedAt(CUTOFF.minus(1, HOURS))
+                .build());
+
+    assertThat(repository.findAcceptedBefore(VERIFIED, CUTOFF)).containsExactly(request);
+  }
+
+  @Test
+  void excludesRequestsInOtherStatuses() {
+    repository.save(
+        redemptionRequestFixture()
+            .userId(userId)
+            .status(RedemptionRequest.Status.IN_REVIEW)
+            .requestedAt(CUTOFF.minus(7, DAYS))
+            .build());
+
+    assertThat(repository.findAcceptedBefore(VERIFIED, CUTOFF)).isEmpty();
+  }
+}

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/redemption/RedemptionRequestRepositoryTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/redemption/RedemptionRequestRepositoryTest.java
@@ -26,7 +26,13 @@ class RedemptionRequestRepositoryTest {
 
   @BeforeEach
   void persistUser() {
-    userId = entityManager.persistFlushFind(sampleUserNonMember().id(null).build()).getId();
+    var user =
+        sampleUserNonMember()
+            .id(null)
+            .personalCode("38812121008")
+            .email("redemption-request-repository-test@tuleva.ee")
+            .build();
+    userId = entityManager.persistFlushFind(user).getId();
   }
 
   @Test


### PR DESCRIPTION
IssuingJob and RedemptionBatchJob select a batch using a 16:00 Tallinn cutoff: before the cutoff they take the second-to-last working day's window, after it the last working day's. FundNavProvider ignored the time of day and always demanded the NAV of previousWorkingDay(today). That is correct only after 16:00 - in the morning the 15:20 calculation has not published it yet, so any catch-up run before the cutoff failed with "Stale NAV" once a minute.

The dealing date is now derived from the cutoff the job already computed and passed in, so the NAV date and the selection window come from a single clock read and cannot drift apart. The lookup is date bounded, so a NAV published between 15:20 and 16:00 no longer reads as stale; the strict date equality check is kept so a genuinely missing NAV still fails loudly.

Redemptions released from review are now priced in the next dealing window instead of the one their original request date falls into. Selecting on requested_at alone let the approval timestamp decide between two already-published NAVs depending on whether release happened before or after 16:00.

Fixes ONBOARDING-SERVICE-447