### PR TITLE
Sanitise the file extension into the WordPress media slug

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/investment/report/publishing/wordpress/WordPressMediaClient.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/report/publishing/wordpress/WordPressMediaClient.java
@@ -147,8 +147,13 @@ public class WordPressMediaClient {
    *
    * <p>Mirrored by {@code toWordPressSlug} in the tuleva repo's {@code investeeringute_aruanne.gs}:
    * both systems upload the same monthly PDF, and {@link #findExistingMedia} matches on {@code
-   * source_url.endsWith("/" + slug)}, so the two must agree character for character or the same
-   * report lands twice under two URLs.
+   * source_url.endsWith("/" + slug)}, so a name the two slug differently lands the same report
+   * twice under two URLs. They agree over the alphabet report names actually use — ASCII plus the
+   * Estonian letters — and not beyond it: the Rhino runtime has no {@code String.normalize}, so the
+   * GAS side folds a fixed list (ä ö õ ü š ž) where this one folds any combining mark. A base name
+   * containing, say, "é" would give {@code e} here and {@code -} there. Names come from {@code
+   * buildPdfName} off the fund titles, which stay inside that alphabet; widening it means widening
+   * both sides together.
    */
   static String toWordPressSlug(String filename) {
     var dotIndex = filename.lastIndexOf('.');

--- a/src/main/java/ee/tuleva/onboarding/investment/report/publishing/wordpress/WordPressMediaClient.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/report/publishing/wordpress/WordPressMediaClient.java
@@ -21,6 +21,9 @@ public class WordPressMediaClient {
       Pattern.compile(
           "^https://tuleva\\.ee/wp-content/uploads/\\d{4}/\\d{2}/[A-Za-z0-9._-]+\\.pdf$");
 
+  private static final String DEFAULT_EXTENSION = "pdf";
+  private static final int MAX_BASE_SLUG_LENGTH = 100;
+
   private final RestClient restClient;
   private final RetryTemplate retryTemplate;
 
@@ -138,30 +141,28 @@ public class WordPressMediaClient {
     return (Integer) pages.getFirst().get("id");
   }
 
-  /**
-   * Both halves are sanitised, because the whole result is interpolated into the {@code
-   * Content-Disposition} header. Leaving the extension raw would let a quote or a line break after
-   * the last dot reach that header unchanged — the base name is only half the string that gets
-   * there. Report names come from the report builder and contain neither, so this is defence in
-   * depth rather than a live hole, but it has to cover the string it actually emits.
-   *
-   * <p>Mirrored by {@code toWordPressSlug} in the tuleva repo's {@code investeeringute_aruanne.gs}:
-   * both systems upload the same monthly PDF, and {@link #findExistingMedia} matches on {@code
-   * source_url.endsWith("/" + slug)}, so a name the two slug differently lands the same report
-   * twice under two URLs. They agree over the alphabet report names actually use — ASCII plus the
-   * Estonian letters — and not beyond it: the Rhino runtime has no {@code String.normalize}, so the
-   * GAS side folds a fixed list (ä ö õ ü š ž) where this one folds any combining mark. A base name
-   * containing, say, "é" would give {@code e} here and {@code -} there. Names come from {@code
-   * buildPdfName} off the fund titles, which stay inside that alphabet; widening it means widening
-   * both sides together.
-   */
   static String toWordPressSlug(String filename) {
     var dotIndex = filename.lastIndexOf('.');
     var base = dotIndex > 0 ? filename.substring(0, dotIndex) : filename;
-    var extension = dotIndex > 0 ? filename.substring(dotIndex + 1) : "pdf";
-    var slug = asciiSlug(base).replaceAll("(^-+)|(-+$)", "");
-    var extensionSlug = asciiSlug(extension).replace("-", "");
-    return slug + "." + (extensionSlug.isEmpty() ? "pdf" : extensionSlug);
+    var extension = dotIndex > 0 ? filename.substring(dotIndex + 1) : DEFAULT_EXTENSION;
+    var baseSlug = toHyphenatedWords(base);
+    if (baseSlug.isEmpty()) {
+      throw new IllegalArgumentException(
+          "Filename sanitises to an empty slug: filename=" + filename);
+    }
+    var extensionSlug = toSingleWord(extension);
+    return baseSlug + "." + (extensionSlug.isEmpty() ? DEFAULT_EXTENSION : extensionSlug);
+  }
+
+  private static String toHyphenatedWords(String value) {
+    var hyphenated = asciiSlug(value);
+    return hyphenated
+        .substring(0, Math.min(hyphenated.length(), MAX_BASE_SLUG_LENGTH))
+        .replaceAll("(^-+)|(-+$)", "");
+  }
+
+  private static String toSingleWord(String value) {
+    return asciiSlug(value).replace("-", "");
   }
 
   private static String asciiSlug(String value) {

--- a/src/main/java/ee/tuleva/onboarding/investment/report/publishing/wordpress/WordPressMediaClient.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/report/publishing/wordpress/WordPressMediaClient.java
@@ -138,17 +138,32 @@ public class WordPressMediaClient {
     return (Integer) pages.getFirst().get("id");
   }
 
+  /**
+   * Both halves are sanitised, because the whole result is interpolated into the {@code
+   * Content-Disposition} header. Leaving the extension raw would let a quote or a line break after
+   * the last dot reach that header unchanged — the base name is only half the string that gets
+   * there. Report names come from the report builder and contain neither, so this is defence in
+   * depth rather than a live hole, but it has to cover the string it actually emits.
+   *
+   * <p>Mirrored by {@code toWordPressSlug} in the tuleva repo's {@code investeeringute_aruanne.gs}:
+   * both systems upload the same monthly PDF, and {@link #findExistingMedia} matches on {@code
+   * source_url.endsWith("/" + slug)}, so the two must agree character for character or the same
+   * report lands twice under two URLs.
+   */
   static String toWordPressSlug(String filename) {
     var dotIndex = filename.lastIndexOf('.');
     var base = dotIndex > 0 ? filename.substring(0, dotIndex) : filename;
     var extension = dotIndex > 0 ? filename.substring(dotIndex + 1) : "pdf";
-    var slug =
-        Normalizer.normalize(base, Normalizer.Form.NFD)
-            .replaceAll("\\p{M}+", "")
-            .toLowerCase(Locale.ROOT)
-            .replaceAll("[^a-z0-9]+", "-")
-            .replaceAll("(^-+)|(-+$)", "");
-    return slug + "." + extension.toLowerCase(Locale.ROOT);
+    var slug = asciiSlug(base).replaceAll("(^-+)|(-+$)", "");
+    var extensionSlug = asciiSlug(extension).replace("-", "");
+    return slug + "." + (extensionSlug.isEmpty() ? "pdf" : extensionSlug);
+  }
+
+  private static String asciiSlug(String value) {
+    return Normalizer.normalize(value, Normalizer.Form.NFD)
+        .replaceAll("\\p{M}+", "")
+        .toLowerCase(Locale.ROOT)
+        .replaceAll("[^a-z0-9]+", "-");
   }
 
   private static String truncate(String s, int maxLen) {

--- a/src/main/java/ee/tuleva/onboarding/investment/report/publishing/wordpress/package-info.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/report/publishing/wordpress/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package ee.tuleva.onboarding.investment.report.publishing.wordpress;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/test/groovy/ee/tuleva/onboarding/investment/report/publishing/wordpress/WordPressMediaClientSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/report/publishing/wordpress/WordPressMediaClientSpec.groovy
@@ -1,0 +1,62 @@
+package ee.tuleva.onboarding.investment.report.publishing.wordpress
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class WordPressMediaClientSpec extends Specification {
+
+  @Unroll
+  def "toWordPressSlug(#filename) == #expectedSlug"() {
+    expect:
+    WordPressMediaClient.toWordPressSlug(filename) == expectedSlug
+    expectedSlug ==~ /[a-z0-9-]+\.[a-z0-9]+/
+
+    where:
+    filename                                                                    || expectedSlug
+    "normal.pdf"                                                                || "normal.pdf"
+    "Report 2026-03.pdf"                                                        || "report-2026-03.pdf"
+    "Tuleva Maailma Aktsiate Pensionifondi investeeringute aruanne 2026-03.pdf" || "tuleva-maailma-aktsiate-pensionifondi-investeeringute-aruanne-2026-03.pdf"
+    "V\u00f5lakirjade fond.pdf"                                                 || "volakirjade-fond.pdf"
+    "file\"name.pdf"                                                            || "file-name.pdf"
+    "file\\name.pdf"                                                            || "file-name.pdf"
+    "report\rinjected.pdf"                                                      || "report-injected.pdf"
+    "report\ninjected.pdf"                                                      || "report-injected.pdf"
+    "report;rm -rf.pdf"                                                         || "report-rm-rf.pdf"
+    "report/x.pdf"                                                              || "report-x.pdf"
+    "../../etc/passwd.pdf"                                                      || "etc-passwd.pdf"
+    "report%2e%2e%2fx.pdf"                                                      || "report-2e-2e-2fx.pdf"
+    "C:\\Windows\\x.pdf"                                                        || "c-windows-x.pdf"
+    "report\u202egpj.pdf"                                                       || "report-gpj.pdf"
+    "report\u200bx.pdf"                                                         || "report-x.pdf"
+    "rep\u0430ort.pdf"                                                          || "rep-ort.pdf"
+    "\u0130stanbul.pdf"                                                         || "istanbul.pdf"
+    "ra\u0131port.pdf"                                                          || "ra-port.pdf"
+    "\u03a3igma.pdf"                                                            || "igma.pdf"
+    "ra\u03c2port.pdf"                                                          || "ra-port.pdf"
+    "\u0130\u0131\u03a3\u03c2 raport.pdf"                                       || "i-raport.pdf"
+    "e\u0301clair.pdf"                                                          || "eclair.pdf"
+    "\u00e9clair.pdf"                                                           || "eclair.pdf"
+    "a.b.pdf"                                                                   || "a-b.pdf"
+    ".pdf"                                                                      || "pdf.pdf"
+    "a" * 140 + ".pdf"                                                          || "a" * 100 + ".pdf"
+    "report.pdf\"; x=\"y"                                                       || "report.pdfxy"
+    "report.pdf\r\nX-Injected: 1"                                               || "report.pdfxinjected1"
+    "  \u00c4\"wild\\\r\n name??  .p d\"f  "                                    || "a-wild-name.pdf"
+    "report.p-df"                                                               || "report.pdf"
+    "report.PDF"                                                                || "report.pdf"
+    "report."                                                                   || "report.pdf"
+    "report"                                                                    || "report.pdf"
+  }
+
+  @Unroll
+  def "toWordPressSlug rejects a filename that sanitises to nothing: #filename"() {
+    when:
+    WordPressMediaClient.toWordPressSlug(filename)
+
+    then:
+    thrown(IllegalArgumentException)
+
+    where:
+    filename << ["", ".", "-", "   ", "....", "???.pdf", "---.pdf", "\u202e.pdf"]
+  }
+}

--- a/src/test/groovy/ee/tuleva/onboarding/investment/report/publishing/wordpress/WordPressMediaClientTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/report/publishing/wordpress/WordPressMediaClientTest.java
@@ -220,4 +220,27 @@ class WordPressMediaClientTest {
     assertThat(WordPressMediaClient.toWordPressSlug("Võlakirjade fond.pdf"))
         .isEqualTo("volakirjade-fond.pdf");
   }
+
+  @Test
+  void toWordPressSlugSanitisesTheExtensionToo() {
+    // The whole slug is interpolated into Content-Disposition, so the half after the last dot has
+    // to be as clean as the half before it.
+    assertThat(WordPressMediaClient.toWordPressSlug("report.pdf\"; x=\"y"))
+        .isEqualTo("report.pdfxy");
+    assertThat(WordPressMediaClient.toWordPressSlug("report.pdf\r\nX-Injected: 1"))
+        .isEqualTo("report.pdfxinjected1");
+    assertThat(WordPressMediaClient.toWordPressSlug("report.PDF")).isEqualTo("report.pdf");
+    // An extension that sanitises away leaves the default rather than a slug ending in a bare dot.
+    assertThat(WordPressMediaClient.toWordPressSlug("report.")).isEqualTo("report.pdf");
+    assertThat(WordPressMediaClient.toWordPressSlug("report")).isEqualTo("report.pdf");
+  }
+
+  @Test
+  void toWordPressSlugEmitsNothingOutsideTheAllowedAlphabet() {
+    // The guarantee the Content-Disposition header depends on, stated as a test rather than as a
+    // comment: whatever goes in, what comes out is [a-z0-9-] then one dot then [a-z0-9].
+    var hostile = "  Ä\"wild\\\r\n name??  .p d\"f  ";
+
+    assertThat(WordPressMediaClient.toWordPressSlug(hostile)).matches("[a-z0-9-]+\\.[a-z0-9]+");
+  }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/investment/report/publishing/wordpress/WordPressMediaClientTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/report/publishing/wordpress/WordPressMediaClientTest.java
@@ -205,42 +205,4 @@ class WordPressMediaClientTest {
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("No WordPress page found");
   }
-
-  @Test
-  void toWordPressSlugLowercasesFoldsDiacriticsAndHyphenates() {
-    assertThat(WordPressMediaClient.toWordPressSlug("normal.pdf")).isEqualTo("normal.pdf");
-    assertThat(WordPressMediaClient.toWordPressSlug("file\"name.pdf")).isEqualTo("file-name.pdf");
-    assertThat(WordPressMediaClient.toWordPressSlug("file\\name.pdf")).isEqualTo("file-name.pdf");
-    assertThat(WordPressMediaClient.toWordPressSlug("Report 2026-03.pdf"))
-        .isEqualTo("report-2026-03.pdf");
-    assertThat(
-            WordPressMediaClient.toWordPressSlug(
-                "Tuleva Maailma Aktsiate Pensionifondi investeeringute aruanne 2026-03.pdf"))
-        .isEqualTo("tuleva-maailma-aktsiate-pensionifondi-investeeringute-aruanne-2026-03.pdf");
-    assertThat(WordPressMediaClient.toWordPressSlug("Võlakirjade fond.pdf"))
-        .isEqualTo("volakirjade-fond.pdf");
-  }
-
-  @Test
-  void toWordPressSlugSanitisesTheExtensionToo() {
-    // The whole slug is interpolated into Content-Disposition, so the half after the last dot has
-    // to be as clean as the half before it.
-    assertThat(WordPressMediaClient.toWordPressSlug("report.pdf\"; x=\"y"))
-        .isEqualTo("report.pdfxy");
-    assertThat(WordPressMediaClient.toWordPressSlug("report.pdf\r\nX-Injected: 1"))
-        .isEqualTo("report.pdfxinjected1");
-    assertThat(WordPressMediaClient.toWordPressSlug("report.PDF")).isEqualTo("report.pdf");
-    // An extension that sanitises away leaves the default rather than a slug ending in a bare dot.
-    assertThat(WordPressMediaClient.toWordPressSlug("report.")).isEqualTo("report.pdf");
-    assertThat(WordPressMediaClient.toWordPressSlug("report")).isEqualTo("report.pdf");
-  }
-
-  @Test
-  void toWordPressSlugEmitsNothingOutsideTheAllowedAlphabet() {
-    // The guarantee the Content-Disposition header depends on, stated as a test rather than as a
-    // comment: whatever goes in, what comes out is [a-z0-9-] then one dot then [a-z0-9].
-    var hostile = "  Ä\"wild\\\r\n name??  .p d\"f  ";
-
-    assertThat(WordPressMediaClient.toWordPressSlug(hostile)).matches("[a-z0-9-]+\\.[a-z0-9]+");
-  }
 }


### PR DESCRIPTION
# Sanitise the file extension into the WordPress media slug

## Problem

`WordPressMediaClient.toWordPressSlug` sanitised the base name and appended the extension verbatim:

```java
var extension = dotIndex > 0 ? filename.substring(dotIndex + 1) : "pdf";
...
return slug + "." + extension.toLowerCase(Locale.ROOT);
```

The result is interpolated straight into a header:

```java
.header("Content-Disposition", "attachment; filename=\"" + slug + "\"")
```

So everything after the last dot reached that header unchanged — a quote closes the
`filename="…"` parameter, a CR/LF starts a new header. The existing test pinned `"` and `\` in the
*base* name and never asked about the extension, which is how the asymmetry survived.

**Not reachable today.** The only caller chain is
`InvestmentReportPublisher` → `FundReportMapping.buildPdfFilename(YearMonth)`, which builds the name
from an enum constant plus two ints, so the extension is always the literal `pdf`. This is defence
in depth that was only covering half the string it emits.

## Fix

Both halves go through the same `asciiSlug` fold: NFD, drop combining marks, lowercase under
`Locale.ROOT`, then replace everything outside `[a-z0-9]` with `-`. The allowlist is the last
operation, so nothing that survives the earlier steps can reintroduce a disallowed byte.

Two absences are now handled symmetrically:

- An extension that sanitises away falls back to `pdf`, rather than leaving a slug ending in a bare
  dot.
- A **base** that sanitises away — `""`, `"...."`, `"???.pdf"`, `"---.pdf"` — now throws
  `IllegalArgumentException`. Previously it produced the slug `".pdf"`: an empty string standing in
  for missing data, which this codebase bans, and which would have been uploaded and deduped
  against.

### The guarantee

The earlier version of this description claimed the output always matches
`[a-z0-9-]+\.[a-z0-9]+`. That was false: the `+` requires at least one character on each side, and
an empty base produced `.pdf`. The guarantee now actually holds, and it holds *because* of the
fail-fast:

> Every returned slug is `[a-z0-9-]+\.[a-z0-9]+` — both halves non-empty, no leading or trailing
> hyphen on the base, no hyphen at all in the extension. If the base cannot produce a non-empty
> slug, the call throws instead of returning one.

The extension deletes hyphens where the base keeps them, so `report.p-df` and `report.pdf` collapse
to the same slug. That is intentional — an extension is one token, not a phrase — and the two halves
are now named for it (`toSingleWord` vs `toHyphenatedWords`) instead of only differing in the
regex.

The base slug is also capped at 100 characters, so the value reaching the `Content-Disposition`
header is bounded. The longest name the system produces today is 72 characters, so nothing real is
affected. (The class's existing `truncate` helper is not reused here: it appends `...`, which would
put dots back into a filename.)

## Behaviour change

For every filename this system actually generates, the slug is **byte-identical** before and after.
The only inputs whose output changes are ones no caller can produce: a base with no alphanumerics
(now throws), a base over 100 characters (now capped), and an extension containing characters
outside `[a-z0-9]` (now folded).

## Mirror, and the one place it diverges

`toWordPressSlug` in the tuleva repo's
`work/investeerimistegevus/apps/investment-reports/investeeringute_aruanne.gs` is a deliberate
mirror of this method — both systems upload the same monthly PDF, and `findExistingMedia` dedups on
`source_url.endsWith("/" + slug)`, so a name the two slug differently lands the same report twice
under two URLs.

They agree over the alphabet report names actually use — ASCII plus the Estonian letters — and not
beyond it. The Rhino runtime behind Apps Script has no `String.normalize`, so the GAS side folds a
fixed list (ä ö õ ü š ž) where this one folds any combining mark. A base name containing `é` gives
`e` here and `-` there. The 100-character cap is a second such point, unreachable at present for the
same reason. Names come from `buildPdfFilename` off the fund titles, which stay inside the shared
alphabet and well inside the cap; widening either means widening both sides together.

## Release coupling: none

This PR is **independent** of the TulevaEE/tuleva#293 / wordpress-theme#69 clasp-push ordering.
Because the produced slug is byte-identical for every filename the system generates today, this can
merge and deploy on its own, in either order, without the GAS side moving.

## Tests

`WordPressMediaClientSpec` — a Spock data table over the sanitiser:

- control characters: lone `\r`, lone `\n`, `\r\n` header injection, `"` quote injection
- shell and path: bare `;`, `/`, `../../etc/passwd.pdf`, percent-encoded `report%2e%2e%2fx.pdf`,
  Windows `C:\Windows\x.pdf`
- invisible and confusable: U+202E RTL override, U+200B zero-width space, Cyrillic U+0430 homoglyph
- locale traps, pinned because `Locale.ROOT` is what makes them safe: `İ` (U+0130), `ı` (U+0131),
  `Σ` (U+03A3), `ς` (U+03C2)
- normalisation: precomposed `é` vs `e` + combining acute, both to `e`
- structure: multi-dot `a.b.pdf`, dotfile `.pdf`, extension-only sanitisation, the 100-character cap
- the empty-slug rejections: `""`, `"."`, `"-"`, `"   "`, `"...."`, `"???.pdf"`, `"---.pdf"`

Every row also asserts the `[a-z0-9-]+\.[a-z0-9]+` shape, so a future row cannot quietly widen the
output alphabet.

`WordPressMediaClientTest` keeps the HTTP-level tests; the slug cases moved to the spec.

## Also in this change

- The package is now `@NullMarked`. `toWordPressSlug(null)` previously NPE'd inside
  `String.lastIndexOf`; the contract is now explicit.
- The Javadoc block that carried the mirror/Rhino notes is gone — that content is in this
  description instead, where it stays readable without sitting in an implementation class.

## Not fixed here (pre-existing, not regressed by this PR)

`AdminController.previewInvestmentReport` interpolates the raw `buildPdfFilename` result into
`Content-Disposition` with no sanitisation at all. It is safe for the same reachability reason —
enum constant plus two ints — but it does emit `õ`, a non-ASCII byte in a header value, where
RFC 6266 calls for the `filename*` form. `FundController` already strips with its own allowlist and
is fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
