### PR TITLE
Add a members-only hackathon registration form

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/config/SecurityConfiguration.java
+++ b/src/main/java/ee/tuleva/onboarding/config/SecurityConfiguration.java
@@ -52,6 +52,8 @@ public class SecurityConfiguration {
                     .hasAuthority(MEMBER)
                     .requestMatchers("/v1/capital-transfer-contracts/**")
                     .hasAuthority(MEMBER)
+                    .requestMatchers("/v1/hackathon-registration/**")
+                    .hasAuthority(MEMBER)
                     .requestMatchers(GET, "/v1/funds")
                     .permitAll()
                     .requestMatchers(GET, "/v1/funds/nav")

--- a/src/main/java/ee/tuleva/onboarding/error/ErrorHandlingControllerAdvice.java
+++ b/src/main/java/ee/tuleva/onboarding/error/ErrorHandlingControllerAdvice.java
@@ -18,6 +18,7 @@ import ee.tuleva.onboarding.error.exception.ErrorsResponseException;
 import ee.tuleva.onboarding.error.response.ErrorResponse;
 import ee.tuleva.onboarding.error.response.ErrorResponseEntityFactory;
 import ee.tuleva.onboarding.error.response.ErrorsResponse;
+import ee.tuleva.onboarding.hackathon.HackathonRegistrationClosedException;
 import ee.tuleva.onboarding.mandate.exception.IdSessionException;
 import ee.tuleva.onboarding.mandate.exception.InvalidMandateException;
 import ee.tuleva.onboarding.mandate.exception.MandateProcessingException;
@@ -182,6 +183,15 @@ public class ErrorHandlingControllerAdvice {
     log.info("ChildIsNotAMinorException: {}", exception.getMessage());
     return new ResponseEntity<>(
         Map.of("error", "CHILD_IS_NOT_A_MINOR", "error_description", exception.getMessage()),
+        BAD_REQUEST);
+  }
+
+  @ExceptionHandler(HackathonRegistrationClosedException.class)
+  public ResponseEntity<Object> handleErrors(HackathonRegistrationClosedException exception) {
+    log.info("HackathonRegistrationClosedException: {}", exception.getMessage());
+    return new ResponseEntity<>(
+        Map.of(
+            "error", "HACKATHON_REGISTRATION_CLOSED", "error_description", exception.getMessage()),
         BAD_REQUEST);
   }
 

--- a/src/main/java/ee/tuleva/onboarding/hackathon/HackathonChallenge.java
+++ b/src/main/java/ee/tuleva/onboarding/hackathon/HackathonChallenge.java
@@ -1,0 +1,8 @@
+package ee.tuleva.onboarding.hackathon;
+
+public enum HackathonChallenge {
+  FAIR_LENDING,
+  INSURANCE,
+  COLLECTIVE_BUYING_POWER,
+  WEALTH_AND_INHERITANCE
+}

--- a/src/main/java/ee/tuleva/onboarding/hackathon/HackathonEmailService.java
+++ b/src/main/java/ee/tuleva/onboarding/hackathon/HackathonEmailService.java
@@ -23,13 +23,6 @@ public class HackathonEmailService {
 
   public void sendRegistrationConfirmation(
       User user, HackathonRegistration registration, Locale locale) {
-    if (user.getEmail() == null || user.getEmail().isBlank()) {
-      log.warn(
-          "User profile has no email, hackathon confirmation will not be sent: userId={}",
-          user.getId());
-      return;
-    }
-
     String templateName = HACKATHON_REGISTRATION.getTemplateName(locale);
 
     MandrillMessage message =
@@ -42,9 +35,14 @@ public class HackathonEmailService {
 
     emailService
         .send(user, message, templateName)
-        .ifPresent(
-            response ->
+        .ifPresentOrElse(
+            status ->
                 emailPersistenceService.save(
-                    user, response.getId(), HACKATHON_REGISTRATION, response.getStatus()));
+                    user, status.getId(), HACKATHON_REGISTRATION, status.getStatus()),
+            () ->
+                log.error(
+                    "Hackathon confirmation email was not delivered: userId={}, templateName={}",
+                    user.getId(),
+                    templateName));
   }
 }

--- a/src/main/java/ee/tuleva/onboarding/hackathon/HackathonEmailService.java
+++ b/src/main/java/ee/tuleva/onboarding/hackathon/HackathonEmailService.java
@@ -1,0 +1,50 @@
+package ee.tuleva.onboarding.hackathon;
+
+import static ee.tuleva.onboarding.mandate.email.EmailVariablesAttachments.getNameMergeVars;
+import static ee.tuleva.onboarding.mandate.email.persistence.EmailType.HACKATHON_REGISTRATION;
+
+import com.microtripit.mandrillapp.lutung.view.MandrillMessage;
+import ee.tuleva.onboarding.mandate.email.persistence.EmailPersistenceService;
+import ee.tuleva.onboarding.notification.email.EmailService;
+import ee.tuleva.onboarding.user.User;
+import java.util.List;
+import java.util.Locale;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class HackathonEmailService {
+
+  private final EmailService emailService;
+  private final EmailPersistenceService emailPersistenceService;
+
+  public void sendRegistrationConfirmation(
+      User user, HackathonRegistration registration, Locale locale) {
+    if (user.getEmail() == null || user.getEmail().isBlank()) {
+      log.warn(
+          "User profile has no email, hackathon confirmation will not be sent: userId={}",
+          user.getId());
+      return;
+    }
+
+    String templateName = HACKATHON_REGISTRATION.getTemplateName(locale);
+
+    MandrillMessage message =
+        emailService.newMandrillMessage(
+            registration.getEmail(),
+            templateName,
+            getNameMergeVars(user),
+            List.of("hackathon"),
+            null);
+
+    emailService
+        .send(user, message, templateName)
+        .ifPresent(
+            response ->
+                emailPersistenceService.save(
+                    user, response.getId(), HACKATHON_REGISTRATION, response.getStatus()));
+  }
+}

--- a/src/main/java/ee/tuleva/onboarding/hackathon/HackathonParticipation.java
+++ b/src/main/java/ee/tuleva/onboarding/hackathon/HackathonParticipation.java
@@ -1,0 +1,7 @@
+package ee.tuleva.onboarding.hackathon;
+
+public enum HackathonParticipation {
+  WITH_TEAM,
+  WITH_IDEA,
+  LOOKING_FOR_TEAM
+}

--- a/src/main/java/ee/tuleva/onboarding/hackathon/HackathonRegistration.java
+++ b/src/main/java/ee/tuleva/onboarding/hackathon/HackathonRegistration.java
@@ -1,0 +1,81 @@
+package ee.tuleva.onboarding.hackathon;
+
+import static jakarta.persistence.EnumType.STRING;
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static org.hibernate.type.SqlTypes.JSON;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.time.Instant;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.jspecify.annotations.Nullable;
+
+@Data
+@Builder
+@Entity
+@Table(name = "hackathon_registration")
+@AllArgsConstructor
+@NoArgsConstructor
+public class HackathonRegistration {
+
+  @Id
+  @GeneratedValue(strategy = IDENTITY)
+  private Long id;
+
+  @NotNull
+  @Column(nullable = false, updatable = false)
+  private Long userId;
+
+  @NotBlank @Email private String email;
+
+  @Nullable private String phoneNumber;
+
+  @Enumerated(STRING)
+  @NotNull
+  private HackathonRole role;
+
+  @JdbcTypeCode(JSON)
+  @NotNull
+  private List<HackathonSkill> skills;
+
+  @JdbcTypeCode(JSON)
+  @NotNull
+  private List<HackathonChallenge> challenges;
+
+  @Enumerated(STRING)
+  @NotNull
+  private HackathonParticipation participation;
+
+  @Nullable private String idea;
+
+  @Nullable private String linkedinUrl;
+
+  @Column(updatable = false)
+  private Instant createdTime;
+
+  private Instant updatedTime;
+
+  public void updateFrom(HackathonRegistrationRequest request, Instant now) {
+    email = request.email();
+    phoneNumber = request.phoneNumber();
+    role = request.role();
+    skills = request.skills();
+    challenges = request.challenges();
+    participation = request.participation();
+    idea = request.idea();
+    linkedinUrl = request.linkedinUrl();
+    updatedTime = now;
+  }
+}

--- a/src/main/java/ee/tuleva/onboarding/hackathon/HackathonRegistrationClosedException.java
+++ b/src/main/java/ee/tuleva/onboarding/hackathon/HackathonRegistrationClosedException.java
@@ -1,0 +1,10 @@
+package ee.tuleva.onboarding.hackathon;
+
+import java.time.Instant;
+
+public class HackathonRegistrationClosedException extends RuntimeException {
+
+  public HackathonRegistrationClosedException(Instant deadline, Instant now) {
+    super("Hackathon registration is closed: deadline=" + deadline + ", now=" + now);
+  }
+}

--- a/src/main/java/ee/tuleva/onboarding/hackathon/HackathonRegistrationController.java
+++ b/src/main/java/ee/tuleva/onboarding/hackathon/HackathonRegistrationController.java
@@ -1,0 +1,35 @@
+package ee.tuleva.onboarding.hackathon;
+
+import ee.tuleva.onboarding.auth.principal.AuthenticatedPerson;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/v1/hackathon-registration")
+@RequiredArgsConstructor
+public class HackathonRegistrationController {
+
+  private final HackathonRegistrationService hackathonRegistrationService;
+
+  @GetMapping
+  @Operation(summary = "Get my hackathon registration, prefilled from my profile if I have none")
+  public HackathonRegistrationDto getRegistration(
+      @AuthenticationPrincipal AuthenticatedPerson authenticatedPerson) {
+    return hackathonRegistrationService.getRegistration(authenticatedPerson);
+  }
+
+  @PostMapping
+  @Operation(summary = "Create or update my hackathon registration")
+  public HackathonRegistrationDto register(
+      @AuthenticationPrincipal AuthenticatedPerson authenticatedPerson,
+      @Valid @RequestBody HackathonRegistrationRequest request) {
+    return hackathonRegistrationService.register(authenticatedPerson, request);
+  }
+}

--- a/src/main/java/ee/tuleva/onboarding/hackathon/HackathonRegistrationDto.java
+++ b/src/main/java/ee/tuleva/onboarding/hackathon/HackathonRegistrationDto.java
@@ -1,0 +1,51 @@
+package ee.tuleva.onboarding.hackathon;
+
+import ee.tuleva.onboarding.user.User;
+import java.time.Instant;
+import java.util.List;
+import org.jspecify.annotations.Nullable;
+
+public record HackathonRegistrationDto(
+    boolean registered,
+    boolean open,
+    Instant deadline,
+    @Nullable String email,
+    @Nullable String phoneNumber,
+    @Nullable HackathonRole role,
+    List<HackathonSkill> skills,
+    List<HackathonChallenge> challenges,
+    @Nullable HackathonParticipation participation,
+    @Nullable String idea,
+    @Nullable String linkedinUrl) {
+
+  public static HackathonRegistrationDto from(
+      HackathonRegistration registration, boolean open, Instant deadline) {
+    return new HackathonRegistrationDto(
+        true,
+        open,
+        deadline,
+        registration.getEmail(),
+        registration.getPhoneNumber(),
+        registration.getRole(),
+        registration.getSkills(),
+        registration.getChallenges(),
+        registration.getParticipation(),
+        registration.getIdea(),
+        registration.getLinkedinUrl());
+  }
+
+  public static HackathonRegistrationDto prefilledFrom(User user, boolean open, Instant deadline) {
+    return new HackathonRegistrationDto(
+        false,
+        open,
+        deadline,
+        user.getEmail(),
+        user.getPhoneNumber(),
+        null,
+        List.of(),
+        List.of(),
+        null,
+        null,
+        null);
+  }
+}

--- a/src/main/java/ee/tuleva/onboarding/hackathon/HackathonRegistrationRepository.java
+++ b/src/main/java/ee/tuleva/onboarding/hackathon/HackathonRegistrationRepository.java
@@ -1,0 +1,10 @@
+package ee.tuleva.onboarding.hackathon;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface HackathonRegistrationRepository
+    extends JpaRepository<HackathonRegistration, Long> {
+
+  Optional<HackathonRegistration> findByUserId(Long userId);
+}

--- a/src/main/java/ee/tuleva/onboarding/hackathon/HackathonRegistrationRequest.java
+++ b/src/main/java/ee/tuleva/onboarding/hackathon/HackathonRegistrationRequest.java
@@ -1,0 +1,55 @@
+package ee.tuleva.onboarding.hackathon;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.time.Instant;
+import java.util.List;
+import org.jspecify.annotations.Nullable;
+
+public record HackathonRegistrationRequest(
+    @NotBlank @Email @Size(max = 255) String email,
+    @Nullable @Size(max = 255) String phoneNumber,
+    @NotNull HackathonRole role,
+    @NotNull List<@NotNull HackathonSkill> skills,
+    @NotNull List<@NotNull HackathonChallenge> challenges,
+    @NotNull HackathonParticipation participation,
+    @Nullable @Size(max = 500) String idea,
+    @Nullable @Size(max = 500) String linkedinUrl) {
+
+  public HackathonRegistrationRequest {
+    if (email != null) {
+      email = email.strip();
+    }
+    phoneNumber = strippedOrNull(phoneNumber);
+    idea = strippedOrNull(idea);
+    linkedinUrl = strippedOrNull(linkedinUrl);
+    if (skills != null) {
+      skills = skills.stream().distinct().toList();
+    }
+    if (challenges != null) {
+      challenges = challenges.stream().distinct().toList();
+    }
+  }
+
+  public HackathonRegistration toRegistration(Long userId, Instant now) {
+    return HackathonRegistration.builder()
+        .userId(userId)
+        .email(email)
+        .phoneNumber(phoneNumber)
+        .role(role)
+        .skills(skills)
+        .challenges(challenges)
+        .participation(participation)
+        .idea(idea)
+        .linkedinUrl(linkedinUrl)
+        .createdTime(now)
+        .updatedTime(now)
+        .build();
+  }
+
+  private static @Nullable String strippedOrNull(@Nullable String value) {
+    return value == null || value.isBlank() ? null : value.strip();
+  }
+}

--- a/src/main/java/ee/tuleva/onboarding/hackathon/HackathonRegistrationService.java
+++ b/src/main/java/ee/tuleva/onboarding/hackathon/HackathonRegistrationService.java
@@ -1,0 +1,94 @@
+package ee.tuleva.onboarding.hackathon;
+
+import ee.tuleva.onboarding.auth.principal.AuthenticatedPerson;
+import ee.tuleva.onboarding.locale.LocaleService;
+import ee.tuleva.onboarding.user.User;
+import ee.tuleva.onboarding.user.UserService;
+import java.time.Clock;
+import java.time.Instant;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+public class HackathonRegistrationService {
+
+  private final HackathonRegistrationRepository repository;
+  private final UserService userService;
+  private final HackathonEmailService hackathonEmailService;
+  private final LocaleService localeService;
+  private final Clock clock;
+  private final Instant deadline;
+
+  public HackathonRegistrationService(
+      HackathonRegistrationRepository repository,
+      UserService userService,
+      HackathonEmailService hackathonEmailService,
+      LocaleService localeService,
+      Clock clock,
+      @Value("${hackathon.registration-deadline}") Instant deadline) {
+    this.repository = repository;
+    this.userService = userService;
+    this.hackathonEmailService = hackathonEmailService;
+    this.localeService = localeService;
+    this.clock = clock;
+    this.deadline = deadline;
+  }
+
+  public HackathonRegistrationDto getRegistration(AuthenticatedPerson authenticatedPerson) {
+    User user = userService.getByIdOrThrow(authenticatedPerson.getUserId());
+    return repository
+        .findByUserId(user.getId())
+        .map(registration -> HackathonRegistrationDto.from(registration, isOpen(), deadline))
+        .orElseGet(() -> HackathonRegistrationDto.prefilledFrom(user, isOpen(), deadline));
+  }
+
+  public HackathonRegistrationDto register(
+      AuthenticatedPerson authenticatedPerson, HackathonRegistrationRequest request) {
+    if (!isOpen()) {
+      throw new HackathonRegistrationClosedException(deadline, clock.instant());
+    }
+
+    User user = userService.getByIdOrThrow(authenticatedPerson.getUserId());
+
+    return repository
+        .findByUserId(user.getId())
+        .map(existing -> update(existing, request))
+        .orElseGet(() -> createOrUpdateConcurrently(user, request));
+  }
+
+  private HackathonRegistrationDto createOrUpdateConcurrently(
+      User user, HackathonRegistrationRequest request) {
+    try {
+      return create(user, request);
+    } catch (DataIntegrityViolationException alreadyRegisteredConcurrently) {
+      return update(
+          repository.findByUserId(user.getId()).orElseThrow(() -> alreadyRegisteredConcurrently),
+          request);
+    }
+  }
+
+  private HackathonRegistrationDto update(
+      HackathonRegistration registration, HackathonRegistrationRequest request) {
+    registration.updateFrom(request, clock.instant());
+    HackathonRegistration saved = repository.save(registration);
+    log.info("Updated hackathon registration: userId={}", saved.getUserId());
+    return HackathonRegistrationDto.from(saved, isOpen(), deadline);
+  }
+
+  private HackathonRegistrationDto create(User user, HackathonRegistrationRequest request) {
+    HackathonRegistration saved =
+        repository.save(request.toRegistration(user.getId(), clock.instant()));
+    log.info(
+        "Created hackathon registration: userId={}, role={}", saved.getUserId(), saved.getRole());
+    hackathonEmailService.sendRegistrationConfirmation(
+        user, saved, localeService.getCurrentLocale());
+    return HackathonRegistrationDto.from(saved, isOpen(), deadline);
+  }
+
+  private boolean isOpen() {
+    return !clock.instant().isAfter(deadline);
+  }
+}

--- a/src/main/java/ee/tuleva/onboarding/hackathon/HackathonRole.java
+++ b/src/main/java/ee/tuleva/onboarding/hackathon/HackathonRole.java
@@ -1,0 +1,6 @@
+package ee.tuleva.onboarding.hackathon;
+
+public enum HackathonRole {
+  PARTICIPANT,
+  MENTOR
+}

--- a/src/main/java/ee/tuleva/onboarding/hackathon/HackathonSkill.java
+++ b/src/main/java/ee/tuleva/onboarding/hackathon/HackathonSkill.java
@@ -1,0 +1,11 @@
+package ee.tuleva.onboarding.hackathon;
+
+public enum HackathonSkill {
+  SOFTWARE_DEVELOPMENT,
+  DESIGN,
+  DATA_AND_AI,
+  LAW_AND_REGULATION,
+  BUSINESS_AND_PRODUCT,
+  MARKETING_AND_COMMUNICATION,
+  FINANCE_AND_INSURANCE
+}

--- a/src/main/java/ee/tuleva/onboarding/hackathon/package-info.java
+++ b/src/main/java/ee/tuleva/onboarding/hackathon/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package ee.tuleva.onboarding.hackathon;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/ee/tuleva/onboarding/mandate/email/persistence/EmailType.java
+++ b/src/main/java/ee/tuleva/onboarding/mandate/email/persistence/EmailType.java
@@ -48,6 +48,8 @@ public enum EmailType {
   PARENT_CHILD_LINK_ADDED("parent_child_link_added"),
 
   MAILCHIMP_CAMPAIGN("mailchimp_campaign"),
+
+  HACKATHON_REGISTRATION("hackathon_registration"),
   ;
 
   private final String templateName;

--- a/src/main/java/ee/tuleva/onboarding/notification/email/EmailService.java
+++ b/src/main/java/ee/tuleva/onboarding/notification/email/EmailService.java
@@ -96,6 +96,14 @@ public class EmailService {
     return send(user, message, templateName, null);
   }
 
+  private static String recipientOf(MandrillMessage message) {
+    if (message.getTo() == null || message.getTo().isEmpty()) {
+      return null;
+    }
+    String email = message.getTo().getFirst().getEmail();
+    return email == null || email.isBlank() ? null : email;
+  }
+
   public Optional<MandrillMessageStatus> send(
       User user, MandrillMessage message, String templateName, Instant sendAt) {
     if (mandrillApi == null) {
@@ -107,9 +115,11 @@ public class EmailService {
       return Optional.empty();
     }
 
-    if (user.getEmail() == null || user.getEmail().isBlank()) {
+    if (recipientOf(message) == null) {
       log.warn(
-          "User has no email, not sending: userId={}, templateName={}", user.getId(), templateName);
+          "Message has no recipient, not sending: userId={}, templateName={}",
+          user.getId(),
+          templateName);
       return Optional.empty();
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -74,6 +74,10 @@ admin:
   api-token: ${ADMIN_API_TOKEN:}
   ops-token: ${ADMIN_OPS_TOKEN:}
 
+hackathon:
+  # 20.09.2026 23:59:59 Estonian time
+  registration-deadline: 2026-09-20T20:59:59Z
+
 mobile-id:
   # use "https://mid.sk.ee/mid-api" for testing signing
   hostUrl: 'https://tsp.demo.sk.ee/mid-api'

--- a/src/main/resources/db/migration/V1_239__create_hackathon_registration.sql
+++ b/src/main/resources/db/migration/V1_239__create_hackathon_registration.sql
@@ -1,0 +1,17 @@
+CREATE TABLE hackathon_registration (
+    id bigserial NOT NULL,
+    user_id bigint NOT NULL,
+    email text NOT NULL,
+    phone_number text,
+    role text NOT NULL,
+    skills jsonb NOT NULL,
+    challenges jsonb NOT NULL,
+    participation text NOT NULL,
+    idea text,
+    linkedin_url text,
+    created_time timestamptz NOT NULL DEFAULT now(),
+    updated_time timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT pk_hackathon_registration PRIMARY KEY (id),
+    CONSTRAINT uq_hackathon_registration_user_id UNIQUE (user_id),
+    CONSTRAINT fk_hackathon_registration_user FOREIGN KEY (user_id) REFERENCES users (id)
+);

--- a/src/test/groovy/ee/tuleva/onboarding/config/SecurityConfigurationSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/config/SecurityConfigurationSpec.groovy
@@ -106,4 +106,16 @@ class SecurityConfigurationSpec extends Specification {
     "/v1/listings" | memberToken | status().isOk()
     "/v1/listings" | userToken   | status().isForbidden()
   }
+
+  def "only members can reach hackathon registration"() {
+    expect:
+    mvc.perform(get(url)
+        .header("Authorization", "Bearer " + token))
+        .andExpect(status)
+
+    where:
+    url                          | token       | status
+    "/v1/hackathon-registration" | userToken   | status().isForbidden()
+    "/v1/hackathon-registration" | memberToken | status().isOk()
+  }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/hackathon/HackathonEmailServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/hackathon/HackathonEmailServiceTest.java
@@ -64,11 +64,22 @@ class HackathonEmailServiceTest {
   }
 
   @Test
-  void sendRegistrationConfirmation_withoutAProfileEmail_doesNotAttemptToSend() {
+  void sendRegistrationConfirmation_withoutAProfileEmail_stillSendsToTheRegistrationEmail() {
     User user = sampleUser().email(null).build();
+    MandrillMessage message = new MandrillMessage();
+    given(
+            emailService.newMandrillMessage(
+                "participant@example.com",
+                "hackathon_registration_et",
+                Map.of("fname", user.getFirstName(), "lname", user.getLastName()),
+                List.of("hackathon"),
+                null))
+        .willReturn(message);
+    given(emailService.send(user, message, "hackathon_registration_et")).willReturn(empty());
 
     hackathonEmailService.sendRegistrationConfirmation(user, registration, Locale.of("et"));
 
-    verifyNoInteractions(emailService, emailPersistenceService);
+    verify(emailService).send(user, message, "hackathon_registration_et");
+    verifyNoInteractions(emailPersistenceService);
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/hackathon/HackathonEmailServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/hackathon/HackathonEmailServiceTest.java
@@ -1,0 +1,74 @@
+package ee.tuleva.onboarding.hackathon;
+
+import static ee.tuleva.onboarding.auth.UserFixture.sampleUser;
+import static ee.tuleva.onboarding.hackathon.HackathonChallenge.FAIR_LENDING;
+import static ee.tuleva.onboarding.hackathon.HackathonParticipation.LOOKING_FOR_TEAM;
+import static ee.tuleva.onboarding.hackathon.HackathonRole.PARTICIPANT;
+import static ee.tuleva.onboarding.hackathon.HackathonSkill.SOFTWARE_DEVELOPMENT;
+import static java.util.Optional.empty;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import com.microtripit.mandrillapp.lutung.view.MandrillMessage;
+import ee.tuleva.onboarding.mandate.email.persistence.EmailPersistenceService;
+import ee.tuleva.onboarding.user.User;
+import java.time.Instant;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class HackathonEmailServiceTest {
+
+  @Mock private ee.tuleva.onboarding.notification.email.EmailService emailService;
+  @Mock private EmailPersistenceService emailPersistenceService;
+
+  @InjectMocks private HackathonEmailService hackathonEmailService;
+
+  private final HackathonRegistration registration =
+      new HackathonRegistrationRequest(
+              "participant@example.com",
+              null,
+              PARTICIPANT,
+              List.of(SOFTWARE_DEVELOPMENT),
+              List.of(FAIR_LENDING),
+              LOOKING_FOR_TEAM,
+              null,
+              null)
+          .toRegistration(999L, Instant.parse("2026-08-12T10:00:00Z"));
+
+  @Test
+  void sendRegistrationConfirmation_sendsTheLocalizedTemplateToTheRegistrationEmail() {
+    User user = sampleUser().build();
+    MandrillMessage message = new MandrillMessage();
+    given(
+            emailService.newMandrillMessage(
+                "participant@example.com",
+                "hackathon_registration_et",
+                Map.of("fname", user.getFirstName(), "lname", user.getLastName()),
+                List.of("hackathon"),
+                null))
+        .willReturn(message);
+    given(emailService.send(user, message, "hackathon_registration_et")).willReturn(empty());
+
+    hackathonEmailService.sendRegistrationConfirmation(user, registration, Locale.of("et"));
+
+    verify(emailService).send(user, message, "hackathon_registration_et");
+    verifyNoInteractions(emailPersistenceService);
+  }
+
+  @Test
+  void sendRegistrationConfirmation_withoutAProfileEmail_doesNotAttemptToSend() {
+    User user = sampleUser().email(null).build();
+
+    hackathonEmailService.sendRegistrationConfirmation(user, registration, Locale.of("et"));
+
+    verifyNoInteractions(emailService, emailPersistenceService);
+  }
+}

--- a/src/test/groovy/ee/tuleva/onboarding/hackathon/HackathonRegistrationControllerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/hackathon/HackathonRegistrationControllerTest.java
@@ -1,0 +1,279 @@
+package ee.tuleva.onboarding.hackathon;
+
+import static ee.tuleva.onboarding.auth.AuthenticatedPersonFixture.sampleAuthenticatedPersonAndMember;
+import static ee.tuleva.onboarding.auth.authority.Authority.MEMBER;
+import static ee.tuleva.onboarding.hackathon.HackathonChallenge.FAIR_LENDING;
+import static ee.tuleva.onboarding.hackathon.HackathonChallenge.WEALTH_AND_INHERITANCE;
+import static ee.tuleva.onboarding.hackathon.HackathonParticipation.LOOKING_FOR_TEAM;
+import static ee.tuleva.onboarding.hackathon.HackathonRole.PARTICIPANT;
+import static ee.tuleva.onboarding.hackathon.HackathonSkill.DATA_AND_AI;
+import static ee.tuleva.onboarding.hackathon.HackathonSkill.SOFTWARE_DEVELOPMENT;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import ee.tuleva.onboarding.auth.principal.AuthenticatedPerson;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(HackathonRegistrationController.class)
+class HackathonRegistrationControllerTest {
+
+  private static final Instant DEADLINE = Instant.parse("2026-09-20T20:59:59Z");
+
+  @Autowired private MockMvc mvc;
+
+  @MockitoBean private HackathonRegistrationService hackathonRegistrationService;
+
+  private final AuthenticatedPerson authenticatedPerson =
+      sampleAuthenticatedPersonAndMember().build();
+
+  private final Authentication authentication =
+      new UsernamePasswordAuthenticationToken(
+          authenticatedPerson, null, List.of(new SimpleGrantedAuthority(MEMBER)));
+
+  @Test
+  void getRegistration_returnsPrefilledFormForANewRegistrant() throws Exception {
+    given(hackathonRegistrationService.getRegistration(authenticatedPerson))
+        .willReturn(
+            new HackathonRegistrationDto(
+                false,
+                true,
+                DEADLINE,
+                "participant@example.com",
+                "+37255555555",
+                null,
+                List.of(),
+                List.of(),
+                null,
+                null,
+                null));
+
+    mvc.perform(get("/v1/hackathon-registration").with(authentication(authentication)).with(csrf()))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.registered", is(false)))
+        .andExpect(jsonPath("$.open", is(true)))
+        .andExpect(jsonPath("$.email", is("participant@example.com")))
+        .andExpect(jsonPath("$.phoneNumber", is("+37255555555")))
+        .andExpect(jsonPath("$.role").doesNotExist());
+  }
+
+  @Test
+  void register_savesTheRegistrationAndReturnsIt() throws Exception {
+    var request =
+        new HackathonRegistrationRequest(
+            "participant@example.com",
+            "+37255555555",
+            PARTICIPANT,
+            List.of(SOFTWARE_DEVELOPMENT, DATA_AND_AI),
+            List.of(FAIR_LENDING, WEALTH_AND_INHERITANCE),
+            LOOKING_FOR_TEAM,
+            "Fondiosaku tagatisel krediidiliin",
+            "https://linkedin.com/in/example");
+
+    given(hackathonRegistrationService.register(eq(authenticatedPerson), eq(request)))
+        .willReturn(
+            new HackathonRegistrationDto(
+                true,
+                true,
+                DEADLINE,
+                request.email(),
+                request.phoneNumber(),
+                request.role(),
+                request.skills(),
+                request.challenges(),
+                request.participation(),
+                request.idea(),
+                request.linkedinUrl()));
+
+    mvc.perform(
+            post("/v1/hackathon-registration")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "email": "participant@example.com",
+                      "phoneNumber": "+37255555555",
+                      "role": "PARTICIPANT",
+                      "skills": ["SOFTWARE_DEVELOPMENT", "DATA_AND_AI"],
+                      "challenges": ["FAIR_LENDING", "WEALTH_AND_INHERITANCE"],
+                      "participation": "LOOKING_FOR_TEAM",
+                      "idea": "Fondiosaku tagatisel krediidiliin",
+                      "linkedinUrl": "https://linkedin.com/in/example"
+                    }
+                    """)
+                .with(authentication(authentication))
+                .with(csrf()))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.registered", is(true)))
+        .andExpect(jsonPath("$.role", is("PARTICIPANT")))
+        .andExpect(jsonPath("$.skills", contains("SOFTWARE_DEVELOPMENT", "DATA_AND_AI")))
+        .andExpect(jsonPath("$.participation", is("LOOKING_FOR_TEAM")));
+
+    verify(hackathonRegistrationService).register(authenticatedPerson, request);
+  }
+
+  @Test
+  void register_withoutOptionalFields_savesTheRegistration() throws Exception {
+    var request =
+        new HackathonRegistrationRequest(
+            "participant@example.com",
+            null,
+            PARTICIPANT,
+            List.of(),
+            List.of(),
+            LOOKING_FOR_TEAM,
+            null,
+            null);
+
+    given(hackathonRegistrationService.register(eq(authenticatedPerson), eq(request)))
+        .willReturn(
+            new HackathonRegistrationDto(
+                true,
+                true,
+                DEADLINE,
+                request.email(),
+                null,
+                request.role(),
+                List.of(),
+                List.of(),
+                request.participation(),
+                null,
+                null));
+
+    mvc.perform(
+            post("/v1/hackathon-registration")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "email": "participant@example.com",
+                      "role": "PARTICIPANT",
+                      "skills": [],
+                      "challenges": [],
+                      "participation": "LOOKING_FOR_TEAM"
+                    }
+                    """)
+                .with(authentication(authentication))
+                .with(csrf()))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.registered", is(true)));
+
+    verify(hackathonRegistrationService).register(authenticatedPerson, request);
+  }
+
+  @Test
+  void register_withInvalidEmail_returnsBadRequest() throws Exception {
+    mvc.perform(
+            post("/v1/hackathon-registration")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "email": "not-an-email",
+                      "role": "PARTICIPANT",
+                      "skills": [],
+                      "challenges": [],
+                      "participation": "LOOKING_FOR_TEAM"
+                    }
+                    """)
+                .with(authentication(authentication))
+                .with(csrf()))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void register_withoutEmail_returnsBadRequest() throws Exception {
+    mvc.perform(
+            post("/v1/hackathon-registration")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "role": "PARTICIPANT",
+                      "skills": [],
+                      "challenges": [],
+                      "participation": "LOOKING_FOR_TEAM"
+                    }
+                    """)
+                .with(authentication(authentication))
+                .with(csrf()))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void register_withoutRole_returnsBadRequest() throws Exception {
+    mvc.perform(
+            post("/v1/hackathon-registration")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "email": "participant@example.com",
+                      "skills": [],
+                      "challenges": [],
+                      "participation": "LOOKING_FOR_TEAM"
+                    }
+                    """)
+                .with(authentication(authentication))
+                .with(csrf()))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void register_withANullSkillInTheList_returnsBadRequest() throws Exception {
+    mvc.perform(
+            post("/v1/hackathon-registration")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "email": "participant@example.com",
+                      "role": "PARTICIPANT",
+                      "skills": [null],
+                      "challenges": [],
+                      "participation": "LOOKING_FOR_TEAM"
+                    }
+                    """)
+                .with(authentication(authentication))
+                .with(csrf()))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void register_withUnknownSkill_returnsBadRequest() throws Exception {
+    mvc.perform(
+            post("/v1/hackathon-registration")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "email": "participant@example.com",
+                      "role": "PARTICIPANT",
+                      "skills": ["UNDERWATER_BASKET_WEAVING"],
+                      "challenges": [],
+                      "participation": "LOOKING_FOR_TEAM"
+                    }
+                    """)
+                .with(authentication(authentication))
+                .with(csrf()))
+        .andExpect(status().isBadRequest());
+  }
+}

--- a/src/test/groovy/ee/tuleva/onboarding/hackathon/HackathonRegistrationControllerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/hackathon/HackathonRegistrationControllerTest.java
@@ -10,6 +10,7 @@ import static ee.tuleva.onboarding.hackathon.HackathonSkill.DATA_AND_AI;
 import static ee.tuleva.onboarding.hackathon.HackathonSkill.SOFTWARE_DEVELOPMENT;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
@@ -177,6 +178,30 @@ class HackathonRegistrationControllerTest {
         .andExpect(jsonPath("$.registered", is(true)));
 
     verify(hackathonRegistrationService).register(authenticatedPerson, request);
+  }
+
+  @Test
+  void register_afterTheDeadline_returnsBadRequestWithTheClosedErrorCode() throws Exception {
+    given(hackathonRegistrationService.register(eq(authenticatedPerson), any()))
+        .willThrow(new HackathonRegistrationClosedException(DEADLINE, DEADLINE.plusSeconds(1)));
+
+    mvc.perform(
+            post("/v1/hackathon-registration")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "email": "participant@example.com",
+                      "role": "PARTICIPANT",
+                      "skills": [],
+                      "challenges": [],
+                      "participation": "LOOKING_FOR_TEAM"
+                    }
+                    """)
+                .with(authentication(authentication))
+                .with(csrf()))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.error", is("HACKATHON_REGISTRATION_CLOSED")));
   }
 
   @Test

--- a/src/test/groovy/ee/tuleva/onboarding/hackathon/HackathonRegistrationRepositoryTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/hackathon/HackathonRegistrationRepositoryTest.java
@@ -1,0 +1,115 @@
+package ee.tuleva.onboarding.hackathon;
+
+import static ee.tuleva.onboarding.hackathon.HackathonChallenge.COLLECTIVE_BUYING_POWER;
+import static ee.tuleva.onboarding.hackathon.HackathonChallenge.FAIR_LENDING;
+import static ee.tuleva.onboarding.hackathon.HackathonParticipation.LOOKING_FOR_TEAM;
+import static ee.tuleva.onboarding.hackathon.HackathonRole.PARTICIPANT;
+import static ee.tuleva.onboarding.hackathon.HackathonSkill.DATA_AND_AI;
+import static ee.tuleva.onboarding.hackathon.HackathonSkill.SOFTWARE_DEVELOPMENT;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import ee.tuleva.onboarding.user.User;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jpa.test.autoconfigure.TestEntityManager;
+import org.springframework.dao.DataIntegrityViolationException;
+
+@DataJpaTest
+class HackathonRegistrationRepositoryTest {
+
+  private static final Instant NOW = Instant.parse("2026-08-12T10:00:00Z");
+
+  @Autowired HackathonRegistrationRepository repository;
+  @Autowired TestEntityManager entityManager;
+
+  private User persistedUser(String personalCode) {
+    return entityManager.persistAndFlush(
+        User.builder()
+            .personalCode(personalCode)
+            .firstName("Test")
+            .lastName("Person")
+            .email(personalCode + "@example.com")
+            .createdDate(Instant.parse("2026-08-12T10:00:00Z"))
+            .updatedDate(Instant.parse("2026-08-12T10:00:00Z"))
+            .active(true)
+            .build());
+  }
+
+  private HackathonRegistration.HackathonRegistrationBuilder registration(Long userId) {
+    return HackathonRegistration.builder()
+        .userId(userId)
+        .email("participant@example.com")
+        .phoneNumber("+37255555555")
+        .role(PARTICIPANT)
+        .skills(List.of(SOFTWARE_DEVELOPMENT, DATA_AND_AI))
+        .challenges(List.of(FAIR_LENDING, COLLECTIVE_BUYING_POWER))
+        .participation(LOOKING_FOR_TEAM)
+        .idea("Fondiosaku tagatisel krediidiliin")
+        .linkedinUrl("https://linkedin.com/in/example")
+        .createdTime(NOW)
+        .updatedTime(NOW);
+  }
+
+  @Test
+  void savesAndReadsBackTheSkillAndChallengeLists() {
+    var user = persistedUser("38812121215");
+
+    repository.saveAndFlush(registration(user.getId()).build());
+    entityManager.clear();
+
+    var found = repository.findByUserId(user.getId()).orElseThrow();
+    assertThat(found.getSkills()).containsExactly(SOFTWARE_DEVELOPMENT, DATA_AND_AI);
+    assertThat(found.getChallenges()).containsExactly(FAIR_LENDING, COLLECTIVE_BUYING_POWER);
+    assertThat(found.getRole()).isEqualTo(PARTICIPANT);
+    assertThat(found.getParticipation()).isEqualTo(LOOKING_FOR_TEAM);
+    assertThat(found.getCreatedTime()).isNotNull();
+    assertThat(found.getUpdatedTime()).isNotNull();
+  }
+
+  @Test
+  void savesEmptySkillAndChallengeLists() {
+    var user = persistedUser("38812121215");
+
+    repository.saveAndFlush(
+        registration(user.getId()).skills(List.of()).challenges(List.of()).build());
+    entityManager.clear();
+
+    var found = repository.findByUserId(user.getId()).orElseThrow();
+    assertThat(found.getSkills()).isEmpty();
+    assertThat(found.getChallenges()).isEmpty();
+  }
+
+  @Test
+  void savesWithoutTheOptionalFields() {
+    var user = persistedUser("38812121215");
+
+    repository.saveAndFlush(
+        registration(user.getId()).phoneNumber(null).idea(null).linkedinUrl(null).build());
+    entityManager.clear();
+
+    var found = repository.findByUserId(user.getId()).orElseThrow();
+    assertThat(found.getPhoneNumber()).isNull();
+    assertThat(found.getIdea()).isNull();
+    assertThat(found.getLinkedinUrl()).isNull();
+  }
+
+  @Test
+  void allowsOnlyOneRegistrationPerUser() {
+    var user = persistedUser("38812121215");
+    repository.saveAndFlush(registration(user.getId()).build());
+
+    assertThatThrownBy(() -> repository.saveAndFlush(registration(user.getId()).build()))
+        .isInstanceOf(DataIntegrityViolationException.class);
+  }
+
+  @Test
+  void findByUserId_withoutARegistration_isEmpty() {
+    var user = persistedUser("38812121215");
+
+    assertThat(repository.findByUserId(user.getId())).isEmpty();
+  }
+}

--- a/src/test/groovy/ee/tuleva/onboarding/hackathon/HackathonRegistrationRepositoryTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/hackathon/HackathonRegistrationRepositoryTest.java
@@ -1,5 +1,6 @@
 package ee.tuleva.onboarding.hackathon;
 
+import static ee.tuleva.onboarding.auth.UserFixture.sampleUser;
 import static ee.tuleva.onboarding.hackathon.HackathonChallenge.COLLECTIVE_BUYING_POWER;
 import static ee.tuleva.onboarding.hackathon.HackathonChallenge.FAIR_LENDING;
 import static ee.tuleva.onboarding.hackathon.HackathonParticipation.LOOKING_FOR_TEAM;
@@ -26,17 +27,8 @@ class HackathonRegistrationRepositoryTest {
   @Autowired HackathonRegistrationRepository repository;
   @Autowired TestEntityManager entityManager;
 
-  private User persistedUser(String personalCode) {
-    return entityManager.persistAndFlush(
-        User.builder()
-            .personalCode(personalCode)
-            .firstName("Test")
-            .lastName("Person")
-            .email(personalCode + "@example.com")
-            .createdDate(Instant.parse("2026-08-12T10:00:00Z"))
-            .updatedDate(Instant.parse("2026-08-12T10:00:00Z"))
-            .active(true)
-            .build());
+  private User persistedUser() {
+    return entityManager.persistAndFlush(sampleUser().id(null).member(null).build());
   }
 
   private HackathonRegistration.HackathonRegistrationBuilder registration(Long userId) {
@@ -56,7 +48,7 @@ class HackathonRegistrationRepositoryTest {
 
   @Test
   void savesAndReadsBackTheSkillAndChallengeLists() {
-    var user = persistedUser("38812121215");
+    var user = persistedUser();
 
     repository.saveAndFlush(registration(user.getId()).build());
     entityManager.clear();
@@ -72,7 +64,7 @@ class HackathonRegistrationRepositoryTest {
 
   @Test
   void savesEmptySkillAndChallengeLists() {
-    var user = persistedUser("38812121215");
+    var user = persistedUser();
 
     repository.saveAndFlush(
         registration(user.getId()).skills(List.of()).challenges(List.of()).build());
@@ -85,7 +77,7 @@ class HackathonRegistrationRepositoryTest {
 
   @Test
   void savesWithoutTheOptionalFields() {
-    var user = persistedUser("38812121215");
+    var user = persistedUser();
 
     repository.saveAndFlush(
         registration(user.getId()).phoneNumber(null).idea(null).linkedinUrl(null).build());
@@ -99,7 +91,7 @@ class HackathonRegistrationRepositoryTest {
 
   @Test
   void allowsOnlyOneRegistrationPerUser() {
-    var user = persistedUser("38812121215");
+    var user = persistedUser();
     repository.saveAndFlush(registration(user.getId()).build());
 
     assertThatThrownBy(() -> repository.saveAndFlush(registration(user.getId()).build()))
@@ -108,7 +100,7 @@ class HackathonRegistrationRepositoryTest {
 
   @Test
   void findByUserId_withoutARegistration_isEmpty() {
-    var user = persistedUser("38812121215");
+    var user = persistedUser();
 
     assertThat(repository.findByUserId(user.getId())).isEmpty();
   }

--- a/src/test/groovy/ee/tuleva/onboarding/hackathon/HackathonRegistrationRequestTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/hackathon/HackathonRegistrationRequestTest.java
@@ -1,0 +1,70 @@
+package ee.tuleva.onboarding.hackathon;
+
+import static ee.tuleva.onboarding.hackathon.HackathonChallenge.INSURANCE;
+import static ee.tuleva.onboarding.hackathon.HackathonParticipation.LOOKING_FOR_TEAM;
+import static ee.tuleva.onboarding.hackathon.HackathonRole.PARTICIPANT;
+import static ee.tuleva.onboarding.hackathon.HackathonSkill.DESIGN;
+import static ee.tuleva.onboarding.hackathon.HackathonSkill.SOFTWARE_DEVELOPMENT;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class HackathonRegistrationRequestTest {
+
+  private HackathonRegistrationRequest request(
+      String email, String phoneNumber, String idea, String linkedinUrl) {
+    return new HackathonRegistrationRequest(
+        email, phoneNumber, PARTICIPANT, List.of(), List.of(), LOOKING_FOR_TEAM, idea, linkedinUrl);
+  }
+
+  @Test
+  void blankOptionalFieldsBecomeNullRatherThanEmptyStrings() {
+    var request = request("participant@example.com", "   ", "", "\t\n");
+
+    assertThat(request.phoneNumber()).isNull();
+    assertThat(request.idea()).isNull();
+    assertThat(request.linkedinUrl()).isNull();
+  }
+
+  @Test
+  void surroundingWhitespaceIsStripped() {
+    var request =
+        request(
+            "  participant@example.com  ",
+            " +37255555555 ",
+            "  Fondiosaku tagatisel krediidiliin  ",
+            " https://linkedin.com/in/example ");
+
+    assertThat(request.email()).isEqualTo("participant@example.com");
+    assertThat(request.phoneNumber()).isEqualTo("+37255555555");
+    assertThat(request.idea()).isEqualTo("Fondiosaku tagatisel krediidiliin");
+    assertThat(request.linkedinUrl()).isEqualTo("https://linkedin.com/in/example");
+  }
+
+  @Test
+  void repeatedSkillsAndChallengesAreCollapsed() {
+    var request =
+        new HackathonRegistrationRequest(
+            "participant@example.com",
+            null,
+            PARTICIPANT,
+            List.of(DESIGN, SOFTWARE_DEVELOPMENT, DESIGN, DESIGN),
+            List.of(INSURANCE, INSURANCE),
+            LOOKING_FOR_TEAM,
+            null,
+            null);
+
+    assertThat(request.skills()).containsExactly(DESIGN, SOFTWARE_DEVELOPMENT);
+    assertThat(request.challenges()).containsExactly(INSURANCE);
+  }
+
+  @Test
+  void missingOptionalFieldsStayNull() {
+    var request = request("participant@example.com", null, null, null);
+
+    assertThat(request.phoneNumber()).isNull();
+    assertThat(request.idea()).isNull();
+    assertThat(request.linkedinUrl()).isNull();
+  }
+}

--- a/src/test/groovy/ee/tuleva/onboarding/hackathon/HackathonRegistrationServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/hackathon/HackathonRegistrationServiceTest.java
@@ -1,0 +1,246 @@
+package ee.tuleva.onboarding.hackathon;
+
+import static ee.tuleva.onboarding.auth.AuthenticatedPersonFixture.sampleAuthenticatedPersonAndMember;
+import static ee.tuleva.onboarding.auth.UserFixture.sampleUser;
+import static ee.tuleva.onboarding.hackathon.HackathonChallenge.FAIR_LENDING;
+import static ee.tuleva.onboarding.hackathon.HackathonParticipation.LOOKING_FOR_TEAM;
+import static ee.tuleva.onboarding.hackathon.HackathonParticipation.WITH_TEAM;
+import static ee.tuleva.onboarding.hackathon.HackathonRole.MENTOR;
+import static ee.tuleva.onboarding.hackathon.HackathonRole.PARTICIPANT;
+import static ee.tuleva.onboarding.hackathon.HackathonSkill.DATA_AND_AI;
+import static ee.tuleva.onboarding.hackathon.HackathonSkill.SOFTWARE_DEVELOPMENT;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import ee.tuleva.onboarding.auth.principal.AuthenticatedPerson;
+import ee.tuleva.onboarding.locale.LocaleService;
+import ee.tuleva.onboarding.user.User;
+import ee.tuleva.onboarding.user.UserService;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+
+@ExtendWith(MockitoExtension.class)
+class HackathonRegistrationServiceTest {
+
+  private static final Instant DEADLINE = Instant.parse("2026-09-20T20:59:59Z");
+  private static final Instant BEFORE_DEADLINE = Instant.parse("2026-08-12T10:00:00Z");
+  private static final Instant AFTER_DEADLINE = Instant.parse("2026-09-21T10:00:00Z");
+
+  @Mock private HackathonRegistrationRepository repository;
+  @Mock private UserService userService;
+  @Mock private HackathonEmailService hackathonEmailService;
+  @Mock private LocaleService localeService;
+
+  private final User user = sampleUser().build();
+  private final AuthenticatedPerson authenticatedPerson =
+      sampleAuthenticatedPersonAndMember().build();
+
+  private HackathonRegistrationService service;
+
+  @BeforeEach
+  void setUp() {
+    service = serviceAt(BEFORE_DEADLINE);
+  }
+
+  private HackathonRegistrationService serviceAt(Instant now) {
+    return new HackathonRegistrationService(
+        repository,
+        userService,
+        hackathonEmailService,
+        localeService,
+        Clock.fixed(now, ZoneOffset.UTC),
+        DEADLINE);
+  }
+
+  private HackathonRegistrationRequest sampleRequest() {
+    return new HackathonRegistrationRequest(
+        "participant@example.com",
+        "+37255555555",
+        PARTICIPANT,
+        List.of(SOFTWARE_DEVELOPMENT, DATA_AND_AI),
+        List.of(FAIR_LENDING),
+        LOOKING_FOR_TEAM,
+        "Fondiosaku tagatisel krediidiliin",
+        "https://linkedin.com/in/example");
+  }
+
+  @Test
+  void getRegistration_withoutAnExistingRegistration_prefillsFromTheUserProfile() {
+    given(userService.getByIdOrThrow(user.getId())).willReturn(user);
+    given(repository.findByUserId(user.getId())).willReturn(Optional.empty());
+
+    var dto = service.getRegistration(authenticatedPerson);
+
+    assertThat(dto)
+        .isEqualTo(
+            new HackathonRegistrationDto(
+                false,
+                true,
+                DEADLINE,
+                user.getEmail(),
+                user.getPhoneNumber(),
+                null,
+                List.of(),
+                List.of(),
+                null,
+                null,
+                null));
+  }
+
+  @Test
+  void getRegistration_withAnExistingRegistration_returnsIt() {
+    var request = sampleRequest();
+    given(userService.getByIdOrThrow(user.getId())).willReturn(user);
+    given(repository.findByUserId(user.getId()))
+        .willReturn(Optional.of(request.toRegistration(user.getId(), BEFORE_DEADLINE)));
+
+    var dto = service.getRegistration(authenticatedPerson);
+
+    assertThat(dto)
+        .isEqualTo(
+            new HackathonRegistrationDto(
+                true,
+                true,
+                DEADLINE,
+                request.email(),
+                request.phoneNumber(),
+                request.role(),
+                request.skills(),
+                request.challenges(),
+                request.participation(),
+                request.idea(),
+                request.linkedinUrl()));
+  }
+
+  @Test
+  void getRegistration_afterTheDeadline_reportsRegistrationClosed() {
+    given(userService.getByIdOrThrow(user.getId())).willReturn(user);
+    given(repository.findByUserId(user.getId())).willReturn(Optional.empty());
+
+    var dto = serviceAt(AFTER_DEADLINE).getRegistration(authenticatedPerson);
+
+    assertThat(dto.open()).isFalse();
+    assertThat(dto.deadline()).isEqualTo(DEADLINE);
+  }
+
+  @Test
+  void register_withoutAnExistingRegistration_savesItAndSendsAConfirmationEmail() {
+    var request = sampleRequest();
+    var saved = request.toRegistration(user.getId(), BEFORE_DEADLINE);
+    given(userService.getByIdOrThrow(user.getId())).willReturn(user);
+    given(repository.findByUserId(user.getId())).willReturn(Optional.empty());
+    given(repository.save(any(HackathonRegistration.class))).willReturn(saved);
+    given(localeService.getCurrentLocale()).willReturn(Locale.of("et"));
+
+    var dto = service.register(authenticatedPerson, request);
+
+    assertThat(dto.registered()).isTrue();
+    assertThat(dto.skills()).containsExactly(SOFTWARE_DEVELOPMENT, DATA_AND_AI);
+    verify(repository).save(request.toRegistration(user.getId(), BEFORE_DEADLINE));
+    verify(hackathonEmailService).sendRegistrationConfirmation(user, saved, Locale.of("et"));
+  }
+
+  @Test
+  void register_withAnExistingRegistration_updatesItWithoutSendingAnotherEmail() {
+    var existing = sampleRequest().toRegistration(user.getId(), BEFORE_DEADLINE);
+    var updated =
+        new HackathonRegistrationRequest(
+            "updated@example.com",
+            null,
+            MENTOR,
+            List.of(DATA_AND_AI),
+            List.of(),
+            WITH_TEAM,
+            null,
+            null);
+    given(userService.getByIdOrThrow(user.getId())).willReturn(user);
+    given(repository.findByUserId(user.getId())).willReturn(Optional.of(existing));
+    given(repository.save(existing)).willReturn(existing);
+
+    var dto = service.register(authenticatedPerson, updated);
+
+    assertThat(dto)
+        .isEqualTo(
+            new HackathonRegistrationDto(
+                true,
+                true,
+                DEADLINE,
+                "updated@example.com",
+                null,
+                MENTOR,
+                List.of(DATA_AND_AI),
+                List.of(),
+                WITH_TEAM,
+                null,
+                null));
+    verify(hackathonEmailService, never())
+        .sendRegistrationConfirmation(any(), any(), any(Locale.class));
+  }
+
+  @Test
+  void register_whenAnotherRequestRegisteredFirst_updatesInsteadOfFailing() {
+    var request = sampleRequest();
+    var concurrentlyCreated = request.toRegistration(user.getId(), BEFORE_DEADLINE);
+    given(userService.getByIdOrThrow(user.getId())).willReturn(user);
+    given(repository.findByUserId(user.getId()))
+        .willReturn(Optional.empty())
+        .willReturn(Optional.of(concurrentlyCreated));
+    given(repository.save(any(HackathonRegistration.class)))
+        .willThrow(new DataIntegrityViolationException("uq_hackathon_registration_user_id"))
+        .willReturn(concurrentlyCreated);
+
+    var dto = service.register(authenticatedPerson, request);
+
+    assertThat(dto.registered()).isTrue();
+    verify(hackathonEmailService, never())
+        .sendRegistrationConfirmation(any(), any(), any(Locale.class));
+  }
+
+  @Test
+  void register_atTheDeadlineInstant_isStillAccepted() {
+    var request = sampleRequest();
+    var saved = request.toRegistration(user.getId(), DEADLINE);
+    given(userService.getByIdOrThrow(user.getId())).willReturn(user);
+    given(repository.findByUserId(user.getId())).willReturn(Optional.empty());
+    given(repository.save(any(HackathonRegistration.class))).willReturn(saved);
+    given(localeService.getCurrentLocale()).willReturn(Locale.of("et"));
+
+    var dto = serviceAt(DEADLINE).register(authenticatedPerson, request);
+
+    assertThat(dto.registered()).isTrue();
+    assertThat(dto.open()).isTrue();
+  }
+
+  @Test
+  void register_oneMillisecondAfterTheDeadline_isRejected() {
+    var service = serviceAt(DEADLINE.plusMillis(1));
+
+    assertThatThrownBy(() -> service.register(authenticatedPerson, sampleRequest()))
+        .isInstanceOf(HackathonRegistrationClosedException.class);
+  }
+
+  @Test
+  void register_afterTheDeadline_isRejected() {
+    var service = serviceAt(AFTER_DEADLINE);
+
+    assertThatThrownBy(() -> service.register(authenticatedPerson, sampleRequest()))
+        .isInstanceOf(HackathonRegistrationClosedException.class);
+
+    verifyNoInteractions(repository, hackathonEmailService);
+  }
+}

--- a/src/test/groovy/ee/tuleva/onboarding/notification/email/EmailServiceSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/notification/email/EmailServiceSpec.groovy
@@ -198,7 +198,20 @@ class EmailServiceSpec extends Specification {
     thrown(EmailDeliveryException)
   }
 
-  def "does not send email when user has no email"() {
+  def "does not send email when the message has no recipient"() {
+    given:
+    def messageWithoutRecipient = service.newMandrillMessage(
+        null, templateName, [:], ["test"], null)
+
+    when:
+    def response = service.send(user, messageWithoutRecipient, templateName)
+
+    then:
+    response == Optional.empty()
+    0 * mandrillMessagesApi._
+  }
+
+  def "sends to the message recipient even when the user profile has no email"() {
     given:
     def userWithoutEmail = sampleUser().email(null).build()
 
@@ -206,8 +219,8 @@ class EmailServiceSpec extends Specification {
     def response = service.send(userWithoutEmail, message, templateName)
 
     then:
-    response == Optional.empty()
-    0 * mandrillMessagesApi._
+    1 * mandrillMessagesApi.sendTemplate(templateName, [:], message, false, null, null) >> [mandrillMessageStatus]
+    response == Optional.of(mandrillMessageStatus)
   }
 
   def "returns empty when Mandrill returns empty response"() {


### PR DESCRIPTION
Members register for the 9-11 October hackathon from the member area rather than a Google Form, so the sign-up flow brings people to our own site and nudges non-members to join. One row per member, editable until the 20 September deadline, which is enforced server-side and reported to the client so it can render a closed state.

The form asks only for what we do not already hold: name and personal code come from the session and are never fields, while email and phone are prefilled from the profile and stay editable because that data can be stale. A Mandrill confirmation goes out on first registration only.