### PR TITLE
Accept savings fund payments from PENDING_KYC representatives

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/party/ParentChildLinkRepository.java
+++ b/src/main/java/ee/tuleva/onboarding/party/ParentChildLinkRepository.java
@@ -1,6 +1,7 @@
 package ee.tuleva.onboarding.party;
 
 import java.time.LocalDate;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -21,10 +22,10 @@ public interface ParentChildLinkRepository extends JpaRepository<ParentChildLink
       ParentChildLinkStatus status, LocalDate date);
 
   boolean
-      existsByParentPersonalCodeAndChildPersonalCodeAndStatusAndSuspendedAtIsNullAndValidUntilAfter(
+      existsByParentPersonalCodeAndChildPersonalCodeAndStatusInAndSuspendedAtIsNullAndValidUntilAfter(
           String parentPersonalCode,
           String childPersonalCode,
-          ParentChildLinkStatus status,
+          Collection<ParentChildLinkStatus> statuses,
           LocalDate date);
 
   Optional<ParentChildLink> findByParentPersonalCodeAndChildPersonalCodeAndRelationshipType(

--- a/src/main/java/ee/tuleva/onboarding/party/ParentChildLinkService.java
+++ b/src/main/java/ee/tuleva/onboarding/party/ParentChildLinkService.java
@@ -6,6 +6,7 @@ import static ee.tuleva.onboarding.party.ParentChildLinkStatus.PENDING_KYC;
 import java.time.Clock;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -25,10 +26,16 @@ public class ParentChildLinkService {
         .toList();
   }
 
-  public boolean isActiveRepresentation(String parentPersonalCode, String childPersonalCode) {
+  public boolean isRepresentation(
+      String parentPersonalCode, String childPersonalCode, Set<ParentChildLinkStatus> statuses) {
     return parentChildLinkRepository
-        .existsByParentPersonalCodeAndChildPersonalCodeAndStatusAndSuspendedAtIsNullAndValidUntilAfter(
-            parentPersonalCode, childPersonalCode, ACTIVE, today());
+        .existsByParentPersonalCodeAndChildPersonalCodeAndStatusInAndSuspendedAtIsNullAndValidUntilAfter(
+            parentPersonalCode, childPersonalCode, statuses, today());
+  }
+
+  // The parent acting *as* the child: requires the parent to have cleared their own KYC.
+  public boolean isActiveRepresentation(String parentPersonalCode, String childPersonalCode) {
+    return isRepresentation(parentPersonalCode, childPersonalCode, Set.of(ACTIVE));
   }
 
   // AML screening scope, not an authorization check: suspended and PENDING_KYC links count,

--- a/src/main/java/ee/tuleva/onboarding/payment/email/SavingsFundSuccessEmailResolver.java
+++ b/src/main/java/ee/tuleva/onboarding/payment/email/SavingsFundSuccessEmailResolver.java
@@ -1,11 +1,15 @@
 package ee.tuleva.onboarding.payment.email;
 
+import static ee.tuleva.onboarding.party.ParentChildLinkStatus.ACTIVE;
+import static ee.tuleva.onboarding.party.ParentChildLinkStatus.PENDING_KYC;
+
 import ee.tuleva.onboarding.party.ParentChildLinkService;
 import ee.tuleva.onboarding.party.Party;
 import ee.tuleva.onboarding.party.PartyId;
 import ee.tuleva.onboarding.party.PartyResolver;
 import ee.tuleva.onboarding.payment.event.SavingsPaymentCreatedEvent;
 import ee.tuleva.onboarding.user.User;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
@@ -32,7 +36,8 @@ class SavingsFundSuccessEmailResolver {
 
   private boolean isRepresentedChild(User payer, PartyId recipient) {
     return !payer.getPersonalCode().equals(recipient.code())
-        && parentChildLinkService.isActiveRepresentation(payer.getPersonalCode(), recipient.code());
+        && parentChildLinkService.isRepresentation(
+            payer.getPersonalCode(), recipient.code(), Set.of(ACTIVE, PENDING_KYC));
   }
 
   private @Nullable String nameOf(PartyId recipient) {

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/PaymentVerificationService.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/PaymentVerificationService.java
@@ -1,5 +1,7 @@
 package ee.tuleva.onboarding.savings.fund;
 
+import static ee.tuleva.onboarding.party.ParentChildLinkStatus.ACTIVE;
+import static ee.tuleva.onboarding.party.ParentChildLinkStatus.PENDING_KYC;
 import static ee.tuleva.onboarding.party.PartyId.Type.LEGAL_ENTITY;
 import static ee.tuleva.onboarding.party.PartyId.Type.PERSON;
 import static ee.tuleva.onboarding.savings.fund.SavingFundPayment.Status.TO_BE_RETURNED;
@@ -21,6 +23,7 @@ import ee.tuleva.onboarding.user.personalcode.PersonalCodeValidator;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -167,10 +170,15 @@ public class PaymentVerificationService {
     return parsePartyId(payment.getRemitterIdCode());
   }
 
+  // Attribution, not authorization: deciding whether an incoming payment is plausibly for this
+  // child, so we attribute it instead of bouncing it. Accepting money grants the payer no access —
+  // acting on the child's behalf goes through isActiveRepresentation. Tuleva intends to accept
+  // third-party payments generally, at which point this widening goes away.
   private boolean isAuthorizedRemitter(PartyId remitter, PartyId party) {
     return remitter.type() == PERSON
         && party.type() == PERSON
-        && parentChildLinkService.isActiveRepresentation(remitter.code(), party.code());
+        && parentChildLinkService.isRepresentation(
+            remitter.code(), party.code(), Set.of(ACTIVE, PENDING_KYC));
   }
 
   Optional<PartyId> extractPartyIdFromDescription(String text) {

--- a/src/test/groovy/ee/tuleva/onboarding/auth/role/RoleSwitchServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/auth/role/RoleSwitchServiceTest.java
@@ -5,9 +5,12 @@ import static ee.tuleva.onboarding.auth.role.RoleType.*;
 import static ee.tuleva.onboarding.company.CompanyFixture.*;
 import static ee.tuleva.onboarding.company.RelationshipType.BOARD_MEMBER;
 import static ee.tuleva.onboarding.event.TrackableEventType.ROLE_SWITCH;
+import static ee.tuleva.onboarding.party.ParentChildLinkStatus.PENDING_KYC;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -358,6 +361,22 @@ class RoleSwitchServiceTest {
     assertThatThrownBy(
             () -> roleSwitchService.switchRole(person, new SwitchRoleCommand(PERSON, CHILD_CODE)))
         .isInstanceOf(RoleSwitchAccessDeniedException.class);
+  }
+
+  @Test
+  void switchToChildOfARepresentativeWhoHasNotClearedKycThrows() {
+    // funding the child is KYC-agnostic, acting as the child is not
+    when(parentChildLinkService.isActiveRepresentation(person.getPersonalCode(), CHILD_CODE))
+        .thenReturn(false);
+
+    assertThatThrownBy(
+            () -> roleSwitchService.switchRole(person, new SwitchRoleCommand(PERSON, CHILD_CODE)))
+        .isInstanceOf(RoleSwitchAccessDeniedException.class);
+    // pins the real invariant: the role-switch path never requests a status set admitting a
+    // representative who has not cleared KYC. Survives a refactor onto
+    // isRepresentation(..., Set.of(ACTIVE)), where a blanket never() would fail spuriously.
+    verify(parentChildLinkService, never())
+        .isRepresentation(any(), any(), argThat(statuses -> statuses.contains(PENDING_KYC)));
   }
 
   @Test

--- a/src/test/groovy/ee/tuleva/onboarding/party/ParentChildLinkRepositoryTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/party/ParentChildLinkRepositoryTest.java
@@ -2,11 +2,13 @@ package ee.tuleva.onboarding.party;
 
 import static ee.tuleva.onboarding.party.ParentChildLinkStatus.ACTIVE;
 import static ee.tuleva.onboarding.party.ParentChildLinkStatus.PENDING_KYC;
+import static ee.tuleva.onboarding.party.RepresentationType.GUARDIAN;
 import static ee.tuleva.onboarding.party.RepresentationType.LEGAL_REPRESENTATIVE;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Instant;
 import java.time.LocalDate;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
@@ -38,6 +40,10 @@ class ParentChildLinkRepositoryTest {
   }
 
   private ParentChildLink savedPendingLink(String parentPersonalCode) {
+    return savedPendingLink(parentPersonalCode, null);
+  }
+
+  private ParentChildLink savedPendingLink(String parentPersonalCode, Instant suspendedAt) {
     return repository.save(
         ParentChildLink.builder()
             .parentPersonalCode(parentPersonalCode)
@@ -45,6 +51,19 @@ class ParentChildLinkRepositoryTest {
             .relationshipType(LEGAL_REPRESENTATIVE)
             .validUntil(EIGHTEENTH_BIRTHDAY)
             .status(PENDING_KYC)
+            .suspendedAt(suspendedAt)
+            .build());
+  }
+
+  private ParentChildLink savedGuardianLink(
+      String parentPersonalCode, ParentChildLinkStatus status) {
+    return repository.save(
+        ParentChildLink.builder()
+            .parentPersonalCode(parentPersonalCode)
+            .childPersonalCode(CHILD)
+            .relationshipType(GUARDIAN)
+            .validUntil(EIGHTEENTH_BIRTHDAY)
+            .status(status)
             .build());
   }
 
@@ -60,15 +79,15 @@ class ParentChildLinkRepositoryTest {
   void activeRepresentationQueriesExcludePendingLinks() {
     savedPendingLink(PARENT);
 
-    // role switch + payments both read through these two queries
+    // the role switch reads through these two queries
     assertThat(
             repository.findByParentPersonalCodeAndStatusAndSuspendedAtIsNullAndValidUntilAfter(
                 PARENT, ACTIVE, EIGHTEENTH_BIRTHDAY.minusDays(1)))
         .isEmpty();
     assertThat(
             repository
-                .existsByParentPersonalCodeAndChildPersonalCodeAndStatusAndSuspendedAtIsNullAndValidUntilAfter(
-                    PARENT, CHILD, ACTIVE, EIGHTEENTH_BIRTHDAY.minusDays(1)))
+                .existsByParentPersonalCodeAndChildPersonalCodeAndStatusInAndSuspendedAtIsNullAndValidUntilAfter(
+                    PARENT, CHILD, Set.of(ACTIVE), EIGHTEENTH_BIRTHDAY.minusDays(1)))
         .isFalse();
   }
 
@@ -140,41 +159,161 @@ class ParentChildLinkRepositoryTest {
 
     assertThat(
             repository
-                .existsByParentPersonalCodeAndChildPersonalCodeAndStatusAndSuspendedAtIsNullAndValidUntilAfter(
-                    PARENT, CHILD, ACTIVE, EIGHTEENTH_BIRTHDAY.minusDays(1)))
+                .existsByParentPersonalCodeAndChildPersonalCodeAndStatusInAndSuspendedAtIsNullAndValidUntilAfter(
+                    PARENT, CHILD, Set.of(ACTIVE), EIGHTEENTH_BIRTHDAY.minusDays(1)))
         .isTrue();
   }
 
   @Test
-  void doesNotRepresentOnValidUntilDate() {
+  void representsActiveChildWhenTheStatusSetIsWidened() {
     savedLink(null);
 
     assertThat(
             repository
-                .existsByParentPersonalCodeAndChildPersonalCodeAndStatusAndSuspendedAtIsNullAndValidUntilAfter(
-                    PARENT, CHILD, ACTIVE, EIGHTEENTH_BIRTHDAY))
-        .isFalse();
+                .existsByParentPersonalCodeAndChildPersonalCodeAndStatusInAndSuspendedAtIsNullAndValidUntilAfter(
+                    PARENT, CHILD, Set.of(ACTIVE, PENDING_KYC), EIGHTEENTH_BIRTHDAY.minusDays(1)))
+        .isTrue();
   }
 
   @Test
-  void doesNotRepresentSuspendedChild() {
+  void representsPendingChildOnlyWhenTheStatusSetIncludesPendingKyc() {
+    // payments ask for the widened set, so a parent who has not cleared KYC still counts;
+    // the role switch asks for ACTIVE only and must not see them
+    savedPendingLink(PARENT);
+
+    assertThat(
+            repository
+                .existsByParentPersonalCodeAndChildPersonalCodeAndStatusInAndSuspendedAtIsNullAndValidUntilAfter(
+                    PARENT, CHILD, Set.of(ACTIVE, PENDING_KYC), EIGHTEENTH_BIRTHDAY.minusDays(1)))
+        .isTrue();
+    assertThat(
+            repository
+                .existsByParentPersonalCodeAndChildPersonalCodeAndStatusInAndSuspendedAtIsNullAndValidUntilAfter(
+                    PARENT, CHILD, Set.of(ACTIVE), EIGHTEENTH_BIRTHDAY.minusDays(1)))
+        .isFalse();
+  }
+
+  // guardians are deliberately not filtered out by relationship type: a court-appointed guardian
+  // represents their ward exactly as a parent represents a child
+  @Test
+  void representsGuardianWardsOnTheSameTermsAsLegalRepresentatives() {
+    var guardianLink = savedGuardianLink(PARENT, ACTIVE);
+    savedGuardianLink(OTHER_PARENT, PENDING_KYC);
+
+    assertThat(
+            repository
+                .existsByParentPersonalCodeAndChildPersonalCodeAndStatusInAndSuspendedAtIsNullAndValidUntilAfter(
+                    PARENT, CHILD, Set.of(ACTIVE), EIGHTEENTH_BIRTHDAY.minusDays(1)))
+        .isTrue();
+    assertThat(
+            repository
+                .existsByParentPersonalCodeAndChildPersonalCodeAndStatusInAndSuspendedAtIsNullAndValidUntilAfter(
+                    PARENT, CHILD, Set.of(ACTIVE, PENDING_KYC), EIGHTEENTH_BIRTHDAY.minusDays(1)))
+        .isTrue();
+    assertThat(
+            repository
+                .existsByParentPersonalCodeAndChildPersonalCodeAndStatusInAndSuspendedAtIsNullAndValidUntilAfter(
+                    OTHER_PARENT,
+                    CHILD,
+                    Set.of(ACTIVE, PENDING_KYC),
+                    EIGHTEENTH_BIRTHDAY.minusDays(1)))
+        .isTrue();
+    assertThat(
+            repository
+                .existsByParentPersonalCodeAndChildPersonalCodeAndStatusInAndSuspendedAtIsNullAndValidUntilAfter(
+                    OTHER_PARENT, CHILD, Set.of(ACTIVE), EIGHTEENTH_BIRTHDAY.minusDays(1)))
+        .isFalse();
+    // the role listing reads through this query, which also ignores relationship type
+    assertThat(
+            repository.findByParentPersonalCodeAndStatusAndSuspendedAtIsNullAndValidUntilAfter(
+                PARENT, ACTIVE, EIGHTEENTH_BIRTHDAY.minusDays(1)))
+        .containsExactly(guardianLink);
+    assertThat(
+            repository.findByParentPersonalCodeAndStatusAndSuspendedAtIsNullAndValidUntilAfter(
+                OTHER_PARENT, ACTIVE, EIGHTEENTH_BIRTHDAY.minusDays(1)))
+        .isEmpty();
+  }
+
+  @Test
+  void representsNoSuspendedActiveChildForAnyStatusSet() {
     savedLink(SUSPENDED);
 
     assertThat(
             repository
-                .existsByParentPersonalCodeAndChildPersonalCodeAndStatusAndSuspendedAtIsNullAndValidUntilAfter(
-                    PARENT, CHILD, ACTIVE, EIGHTEENTH_BIRTHDAY.minusDays(1)))
+                .existsByParentPersonalCodeAndChildPersonalCodeAndStatusInAndSuspendedAtIsNullAndValidUntilAfter(
+                    PARENT, CHILD, Set.of(ACTIVE), EIGHTEENTH_BIRTHDAY.minusDays(1)))
+        .isFalse();
+    assertThat(
+            repository
+                .existsByParentPersonalCodeAndChildPersonalCodeAndStatusInAndSuspendedAtIsNullAndValidUntilAfter(
+                    PARENT, CHILD, Set.of(ACTIVE, PENDING_KYC), EIGHTEENTH_BIRTHDAY.minusDays(1)))
         .isFalse();
   }
 
   @Test
-  void doesNotRepresentUnknownChild() {
+  void representsNoSuspendedPendingChildForAnyStatusSet() {
+    savedPendingLink(PARENT, SUSPENDED);
+
+    assertThat(
+            repository
+                .existsByParentPersonalCodeAndChildPersonalCodeAndStatusInAndSuspendedAtIsNullAndValidUntilAfter(
+                    PARENT, CHILD, Set.of(ACTIVE), EIGHTEENTH_BIRTHDAY.minusDays(1)))
+        .isFalse();
+    assertThat(
+            repository
+                .existsByParentPersonalCodeAndChildPersonalCodeAndStatusInAndSuspendedAtIsNullAndValidUntilAfter(
+                    PARENT, CHILD, Set.of(ACTIVE, PENDING_KYC), EIGHTEENTH_BIRTHDAY.minusDays(1)))
+        .isFalse();
+  }
+
+  @Test
+  void representsNoExpiredActiveChildForAnyStatusSet() {
     savedLink(null);
 
     assertThat(
             repository
-                .existsByParentPersonalCodeAndChildPersonalCodeAndStatusAndSuspendedAtIsNullAndValidUntilAfter(
-                    PARENT, "99999999999", ACTIVE, EIGHTEENTH_BIRTHDAY.minusDays(1)))
+                .existsByParentPersonalCodeAndChildPersonalCodeAndStatusInAndSuspendedAtIsNullAndValidUntilAfter(
+                    PARENT, CHILD, Set.of(ACTIVE), EIGHTEENTH_BIRTHDAY))
+        .isFalse();
+    assertThat(
+            repository
+                .existsByParentPersonalCodeAndChildPersonalCodeAndStatusInAndSuspendedAtIsNullAndValidUntilAfter(
+                    PARENT, CHILD, Set.of(ACTIVE, PENDING_KYC), EIGHTEENTH_BIRTHDAY))
+        .isFalse();
+  }
+
+  @Test
+  void representsNoExpiredPendingChildForAnyStatusSet() {
+    savedPendingLink(PARENT);
+
+    assertThat(
+            repository
+                .existsByParentPersonalCodeAndChildPersonalCodeAndStatusInAndSuspendedAtIsNullAndValidUntilAfter(
+                    PARENT, CHILD, Set.of(ACTIVE), EIGHTEENTH_BIRTHDAY))
+        .isFalse();
+    assertThat(
+            repository
+                .existsByParentPersonalCodeAndChildPersonalCodeAndStatusInAndSuspendedAtIsNullAndValidUntilAfter(
+                    PARENT, CHILD, Set.of(ACTIVE, PENDING_KYC), EIGHTEENTH_BIRTHDAY))
+        .isFalse();
+  }
+
+  @Test
+  void representsNoUnknownChildForAnyStatusSet() {
+    savedLink(null);
+
+    assertThat(
+            repository
+                .existsByParentPersonalCodeAndChildPersonalCodeAndStatusInAndSuspendedAtIsNullAndValidUntilAfter(
+                    PARENT, "99999999999", Set.of(ACTIVE), EIGHTEENTH_BIRTHDAY.minusDays(1)))
+        .isFalse();
+    assertThat(
+            repository
+                .existsByParentPersonalCodeAndChildPersonalCodeAndStatusInAndSuspendedAtIsNullAndValidUntilAfter(
+                    PARENT,
+                    "99999999999",
+                    Set.of(ACTIVE, PENDING_KYC),
+                    EIGHTEENTH_BIRTHDAY.minusDays(1)))
         .isFalse();
   }
 

--- a/src/test/groovy/ee/tuleva/onboarding/party/ParentChildLinkServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/party/ParentChildLinkServiceTest.java
@@ -5,12 +5,14 @@ import static ee.tuleva.onboarding.party.ParentChildLinkStatus.PENDING_KYC;
 import static ee.tuleva.onboarding.party.RepresentationType.LEGAL_REPRESENTATIVE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 
 import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
 import java.util.List;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -54,14 +56,44 @@ class ParentChildLinkServiceTest {
   }
 
   @Test
-  void isActiveRepresentationWhenActiveLinkExistsAsOfToday() {
+  void isRepresentationWhenALinkWithOneOfTheRequestedStatusesExistsAsOfToday() {
     given(
             parentChildLinkRepository
-                .existsByParentPersonalCodeAndChildPersonalCodeAndStatusAndSuspendedAtIsNullAndValidUntilAfter(
-                    PARENT, CHILD, ACTIVE, TODAY))
+                .existsByParentPersonalCodeAndChildPersonalCodeAndStatusInAndSuspendedAtIsNullAndValidUntilAfter(
+                    PARENT, CHILD, Set.of(ACTIVE, PENDING_KYC), TODAY))
+        .willReturn(true);
+
+    assertThat(service.isRepresentation(PARENT, CHILD, Set.of(ACTIVE, PENDING_KYC))).isTrue();
+  }
+
+  @Test
+  void isNotRepresentationWhenNoLinkHasOneOfTheRequestedStatuses() {
+    assertThat(service.isRepresentation(PARENT, CHILD, Set.of(ACTIVE, PENDING_KYC))).isFalse();
+  }
+
+  @Test
+  void isRepresentationPassesTheRequestedStatusSetStraightToTheQuery() {
+    given(
+            parentChildLinkRepository
+                .existsByParentPersonalCodeAndChildPersonalCodeAndStatusInAndSuspendedAtIsNullAndValidUntilAfter(
+                    PARENT, CHILD, Set.of(ACTIVE), TODAY))
+        .willReturn(true);
+
+    assertThat(service.isRepresentation(PARENT, CHILD, Set.of(ACTIVE))).isTrue();
+  }
+
+  @Test
+  void isActiveRepresentationDelegatesWithTheActiveStatusOnly() {
+    given(
+            parentChildLinkRepository
+                .existsByParentPersonalCodeAndChildPersonalCodeAndStatusInAndSuspendedAtIsNullAndValidUntilAfter(
+                    PARENT, CHILD, Set.of(ACTIVE), TODAY))
         .willReturn(true);
 
     assertThat(service.isActiveRepresentation(PARENT, CHILD)).isTrue();
+    verify(parentChildLinkRepository)
+        .existsByParentPersonalCodeAndChildPersonalCodeAndStatusInAndSuspendedAtIsNullAndValidUntilAfter(
+            PARENT, CHILD, Set.of(ACTIVE), TODAY);
   }
 
   @Test

--- a/src/test/groovy/ee/tuleva/onboarding/payment/email/SavingsFundSuccessEmailResolverTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/payment/email/SavingsFundSuccessEmailResolverTest.java
@@ -1,10 +1,15 @@
 package ee.tuleva.onboarding.payment.email;
 
+import static ee.tuleva.onboarding.party.ParentChildLinkStatus.ACTIVE;
+import static ee.tuleva.onboarding.party.ParentChildLinkStatus.PENDING_KYC;
 import static ee.tuleva.onboarding.party.PartyId.Type.LEGAL_ENTITY;
 import static ee.tuleva.onboarding.party.PartyId.Type.PERSON;
 import static java.util.Locale.ENGLISH;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
 import ee.tuleva.onboarding.company.Company;
@@ -14,6 +19,7 @@ import ee.tuleva.onboarding.party.PartyResolver;
 import ee.tuleva.onboarding.payment.event.SavingsPaymentCreatedEvent;
 import ee.tuleva.onboarding.user.User;
 import java.util.Optional;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -44,22 +50,27 @@ class SavingsFundSuccessEmailResolverTest {
   }
 
   @Test
-  void paymentForRepresentedChildResolvesToChildEmailWithChildName() {
+  void paymentForRepresentedChildResolvesToChildEmailRegardlessOfTheRepresentativesKycStatus() {
     String childCode = "51111111111";
     User child = User.builder().personalCode(childCode).firstName("Kid").lastName("Tester").build();
-    given(parentChildLinkService.isActiveRepresentation(payer.getPersonalCode(), childCode))
+    given(
+            parentChildLinkService.isRepresentation(
+                payer.getPersonalCode(), childCode, Set.of(ACTIVE, PENDING_KYC)))
         .willReturn(true);
     given(partyResolver.resolve(new PartyId(PERSON, childCode))).willReturn(Optional.of(child));
 
     var resolved = resolver.resolve(event(new PartyId(PERSON, childCode)));
 
     assertThat(resolved).isEqualTo(SavingsFundPaymentEmail.childSuccess(child.name()));
+    verify(parentChildLinkService, never()).isActiveRepresentation(any(), any());
   }
 
   @Test
   void paymentForAnotherPersonWhoIsNotARepresentedChildResolvesToPersonEmail() {
     String otherCode = "49001010001";
-    given(parentChildLinkService.isActiveRepresentation(payer.getPersonalCode(), otherCode))
+    given(
+            parentChildLinkService.isRepresentation(
+                payer.getPersonalCode(), otherCode, Set.of(ACTIVE, PENDING_KYC)))
         .willReturn(false);
 
     var resolved = resolver.resolve(event(new PartyId(PERSON, otherCode)));

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/PaymentVerificationServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/PaymentVerificationServiceTest.java
@@ -1,5 +1,7 @@
 package ee.tuleva.onboarding.savings.fund;
 
+import static ee.tuleva.onboarding.party.ParentChildLinkStatus.ACTIVE;
+import static ee.tuleva.onboarding.party.ParentChildLinkStatus.PENDING_KYC;
 import static ee.tuleva.onboarding.party.PartyId.Type.LEGAL_ENTITY;
 import static ee.tuleva.onboarding.party.PartyId.Type.PERSON;
 import static ee.tuleva.onboarding.savings.fund.SavingFundPayment.Status.TO_BE_RETURNED;
@@ -27,6 +29,7 @@ import java.time.LocalDate;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.ApplicationEventPublisher;
 
@@ -626,7 +629,9 @@ class PaymentVerificationServiceTest {
             .build();
     when(userRepository.findByPersonalCode(parentCode)).thenReturn(Optional.of(parent));
     when(userRepository.findByPersonalCode(childCode)).thenReturn(Optional.of(child));
-    when(parentChildLinkService.isActiveRepresentation(parentCode, childCode)).thenReturn(false);
+    when(parentChildLinkService.isRepresentation(
+            parentCode, childCode, Set.of(ACTIVE, PENDING_KYC)))
+        .thenReturn(false);
 
     service.process(payment);
 
@@ -674,7 +679,9 @@ class PaymentVerificationServiceTest {
             .build();
     when(userRepository.findByPersonalCode(remitterCode)).thenReturn(Optional.empty());
     when(userRepository.findByPersonalCode(childCode)).thenReturn(Optional.of(child));
-    when(parentChildLinkService.isActiveRepresentation(remitterCode, childCode)).thenReturn(false);
+    when(parentChildLinkService.isRepresentation(
+            remitterCode, childCode, Set.of(ACTIVE, PENDING_KYC)))
+        .thenReturn(false);
 
     service.process(payment);
 
@@ -715,7 +722,7 @@ class PaymentVerificationServiceTest {
   }
 
   @Test
-  void process_parentRepresentingChild_activeLink_paymentVerifiedForChild() {
+  void process_parentRepresentingChild_validLink_paymentVerifiedForChild() {
     var parentCode = "38812121215";
     var childCode = "61506150006";
     var payment = createPayment(parentCode, "for child " + childCode);
@@ -729,7 +736,9 @@ class PaymentVerificationServiceTest {
     when(userRepository.findByPersonalCode(childCode)).thenReturn(Optional.of(child));
     when(savingsFundOnboardingService.isOnboardingCompleted(new PartyId(PERSON, childCode)))
         .thenReturn(true);
-    when(parentChildLinkService.isActiveRepresentation(parentCode, childCode)).thenReturn(true);
+    when(parentChildLinkService.isRepresentation(
+            parentCode, childCode, Set.of(ACTIVE, PENDING_KYC)))
+        .thenReturn(true);
 
     service.process(payment);
 
@@ -758,14 +767,17 @@ class PaymentVerificationServiceTest {
                     payment.getId(),
                     "amount",
                     payment.getAmount())));
+    verify(parentChildLinkService, never()).isActiveRepresentation(any(), any());
   }
 
   @Test
-  void process_parentRepresentingChild_noActiveLink_bouncesAsCodeMismatch() {
+  void process_parentRepresentingChild_noValidLink_bouncesAsCodeMismatch() {
     var parentCode = "38812121215";
     var childCode = "61506150006";
     var payment = createPayment(parentCode, "for child " + childCode);
-    when(parentChildLinkService.isActiveRepresentation(parentCode, childCode)).thenReturn(false);
+    when(parentChildLinkService.isRepresentation(
+            parentCode, childCode, Set.of(ACTIVE, PENDING_KYC)))
+        .thenReturn(false);
 
     service.process(payment);
 

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/SavingsFundPaymentIntegrationTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/SavingsFundPaymentIntegrationTest.java
@@ -9,7 +9,9 @@ import static ee.tuleva.onboarding.ledger.LedgerTransaction.TransactionType.PAYM
 import static ee.tuleva.onboarding.ledger.LedgerTransaction.TransactionType.PAYMENT_CANCELLED;
 import static ee.tuleva.onboarding.ledger.SystemAccount.*;
 import static ee.tuleva.onboarding.ledger.UserAccount.*;
+import static ee.tuleva.onboarding.party.ParentChildLinkStatus.PENDING_KYC;
 import static ee.tuleva.onboarding.party.PartyId.Type.PERSON;
+import static ee.tuleva.onboarding.party.RepresentationType.LEGAL_REPRESENTATIVE;
 import static ee.tuleva.onboarding.savings.fund.SavingFundPayment.Status.*;
 import static ee.tuleva.onboarding.savings.fund.SavingsFundOnboardingStatus.COMPLETED;
 import static java.math.BigDecimal.ZERO;
@@ -28,6 +30,8 @@ import ee.tuleva.onboarding.ledger.LedgerEntry;
 import ee.tuleva.onboarding.ledger.LedgerParty;
 import ee.tuleva.onboarding.ledger.LedgerService;
 import ee.tuleva.onboarding.ledger.SavingsFundLedger;
+import ee.tuleva.onboarding.party.ParentChildLink;
+import ee.tuleva.onboarding.party.ParentChildLinkRepository;
 import ee.tuleva.onboarding.party.PartyId;
 import ee.tuleva.onboarding.savings.fund.issuing.FundAccountPaymentJob;
 import ee.tuleva.onboarding.savings.fund.issuing.IssuingJob;
@@ -72,6 +76,7 @@ class SavingsFundPaymentIntegrationTest {
   @Autowired private JdbcClient jdbcClient;
   @Autowired private SavingsFundLedger savingsFundLedger;
   @Autowired private UnattributedPaymentAttributionService attributionService;
+  @Autowired private ParentChildLinkRepository parentChildLinkRepository;
 
   // Monday 2025-09-29 17:00 EET (15:00 UTC) - after 16:00 cutoff
   private static final Instant NOW = Instant.parse("2025-09-29T15:00:00Z");
@@ -408,6 +413,10 @@ class SavingsFundPaymentIntegrationTest {
         testUser.getPersonalCode(), LedgerParty.PartyType.PERSON, CASH);
   }
 
+  private LedgerAccount getCashAccount(String personalCode) {
+    return ledgerService.getPartyAccount(personalCode, LedgerParty.PartyType.PERSON, CASH);
+  }
+
   private LedgerAccount getUserCashReservedAccount() {
     return ledgerService.getPartyAccount(
         testUser.getPersonalCode(), LedgerParty.PartyType.PERSON, CASH_RESERVED);
@@ -638,6 +647,99 @@ class SavingsFundPaymentIntegrationTest {
     // Assert final ledger: bounce back recorded, clearing accounts balanced
     assertThat(scopedBalance(getUnreconciledBankReceiptsAccount())).isEqualByComparingTo(ZERO);
     assertThat(scopedBalance(getIncomingPaymentsClearingAccount())).isEqualByComparingTo(ZERO);
+  }
+
+  @Test
+  @DisplayName(
+      "A legal representative who has not cleared KYC can still fund the child: XML → RECEIVED → VERIFIED for the child")
+  void paymentFromPendingRepresentativeIsVerifiedForTheChild() {
+    var childCode = "61506150006";
+    userRepository.save(
+        User.builder()
+            .firstName("Mari")
+            .lastName("Tamm")
+            .personalCode(childCode)
+            .email("mari.tamm@example.com")
+            .phoneNumber("+372 5555 7777")
+            .build());
+    savingsFundOnboardingRepository.saveOnboardingStatus(childCode, PERSON, COMPLETED);
+    parentChildLinkRepository.save(
+        ParentChildLink.builder()
+            .parentPersonalCode(testUser.getPersonalCode())
+            .childPersonalCode(childCode)
+            .relationshipType(LEGAL_REPRESENTATIVE)
+            .validUntil(LocalDate.of(2033, 6, 15))
+            .status(PENDING_KYC)
+            .build());
+
+    persistXmlMessage(createPaymentForChildXml(childCode), NOW);
+
+    // Step 1: Process XML message → Payment should be RECEIVED
+    eventPublisher.publishEvent(new ProcessBankMessagesRequested());
+
+    var payment = paymentRepository.findByExternalId("2025092909000-2").orElseThrow();
+    assertThat(payment.getStatus()).isEqualTo(RECEIVED);
+    var paymentId = payment.getId();
+    ownedPaymentIds.add(paymentId);
+
+    // Step 2: Run verification job → Payment should be VERIFIED and attached to the child
+    paymentVerificationJob.runJob();
+
+    payment = paymentRepository.findById(paymentId).orElseThrow();
+    assertThat(payment.getStatus()).isEqualTo(VERIFIED);
+    assertThat(payment.getPartyId()).isEqualTo(new PartyId(PERSON, childCode));
+    assertThat(payment.getReturnReason()).isNull();
+
+    // Assert ledger: the cash liability lands on the child, not on the paying parent
+    var paymentAmount = new BigDecimal("50.00");
+    assertThat(scopedBalance(getCashAccount(childCode)))
+        .isEqualByComparingTo(paymentAmount.negate());
+    assertThat(scopedBalance(getUserCashAccount())).isEqualByComparingTo(ZERO);
+    assertThat(scopedBalance(getIncomingPaymentsClearingAccount()))
+        .isEqualByComparingTo(paymentAmount);
+  }
+
+  private String createPaymentForChildXml(String childCode) {
+    return "<?xml version=\"1.0\" encoding=\"UTF-8\"?> "
+        + "<Document xmlns=\"urn:iso:std:iso:20022:tech:xsd:camt.052.001.02\"> "
+        + "<BkToCstmrAcctRpt> "
+        + "<GrpHdr> <MsgId>test-for-child</MsgId> <CreDtTm>2025-09-29T09:00:00</CreDtTm> </GrpHdr> "
+        + "<Rpt> "
+        + "<Id>test-for-child-1</Id> "
+        + "<CreDtTm>2025-09-29T09:00:00</CreDtTm> "
+        + "<FrToDt> "
+        + "<FrDtTm>2025-09-29T00:00:00</FrDtTm> "
+        + "<ToDtTm>2025-09-29T09:00:00</ToDtTm> "
+        + "</FrToDt> "
+        + "<Acct> "
+        + "<Id> <IBAN>EE442200221092874625</IBAN> </Id> "
+        + "<Ownr> <Nm>TULEVA FONDID AS</Nm> "
+        + "<Id> <OrgId> <Othr> <Id>14118923</Id> </Othr> </OrgId> </Id> "
+        + "</Ownr> "
+        + "</Acct> "
+        + "<Ntry> "
+        + "<NtryRef>2025092909000-2</NtryRef>"
+        + "<Amt Ccy=\"EUR\">50.00</Amt> "
+        + "<CdtDbtInd>CRDT</CdtDbtInd> "
+        + "<Sts>BOOK</Sts> "
+        + "<BookgDt> <Dt>2025-09-29</Dt> </BookgDt> "
+        + "<NtryDtls> <TxDtls> "
+        + "<Refs> <AcctSvcrRef>2025092909000-2</AcctSvcrRef> </Refs> "
+        + "<AmtDtls> <TxAmt> <Amt Ccy=\"EUR\">50.00</Amt> </TxAmt> </AmtDtls> "
+        + "<RltdPties> "
+        + "<Dbtr> <Nm>Jüri Tamm</Nm> "
+        + "<Id> <PrvtId> <Othr> <Id>39910273027</Id> </Othr> </PrvtId> </Id> "
+        + "</Dbtr> "
+        + "<DbtrAcct> <Id> <IBAN>EE982200221234567890</IBAN> </Id> </DbtrAcct> "
+        + "</RltdPties> "
+        + "<RmtInf> <Ustrd>Payment for "
+        + childCode
+        + "</Ustrd> </RmtInf> "
+        + "</TxDtls> </NtryDtls> "
+        + "</Ntry> "
+        + "</Rpt> "
+        + "</BkToCstmrAcctRpt> "
+        + "</Document>";
   }
 
   private String createUnverifiablePaymentXml() {


### PR DESCRIPTION
A legal representative's payment for their child was returned with a misleading code-mismatch reason because their parent_child_link was PENDING_KYC. Funding a child's account does not require the representative to have cleared their own KYC; acting as the child still does.

Replace the single-status representation query with a StatusIn allowlist: isRepresentation(parent, child, statuses) is the primitive, and isActiveRepresentation delegates with Set.of(ACTIVE). The payment verification and success-email paths pass Set.of(ACTIVE, PENDING_KYC); RoleSwitchService keeps requiring ACTIVE, which is what prevents a representative who has not cleared KYC from acting on the child's behalf.

The allowlist is fail-closed: a future status is excluded until each call site is deliberately revisited.

Relationship type stays unfiltered everywhere, as before: a court-appointed guardian represents their ward exactly as a parent represents a child, and the pre-existing ACTIVE-only role-switch query never filtered it either. Now pinned by a test.

Claude-Session: https://claude.ai/code/session_01GDTViwJYiRrqDTp7rwGhNq