### PR TITLE
Email first-time III pillar payers and cancel spurious payment reminders

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/analytics/transaction/thirdpillar/FirstThirdPillarPayment.java
+++ b/src/main/java/ee/tuleva/onboarding/analytics/transaction/thirdpillar/FirstThirdPillarPayment.java
@@ -1,0 +1,45 @@
+package ee.tuleva.onboarding.analytics.transaction.thirdpillar;
+
+import ee.tuleva.onboarding.auth.principal.Person;
+import ee.tuleva.onboarding.notification.email.Emailable;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+public record FirstThirdPillarPayment(
+    String personalCode,
+    String firstName,
+    String lastName,
+    String email,
+    String languagePreference,
+    BigDecimal amount,
+    LocalDate firstPaymentDate,
+    boolean hasAccount,
+    boolean suggestSecondPillar,
+    boolean suggestPaymentRate,
+    boolean suggestMembership)
+    implements Person, Emailable {
+
+  @Override
+  public String getPersonalCode() {
+    return personalCode;
+  }
+
+  @Override
+  public String getFirstName() {
+    return firstName;
+  }
+
+  @Override
+  public String getLastName() {
+    return lastName;
+  }
+
+  @Override
+  public String getEmail() {
+    return email;
+  }
+
+  public String emailLanguage() {
+    return "ENG".equalsIgnoreCase(languagePreference) ? "en" : "et";
+  }
+}

--- a/src/main/java/ee/tuleva/onboarding/analytics/transaction/thirdpillar/FirstThirdPillarPaymentRepository.java
+++ b/src/main/java/ee/tuleva/onboarding/analytics/transaction/thirdpillar/FirstThirdPillarPaymentRepository.java
@@ -75,7 +75,9 @@ public class FirstThirdPillarPaymentRepository {
           AND NOT EXISTS (
             SELECT 1 FROM email e
             WHERE e.personal_code = fa.personal_id
-              AND e.type IN ('THIRD_PILLAR_PAYMENT_ARRIVED', 'THIRD_PILLAR_PAYMENT_SUCCESS_MANDATE'))
+              AND e.type IN ('THIRD_PILLAR_PAYMENT_ARRIVED',
+                             'THIRD_PILLAR_PAYMENT_SUCCESS_MANDATE',
+                             'THIRD_PILLAR_PAYMENT_REMINDER_MANDATE'))
           AND NOT EXISTS (
             SELECT 1 FROM third_pillar_payment_arrived_claim c
             WHERE c.personal_code = fa.personal_id)

--- a/src/main/java/ee/tuleva/onboarding/analytics/transaction/thirdpillar/FirstThirdPillarPaymentRepository.java
+++ b/src/main/java/ee/tuleva/onboarding/analytics/transaction/thirdpillar/FirstThirdPillarPaymentRepository.java
@@ -1,0 +1,105 @@
+package ee.tuleva.onboarding.analytics.transaction.thirdpillar;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.simple.JdbcClient;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class FirstThirdPillarPaymentRepository {
+
+  static final String OWN_MONEY_SOURCE = "Osakute väljalase isikult laekumiste alusel";
+
+  private final JdbcClient jdbcClient;
+
+  public Optional<LocalDate> oldestOwnPaymentDate() {
+    return jdbcClient
+        .sql(
+            """
+            SELECT MIN(reporting_date) FROM analytics.third_pillar_transactions
+            WHERE transaction_source = :ownMoneySource
+            """)
+        .param("ownMoneySource", OWN_MONEY_SOURCE)
+        .query(LocalDate.class)
+        .optional();
+  }
+
+  public List<FirstThirdPillarPayment> fetchUnemailedFirstPayments(LocalDate windowStart) {
+    String sql =
+        """
+        WITH own_payments AS (
+          SELECT personal_id, reporting_date, transaction_value
+          FROM analytics.third_pillar_transactions
+          WHERE transaction_source = :ownMoneySource
+        ),
+        first_payments AS (
+          SELECT personal_id, MIN(reporting_date) AS first_payment_date
+          FROM own_payments
+          GROUP BY personal_id
+          HAVING MIN(reporting_date) >= :windowStart
+        ),
+        first_amounts AS (
+          SELECT fp.personal_id, fp.first_payment_date, SUM(op.transaction_value) AS amount
+          FROM first_payments fp
+          JOIN own_payments op
+            ON op.personal_id = fp.personal_id AND op.reporting_date = fp.first_payment_date
+          GROUP BY fp.personal_id, fp.first_payment_date
+        ),
+        latest_unit_owner AS (
+          SELECT * FROM unit_owner
+          WHERE snapshot_date = (SELECT MAX(snapshot_date) FROM unit_owner)
+        )
+        SELECT fa.personal_id,
+               COALESCE(u.first_name, uo.first_name) AS first_name,
+               COALESCE(u.last_name, uo.last_name) AS last_name,
+               COALESCE(NULLIF(u.email, ''), NULLIF(uo.email, '')) AS email,
+               COALESCE(uo.language_preference, 'EST') AS language_preference,
+               fa.amount,
+               fa.first_payment_date,
+               (u.id IS NOT NULL) AS has_account,
+               (uo.personal_id IS NULL
+                 OR uo.p2_choice IS NULL
+                 OR uo.p2_choice NOT IN ('TUK75', 'TUK00')) AS suggest_second_pillar,
+               (COALESCE(uo.p2_next_rate, uo.p2_rate, 2) < 6) AS suggest_payment_rate,
+               (m.id IS NULL) AS suggest_membership
+        FROM first_amounts fa
+        LEFT JOIN users u ON u.personal_code = fa.personal_id
+        LEFT JOIN latest_unit_owner uo ON uo.personal_id = fa.personal_id
+        LEFT JOIN member m ON m.user_id = u.id
+        WHERE COALESCE(NULLIF(u.email, ''), NULLIF(uo.email, '')) IS NOT NULL
+          AND COALESCE(u.first_name, uo.first_name) IS NOT NULL
+          AND COALESCE(u.last_name, uo.last_name) IS NOT NULL
+          AND NOT EXISTS (
+            SELECT 1 FROM email e
+            WHERE e.personal_code = fa.personal_id
+              AND e.type IN ('THIRD_PILLAR_PAYMENT_ARRIVED', 'THIRD_PILLAR_PAYMENT_SUCCESS_MANDATE'))
+          AND NOT EXISTS (
+            SELECT 1 FROM third_pillar_payment_arrived_claim c
+            WHERE c.personal_code = fa.personal_id)
+        ORDER BY fa.first_payment_date, fa.personal_id
+        """;
+
+    return jdbcClient
+        .sql(sql)
+        .param("ownMoneySource", OWN_MONEY_SOURCE)
+        .param("windowStart", windowStart)
+        .query(
+            (rs, rowNum) ->
+                new FirstThirdPillarPayment(
+                    rs.getString("personal_id"),
+                    rs.getString("first_name"),
+                    rs.getString("last_name"),
+                    rs.getString("email"),
+                    rs.getString("language_preference"),
+                    rs.getBigDecimal("amount"),
+                    rs.getObject("first_payment_date", LocalDate.class),
+                    rs.getBoolean("has_account"),
+                    rs.getBoolean("suggest_second_pillar"),
+                    rs.getBoolean("suggest_payment_rate"),
+                    rs.getBoolean("suggest_membership")))
+        .list();
+  }
+}

--- a/src/main/java/ee/tuleva/onboarding/analytics/transaction/thirdpillar/FirstThirdPillarPaymentRepository.java
+++ b/src/main/java/ee/tuleva/onboarding/analytics/transaction/thirdpillar/FirstThirdPillarPaymentRepository.java
@@ -53,8 +53,8 @@ public class FirstThirdPillarPaymentRepository {
           WHERE snapshot_date = (SELECT MAX(snapshot_date) FROM unit_owner)
         )
         SELECT fa.personal_id,
-               COALESCE(u.first_name, uo.first_name) AS first_name,
-               COALESCE(u.last_name, uo.last_name) AS last_name,
+               COALESCE(NULLIF(u.first_name, ''), NULLIF(uo.first_name, '')) AS first_name,
+               COALESCE(NULLIF(u.last_name, ''), NULLIF(uo.last_name, '')) AS last_name,
                COALESCE(NULLIF(u.email, ''), NULLIF(uo.email, '')) AS email,
                COALESCE(uo.language_preference, 'EST') AS language_preference,
                fa.amount,
@@ -70,8 +70,8 @@ public class FirstThirdPillarPaymentRepository {
         LEFT JOIN latest_unit_owner uo ON uo.personal_id = fa.personal_id
         LEFT JOIN member m ON m.user_id = u.id
         WHERE COALESCE(NULLIF(u.email, ''), NULLIF(uo.email, '')) IS NOT NULL
-          AND COALESCE(u.first_name, uo.first_name) IS NOT NULL
-          AND COALESCE(u.last_name, uo.last_name) IS NOT NULL
+          AND COALESCE(NULLIF(u.first_name, ''), NULLIF(uo.first_name, '')) IS NOT NULL
+          AND COALESCE(NULLIF(u.last_name, ''), NULLIF(uo.last_name, '')) IS NOT NULL
           AND NOT EXISTS (
             SELECT 1 FROM email e
             WHERE e.personal_code = fa.personal_id

--- a/src/main/java/ee/tuleva/onboarding/mandate/email/ThirdPillarPaymentReminderController.java
+++ b/src/main/java/ee/tuleva/onboarding/mandate/email/ThirdPillarPaymentReminderController.java
@@ -1,0 +1,29 @@
+package ee.tuleva.onboarding.mandate.email;
+
+import static ee.tuleva.onboarding.mandate.email.persistence.EmailType.THIRD_PILLAR_PAYMENT_REMINDER_MANDATE;
+
+import ee.tuleva.onboarding.auth.principal.AuthenticatedPerson;
+import ee.tuleva.onboarding.mandate.email.persistence.EmailPersistenceService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/v1/third-pillar-payment-reminders")
+@RequiredArgsConstructor
+class ThirdPillarPaymentReminderController {
+
+  private final EmailPersistenceService emailPersistenceService;
+
+  @PostMapping("/cancellations")
+  public CancellationResponse cancel(
+      @AuthenticationPrincipal AuthenticatedPerson authenticatedPerson) {
+    var cancelledEmails =
+        emailPersistenceService.cancel(authenticatedPerson, THIRD_PILLAR_PAYMENT_REMINDER_MANDATE);
+    return new CancellationResponse(cancelledEmails.size());
+  }
+
+  record CancellationResponse(int cancelledCount) {}
+}

--- a/src/main/java/ee/tuleva/onboarding/mandate/email/persistence/EmailType.java
+++ b/src/main/java/ee/tuleva/onboarding/mandate/email/persistence/EmailType.java
@@ -23,6 +23,7 @@ public enum EmailType {
   THIRD_PILLAR_SUGGEST_SECOND("third_pillar_suggest_second"),
   THIRD_PILLAR_PAYMENT_REMINDER_MANDATE("third_pillar_payment_reminder_mandate"),
   THIRD_PILLAR_PAYMENT_SUCCESS_MANDATE("third_pillar_payment_success_mandate"),
+  THIRD_PILLAR_PAYMENT_ARRIVED("third_pillar_payment_arrived"),
 
   MEMBERSHIP("membership"),
   BATCH_FAILED("batch_failed"),

--- a/src/main/java/ee/tuleva/onboarding/notification/email/EmailService.java
+++ b/src/main/java/ee/tuleva/onboarding/notification/email/EmailService.java
@@ -10,8 +10,8 @@ import com.microtripit.mandrillapp.lutung.view.MandrillMessage.MessageContent;
 import com.microtripit.mandrillapp.lutung.view.MandrillMessage.Recipient;
 import com.microtripit.mandrillapp.lutung.view.MandrillMessageStatus;
 import com.microtripit.mandrillapp.lutung.view.MandrillScheduledMessageInfo;
+import ee.tuleva.onboarding.auth.principal.Person;
 import ee.tuleva.onboarding.config.EmailConfiguration;
-import ee.tuleva.onboarding.user.User;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.Date;
@@ -92,8 +92,8 @@ public class EmailService {
   }
 
   public Optional<MandrillMessageStatus> send(
-      User user, MandrillMessage message, String templateName) {
-    return send(user, message, templateName, null);
+      Person person, MandrillMessage message, String templateName) {
+    return send(person, message, templateName, null);
   }
 
   private static String recipientOf(MandrillMessage message) {
@@ -105,20 +105,20 @@ public class EmailService {
   }
 
   public Optional<MandrillMessageStatus> send(
-      User user, MandrillMessage message, String templateName, Instant sendAt) {
+      Person person, MandrillMessage message, String templateName, Instant sendAt) {
     if (mandrillApi == null) {
       log.warn(
-          "Mandrill not initialised, not sending email for user: userId={}, sendAt={}, templateName={}",
-          user.getId(),
-          templateName,
-          sendAt);
+          "Mandrill not initialised, not sending email for person: personalCode={}, sendAt={}, templateName={}",
+          person.getPersonalCode(),
+          sendAt,
+          templateName);
       return Optional.empty();
     }
 
     if (recipientOf(message) == null) {
       log.warn(
-          "Message has no recipient, not sending: userId={}, templateName={}",
-          user.getId(),
+          "Message has no recipient, not sending: personalCode={}, templateName={}",
+          person.getPersonalCode(),
           templateName);
       return Optional.empty();
     }
@@ -126,8 +126,8 @@ public class EmailService {
     try {
       Date sendDate = sendAt != null ? Date.from(sendAt) : null;
       log.info(
-          "Sending email to user: userId={}, sendAt={}, templateName={}",
-          user.getId(),
+          "Sending email to person: personalCode={}, sendAt={}, templateName={}",
+          person.getPersonalCode(),
           sendDate,
           templateName);
 
@@ -142,8 +142,8 @@ public class EmailService {
 
       if (response.getStatus() != null && FAILED_STATUSES.contains(response.getStatus())) {
         log.warn(
-            "Mandrill did not deliver email: userId={}, templateName={}, status={}, rejectReason={}, id={}",
-            user.getId(),
+            "Mandrill did not deliver email: personalCode={}, templateName={}, status={}, rejectReason={}, id={}",
+            person.getPersonalCode(),
             templateName,
             response.getStatus(),
             response.getRejectReason(),
@@ -156,7 +156,11 @@ public class EmailService {
       log.error(mandrillApiError.getMandrillErrorAsJson(), mandrillApiError);
       return Optional.empty();
     } catch (Exception e) {
-      log.error("Failed to send email: userId={}, templateName={}", user.getId(), templateName, e);
+      log.error(
+          "Failed to send email: personalCode={}, templateName={}",
+          person.getPersonalCode(),
+          templateName,
+          e);
       return Optional.empty();
     }
   }

--- a/src/main/java/ee/tuleva/onboarding/notification/email/firstpayment/ThirdPillarPaymentArrivedClaims.java
+++ b/src/main/java/ee/tuleva/onboarding/notification/email/firstpayment/ThirdPillarPaymentArrivedClaims.java
@@ -1,0 +1,39 @@
+package ee.tuleva.onboarding.notification.email.firstpayment;
+
+import java.time.Clock;
+import java.time.OffsetDateTime;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.jdbc.core.simple.JdbcClient;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ThirdPillarPaymentArrivedClaims {
+
+  private final JdbcClient jdbcClient;
+  private final Clock clock;
+
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  public boolean claim(String personalCode) {
+    try {
+      jdbcClient
+          .sql(
+              """
+              INSERT INTO third_pillar_payment_arrived_claim (personal_code, created_at)
+              VALUES (:personalCode, :createdAt)
+              """)
+          .param("personalCode", personalCode)
+          .param("createdAt", OffsetDateTime.now(clock))
+          .update();
+      return true;
+    } catch (DuplicateKeyException e) {
+      log.info("Payment arrived email already claimed, skipping: personalCode={}", personalCode);
+      return false;
+    }
+  }
+}

--- a/src/main/java/ee/tuleva/onboarding/notification/email/firstpayment/ThirdPillarPaymentArrivedEmailService.java
+++ b/src/main/java/ee/tuleva/onboarding/notification/email/firstpayment/ThirdPillarPaymentArrivedEmailService.java
@@ -1,0 +1,75 @@
+package ee.tuleva.onboarding.notification.email.firstpayment;
+
+import static ee.tuleva.onboarding.mandate.email.persistence.EmailType.THIRD_PILLAR_PAYMENT_ARRIVED;
+
+import ee.tuleva.onboarding.analytics.transaction.thirdpillar.FirstThirdPillarPayment;
+import ee.tuleva.onboarding.mandate.email.persistence.EmailPersistenceService;
+import ee.tuleva.onboarding.notification.email.EmailService;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ThirdPillarPaymentArrivedEmailService {
+
+  private static final DateTimeFormatter PAYMENT_DATE_FORMAT =
+      DateTimeFormatter.ofPattern("dd.MM.yyyy");
+
+  private final ThirdPillarPaymentArrivedClaims claims;
+  private final EmailService emailService;
+  private final EmailPersistenceService emailPersistenceService;
+
+  public boolean send(FirstThirdPillarPayment payment) {
+    if (!claims.claim(payment.personalCode())) {
+      return false;
+    }
+
+    String templateName = THIRD_PILLAR_PAYMENT_ARRIVED.getTemplateName(payment.emailLanguage());
+    var message =
+        emailService.newMandrillMessage(
+            payment.getEmail(), templateName, mergeVars(payment), tags(payment), null);
+
+    return emailService
+        .send(payment, message, templateName)
+        .map(
+            response -> {
+              emailPersistenceService.save(
+                  payment, response.getId(), THIRD_PILLAR_PAYMENT_ARRIVED, response.getStatus());
+              return true;
+            })
+        .orElseGet(
+            () -> {
+              log.error(
+                  "Payment arrived email failed to send, keeping claim: personalCode={}",
+                  payment.personalCode());
+              return false;
+            });
+  }
+
+  private Map<String, Object> mergeVars(FirstThirdPillarPayment payment) {
+    return Map.of(
+        "fname", payment.getFirstName(),
+        "lname", payment.getLastName(),
+        "amount", payment.amount(),
+        "paymentDate", payment.firstPaymentDate().format(PAYMENT_DATE_FORMAT),
+        "hasAccount", payment.hasAccount(),
+        "suggestSecondPillar", payment.suggestSecondPillar(),
+        "suggestPaymentRate", payment.suggestPaymentRate(),
+        "suggestMembership", payment.suggestMembership());
+  }
+
+  private List<String> tags(FirstThirdPillarPayment payment) {
+    List<String> tags = new ArrayList<>();
+    tags.add("third_pillar_payment_arrived");
+    if (payment.suggestSecondPillar()) {
+      tags.add("suggest_2");
+    }
+    return tags;
+  }
+}

--- a/src/main/java/ee/tuleva/onboarding/notification/email/firstpayment/ThirdPillarPaymentArrivedJob.java
+++ b/src/main/java/ee/tuleva/onboarding/notification/email/firstpayment/ThirdPillarPaymentArrivedJob.java
@@ -1,0 +1,102 @@
+package ee.tuleva.onboarding.notification.email.firstpayment;
+
+import ee.tuleva.onboarding.analytics.transaction.thirdpillar.FirstThirdPillarPayment;
+import ee.tuleva.onboarding.analytics.transaction.thirdpillar.FirstThirdPillarPaymentRepository;
+import java.time.Clock;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@Profile("!dev")
+@Slf4j
+public class ThirdPillarPaymentArrivedJob {
+
+  private final FirstThirdPillarPaymentRepository repository;
+  private final ThirdPillarPaymentArrivedEmailService emailService;
+  private final Clock clock;
+  private final boolean dryRun;
+  private final int maxRecipients;
+  private final LocalDate historyFloor;
+  private final int windowDays;
+
+  public ThirdPillarPaymentArrivedJob(
+      FirstThirdPillarPaymentRepository repository,
+      ThirdPillarPaymentArrivedEmailService emailService,
+      Clock clock,
+      @Value("${third-pillar-payment-arrived.dry-run:true}") boolean dryRun,
+      @Value("${third-pillar-payment-arrived.max-recipients:200}") int maxRecipients,
+      @Value("${third-pillar-payment-arrived.history-floor:2022-01-01}") LocalDate historyFloor,
+      @Value("${third-pillar-payment-arrived.window-days:30}") int windowDays) {
+    this.repository = repository;
+    this.emailService = emailService;
+    this.clock = clock;
+    this.dryRun = dryRun;
+    this.maxRecipients = maxRecipients;
+    this.historyFloor = historyFloor;
+    this.windowDays = windowDays;
+  }
+
+  @Scheduled(cron = "${third-pillar-payment-arrived.cron:0 0 12 * * TUE}", zone = "Europe/Tallinn")
+  @SchedulerLock(
+      name = "ThirdPillarPaymentArrivedJob_run",
+      lockAtMostFor = "23h",
+      lockAtLeastFor = "10m")
+  public void run() {
+    Optional<LocalDate> oldestPayment = repository.oldestOwnPaymentDate();
+    if (oldestPayment.isEmpty() || oldestPayment.get().isAfter(historyFloor)) {
+      log.error(
+          "Transaction history too shallow to trust first-payment detection, refusing to run:"
+              + " oldestPayment={}, historyFloor={}",
+          oldestPayment.orElse(null),
+          historyFloor);
+      return;
+    }
+
+    LocalDate windowStart = LocalDate.now(clock).minusDays(windowDays);
+    List<FirstThirdPillarPayment> audience = repository.fetchUnemailedFirstPayments(windowStart);
+
+    if (audience.size() > maxRecipients) {
+      log.error(
+          "Too many first payment email recipients, refusing to run: audience={}, maxRecipients={}",
+          audience.size(),
+          maxRecipients);
+      return;
+    }
+
+    if (dryRun) {
+      log.info(
+          "Dry run, not sending payment arrived emails: audience={}, windowStart={}",
+          audience.size(),
+          windowStart);
+      return;
+    }
+
+    int sent = 0;
+    int failed = 0;
+    for (FirstThirdPillarPayment payment : audience) {
+      try {
+        if (emailService.send(payment)) {
+          sent++;
+        } else {
+          failed++;
+        }
+      } catch (Exception e) {
+        failed++;
+        log.error(
+            "Failed to process payment arrived email: personalCode={}", payment.personalCode(), e);
+      }
+    }
+    log.info(
+        "Payment arrived emails processed: audience={}, sent={}, skippedOrFailed={}",
+        audience.size(),
+        sent,
+        failed);
+  }
+}

--- a/src/main/java/ee/tuleva/onboarding/notification/email/firstpayment/package-info.java
+++ b/src/main/java/ee/tuleva/onboarding/notification/email/firstpayment/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package ee.tuleva.onboarding.notification.email.firstpayment;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/resources/db/migration/V1_246__create_third_pillar_payment_arrived_claim.sql
+++ b/src/main/resources/db/migration/V1_246__create_third_pillar_payment_arrived_claim.sql
@@ -1,0 +1,6 @@
+CREATE TABLE third_pillar_payment_arrived_claim
+(
+    personal_code TEXT        NOT NULL,
+    created_at    TIMESTAMPTZ NOT NULL,
+    CONSTRAINT third_pillar_payment_arrived_claim_pk PRIMARY KEY (personal_code)
+);

--- a/src/test/groovy/ee/tuleva/onboarding/mandate/email/ThirdPillarPaymentReminderControllerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/mandate/email/ThirdPillarPaymentReminderControllerTest.java
@@ -1,0 +1,49 @@
+package ee.tuleva.onboarding.mandate.email;
+
+import static ee.tuleva.onboarding.auth.AuthenticatedPersonFixture.sampleAuthenticatedPersonAndMember;
+import static ee.tuleva.onboarding.auth.authority.Authority.USER;
+import static ee.tuleva.onboarding.mandate.email.persistence.EmailType.THIRD_PILLAR_PAYMENT_REMINDER_MANDATE;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import ee.tuleva.onboarding.mandate.email.persistence.EmailPersistenceService;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(ThirdPillarPaymentReminderController.class)
+@AutoConfigureMockMvc
+class ThirdPillarPaymentReminderControllerTest {
+
+  @Autowired private MockMvc mvc;
+
+  @MockitoBean private EmailPersistenceService emailPersistenceService;
+
+  @Test
+  void cancelsPendingPaymentRemindersForTheAuthenticatedUser() throws Exception {
+    var person = sampleAuthenticatedPersonAndMember().build();
+    var auth =
+        new UsernamePasswordAuthenticationToken(
+            person, null, List.of(new SimpleGrantedAuthority(USER)));
+    given(emailPersistenceService.cancel(person, THIRD_PILLAR_PAYMENT_REMINDER_MANDATE))
+        .willReturn(List.of());
+
+    mvc.perform(
+            post("/v1/third-pillar-payment-reminders/cancellations")
+                .with(csrf())
+                .with(authentication(auth)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.cancelledCount", is(0)));
+  }
+}

--- a/src/test/groovy/ee/tuleva/onboarding/notification/email/firstpayment/TestPersonalCodes.java
+++ b/src/test/groovy/ee/tuleva/onboarding/notification/email/firstpayment/TestPersonalCodes.java
@@ -1,0 +1,26 @@
+package ee.tuleva.onboarding.notification.email.firstpayment;
+
+final class TestPersonalCodes {
+
+  private TestPersonalCodes() {}
+
+  static String withValidChecksum(String firstTenDigits) {
+    int[] digits = firstTenDigits.chars().map(Character::getNumericValue).toArray();
+    int checksum = weightedMod11(digits, new int[] {1, 2, 3, 4, 5, 6, 7, 8, 9, 1});
+    if (checksum == 10) {
+      checksum = weightedMod11(digits, new int[] {3, 4, 5, 6, 7, 8, 9, 1, 2, 3});
+      if (checksum == 10) {
+        checksum = 0;
+      }
+    }
+    return firstTenDigits + checksum;
+  }
+
+  private static int weightedMod11(int[] digits, int[] weights) {
+    int sum = 0;
+    for (int i = 0; i < digits.length; i++) {
+      sum += digits[i] * weights[i];
+    }
+    return sum % 11;
+  }
+}

--- a/src/test/groovy/ee/tuleva/onboarding/notification/email/firstpayment/ThirdPillarPaymentArrivedEmailIntegrationTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/notification/email/firstpayment/ThirdPillarPaymentArrivedEmailIntegrationTest.java
@@ -1,0 +1,288 @@
+package ee.tuleva.onboarding.notification.email.firstpayment;
+
+import static ee.tuleva.onboarding.analytics.transaction.thirdpillar.AnalyticsThirdPillarTransactionFixture.exampleTransactionBuilder;
+import static ee.tuleva.onboarding.mandate.email.persistence.EmailType.THIRD_PILLAR_PAYMENT_ARRIVED;
+import static ee.tuleva.onboarding.mandate.email.persistence.EmailType.THIRD_PILLAR_PAYMENT_SUCCESS_MANDATE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.microtripit.mandrillapp.lutung.view.MandrillMessage;
+import com.microtripit.mandrillapp.lutung.view.MandrillMessageStatus;
+import ee.tuleva.onboarding.analytics.transaction.thirdpillar.AnalyticsThirdPillarTransactionRepository;
+import ee.tuleva.onboarding.analytics.transaction.unitowner.UnitOwner;
+import ee.tuleva.onboarding.analytics.transaction.unitowner.UnitOwnerRepository;
+import ee.tuleva.onboarding.auth.principal.Person;
+import ee.tuleva.onboarding.mandate.email.persistence.EmailPersistenceService;
+import ee.tuleva.onboarding.mandate.email.persistence.EmailRepository;
+import ee.tuleva.onboarding.mandate.email.persistence.EmailStatus;
+import ee.tuleva.onboarding.notification.email.EmailService;
+import ee.tuleva.onboarding.user.User;
+import ee.tuleva.onboarding.user.UserRepository;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.simple.JdbcClient;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+@SpringBootTest
+@TestPropertySource(
+    properties = {
+      "third-pillar-payment-arrived.dry-run=false",
+      "third-pillar-payment-arrived.history-floor=9999-12-31"
+    })
+class ThirdPillarPaymentArrivedEmailIntegrationTest {
+
+  private static final String OWN_MONEY_SOURCE = "Osakute väljalase isikult laekumiste alusel";
+  private static final String EMPLOYER_SOURCE = "Osakute väljalase tööandjalt laekumiste alusel";
+
+  private static final String ACCOUNT_HOLDER = TestPersonalCodes.withValidChecksum("3860101000");
+  private static final String IN_APP_PAYER = TestPersonalCodes.withValidChecksum("3850101000");
+  private static final String LONG_TIME_SAVER = TestPersonalCodes.withValidChecksum("3881212121");
+  private static final String EMPLOYER_PAID = TestPersonalCodes.withValidChecksum("3900101000");
+  private static final String REGISTRY_ONLY = TestPersonalCodes.withValidChecksum("3870101000");
+
+  @Autowired private ThirdPillarPaymentArrivedJob job;
+  @Autowired private AnalyticsThirdPillarTransactionRepository transactionRepository;
+  @Autowired private UnitOwnerRepository unitOwnerRepository;
+  @Autowired private UserRepository userRepository;
+  @Autowired private EmailRepository emailRepository;
+  @Autowired private EmailPersistenceService emailPersistenceService;
+  @Autowired private JdbcClient jdbcClient;
+
+  @MockitoBean private EmailService emailService;
+
+  @BeforeEach
+  void stubMandrill() {
+    given(emailService.newMandrillMessage(any(), any(), any(), any(), any()))
+        .willReturn(new MandrillMessage());
+    var response = org.mockito.Mockito.mock(MandrillMessageStatus.class);
+    given(response.getId()).willReturn("mandrill-id");
+    given(response.getStatus()).willReturn("sent");
+    given(emailService.send(any(Person.class), any(), any())).willReturn(Optional.of(response));
+  }
+
+  @AfterEach
+  void cleanUp() {
+    transactionRepository.deleteAll();
+    unitOwnerRepository.deleteAll();
+    emailRepository.deleteAll();
+    userRepository.deleteAll();
+    jdbcClient.sql("DELETE FROM third_pillar_payment_arrived_claim").update();
+  }
+
+  @Test
+  void sendsTheEmailOnceToAFirstTimePayerWithAnAccount() {
+    saveUser(ACCOUNT_HOLDER, "account.holder@example.com");
+    saveOwnPayment(ACCOUNT_HOLDER, LocalDate.now().minusDays(1), new BigDecimal("300.00"));
+
+    job.run();
+    job.run();
+
+    verify(emailService, times(1))
+        .newMandrillMessage(
+            eq("account.holder@example.com"),
+            eq("third_pillar_payment_arrived_et"),
+            argThat(
+                mergeVars ->
+                    Boolean.TRUE.equals(mergeVars.get("suggestSecondPillar"))
+                        && Boolean.TRUE.equals(mergeVars.get("hasAccount"))
+                        && LocalDate.now()
+                            .minusDays(1)
+                            .format(java.time.format.DateTimeFormatter.ofPattern("dd.MM.yyyy"))
+                            .equals(mergeVars.get("paymentDate"))
+                        && new BigDecimal("300.00").compareTo((BigDecimal) mergeVars.get("amount"))
+                            == 0),
+            any(),
+            any());
+    verify(emailService, times(1))
+        .send(
+            argThat((Person person) -> ACCOUNT_HOLDER.equals(person.getPersonalCode())),
+            any(),
+            eq("third_pillar_payment_arrived_et"));
+    assertThat(sentEmailCount()).isEqualTo(1);
+    assertThat(claimCount()).isEqualTo(1);
+  }
+
+  @Test
+  void skipsAnInAppPayerWhoAlreadyGotThePaymentSuccessEmail() {
+    User user = saveUser(IN_APP_PAYER, "in.app@example.com");
+    emailPersistenceService.save(user, THIRD_PILLAR_PAYMENT_SUCCESS_MANDATE, EmailStatus.SENT);
+    saveOwnPayment(IN_APP_PAYER, LocalDate.now().minusDays(1), new BigDecimal("100.00"));
+
+    job.run();
+
+    verify(emailService, never()).send(any(Person.class), any(), any());
+  }
+
+  @Test
+  void skipsASaverWhoseFirstPaymentWasLongAgo() {
+    saveUser(LONG_TIME_SAVER, "long.time@example.com");
+    saveOwnPayment(LONG_TIME_SAVER, LocalDate.now().minusYears(2), new BigDecimal("50.00"));
+    saveOwnPayment(LONG_TIME_SAVER, LocalDate.now().minusDays(1), new BigDecimal("100.00"));
+
+    job.run();
+
+    verify(emailService, never()).send(any(Person.class), any(), any());
+  }
+
+  @Test
+  void skipsEmployerPaidContributions() {
+    saveUser(EMPLOYER_PAID, "employer.paid@example.com");
+    transactionRepository.save(
+        exampleTransactionBuilder()
+            .personalId(EMPLOYER_PAID)
+            .reportingDate(LocalDate.now().minusDays(1))
+            .transactionSource(EMPLOYER_SOURCE)
+            .transactionValue(new BigDecimal("100.00"))
+            .build());
+
+    job.run();
+
+    verify(emailService, never()).send(any(Person.class), any(), any());
+  }
+
+  @Test
+  void sendsToARegistryOnlyPayerUsingTheirRegistryEmailAndLanguage() {
+    saveUnitOwner(REGISTRY_ONLY, "registry.only@example.com", "ENG", "LXK75");
+    saveOwnPayment(REGISTRY_ONLY, LocalDate.now().minusDays(2), new BigDecimal("250.00"));
+
+    job.run();
+
+    verify(emailService, times(1))
+        .newMandrillMessage(
+            eq("registry.only@example.com"),
+            eq("third_pillar_payment_arrived_en"),
+            argThat(
+                mergeVars ->
+                    Boolean.TRUE.equals(mergeVars.get("suggestSecondPillar"))
+                        && Boolean.FALSE.equals(mergeVars.get("hasAccount"))),
+            any(),
+            any());
+    verify(emailService, times(1))
+        .send(
+            argThat((Person person) -> REGISTRY_ONLY.equals(person.getPersonalCode())),
+            any(),
+            eq("third_pillar_payment_arrived_en"));
+  }
+
+  @Test
+  void fallsBackToTheRegistryEmailWhenTheAccountEmailIsBlank() {
+    userRepository.save(
+        User.builder()
+            .personalCode(ACCOUNT_HOLDER)
+            .email("")
+            .firstName("First")
+            .lastName("Last")
+            .createdDate(Instant.now())
+            .updatedDate(Instant.now())
+            .build());
+    saveUnitOwner(ACCOUNT_HOLDER, "registry.fallback@example.com", "EST", "LXK75");
+    saveOwnPayment(ACCOUNT_HOLDER, LocalDate.now().minusDays(1), new BigDecimal("100.00"));
+
+    job.run();
+
+    verify(emailService, times(1))
+        .newMandrillMessage(
+            eq("registry.fallback@example.com"),
+            eq("third_pillar_payment_arrived_et"),
+            any(),
+            any(),
+            any());
+  }
+
+  @Test
+  void skipsWithoutClaimingWhenTheRecipientHasNoName() {
+    unitOwnerRepository.save(
+        UnitOwner.builder()
+            .personalId(REGISTRY_ONLY)
+            .snapshotDate(LocalDate.now())
+            .dateCreated(java.time.LocalDateTime.now())
+            .email("nameless@example.com")
+            .languagePreference("EST")
+            .build());
+    saveOwnPayment(REGISTRY_ONLY, LocalDate.now().minusDays(1), new BigDecimal("100.00"));
+
+    job.run();
+
+    verify(emailService, never()).send(any(Person.class), any(), any());
+    assertThat(claimCount()).isZero();
+  }
+
+  @Test
+  void keepsTheClaimAndSendsNothingLaterWhenMandrillFails() {
+    saveUser(ACCOUNT_HOLDER, "account.holder@example.com");
+    saveOwnPayment(ACCOUNT_HOLDER, LocalDate.now().minusDays(1), new BigDecimal("300.00"));
+    given(emailService.send(any(Person.class), any(), any())).willReturn(Optional.empty());
+
+    job.run();
+    job.run();
+
+    verify(emailService, times(1)).send(any(Person.class), any(), any());
+    assertThat(claimCount()).isEqualTo(1);
+    assertThat(sentEmailCount()).isZero();
+  }
+
+  private void saveOwnPayment(String personalCode, LocalDate date, BigDecimal amount) {
+    transactionRepository.save(
+        exampleTransactionBuilder()
+            .personalId(personalCode)
+            .reportingDate(date)
+            .transactionSource(OWN_MONEY_SOURCE)
+            .transactionValue(amount)
+            .build());
+  }
+
+  private User saveUser(String personalCode, String email) {
+    return userRepository.save(
+        User.builder()
+            .personalCode(personalCode)
+            .email(email)
+            .firstName("First")
+            .lastName("Last")
+            .createdDate(Instant.now())
+            .updatedDate(Instant.now())
+            .build());
+  }
+
+  private void saveUnitOwner(String personalCode, String email, String language, String p2Choice) {
+    unitOwnerRepository.save(
+        UnitOwner.builder()
+            .personalId(personalCode)
+            .snapshotDate(LocalDate.now())
+            .dateCreated(java.time.LocalDateTime.now())
+            .firstName("Registry")
+            .lastName("Person")
+            .email(email)
+            .languagePreference(language)
+            .p2choice(p2Choice)
+            .build());
+  }
+
+  private int sentEmailCount() {
+    return jdbcClient
+        .sql("SELECT COUNT(*) FROM email WHERE type = :type")
+        .param("type", THIRD_PILLAR_PAYMENT_ARRIVED.name())
+        .query(Integer.class)
+        .single();
+  }
+
+  private int claimCount() {
+    return jdbcClient
+        .sql("SELECT COUNT(*) FROM third_pillar_payment_arrived_claim")
+        .query(Integer.class)
+        .single();
+  }
+}

--- a/src/test/groovy/ee/tuleva/onboarding/notification/email/firstpayment/ThirdPillarPaymentArrivedEmailIntegrationTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/notification/email/firstpayment/ThirdPillarPaymentArrivedEmailIntegrationTest.java
@@ -2,6 +2,7 @@ package ee.tuleva.onboarding.notification.email.firstpayment;
 
 import static ee.tuleva.onboarding.analytics.transaction.thirdpillar.AnalyticsThirdPillarTransactionFixture.exampleTransactionBuilder;
 import static ee.tuleva.onboarding.mandate.email.persistence.EmailType.THIRD_PILLAR_PAYMENT_ARRIVED;
+import static ee.tuleva.onboarding.mandate.email.persistence.EmailType.THIRD_PILLAR_PAYMENT_REMINDER_MANDATE;
 import static ee.tuleva.onboarding.mandate.email.persistence.EmailType.THIRD_PILLAR_PAYMENT_SUCCESS_MANDATE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -128,6 +129,18 @@ class ThirdPillarPaymentArrivedEmailIntegrationTest {
     job.run();
 
     verify(emailService, never()).send(any(Person.class), any(), any());
+  }
+
+  @Test
+  void skipsAnInAppMandateSignerWhoIsAlreadyInTheExistingEmailSequence() {
+    User user = saveUser(IN_APP_PAYER, "mandate.signer@example.com");
+    emailPersistenceService.save(user, THIRD_PILLAR_PAYMENT_REMINDER_MANDATE, EmailStatus.SENT);
+    saveOwnPayment(IN_APP_PAYER, LocalDate.now().minusDays(1), new BigDecimal("100.00"));
+
+    job.run();
+
+    verify(emailService, never()).send(any(Person.class), any(), any());
+    assertThat(claimCount()).isZero();
   }
 
   @Test

--- a/src/test/groovy/ee/tuleva/onboarding/notification/email/firstpayment/ThirdPillarPaymentArrivedEmailIntegrationTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/notification/email/firstpayment/ThirdPillarPaymentArrivedEmailIntegrationTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.verify;
 import com.microtripit.mandrillapp.lutung.view.MandrillMessage;
 import com.microtripit.mandrillapp.lutung.view.MandrillMessageStatus;
 import ee.tuleva.onboarding.analytics.transaction.thirdpillar.AnalyticsThirdPillarTransactionRepository;
+import ee.tuleva.onboarding.analytics.transaction.thirdpillar.FirstThirdPillarPayment;
 import ee.tuleva.onboarding.analytics.transaction.unitowner.UnitOwner;
 import ee.tuleva.onboarding.analytics.transaction.unitowner.UnitOwnerRepository;
 import ee.tuleva.onboarding.auth.principal.Person;
@@ -61,6 +62,8 @@ class ThirdPillarPaymentArrivedEmailIntegrationTest {
   @Autowired private EmailRepository emailRepository;
   @Autowired private EmailPersistenceService emailPersistenceService;
   @Autowired private JdbcClient jdbcClient;
+  @Autowired private ThirdPillarPaymentArrivedClaims claims;
+  @Autowired private ThirdPillarPaymentArrivedEmailService paymentArrivedEmailService;
 
   @MockitoBean private EmailService emailService;
 
@@ -219,6 +222,55 @@ class ThirdPillarPaymentArrivedEmailIntegrationTest {
 
     verify(emailService, never()).send(any(Person.class), any(), any());
     assertThat(claimCount()).isZero();
+  }
+
+  @Test
+  void skipsWithoutClaimingWhenTheRecipientNameIsBlank() {
+    unitOwnerRepository.save(
+        UnitOwner.builder()
+            .personalId(REGISTRY_ONLY)
+            .snapshotDate(LocalDate.now())
+            .dateCreated(java.time.LocalDateTime.now())
+            .firstName("")
+            .lastName("")
+            .email("blank.name@example.com")
+            .languagePreference("EST")
+            .build());
+    saveOwnPayment(REGISTRY_ONLY, LocalDate.now().minusDays(1), new BigDecimal("100.00"));
+
+    job.run();
+
+    verify(emailService, never()).send(any(Person.class), any(), any());
+    assertThat(claimCount()).isZero();
+  }
+
+  @Test
+  void rejectsASecondClaimForTheSamePerson() {
+    assertThat(claims.claim(ACCOUNT_HOLDER)).isTrue();
+    assertThat(claims.claim(ACCOUNT_HOLDER)).isFalse();
+  }
+
+  @Test
+  void doesNotSendWhenTheClaimIsAlreadyTaken() {
+    claims.claim(REGISTRY_ONLY);
+
+    boolean sent =
+        paymentArrivedEmailService.send(
+            new FirstThirdPillarPayment(
+                REGISTRY_ONLY,
+                "First",
+                "Last",
+                "already.claimed@example.com",
+                "EST",
+                new BigDecimal("100.00"),
+                LocalDate.now().minusDays(1),
+                false,
+                true,
+                true,
+                true));
+
+    assertThat(sent).isFalse();
+    verify(emailService, never()).send(any(Person.class), any(), any());
   }
 
   @Test

--- a/src/test/groovy/ee/tuleva/onboarding/notification/email/firstpayment/ThirdPillarPaymentArrivedJobTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/notification/email/firstpayment/ThirdPillarPaymentArrivedJobTest.java
@@ -1,0 +1,106 @@
+package ee.tuleva.onboarding.notification.email.firstpayment;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import ee.tuleva.onboarding.analytics.transaction.thirdpillar.FirstThirdPillarPayment;
+import ee.tuleva.onboarding.analytics.transaction.thirdpillar.FirstThirdPillarPaymentRepository;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class ThirdPillarPaymentArrivedJobTest {
+
+  private static final String FIRST_PAYER = TestPersonalCodes.withValidChecksum("3860101000");
+  private static final String SECOND_PAYER = TestPersonalCodes.withValidChecksum("3850101000");
+
+  private final FirstThirdPillarPaymentRepository repository =
+      mock(FirstThirdPillarPaymentRepository.class);
+  private final ThirdPillarPaymentArrivedEmailService emailService =
+      mock(ThirdPillarPaymentArrivedEmailService.class);
+  private final Clock clock = Clock.fixed(Instant.parse("2026-08-18T10:00:00Z"), ZoneOffset.UTC);
+
+  private ThirdPillarPaymentArrivedJob job(boolean dryRun, int maxRecipients) {
+    return new ThirdPillarPaymentArrivedJob(
+        repository, emailService, clock, dryRun, maxRecipients, LocalDate.parse("2022-01-01"), 30);
+  }
+
+  private FirstThirdPillarPayment payment(String personalCode) {
+    return new FirstThirdPillarPayment(
+        personalCode,
+        "First",
+        "Last",
+        "first.last@example.com",
+        "EST",
+        new BigDecimal("100.00"),
+        LocalDate.parse("2026-08-16"),
+        true,
+        true,
+        true,
+        false);
+  }
+
+  @Test
+  void refusesToRunWhenTransactionHistoryIsTooShallow() {
+    given(repository.oldestOwnPaymentDate()).willReturn(Optional.of(LocalDate.parse("2024-01-01")));
+
+    job(false, 200).run();
+
+    verify(emailService, never()).send(any());
+  }
+
+  @Test
+  void refusesToRunWhenThereAreNoTransactionsAtAll() {
+    given(repository.oldestOwnPaymentDate()).willReturn(Optional.empty());
+
+    job(false, 200).run();
+
+    verify(emailService, never()).send(any());
+  }
+
+  @Test
+  void refusesToRunWhenTheAudienceExceedsTheRecipientCap() {
+    given(repository.oldestOwnPaymentDate()).willReturn(Optional.of(LocalDate.parse("2020-01-01")));
+    given(repository.fetchUnemailedFirstPayments(LocalDate.parse("2026-07-19")))
+        .willReturn(List.of(payment(FIRST_PAYER), payment(SECOND_PAYER)));
+
+    job(false, 1).run();
+
+    verify(emailService, never()).send(any());
+  }
+
+  @Test
+  void fetchesButDoesNotSendOnADryRun() {
+    given(repository.oldestOwnPaymentDate()).willReturn(Optional.of(LocalDate.parse("2020-01-01")));
+    given(repository.fetchUnemailedFirstPayments(LocalDate.parse("2026-07-19")))
+        .willReturn(List.of(payment(FIRST_PAYER)));
+
+    job(true, 200).run();
+
+    verify(emailService, never()).send(any());
+  }
+
+  @Test
+  void oneFailingRecipientDoesNotStopTheOthers() {
+    var failing = payment(FIRST_PAYER);
+    var succeeding = payment(SECOND_PAYER);
+    given(repository.oldestOwnPaymentDate()).willReturn(Optional.of(LocalDate.parse("2020-01-01")));
+    given(repository.fetchUnemailedFirstPayments(LocalDate.parse("2026-07-19")))
+        .willReturn(List.of(failing, succeeding));
+    given(emailService.send(failing)).willThrow(new RuntimeException("mandrill exploded"));
+    given(emailService.send(succeeding)).willReturn(true);
+
+    job(false, 200).run();
+
+    verify(emailService, times(1)).send(succeeding);
+  }
+}


### PR DESCRIPTION
# Email first-time III pillar payers and cancel spurious payment reminders

Part of this week's focus (TulevaEE/tuleva#222): ~470 people make their first III pillar payment each month, but only the ~130 who pay through the in-app Montonio flow get a confirmation email. The rest (internet-bank transfers, standing orders) get nothing, ever — and they convert to bringing their II pillar over at 5% vs 26-28% for app users. Their payments are already visible in the daily EPIS transaction sync; this PR turns that into a payment-received email with the II pillar suggestion block.

## What changed

**`ThirdPillarPaymentArrivedJob`** (new, scheduled, weekly Tue 12:00 by default, cron via config so flipping to daily is an env change)
- Audience: first-ever own-money payment (`transaction_source = 'Osakute väljalase isikult laekumiste alusel'`), first-ness checked against full table history (`MIN(reporting_date)` per person, all-history), same-day rows summed into one receipt. Employer, insurance, inheritance, and transfer-in rows excluded. Trailing 30-day window so people whose contact data arrives late (weekly `unit_owner` refresh) are picked up on a later run.
- Recipients: `users.email` with registry (`unit_owner.email`) fallback for people without a Tuleva account — they are our unit owners, and this is a transactional service message. Blank emails fall through to the registry; rows without a resolvable email or name are skipped without being marked, so they retry on later runs.
- Merge vars: name, amount, payment date, `hasAccount`, and `suggestSecondPillar`/`suggestPaymentRate`/`suggestMembership` derived from registry data in SQL (same keys as the existing success-email conditional chain — no EPIS calls per recipient).
- Guard rails: refuses to run if transaction history is shallower than the configured floor (first-ness would be untrustworthy), refuses on audience > `max-recipients` (200), `dry-run` defaults ON (first cycle is eyeball-only), per-person try/catch, greppable counters, `@SchedulerLock`.
- Dedup is claim-before-send via a new `third_pillar_payment_arrived_claim` table (`personal_code` PK): the claim INSERT commits in its own transaction before Mandrill is called, so a send-succeeded-but-persist-failed crash can never double-send; a Mandrill failure keeps the claim and is surfaced via `log.error` (at-most-once by design — a retry is an explicit operator decision). Anyone already in the in-app email sequence is excluded (their `THIRD_PILLAR_PAYMENT_SUCCESS_MANDATE` or `THIRD_PILLAR_PAYMENT_REMINDER_MANDATE` email row marks that), so each person sits in exactly one sequence and an in-app mandate signer who pays by bank transfer is not emailed a third time in a week. One receipt per person for now; a cooldown-based repeat with evolving next-step nudges is a planned follow-up.

**`ThirdPillarPaymentReminderController`** (new)
- `POST /v1/third-pillar-payment-reminders/cancellations` cancels all of the authenticated user's pending `THIRD_PILLAR_PAYMENT_REMINDER_MANDATE` emails (DB row + Mandrill scheduled send, idempotent). Called by the client's new recurring-payment confirmation screen — standing orders never create a `Payment`, so that reminder always fired spuriously.

**`EmailService`**
- `send(User, ...)` became `send(Person, ...)` (no behavior change) so registry-only recipients without a `users` row can receive email.

**Migration**
- `V1_246__create_third_pillar_payment_arrived_claim.sql` — renumber above master max at merge time if a racing PR claims it.

## Rollout

1. Mandrill templates `third_pillar_payment_arrived_et`/`_en` exist as unpublished drafts (cloned from the payment-success template with a receipt intro, a `hasAccount` branch whose no-account path nudges "log in and see everything in one place", and the existing suggestion chain). Review + publish before enabling.
2. Deploy with `dry-run` on (default); eyeball the first cycle's audience count in logs.
3. Set `max-recipients` just above the observed audience (the first real send covers a full 30-day window, so the 200 default may legitimately be too low for it), then set `third-pillar-payment-arrived.dry-run=false` for the first real send (next Tuesday); flip cron to daily once trusted. Any audience above the cap sends nothing and raises a log.error.
4. Deploy this before the client PR (the reminder-cancellation endpoint).

## Testing

Full suite green. New coverage: 12-scenario `@SpringBootTest` integration test (first payer with account, in-app payer excluded, old-history excluded, employer-source excluded, registry-only recipient with EN template, blank-email registry fallback, nameless and blank-name rows skipped without claim, in-app mandate signer excluded, claim collision rejected, pre-claimed person not sent, Mandrill-failure keeps claim and never re-sends) + 5 job-guard unit tests + `@WebMvcTest` for the controller.
