### PR TITLE
Check the depot fee base against the definition in force when it was accrued

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/investment/check/fee/FeeBaseCompletenessChecker.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/check/fee/FeeBaseCompletenessChecker.java
@@ -42,18 +42,22 @@ class FeeBaseCompletenessChecker {
   private final NavLedgerRepository navLedgerRepository;
   private final PublicHolidays publicHolidays;
   private final BigDecimal feeBaseTolerance;
+  private final LocalDate depotAssetBaseFrom;
 
   FeeBaseCompletenessChecker(
       FeeAccrualRepository feeAccrualRepository,
       FundNavQueryService fundNavQueryService,
       NavLedgerRepository navLedgerRepository,
       PublicHolidays publicHolidays,
-      @Value("${investment.fee-check.fee-base-tolerance:0.01}") BigDecimal feeBaseTolerance) {
+      @Value("${investment.fee-check.fee-base-tolerance:0.01}") BigDecimal feeBaseTolerance,
+      @Value("${investment.fee-check.depot-asset-base-from:2026-08-15}")
+          LocalDate depotAssetBaseFrom) {
     this.feeAccrualRepository = feeAccrualRepository;
     this.fundNavQueryService = fundNavQueryService;
     this.navLedgerRepository = navLedgerRepository;
     this.publicHolidays = publicHolidays;
     this.feeBaseTolerance = feeBaseTolerance;
+    this.depotAssetBaseFrom = depotAssetBaseFrom;
   }
 
   List<FeeCheckFinding> check(TulevaFund fund, LocalDate from, LocalDate to) {
@@ -137,13 +141,17 @@ class FeeBaseCompletenessChecker {
   }
 
   private Optional<BigDecimal> expectedBase(TulevaFund fund, FeeType feeType, LocalDate date) {
-    return feeType == FeeType.DEPOT
+    return chargesDepotOnAssetValue(feeType, date)
         ? fundNavQueryService
             .findAssetTotal(fund.getCode(), date)
             .map(total -> total.add(assetSideBlackrockAdjustment(fund, date)))
         : fundNavQueryService
             .findFeeBaseComponentTotal(fund.getCode(), date)
             .map(total -> total.add(navFeeBaseBlackrockAdjustment(fund, date)));
+  }
+
+  private boolean chargesDepotOnAssetValue(FeeType feeType, LocalDate accrualDate) {
+    return feeType == FeeType.DEPOT && !accrualDate.isBefore(depotAssetBaseFrom);
   }
 
   private BigDecimal navFeeBaseBlackrockAdjustment(TulevaFund fund, LocalDate positionReportDate) {

--- a/src/test/groovy/ee/tuleva/onboarding/investment/check/fee/FeeBaseCompletenessCheckerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/check/fee/FeeBaseCompletenessCheckerTest.java
@@ -43,6 +43,7 @@ class FeeBaseCompletenessCheckerTest {
   private static final LocalDate SATURDAY = LocalDate.of(2026, 6, 6);
   private static final BigDecimal NAV_TOTAL = new BigDecimal("1000000.00");
   private static final BigDecimal ASSET_TOTAL = new BigDecimal("1080000.00");
+  private static final LocalDate DEPOT_ASSET_BASE_FROM = LocalDate.of(2026, 1, 1);
 
   @Mock private FeeAccrualRepository feeAccrualRepository;
   @Mock private FundNavQueryService fundNavQueryService;
@@ -58,7 +59,37 @@ class FeeBaseCompletenessCheckerTest {
             fundNavQueryService,
             navLedgerRepository,
             new PublicHolidays(),
-            new BigDecimal("0.01"));
+            new BigDecimal("0.01"),
+            DEPOT_ASSET_BASE_FROM);
+  }
+
+  private FeeBaseCompletenessChecker checkerWithDepotAssetBaseFrom(LocalDate from) {
+    return new FeeBaseCompletenessChecker(
+        feeAccrualRepository,
+        fundNavQueryService,
+        navLedgerRepository,
+        new PublicHolidays(),
+        new BigDecimal("0.01"),
+        from);
+  }
+
+  @Test
+  void aDepotBaseWrittenBeforeTheAssetValueCutoverIsCheckedAgainstTheNetNavBase() {
+    checker = checkerWithDepotAssetBaseFrom(LATER_WORKING_DAY);
+    givenAccruals(base(WORKING_DAY, MANAGEMENT, NAV_TOTAL), base(WORKING_DAY, DEPOT, NAV_TOTAL));
+    givenNavFeeBaseTotal(WORKING_DAY, NAV_TOTAL);
+
+    assertThat(check(TUK75)).singleElement().extracting(FeeCheckFinding::severity).isEqualTo(PASS);
+  }
+
+  @Test
+  void aDepotBaseOnTheCutoverDayIsAlreadyCheckedAgainstTheAssetValue() {
+    checker = checkerWithDepotAssetBaseFrom(WORKING_DAY);
+    givenAccruals(base(WORKING_DAY, MANAGEMENT, NAV_TOTAL), base(WORKING_DAY, DEPOT, NAV_TOTAL));
+    givenBothFeeBaseTotalsEqual(WORKING_DAY, NAV_TOTAL);
+    givenAssetTotal(WORKING_DAY, ASSET_TOTAL);
+
+    assertThat(check(TUK75).getFirst().severity()).isEqualTo(FAIL);
   }
 
   @Test

--- a/src/test/groovy/ee/tuleva/onboarding/investment/check/fee/FeeCheckIntegrationTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/check/fee/FeeCheckIntegrationTest.java
@@ -26,11 +26,13 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.simple.JdbcClient;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
 @Transactional
+@TestPropertySource(properties = "investment.fee-check.depot-asset-base-from=2025-01-01")
 class FeeCheckIntegrationTest {
 
   private static final ZoneId ESTONIAN_ZONE = ZoneId.of("Europe/Tallinn");


### PR DESCRIPTION
## Problem

Production `FEE_BASE_COMPLETENESS` has been failing for TKF100 and TUV100 since the depot fee batch deployed:

```
[FAIL] FEE_BASE_COMPLETENESS TKF100/ALL: Fee base does not match the published NAV
components on 15 day(s): 2026-07-14 {DEPOT=base=12505122.57
navComponents=12732186.40 missing=227063.83} ...
```

#1847 moved the depot fee base from the net NAV base (netovara) to the asset value (aktiva), in both the writer and the checker. Accruals written before that deploy hold the old base; the check recomputes their expected value under the new definition. The reported `missing` is the day's `LIABILITY` account, exactly.

Verified against production on three dates per fund:

| date | aktiva | LIABILITY | stored base | reported missing |
|---|---|---|---|---|
| 2026-07-14 TKF100 | 12,732,186.40 | −227,063.83 | 12,505,122.57 | 227,063.83 |
| 2026-07-21 TKF100 | 12,701,851.02 | −50,227.91 | 12,651,623.11 | 50,227.91 |
| 2026-08-04 TKF100 | 14,319,655.11 | −548,491.98 | 13,771,163.13 | 548,491.98 |
| 2026-07-09 TUV100 | 564,496,641.31 | −392,830.00 | 564,103,811.31 | 392,830.00 |

`stored base = aktiva − LIABILITY` in every case.

**No fee is affected.** Every depot accrual in the reported range has `annual_rate = 0` and `daily_amount_gross = 0.000000`, and no depot fee has ever reduced a NAV.

## Fix

`expectedBase` now applies the asset-value definition only from the cutover date onward, and the superseded net-NAV definition before it — a faithful revert of the pre-#1847 expectation for those dates. The date is a property, `investment.fee-check.depot-asset-base-from`, defaulting to `2026-08-15`, the first accrual date written by the new code.

Backfilling `investment_fee_accrual.base_value` was the alternative. It was rejected: those rows record what was charged on the day, and rewriting them to satisfy a check whose definition changed afterwards inverts the causality — even at zero money.

## Tests

- `aDepotBaseWrittenBeforeTheAssetValueCutoverIsCheckedAgainstTheNetNavBase` — verified red before the fix
- `aDepotBaseOnTheCutoverDayIsAlreadyCheckedAgainstTheAssetValue` — pins the boundary as inclusive
- `aDepotBaseThatIsSilentlyTheNetNavBaseFails` still fails after the cutover, so the wrong-base bug that test guards is still caught
- `FeeCheckIntegrationTest` pins the cutover via `@TestPropertySource` since its fixtures predate the default

777 tests green across the fee, NAV and tracking-difference suites.