### PR TITLE
Publish the price source priority so SQL consumers cannot disagree with us

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/comparisons/fundvalue/PriceSourcePriorityPublisher.java
+++ b/src/main/java/ee/tuleva/onboarding/comparisons/fundvalue/PriceSourcePriorityPublisher.java
@@ -1,0 +1,55 @@
+package ee.tuleva.onboarding.comparisons.fundvalue;
+
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Publishes the {@link PriorityPriceProvider#priceFeeds()} ordering into {@code
+ * price_source_priority}, so SQL consumers rank price sources exactly the way this service does.
+ *
+ * <p>The Java list stays the single source of truth; the table is a derived copy, rewritten on
+ * every application start. The consumer it exists for is the NAV price query in the tuleva repo
+ * ({@code apps/nav-calc/instrumentide-värsked-hinnad.sql}), which carried its own hardcoded
+ * ordering and had drifted out of step: on a same-date tie it preferred the exchange price where
+ * {@link PriorityPriceProvider} prefers EODHD.
+ *
+ * <p>This does not affect price resolution — it only writes the table.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PriceSourcePriorityPublisher {
+
+  private final NamedParameterJdbcTemplate jdbcTemplate;
+
+  private static final String INSERT =
+      """
+      INSERT INTO price_source_priority (price_source, rank, updated_at)
+      VALUES (:priceSource, :rank, now())
+      """;
+
+  /**
+   * Replace wholesale rather than upsert: the table is derived, and a full rewrite inside one
+   * transaction keeps the UNIQUE constraint on rank from tripping midway through a reordering.
+   */
+  @EventListener(ApplicationReadyEvent.class)
+  @Transactional
+  public void publish() {
+    List<String> sources =
+        PriorityPriceProvider.priceFeeds().stream().map(feed -> feed.source().name()).toList();
+
+    jdbcTemplate.update("DELETE FROM price_source_priority", Map.of());
+    for (int i = 0; i < sources.size(); i++) {
+      jdbcTemplate.update(INSERT, Map.of("priceSource", sources.get(i), "rank", i + 1));
+    }
+
+    log.info("Published price source priority: {}", sources);
+  }
+}

--- a/src/main/resources/db/migration/V1_248__price_source_priority.sql
+++ b/src/main/resources/db/migration/V1_248__price_source_priority.sql
@@ -1,0 +1,40 @@
+-- =============================================================================
+-- price_source_priority: the price-source tie-break order, published for SQL consumers.
+--
+-- The ordering itself stays owned by PriorityPriceProvider.PRICE_FEEDS in Java —
+-- this table is a PUBLISHED COPY, rewritten from that list on every application
+-- start (PriceSourcePriorityPublisher). Do not edit it by hand: change PRICE_FEEDS
+-- and deploy, and the table follows.
+--
+-- It exists because the NAV price query in the tuleva repo
+-- (work/investeerimistegevus/apps/nav-calc/instrumentide-värsked-hinnad.sql) ranked
+-- sources with its own hardcoded CASE, which had drifted out of step with the Java:
+-- for an ETF on the same date the query preferred the exchange price while
+-- PriorityPriceProvider preferred EODHD. Reading the order from here means the sheet
+-- and the service can no longer disagree about which source wins.
+--
+-- The seed below matches PRICE_FEEDS at the time of writing, so the table is usable
+-- before the app has started once.
+-- =============================================================================
+
+CREATE TABLE price_source_priority (
+    price_source varchar(30)  NOT NULL,
+    rank         int          NOT NULL,
+    updated_at   timestamptz  NOT NULL DEFAULT now(),
+
+    CONSTRAINT price_source_priority_pkey PRIMARY KEY (price_source),
+    CONSTRAINT price_source_priority_rank_uq UNIQUE (rank)
+);
+
+COMMENT ON TABLE price_source_priority IS
+    'Published copy of PriorityPriceProvider.PRICE_FEEDS ordering. Rewritten on app start; do not edit by hand.';
+COMMENT ON COLUMN price_source_priority.rank IS
+    'Lower wins. Applied only after the price date — a fresher price from a lower-ranked source still wins.';
+
+INSERT INTO price_source_priority (price_source, rank) VALUES
+    ('BLACKROCK',       1),
+    ('MORNINGSTAR',     2),
+    ('EODHD',           3),
+    ('DEUTSCHE_BOERSE', 4),
+    ('EURONEXT',        5),
+    ('YAHOO',           6);

--- a/src/test/groovy/ee/tuleva/onboarding/comparisons/fundvalue/PriceSourcePriorityPublisherTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/comparisons/fundvalue/PriceSourcePriorityPublisherTest.java
@@ -1,0 +1,66 @@
+package ee.tuleva.onboarding.comparisons.fundvalue;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+
+@ExtendWith(MockitoExtension.class)
+class PriceSourcePriorityPublisherTest {
+
+  @Mock private NamedParameterJdbcTemplate jdbcTemplate;
+
+  @InjectMocks private PriceSourcePriorityPublisher publisher;
+
+  @Test
+  void publish_writesEveryPriceFeedInPriorityProviderOrder() {
+    publisher.publish();
+
+    ArgumentCaptor<Map<String, ?>> params = ArgumentCaptor.captor();
+    verify(jdbcTemplate, org.mockito.Mockito.atLeastOnce()).update(anyString(), params.capture());
+
+    List<String> written = new ArrayList<>();
+    for (Map<String, ?> p : params.getAllValues()) {
+      if (p.containsKey("priceSource")) {
+        assertThat(p.get("rank")).isEqualTo(written.size() + 1); // ranks are 1..n, in order
+        written.add(String.valueOf(p.get("priceSource")));
+      }
+    }
+
+    List<String> expected =
+        PriorityPriceProvider.priceFeeds().stream().map(feed -> feed.source().name()).toList();
+
+    assertThat(written).isEqualTo(expected);
+  }
+
+  @Test
+  void publish_clearsTheTableFirstSoARemovedSourceCannotLinger() {
+    publisher.publish();
+
+    verify(jdbcTemplate).update(eq("DELETE FROM price_source_priority"), eq(Map.of()));
+  }
+
+  @Test
+  void publishedOrderMatchesTheOrderResolveActuallyApplies() {
+    // The published rank must be the same tie-break PriorityPriceProvider uses when two sources
+    // carry the same date, otherwise a SQL consumer reading this table would disagree with us.
+    List<String> feedOrder =
+        PriorityPriceProvider.priceFeeds().stream().map(feed -> feed.source().name()).toList();
+
+    assertThat(feedOrder).startsWith("BLACKROCK", "MORNINGSTAR", "EODHD");
+    assertThat(feedOrder)
+        .containsExactlyInAnyOrderElementsOf(
+            java.util.Arrays.stream(PriceSource.values()).map(Enum::name).toList());
+  }
+}


### PR DESCRIPTION
`PriorityPriceProvider.PRICE_FEEDS` decides which source wins when two carry the **same price date**. The NAV price query in the tuleva repo (`apps/nav-calc/instrumentide-värsked-hinnad.sql`) had its own copy of that ordering, hardcoded as a `CASE` — and the two had already drifted:

| | this service | the NAV query |
|---|---|---|
| 1 | BlackRock | BlackRock |
| 2 | Morningstar | StockMKT (exchange) |
| 3 | **EODHD** | Morningstar |
| 4 | Deutsche Börse | **EODHD** |
| 5 | Euronext | — |
| 6 | Yahoo | *(absent — the NAV must not use Yahoo)* |

For an **ETF** priced on the same date by both the exchange and EODHD, the query picks the exchange and this service picks EODHD — opposite answers. Nothing looks wrong today only because the sources currently agree to five decimal places; that is a property of the data, not of the design. The failure it sets up is the NAV sheet and the ledger/TD checks each holding a defensible but *different* "the price", with nothing to point at.

## What this does

Rather than teach the SQL the same list a second time, the list is **published**: `price_source_priority` is rewritten from `PRICE_FEEDS` on every application start. Java stays the source of truth, the table is derived, and the query reads it. **Change the order in `PRICE_FEEDS`, deploy, and the SQL follows** — which is the actual requirement; a second hardcoded list would just drift again.

- `V1_248__price_source_priority.sql` — table + seed of the current order, so it is usable before the app has started once.
- `PriceSourcePriorityPublisher` — `@EventListener(ApplicationReadyEvent)`, replaces the contents **wholesale in one transaction** (the `UNIQUE` constraint on `rank` would otherwise trip partway through a reordering).

**Price resolution behaviour is unchanged** — the publisher only writes the table. No existing code path reads it.

## Deliberately not the D5 pattern

`benchmark_category_proxy` was created, seeded, and then never read, which is why D5 exists in the centralization plan. The direction here is the opposite: the **code** stays authoritative and the table is a projection of it, so the two cannot fall out of step even if the table is ignored.

## Tests

`PriceSourcePriorityPublisherTest` — 3 tests, passing: every feed is written in `PRICE_FEEDS` order with ranks `1..n`; the table is cleared first so a removed source cannot linger; and the published order covers every `PriceSource` value with BlackRock/Morningstar/EODHD at the top, so adding an enum constant without placing it in `PRICE_FEEDS` fails the build rather than silently ranking 999 in SQL.

## Companion PR — merge/deploy order matters

[TulevaEE/tuleva#323](https://github.com/TulevaEE/tuleva/pull/323) switches the NAV price query to read this table. **This PR must deploy first** — until the table exists, that query errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)