### PR TITLE
Sum both R17 unit columns when parsing PEVA switching flows

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/investment/epis/parser/EpisCsvParser.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/epis/parser/EpisCsvParser.java
@@ -79,9 +79,24 @@ public class EpisCsvParser {
     return group + " " + sub;
   }
 
+  /**
+   * The value of the first column matching any keyword, an exact column name winning over a longer
+   * one that merely contains it.
+   *
+   * <p>Without the exact pass the answer depends on column order, and R17 has two collisions:
+   * "summa" is also inside "Summa (PF valitseja)", and "pf valitseja" is inside it as well. Both
+   * resolve correctly today only because the rows are a LinkedHashMap in column order and the
+   * shorter column happens to come first. An export that reordered them would have made the amount
+   * cross-check read 0.00 and reject every row.
+   */
   public static @Nullable String findValue(Map<String, String> row, String... keywords) {
     for (String keyword : keywords) {
       String normalizedKeyword = normalize(keyword);
+      for (Map.Entry<String, String> entry : row.entrySet()) {
+        if (entry.getKey().equals(normalizedKeyword)) {
+          return entry.getValue();
+        }
+      }
       for (Map.Entry<String, String> entry : row.entrySet()) {
         if (entry.getKey().contains(normalizedKeyword)) {
           return entry.getValue();

--- a/src/main/java/ee/tuleva/onboarding/investment/epis/parser/EpisCsvParser.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/epis/parser/EpisCsvParser.java
@@ -79,28 +79,26 @@ public class EpisCsvParser {
     return group + " " + sub;
   }
 
-  /**
-   * The value of the first column matching any keyword, an exact column name winning over a longer
-   * one that merely contains it.
-   *
-   * <p>Without the exact pass the answer depends on column order, and R17 has two collisions:
-   * "summa" is also inside "Summa (PF valitseja)", and "pf valitseja" is inside it as well. Both
-   * resolve correctly today only because the rows are a LinkedHashMap in column order and the
-   * shorter column happens to come first. An export that reordered them would have made the amount
-   * cross-check read 0.00 and reject every row.
-   */
   public static @Nullable String findValue(Map<String, String> row, String... keywords) {
     for (String keyword : keywords) {
       String normalizedKeyword = normalize(keyword);
-      for (Map.Entry<String, String> entry : row.entrySet()) {
-        if (entry.getKey().equals(normalizedKeyword)) {
-          return entry.getValue();
-        }
+      String exactColumnMatch = row.get(normalizedKeyword);
+      if (exactColumnMatch != null) {
+        return exactColumnMatch;
       }
-      for (Map.Entry<String, String> entry : row.entrySet()) {
-        if (entry.getKey().contains(normalizedKeyword)) {
-          return entry.getValue();
-        }
+      String containsMatch = valueOfColumnContaining(row, normalizedKeyword);
+      if (containsMatch != null) {
+        return containsMatch;
+      }
+    }
+    return null;
+  }
+
+  private static @Nullable String valueOfColumnContaining(
+      Map<String, String> row, String normalizedKeyword) {
+    for (Map.Entry<String, String> entry : row.entrySet()) {
+      if (entry.getKey().contains(normalizedKeyword)) {
+        return entry.getValue();
       }
     }
     return null;

--- a/src/main/java/ee/tuleva/onboarding/investment/epis/parser/R17ReportParser.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/epis/parser/R17ReportParser.java
@@ -24,6 +24,8 @@ public class R17ReportParser {
   private static final String HEADER_MARKER = "Väärtpaber";
   private static final DecimalConvention DECIMAL_CONVENTION = DecimalConvention.PERIOD_DECIMAL;
   private static final BigDecimal MAX_REASONABLE_UNITS = new BigDecimal("100000000");
+  private static final BigDecimal AMOUNT_TOLERANCE_RATIO = new BigDecimal("0.005");
+  private static final BigDecimal MIN_AMOUNT_TOLERANCE_EUR = BigDecimal.ONE;
 
   private final EpisCsvParser csvParser;
 
@@ -47,6 +49,7 @@ public class R17ReportParser {
       if (units.compareTo(MAX_REASONABLE_UNITS) > 0) {
         throw new IllegalArgumentException("R17 row units exceed sanity limit: units=" + units);
       }
+      validateUnitsAgainstReportedAmount(row, fundRaw, toiming, units);
 
       Optional<TulevaFund> fund = FundResolver.resolve(fundRaw);
       if (fund.isEmpty()) {
@@ -107,6 +110,33 @@ public class R17ReportParser {
       }
     }
     return null;
+  }
+
+  private static void validateUnitsAgainstReportedAmount(
+      Map<String, String> row, String fund, String toiming, BigDecimal units) {
+    BigDecimal price = parseNumber(findValue(row, "hind"), DECIMAL_CONVENTION);
+    BigDecimal reportedAmount = parseNumber(findValue(row, "summa"), DECIMAL_CONVENTION);
+    if (price == null || reportedAmount == null || price.signum() <= 0) {
+      return;
+    }
+    BigDecimal expectedAmount = units.multiply(price);
+    BigDecimal tolerance =
+        reportedAmount.abs().multiply(AMOUNT_TOLERANCE_RATIO).max(MIN_AMOUNT_TOLERANCE_EUR);
+    if (expectedAmount.subtract(reportedAmount.abs()).abs().compareTo(tolerance) > 0) {
+      throw new IllegalArgumentException(
+          "R17 units do not match the reported amount: fund="
+              + fund
+              + ", toiming="
+              + toiming
+              + ", units="
+              + units
+              + ", price="
+              + price
+              + ", expectedAmount="
+              + expectedAmount
+              + ", reportedAmount="
+              + reportedAmount);
+    }
   }
 
   private static BigDecimal requiredUnits(Map<String, String> row, String fund, String toiming) {

--- a/src/main/java/ee/tuleva/onboarding/investment/epis/parser/R17ReportParser.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/epis/parser/R17ReportParser.java
@@ -110,13 +110,19 @@ public class R17ReportParser {
   }
 
   private static BigDecimal requiredUnits(Map<String, String> row, String fund, String toiming) {
-    BigDecimal units =
+    BigDecimal feeBearingUnits =
         parseNumber(findValue(row, "osakud (teenustasuga)", "osakuid"), DECIMAL_CONVENTION);
-    if (units == null) {
+    BigDecimal feeFreeUnits =
+        parseNumber(findValue(row, "osakud (teenustasuta)"), DECIMAL_CONVENTION);
+    if (feeBearingUnits == null && feeFreeUnits == null) {
       throw new IllegalArgumentException(
           "R17 required units missing: fund=" + fund + ", toiming=" + toiming);
     }
-    return units;
+    return zeroIfNull(feeBearingUnits).add(zeroIfNull(feeFreeUnits));
+  }
+
+  private static BigDecimal zeroIfNull(@Nullable BigDecimal value) {
+    return value == null ? BigDecimal.ZERO : value;
   }
 
   private static String trimmed(@Nullable String value) {

--- a/src/main/java/ee/tuleva/onboarding/investment/epis/parser/R17ReportParser.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/epis/parser/R17ReportParser.java
@@ -3,6 +3,8 @@ package ee.tuleva.onboarding.investment.epis.parser;
 import static ee.tuleva.onboarding.investment.epis.parser.EpisCsvParser.findDate;
 import static ee.tuleva.onboarding.investment.epis.parser.EpisCsvParser.findValue;
 import static ee.tuleva.onboarding.investment.epis.parser.EpisCsvParser.parseNumber;
+import static java.math.BigDecimal.ZERO;
+import static java.util.Objects.requireNonNullElse;
 
 import ee.tuleva.onboarding.fund.TulevaFund;
 import ee.tuleva.onboarding.investment.epis.R17Result;
@@ -25,7 +27,7 @@ public class R17ReportParser {
   private static final DecimalConvention DECIMAL_CONVENTION = DecimalConvention.PERIOD_DECIMAL;
   private static final BigDecimal MAX_REASONABLE_UNITS = new BigDecimal("100000000");
   private static final BigDecimal MIN_AMOUNT_TOLERANCE_EUR = new BigDecimal("0.02");
-  private static final BigDecimal HALF = new BigDecimal("0.5");
+  private static final BigDecimal HALF_PRICE_STEP = new BigDecimal("0.000005");
 
   private final EpisCsvParser csvParser;
 
@@ -50,18 +52,7 @@ public class R17ReportParser {
       if (fund.isEmpty()) {
         continue;
       }
-
-      // Both row checks run only after the fund is ours. R17 carries rows for other managers'
-      // funds, which the line above drops; their internal consistency is not ours to enforce, and
-      // rejecting the upload over one would leave the operator with nothing to fix — the row
-      // belongs to someone else. That matters more for the sanity limit than it looks: the units
-      // it measures are now the two columns added together, so a large manager's row can reach a
-      // number that neither of its columns alone did.
-      if (units.compareTo(MAX_REASONABLE_UNITS) > 0) {
-        throw new IllegalArgumentException(
-            "R17 row units exceed sanity limit: fund=" + fundRaw + ", units=" + units);
-      }
-      validateUnitsAgainstReportedAmount(row, fundRaw, toiming, units);
+      validateOurRow(row, fundRaw, toiming, units);
 
       UnitAccumulator accumulator =
           accumulators.computeIfAbsent(fund.get().getCode(), code -> new UnitAccumulator());
@@ -120,21 +111,29 @@ public class R17ReportParser {
     return null;
   }
 
+  private static void validateOurRow(
+      Map<String, String> row, String fund, String toiming, BigDecimal units) {
+    if (units.compareTo(MAX_REASONABLE_UNITS) > 0) {
+      throw new IllegalArgumentException(
+          "R17 row units exceed sanity limit: fund=" + fund + ", units=" + units);
+    }
+    validateUnitsAgainstReportedAmount(row, fund, toiming, units);
+  }
+
   private static void validateUnitsAgainstReportedAmount(
       Map<String, String> row, String fund, String toiming, BigDecimal units) {
-    BigDecimal price = parseNumber(findValue(row, "hind"), DECIMAL_CONVENTION);
-    BigDecimal reportedAmount = parseNumber(findValue(row, "summa"), DECIMAL_CONVENTION);
-    if (price == null || reportedAmount == null || price.signum() <= 0) {
+    String priceCell = findValue(row, "hind");
+    String amountCell = findValue(row, "summa");
+    if (priceCell == null || amountCell == null) {
       return;
     }
-    // A zero amount means "not applicable" in R17, the way Summa (PF valitseja) is 0 on every
-    // row, so it is not a mismatch. The GAS side has always read it that way.
-    if (reportedAmount.signum() == 0) {
+    BigDecimal reportedAmount = parseNumber(amountCell, DECIMAL_CONVENTION);
+    if (reportedAmount == null || isNotApplicable(reportedAmount)) {
       return;
     }
+    BigDecimal price = requiredPrice(priceCell, fund, toiming, units);
     BigDecimal expectedAmount = units.multiply(price);
-    BigDecimal tolerance = tolerance(units, price);
-    if (expectedAmount.subtract(reportedAmount.abs()).abs().compareTo(tolerance) > 0) {
+    if (expectedAmount.subtract(reportedAmount.abs()).abs().compareTo(amountTolerance(units)) > 0) {
       throw new IllegalArgumentException(
           "R17 units do not match the reported amount: fund="
               + fund
@@ -151,14 +150,29 @@ public class R17ReportParser {
     }
   }
 
-  // The allowance comes from the price's own precision, not from a percentage of the amount.
-  // Summa is computed from an unrounded price while the report shows a rounded one, so the
-  // largest legitimate divergence is half a price step times the units. On a 20M EUR row that
-  // is a few hundred euros, where 0.5% of the amount would be 100_000 — wide enough for a
-  // whole missing units column to hide inside.
-  private static BigDecimal tolerance(BigDecimal units, BigDecimal price) {
-    BigDecimal priceStep = BigDecimal.ONE.movePointLeft(Math.max(price.scale(), 0));
-    return units.multiply(priceStep).multiply(HALF).max(MIN_AMOUNT_TOLERANCE_EUR);
+  private static boolean isNotApplicable(BigDecimal reportedAmount) {
+    return reportedAmount.signum() == 0;
+  }
+
+  private static BigDecimal requiredPrice(
+      String priceCell, String fund, String toiming, BigDecimal units) {
+    BigDecimal price = parseNumber(priceCell, DECIMAL_CONVENTION);
+    if (price == null || price.signum() <= 0) {
+      throw new IllegalArgumentException(
+          "R17 row has units and a reported amount but no usable price: fund="
+              + fund
+              + ", toiming="
+              + toiming
+              + ", units="
+              + units
+              + ", price="
+              + priceCell);
+    }
+    return price;
+  }
+
+  private static BigDecimal amountTolerance(BigDecimal units) {
+    return units.multiply(HALF_PRICE_STEP).max(MIN_AMOUNT_TOLERANCE_EUR);
   }
 
   private static BigDecimal requiredUnits(Map<String, String> row, String fund, String toiming) {
@@ -170,11 +184,7 @@ public class R17ReportParser {
       throw new IllegalArgumentException(
           "R17 required units missing: fund=" + fund + ", toiming=" + toiming);
     }
-    return zeroIfNull(feeBearingUnits).add(zeroIfNull(feeFreeUnits));
-  }
-
-  private static BigDecimal zeroIfNull(@Nullable BigDecimal value) {
-    return value == null ? BigDecimal.ZERO : value;
+    return requireNonNullElse(feeBearingUnits, ZERO).add(requireNonNullElse(feeFreeUnits, ZERO));
   }
 
   private static String trimmed(@Nullable String value) {
@@ -186,7 +196,7 @@ public class R17ReportParser {
   }
 
   private static final class UnitAccumulator {
-    private BigDecimal pikUnits = BigDecimal.ZERO;
-    private BigDecimal netUnits = BigDecimal.ZERO;
+    private BigDecimal pikUnits = ZERO;
+    private BigDecimal netUnits = ZERO;
   }
 }

--- a/src/main/java/ee/tuleva/onboarding/investment/epis/parser/R17ReportParser.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/epis/parser/R17ReportParser.java
@@ -49,12 +49,17 @@ public class R17ReportParser {
       if (units.compareTo(MAX_REASONABLE_UNITS) > 0) {
         throw new IllegalArgumentException("R17 row units exceed sanity limit: units=" + units);
       }
-      validateUnitsAgainstReportedAmount(row, fundRaw, toiming, units);
 
       Optional<TulevaFund> fund = FundResolver.resolve(fundRaw);
       if (fund.isEmpty()) {
         continue;
       }
+
+      // Only after the fund is ours. R17 carries rows for other managers' funds, which the line
+      // above drops; their internal consistency is not ours to enforce, and rejecting the upload
+      // over one would leave the operator with nothing to fix — the row belongs to someone else.
+      validateUnitsAgainstReportedAmount(row, fundRaw, toiming, units);
+
       UnitAccumulator accumulator =
           accumulators.computeIfAbsent(fund.get().getCode(), code -> new UnitAccumulator());
 

--- a/src/main/java/ee/tuleva/onboarding/investment/epis/parser/R17ReportParser.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/epis/parser/R17ReportParser.java
@@ -46,18 +46,21 @@ public class R17ReportParser {
       if (units.signum() == 0) {
         continue;
       }
-      if (units.compareTo(MAX_REASONABLE_UNITS) > 0) {
-        throw new IllegalArgumentException("R17 row units exceed sanity limit: units=" + units);
-      }
-
       Optional<TulevaFund> fund = FundResolver.resolve(fundRaw);
       if (fund.isEmpty()) {
         continue;
       }
 
-      // Only after the fund is ours. R17 carries rows for other managers' funds, which the line
-      // above drops; their internal consistency is not ours to enforce, and rejecting the upload
-      // over one would leave the operator with nothing to fix — the row belongs to someone else.
+      // Both row checks run only after the fund is ours. R17 carries rows for other managers'
+      // funds, which the line above drops; their internal consistency is not ours to enforce, and
+      // rejecting the upload over one would leave the operator with nothing to fix — the row
+      // belongs to someone else. That matters more for the sanity limit than it looks: the units
+      // it measures are now the two columns added together, so a large manager's row can reach a
+      // number that neither of its columns alone did.
+      if (units.compareTo(MAX_REASONABLE_UNITS) > 0) {
+        throw new IllegalArgumentException(
+            "R17 row units exceed sanity limit: fund=" + fundRaw + ", units=" + units);
+      }
       validateUnitsAgainstReportedAmount(row, fundRaw, toiming, units);
 
       UnitAccumulator accumulator =

--- a/src/main/java/ee/tuleva/onboarding/investment/epis/parser/R17ReportParser.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/epis/parser/R17ReportParser.java
@@ -24,8 +24,8 @@ public class R17ReportParser {
   private static final String HEADER_MARKER = "Väärtpaber";
   private static final DecimalConvention DECIMAL_CONVENTION = DecimalConvention.PERIOD_DECIMAL;
   private static final BigDecimal MAX_REASONABLE_UNITS = new BigDecimal("100000000");
-  private static final BigDecimal AMOUNT_TOLERANCE_RATIO = new BigDecimal("0.005");
-  private static final BigDecimal MIN_AMOUNT_TOLERANCE_EUR = BigDecimal.ONE;
+  private static final BigDecimal MIN_AMOUNT_TOLERANCE_EUR = new BigDecimal("0.02");
+  private static final BigDecimal HALF = new BigDecimal("0.5");
 
   private final EpisCsvParser csvParser;
 
@@ -124,9 +124,13 @@ public class R17ReportParser {
     if (price == null || reportedAmount == null || price.signum() <= 0) {
       return;
     }
+    // A zero amount means "not applicable" in R17, the way Summa (PF valitseja) is 0 on every
+    // row, so it is not a mismatch. The GAS side has always read it that way.
+    if (reportedAmount.signum() == 0) {
+      return;
+    }
     BigDecimal expectedAmount = units.multiply(price);
-    BigDecimal tolerance =
-        reportedAmount.abs().multiply(AMOUNT_TOLERANCE_RATIO).max(MIN_AMOUNT_TOLERANCE_EUR);
+    BigDecimal tolerance = tolerance(units, price);
     if (expectedAmount.subtract(reportedAmount.abs()).abs().compareTo(tolerance) > 0) {
       throw new IllegalArgumentException(
           "R17 units do not match the reported amount: fund="
@@ -142,6 +146,16 @@ public class R17ReportParser {
               + ", reportedAmount="
               + reportedAmount);
     }
+  }
+
+  // The allowance comes from the price's own precision, not from a percentage of the amount.
+  // Summa is computed from an unrounded price while the report shows a rounded one, so the
+  // largest legitimate divergence is half a price step times the units. On a 20M EUR row that
+  // is a few hundred euros, where 0.5% of the amount would be 100_000 — wide enough for a
+  // whole missing units column to hide inside.
+  private static BigDecimal tolerance(BigDecimal units, BigDecimal price) {
+    BigDecimal priceStep = BigDecimal.ONE.movePointLeft(Math.max(price.scale(), 0));
+    return units.multiply(priceStep).multiply(HALF).max(MIN_AMOUNT_TOLERANCE_EUR);
   }
 
   private static BigDecimal requiredUnits(Map<String, String> row, String fund, String toiming) {

--- a/src/test/groovy/ee/tuleva/onboarding/investment/epis/EpisReportIngestionServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/epis/EpisReportIngestionServiceTest.java
@@ -81,9 +81,9 @@ class EpisReportIngestionServiceTest {
       Staatus;;;;Seisuga;;Valuuta;;
       Netitud;;;;01.08.2026;;EUR;;
       Väärtpaber;NAV;Toiming;PF valitseja/PIK;Hind;Osakud (teenustasuta);Osakud (teenustasuga);Summa;Summa (PF valitseja)
-      Tuleva Maailma Aktsiate Pensionifond;0.80;Tagasivõtt;PIK;0.80;100.000;100.000;80.00;0.00
-      Tuleva Maailma Aktsiate Pensionifond;0.80;Väljalase;Teine PF valitseja;0.80;200.000;200.000;160.00;0.00
-      Tuleva Maailma Võlakirjade Pensionifond;0.70;Tagasivõtt;Teine PF valitseja;0.70;50.000;50.000;35.00;0.00
+      Tuleva Maailma Aktsiate Pensionifond;0.80;Tagasivõtt;PIK;0.80;40.000;60.000;80.00;0.00
+      Tuleva Maailma Aktsiate Pensionifond;0.80;Väljalase;Teine PF valitseja;0.80;80.000;120.000;160.00;0.00
+      Tuleva Maailma Võlakirjade Pensionifond;0.70;Tagasivõtt;Teine PF valitseja;0.70;20.000;30.000;35.00;0.00
       """;
 
   @Test

--- a/src/test/groovy/ee/tuleva/onboarding/investment/epis/parser/R17ReportParserTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/epis/parser/R17ReportParserTest.java
@@ -294,6 +294,37 @@ class R17ReportParserTest {
   }
 
   @Test
+  void throwsWhenUnitsTimesPriceDisagreesWithReportedAmount() {
+    String csv =
+        """
+        Staatus;;;;Seisuga;;Valuuta;;
+        Netitud;;;;15.04.2026;;EUR;;
+        %s
+        Tuleva Maailma Aktsiate Pensionifond;0.80;Tagasivõtt;PIK;0.80;40.000;60.000;800.00;0.00
+        """
+            .formatted(HEADER_ROW);
+
+    assertThatThrownBy(() -> parser.parse(csv, LOCK_DATE, EXEC_DATE))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void toleratesRoundingBetweenUnitsTimesPriceAndReportedAmount() {
+    String csv =
+        """
+        Staatus;;;;Seisuga;;Valuuta;;
+        Netitud;;;;15.04.2026;;EUR;;
+        %s
+        Tuleva Maailma Aktsiate Pensionifond;0.61267;Tagasivõtt;PIK;0.61267;400000.000;300000.000;428869.02;0.00
+        """
+            .formatted(HEADER_ROW);
+
+    Map<String, R17Result> result = parser.parse(csv, LOCK_DATE, EXEC_DATE);
+
+    assertThat(result.get("TUK75").pikUnits()).isEqualByComparingTo("700000.000");
+  }
+
+  @Test
   void acceptsRowWhenOnlyOneUnitColumnIsPopulated() {
     String csv =
         """

--- a/src/test/groovy/ee/tuleva/onboarding/investment/epis/parser/R17ReportParserTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/epis/parser/R17ReportParserTest.java
@@ -324,6 +324,36 @@ class R17ReportParserTest {
   }
 
   @Test
+  void catchesADroppedUnitComponentWhenThePriceIsPrintedWithTwoDecimals() {
+    String csv =
+        """
+        Staatus;;;;Seisuga;;Valuuta;;
+        Netitud;;;;15.04.2026;;EUR;;
+        %s
+        Tuleva Maailma Aktsiate Pensionifond;0.80;Väljalase;Teine PF valitseja;0.80;40000.000;60000.000;80400.00;0.00
+        """
+            .formatted(HEADER_ROW);
+
+    assertThatThrownBy(() -> parser.parse(csv, LOCK_DATE, EXEC_DATE))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void throwsWhenThePriceColumnIsPresentButTheRowHasNoPrice() {
+    String csv =
+        """
+        Staatus;;;;Seisuga;;Valuuta;;
+        Netitud;;;;15.04.2026;;EUR;;
+        %s
+        Tuleva Maailma Aktsiate Pensionifond;0.80;Väljalase;Oma;;40.000;60.000;80.00;0.00
+        """
+            .formatted(HEADER_ROW);
+
+    assertThatThrownBy(() -> parser.parse(csv, LOCK_DATE, EXEC_DATE))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
   void ignoresAZeroAmountAsNotApplicable() {
     String csv =
         """
@@ -404,10 +434,6 @@ class R17ReportParserTest {
     assertThat(result.get("TUK75").pikUnits()).isEqualByComparingTo("100.000");
   }
 
-  /**
-   * R17 carries rows for other managers' funds and we drop them. An inconsistent one must not take
-   * the upload down with it — the operator cannot fix a row that belongs to someone else.
-   */
   @Test
   void ignoresTheReportedAmountOnRowsForFundsThatAreNotOurs() {
     String csv =
@@ -426,12 +452,6 @@ class R17ReportParserTest {
     assertThat(result).doesNotContainKey("MINGIMUUFOND");
   }
 
-  /**
-   * The same rule for the sanity limit, and it bites harder here: the number it measures is now the
-   * two unit columns added together, so a large manager's row can pass 100M when neither of its own
-   * columns did. Rejecting the whole upload over the size of someone else's fund would be a new way
-   * to lose a cycle.
-   */
   @Test
   void aForeignFundsRowBeyondTheSanityLimitDoesNotRejectTheUpload() {
     String csv =
@@ -450,7 +470,6 @@ class R17ReportParserTest {
     assertThat(result).doesNotContainKey("MINGIMUUFOND");
   }
 
-  /** Our own row still has to stay inside it. */
   @Test
   void ourOwnRowBeyondTheSanityLimitStillThrows() {
     String csv =
@@ -466,10 +485,6 @@ class R17ReportParserTest {
         .isInstanceOf(IllegalArgumentException.class);
   }
 
-  /**
-   * "Summa" is also a substring of "Summa (PF valitseja)". If the cross-check reads the latter it
-   * sees 0.00 and rejects every row, so the match must not depend on which column comes first.
-   */
   @Test
   void readsTheRowAmountEvenWhenThePfValitsejaAmountColumnComesFirst() {
     String reorderedHeader =
@@ -479,7 +494,7 @@ class R17ReportParserTest {
         Staatus;;;;Seisuga;;Valuuta;;
         Netitud;;;;15.04.2026;;EUR;;
         %s
-        Tuleva Maailma Aktsiate Pensionifond;0.80;Väljalase;Oma;0.80;40.000;60.000;0.00;80.00
+        Tuleva Maailma Aktsiate Pensionifond;0.80;Väljalase;Oma;0.80;40.000;60.000;999.00;80.00
         """
             .formatted(reorderedHeader);
 

--- a/src/test/groovy/ee/tuleva/onboarding/investment/epis/parser/R17ReportParserTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/epis/parser/R17ReportParserTest.java
@@ -237,7 +237,7 @@ class R17ReportParserTest {
         Staatus;;;;Seisuga;;Valuuta;;
         Netitud;;;;15.04.2026;;EUR;;
         %s
-        Tuleva Maailma Aktsiate Pensionifond;0.80;Väljalase;Oma;0.80;40.500;60.000;80.00;0.00
+        Tuleva Maailma Aktsiate Pensionifond;0.80;Väljalase;Oma;0.80;40.500;60.000;80.40;0.00
         """
             .formatted(HEADER_ROW);
 
@@ -306,6 +306,37 @@ class R17ReportParserTest {
 
     assertThatThrownBy(() -> parser.parse(csv, LOCK_DATE, EXEC_DATE))
         .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void catchesAMissingUnitComponentTooSmallForAPercentageTolerance() {
+    String csv =
+        """
+        Staatus;;;;Seisuga;;Valuuta;;
+        Netitud;;;;15.04.2026;;EUR;;
+        %s
+        Tuleva Maailma Aktsiate Pensionifond;1.6167;Väljalase;Teine PF valitseja;1.6167;0;12643992.000;20501430.35;0.00
+        """
+            .formatted(HEADER_ROW);
+
+    assertThatThrownBy(() -> parser.parse(csv, LOCK_DATE, EXEC_DATE))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void ignoresAZeroAmountAsNotApplicable() {
+    String csv =
+        """
+        Staatus;;;;Seisuga;;Valuuta;;
+        Netitud;;;;15.04.2026;;EUR;;
+        %s
+        Tuleva Maailma Aktsiate Pensionifond;0.80;Tagasivõtt;PIK;0.80;40.000;60.000;0.00;0.00
+        """
+            .formatted(HEADER_ROW);
+
+    Map<String, R17Result> result = parser.parse(csv, LOCK_DATE, EXEC_DATE);
+
+    assertThat(result.get("TUK75").pikUnits()).isEqualByComparingTo("100.000");
   }
 
   @Test

--- a/src/test/groovy/ee/tuleva/onboarding/investment/epis/parser/R17ReportParserTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/epis/parser/R17ReportParserTest.java
@@ -427,6 +427,46 @@ class R17ReportParserTest {
   }
 
   /**
+   * The same rule for the sanity limit, and it bites harder here: the number it measures is now the
+   * two unit columns added together, so a large manager's row can pass 100M when neither of its own
+   * columns did. Rejecting the whole upload over the size of someone else's fund would be a new way
+   * to lose a cycle.
+   */
+  @Test
+  void aForeignFundsRowBeyondTheSanityLimitDoesNotRejectTheUpload() {
+    String csv =
+        """
+        Staatus;;;;Seisuga;;Valuuta;;
+        Netitud;;;;15.04.2026;;EUR;;
+        %s
+        Mingi Muu Fond;0.80;Väljalase;Oma;0.80;60000000.000;60000000.000;96000000.00;0.00
+        Tuleva Maailma Aktsiate Pensionifond;0.80;Väljalase;Oma;0.80;40.000;60.000;80.00;0.00
+        """
+            .formatted(HEADER_ROW);
+
+    Map<String, R17Result> result = parser.parse(csv, LOCK_DATE, EXEC_DATE);
+
+    assertThat(result.get("TUK75").switchingNetUnits()).isEqualByComparingTo("100.000");
+    assertThat(result).doesNotContainKey("MINGIMUUFOND");
+  }
+
+  /** Our own row still has to stay inside it. */
+  @Test
+  void ourOwnRowBeyondTheSanityLimitStillThrows() {
+    String csv =
+        """
+        Staatus;;;;Seisuga;;Valuuta;;
+        Netitud;;;;15.04.2026;;EUR;;
+        %s
+        Tuleva Maailma Aktsiate Pensionifond;0.80;Väljalase;Oma;0.80;60000000.000;60000000.000;96000000.00;0.00
+        """
+            .formatted(HEADER_ROW);
+
+    assertThatThrownBy(() -> parser.parse(csv, LOCK_DATE, EXEC_DATE))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  /**
    * "Summa" is also a substring of "Summa (PF valitseja)". If the cross-check reads the latter it
    * sees 0.00 and rejects every row, so the match must not depend on which column comes first.
    */

--- a/src/test/groovy/ee/tuleva/onboarding/investment/epis/parser/R17ReportParserTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/epis/parser/R17ReportParserTest.java
@@ -372,4 +372,48 @@ class R17ReportParserTest {
 
     assertThat(result.get("TUK75").pikUnits()).isEqualByComparingTo("100.000");
   }
+
+  /**
+   * R17 carries rows for other managers' funds and we drop them. An inconsistent one must not take
+   * the upload down with it — the operator cannot fix a row that belongs to someone else.
+   */
+  @Test
+  void ignoresTheReportedAmountOnRowsForFundsThatAreNotOurs() {
+    String csv =
+        """
+        Staatus;;;;Seisuga;;Valuuta;;
+        Netitud;;;;15.04.2026;;EUR;;
+        %s
+        Mingi Muu Fond;0.80;Väljalase;Oma;0.80;40.000;60.000;999999.00;0.00
+        Tuleva Maailma Aktsiate Pensionifond;0.80;Väljalase;Oma;0.80;40.000;60.000;80.00;0.00
+        """
+            .formatted(HEADER_ROW);
+
+    Map<String, R17Result> result = parser.parse(csv, LOCK_DATE, EXEC_DATE);
+
+    assertThat(result.get("TUK75").switchingNetUnits()).isEqualByComparingTo("100.000");
+    assertThat(result).doesNotContainKey("MINGIMUUFOND");
+  }
+
+  /**
+   * "Summa" is also a substring of "Summa (PF valitseja)". If the cross-check reads the latter it
+   * sees 0.00 and rejects every row, so the match must not depend on which column comes first.
+   */
+  @Test
+  void readsTheRowAmountEvenWhenThePfValitsejaAmountColumnComesFirst() {
+    String reorderedHeader =
+        "Väärtpaber;NAV;Toiming;PF valitseja/PIK;Hind;Osakud (teenustasuta);Osakud (teenustasuga);Summa (PF valitseja);Summa";
+    String csv =
+        """
+        Staatus;;;;Seisuga;;Valuuta;;
+        Netitud;;;;15.04.2026;;EUR;;
+        %s
+        Tuleva Maailma Aktsiate Pensionifond;0.80;Väljalase;Oma;0.80;40.000;60.000;0.00;80.00
+        """
+            .formatted(reorderedHeader);
+
+    Map<String, R17Result> result = parser.parse(csv, LOCK_DATE, EXEC_DATE);
+
+    assertThat(result.get("TUK75").switchingNetUnits()).isEqualByComparingTo("100.000");
+  }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/investment/epis/parser/R17ReportParserTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/epis/parser/R17ReportParserTest.java
@@ -24,10 +24,10 @@ class R17ReportParserTest {
         Staatus;;;;Seisuga;;Valuuta;;
         Netitud;;;;15.04.2026;;EUR;;
         %s
-        Tuleva Maailma Aktsiate Pensionifond;0.80;Tagasivõtt;PIK;0.80;100.000;100.000;80.00;0.00
-        Tuleva Maailma Aktsiate Pensionifond;0.80;Väljalase;Teine PF valitseja;0.80;200.000;200.000;160.00;0.00
-        Tuleva Maailma Aktsiate Pensionifond;0.80;Tagasivõtt;Teine PF valitseja;0.80;50.000;50.000;40.00;0.00
-        Tuleva Maailma Võlakirjade Pensionifond;0.70;Väljalase;Oma;0.70;300.000;300.000;210.00;0.00
+        Tuleva Maailma Aktsiate Pensionifond;0.80;Tagasivõtt;PIK;0.80;40.000;60.000;80.00;0.00
+        Tuleva Maailma Aktsiate Pensionifond;0.80;Väljalase;Teine PF valitseja;0.80;80.000;120.000;160.00;0.00
+        Tuleva Maailma Aktsiate Pensionifond;0.80;Tagasivõtt;Teine PF valitseja;0.80;20.000;30.000;40.00;0.00
+        Tuleva Maailma Võlakirjade Pensionifond;0.70;Väljalase;Oma;0.70;100.000;200.000;210.00;0.00
         """
             .formatted(HEADER_ROW);
 
@@ -41,13 +41,35 @@ class R17ReportParserTest {
   }
 
   @Test
+  void sumsFeeFreeAndFeeBearingUnitColumns() {
+    String csv =
+        """
+        Staatus;;;;Seisuga;;Valuuta;;
+        Esialgne nimekiri moodustatud;;;;16.08.2026;;EUR;;
+        %s
+        TUK00;0.61267;Tagasivõtt;Oma PF valitseja;0.61267;400000.000;300000.000;428869.00;0
+        TUK00;0.61267;Tagasivõtt;Teised PF valitsejad;0.61267;300000.000;200000.000;306335.00;0
+        TUK00;0.61267;Tagasivõtt;PIK;0.61267;0;1000.000;612.67;0
+        TUK00;0.61267;Väljalase;Oma PF valitseja;0.61267;0;150000.000;91900.50;0
+        TUK00;0.61267;Väljalase;Teised PF valitsejad;0.61267;100000.000;400000.000;306335.00;0
+        """
+            .formatted(HEADER_ROW);
+
+    Map<String, R17Result> result =
+        parser.parse(csv, LocalDate.of(2026, 7, 31), LocalDate.of(2026, 9, 1));
+
+    assertThat(result.get("TUK00").pikUnits()).isEqualByComparingTo("1000.000");
+    assertThat(result.get("TUK00").switchingNetUnits()).isEqualByComparingTo("-550000.000");
+  }
+
+  @Test
   void throwsWhenSeisugaDateOutsideCycleWindow() {
     String csv =
         """
         Staatus;;;;Seisuga;;Valuuta;;
         Netitud;;;;15.03.2026;;EUR;;
         %s
-        Tuleva Maailma Aktsiate Pensionifond;0.80;Tagasivõtt;PIK;0.80;100.000;100.000;80.00;0.00
+        Tuleva Maailma Aktsiate Pensionifond;0.80;Tagasivõtt;PIK;0.80;40.000;60.000;80.00;0.00
         """
             .formatted(HEADER_ROW);
 
@@ -62,7 +84,7 @@ class R17ReportParserTest {
         Staatus;;;;Seisuga;;Valuuta;;
         Netitud;;;;31.03.2026;;EUR;;
         %s
-        Tuleva Maailma Aktsiate Pensionifond;0.80;Tagasivõtt;PIK;0.80;100.000;100.000;80.00;0.00
+        Tuleva Maailma Aktsiate Pensionifond;0.80;Tagasivõtt;PIK;0.80;40.000;60.000;80.00;0.00
         """
             .formatted(HEADER_ROW);
 
@@ -78,7 +100,7 @@ class R17ReportParserTest {
         Staatus;;;;Seisuga;;Valuuta;;
         Netitud;;;;15.05.2026;;EUR;;
         %s
-        Tuleva Maailma Aktsiate Pensionifond;0.80;Tagasivõtt;PIK;0.80;100.000;100.000;80.00;0.00
+        Tuleva Maailma Aktsiate Pensionifond;0.80;Tagasivõtt;PIK;0.80;40.000;60.000;80.00;0.00
         """
             .formatted(HEADER_ROW);
 
@@ -93,7 +115,7 @@ class R17ReportParserTest {
         Staatus;;;;Seisuga;;Valuuta;;
         Netitud;;;;teadmata;;EUR;;
         %s
-        Tuleva Maailma Aktsiate Pensionifond;0.80;Tagasivõtt;PIK;0.80;100.000;100.000;80.00;0.00
+        Tuleva Maailma Aktsiate Pensionifond;0.80;Tagasivõtt;PIK;0.80;40.000;60.000;80.00;0.00
         """
             .formatted(HEADER_ROW);
 
@@ -109,7 +131,7 @@ class R17ReportParserTest {
         Staatus;;;;Seisuga;;Valuuta;;
         Netitud;;;;15.04.2026;;EUR;;
         %s
-        Tuleva Maailma Aktsiate Pensionifond;0.80;Tagasivõtt;PIK;0.80;100.000;100.000;80.00;0.00
+        Tuleva Maailma Aktsiate Pensionifond;0.80;Tagasivõtt;PIK;0.80;40.000;60.000;80.00;0.00
         """
             .formatted(HEADER_ROW);
 
@@ -124,7 +146,7 @@ class R17ReportParserTest {
         """
         Seisuga teadmata;;;;;;;;
         %s
-        Tuleva Maailma Aktsiate Pensionifond;0.80;Tagasivõtt;PIK;0.80;100.000;100.000;80.00;0.00
+        Tuleva Maailma Aktsiate Pensionifond;0.80;Tagasivõtt;PIK;0.80;40.000;60.000;80.00;0.00
         """
             .formatted(HEADER_ROW);
 
@@ -137,7 +159,7 @@ class R17ReportParserTest {
     String csv =
         """
         %s
-        Tuleva Maailma Aktsiate Pensionifond;0.80;Tagasivõtt;PIK;0.80;100.000;100.000;80.00;0.00
+        Tuleva Maailma Aktsiate Pensionifond;0.80;Tagasivõtt;PIK;0.80;40.000;60.000;80.00;0.00
         """
             .formatted(HEADER_ROW);
 
@@ -151,7 +173,7 @@ class R17ReportParserTest {
         """
         Seisuga: 15.04.2026;;;;;;;;
         %s
-        Tuleva Maailma Aktsiate Pensionifond;0.80;Tagasivõtt;PIK;0.80;100.000;100.000;80.00;0.00
+        Tuleva Maailma Aktsiate Pensionifond;0.80;Tagasivõtt;PIK;0.80;40.000;60.000;80.00;0.00
         """
             .formatted(HEADER_ROW);
 
@@ -167,7 +189,7 @@ class R17ReportParserTest {
         Staatus;;;;Seisuga;;Valuuta;;
         Netitud;;;;15.04.2026;;EUR;;
         %s
-        Tuleva Maailma Aktsiate Pensionifond;0.80;Tagasivõtt;Teine PF valitseja;0.80;-50.000;-50.000;-40.00;0.00
+        Tuleva Maailma Aktsiate Pensionifond;0.80;Tagasivõtt;Teine PF valitseja;0.80;-20.000;-30.000;-40.00;0.00
         """
             .formatted(HEADER_ROW);
 
@@ -199,7 +221,7 @@ class R17ReportParserTest {
         Netitud;;;;15.04.2026;;EUR;;
         %s
         Tuleva Maailma Aktsiate Pensionifond;0.80;Väljalase;Oma;0.80;0;0;0.00;0.00
-        Mingi Muu Fond;0.80;Väljalase;Oma;0.80;100.000;100.000;80.00;0.00
+        Mingi Muu Fond;0.80;Väljalase;Oma;0.80;40.000;60.000;80.00;0.00
         """
             .formatted(HEADER_ROW);
 
@@ -215,7 +237,7 @@ class R17ReportParserTest {
         Staatus;;;;Seisuga;;Valuuta;;
         Netitud;;;;15.04.2026;;EUR;;
         %s
-        Tuleva Maailma Aktsiate Pensionifond;0.80;Väljalase;Oma;0.80;100.500;100.500;80.00;0.00
+        Tuleva Maailma Aktsiate Pensionifond;0.80;Väljalase;Oma;0.80;40.500;60.000;80.00;0.00
         """
             .formatted(HEADER_ROW);
 
@@ -231,7 +253,7 @@ class R17ReportParserTest {
         Staatus;;;;Seisuga;;Valuuta;;
         Netitud;;;;15.04.2026;;EUR;;
         %s
-        Tuleva Maailma Aktsiate Pensionifond;0.80;Väljalase;Oma;0.80;150000000.000;150000000.000;80.00;0.00
+        Tuleva Maailma Aktsiate Pensionifond;0.80;Väljalase;Oma;0.80;60000000.000;60000000.000;80.00;0.00
         """
             .formatted(HEADER_ROW);
 
@@ -246,7 +268,7 @@ class R17ReportParserTest {
         Staatus;;;;Seisuga;;Valuuta;;
         Netitud;;;;15.04.2026;;EUR;;
         %s
-        Tuleva Maailma Aktsiate Pensionifond;0.80;Tagasivõtt;PIK;0.80;100.000;100.000;80.00;999.00
+        Tuleva Maailma Aktsiate Pensionifond;0.80;Tagasivõtt;PIK;0.80;40.000;60.000;80.00;999.00
         """
             .formatted(HEADER_ROW);
 
@@ -263,12 +285,28 @@ class R17ReportParserTest {
         Staatus;;;;Seisuga;;Valuuta;;
         Netitud;;;;15.04.2026;;EUR;;
         %s
-        Tuleva Maailma Aktsiate Pensionifond;0.80;Tagasivõtt;PIK;0.80;100.000;;80.00;0.00
+        Tuleva Maailma Aktsiate Pensionifond;0.80;Tagasivõtt;PIK;0.80;;;80.00;0.00
         """
             .formatted(HEADER_ROW);
 
     assertThatThrownBy(() -> parser.parse(csv, LOCK_DATE, EXEC_DATE))
         .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void acceptsRowWhenOnlyOneUnitColumnIsPopulated() {
+    String csv =
+        """
+        Staatus;;;;Seisuga;;Valuuta;;
+        Netitud;;;;15.04.2026;;EUR;;
+        %s
+        Tuleva Maailma Aktsiate Pensionifond;0.80;Tagasivõtt;PIK;0.80;100.000;;80.00;0.00
+        """
+            .formatted(HEADER_ROW);
+
+    Map<String, R17Result> result = parser.parse(csv, LOCK_DATE, EXEC_DATE);
+
+    assertThat(result.get("TUK75").pikUnits()).isEqualByComparingTo("100.000");
   }
 
   @Test
@@ -295,7 +333,7 @@ class R17ReportParserTest {
         Staatus;;;;Seisuga;;Valuuta;;
         Netitud;;;;15.04.2026;;EUR;;
         %s
-        Tuleva Maailma Aktsiate Pensionifond;0.80;Tagasivõtt;PIK;0.80;100.000;100.000;80.00;0.00
+        Tuleva Maailma Aktsiate Pensionifond;0.80;Tagasivõtt;PIK;0.80;40.000;60.000;80.00;0.00
         """
                 .formatted(HEADER_ROW);
 


### PR DESCRIPTION
# Sum both R17 unit columns when parsing PEVA switching flows

R17 splits each row's units into `Osakud (teenustasuta)` and `Osakud (teenustasuga)`; the row total
is their sum, which the report's own `Hind` and `Summa` columns confirm. The parser read only the
fee-bearing column, so every fee-free unit was dropped.

For the 01.09.2026 cycle that flipped TUK00's switching net from an outflow to an inflow,
understating `liquidityRequired` by 394,520.61 EUR and `paymentLimit` by 365,711.83 EUR in
`PevaRavaFlowService`, which `TransactionInputService` adds to fund liabilities.

Every existing R17 fixture carried identical values in both columns, so the assertions held
whichever column was read — the tests encoded the bug. Fixtures now split their values across the
two columns with the same expected totals.

## Blast radius: nothing persisted (checked against production)

`epis_report_summary` is empty (0 rows), and `investment_report` holds only SEB
`PENDING_TRANSACTIONS`/`POSITIONS` and Swedbank `POSITIONS` — there is no R17 row anywhere in the
database. Flows are computed from the persisted `EpisReportSummary`, not from the raw CSV, so with
no persisted R17 there is no PEVA flow that was computed under the buggy parser: nothing to restate,
and no cycle advanced on a wrong number. The first ingest after this merge is the first one that
counts.

## What else is in the change

**A cross-check, because nothing checked the parser's own output.** R17 carries `Hind` and `Summa`
per row, so units x price must reproduce `Summa`. Had the check existed, the dropped fee-free column
would have failed the very first ingest instead of feeding a wrong liquidity figure into trade
preparation. It throws rather than warns: ingestion is a manual admin upload, so a hard failure is
visible to the operator who can re-export, while a log warning would be missed and the wrong figure
would still be persisted.

**Only our own rows are judged.** Both row checks now run below the `FundResolver` skip. R17 carries
rows for other managers' funds, which we drop anyway; rejecting the whole upload over one would
leave the operator with nothing to fix. This is a behaviour change beyond the cross-check: the
100M-unit sanity limit moved with it, so a *foreign* fund's row above 100M units no longer rejects
the upload. That matters more than it looks now that the number measured is the two columns added
together — a large manager's row can pass 100M when neither of its own columns did. Our own rows
still throw, and the message names the fund.

**`findValue` prefers an exact column name over a longer one that merely contains it.** "summa" is
also inside "Summa (PF valitseja)". The cross-check resolved to the right column only by accident of
column order; a reordered export would have made it read 0.00 and reject every row. The exact pass
is in `EpisCsvParser` and is shared by all the EPIS parsers, so the full suite mattered more here
than the two new tests.

**A zero `Summa` means "not applicable", not a mismatch** — the way `Summa (PF valitseja)` is 0.00
on every row. GAS has always skipped it; Java threw, and Java's was the behaviour that rejects an
upload.

**A row with units and a reported amount but no usable price now fails loudly.** Previously a blank
or non-positive `Hind` silently skipped the cross-check, which is exactly where a dropped units
column could still hide. A report shape that has no `Hind`/`Summa` columns at all (the older
single-column format) still parses — there is nothing to cross-check against there.

## Tolerance: corrected numbers

Earlier descriptions of this branch said the tolerance was 0.5% of the reported amount with a 1 EUR
floor. It is not:

    tolerance = units x 0.000005, floored at 0.02 EUR

i.e. half a price step at 5 decimals, times the units. `Summa` is computed from an unrounded price
while the report shows a rounded one, so the largest legitimate divergence is half a price step per
unit; a real row's cent of rounding still fits under the 0.02 EUR floor.

The claim that "the smallest real divergence was 55% of the row amount" was also wrong, and is the
reason the percentage tolerance had to go. `R17ReportParserTest`
`catchesAMissingUnitComponentTooSmallForAPercentageTolerance` demonstrates **0.29%**: 12,643,992
units x 1.6167 = 20,441,541.87 against a reported 20,501,430.35, a gap of 59,888.48 EUR. A 0.5%
tolerance on that row is 102,507 EUR — it would have passed a divergence of exactly the kind this PR
exists to catch. The new tolerance on the same row is 63.22 EUR.

The price step is a fixed 5 decimals rather than `price.scale()`, because deriving it from the
exporter's formatting is not safe: a price printed as `0.8` instead of `0.80` widens the tolerance
10x, and one that `parseNumber` reads as thousands-grouping (`1,234` under `PERIOD_DECIMAL` → `1234`,
scale 0) widens it to `units x 0.5` — again wide enough to hide an entire dropped column.

## Known limitations, still open

**The real R17 header row is unverified.** The two Estonian column names and the single header row
come from fixtures, not from a genuine EPIS export, and there is no persisted R17 in the database to
check them against. They are deliberately left as they are; guessing at them would be worse than the
bug this PR fixes. Verifying them against a real EPIS file is the one outstanding item.

**The `pfvalitseja` lookup is still resolved by column order.** The exact-match pass fixes the
`summa` collision because a column is literally named `Summa`, but no header equals `pfvalitseja` —
the real one is `PF valitseja/PIK` — so that lookup still falls through to the contains pass and
picks whichever of `PF valitseja/PIK` and `Summa (PF valitseja)` comes first. An export that
reordered them would silently misclassify PIK redemptions as switching flows, and the amount
cross-check would not catch it, because the units on the row are unchanged. Fixing it needs the real
header text, which we do not have.

## Tests

`R17ReportParserTest` covers: summing the two columns, the single-populated-column (older format)
case, the units-vs-amount cross-check, a divergence too small for a percentage tolerance, a
divergence hidden by a price printed with two decimals, a zero amount read as N/A, rounding
tolerated, a missing price on a row that has an amount, foreign-fund rows ignored by both row checks
including above the sanity limit, our own row still throwing above it, and the amount column read
correctly when `Summa (PF valitseja)` comes first. `EpisReportIngestionServiceTest` fixtures were
made internally consistent. Full suite green.
