### PR TITLE
Fetch end-of-day statements for pension fund accounts too

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/banking/seb/fetcher/SebStatementFetchingScheduler.java
+++ b/src/main/java/ee/tuleva/onboarding/banking/seb/fetcher/SebStatementFetchingScheduler.java
@@ -42,7 +42,7 @@ public class SebStatementFetchingScheduler {
       lockAtLeastFor = "30m")
   public void fetchEodTransactions() {
     log.info("Running SEB end-of-day transactions fetching scheduler");
-    for (BankAccount account : bankAccounts.findAll(TKF100)) {
+    for (BankAccount account : bankAccounts.findAll()) {
       try {
         eventPublisher.publishEvent(new FetchSebEodTransactionsRequested(account));
       } catch (Exception exception) {

--- a/src/test/groovy/ee/tuleva/onboarding/banking/seb/fetcher/SebStatementFetchingSchedulerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/banking/seb/fetcher/SebStatementFetchingSchedulerTest.java
@@ -2,6 +2,9 @@ package ee.tuleva.onboarding.banking.seb.fetcher;
 
 import static ee.tuleva.onboarding.banking.BankAccountType.*;
 import static ee.tuleva.onboarding.fund.TulevaFund.TKF100;
+import static ee.tuleva.onboarding.fund.TulevaFund.TUK00;
+import static ee.tuleva.onboarding.fund.TulevaFund.TUK75;
+import static ee.tuleva.onboarding.fund.TulevaFund.TUV100;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
@@ -10,7 +13,6 @@ import ee.tuleva.onboarding.banking.BankAccounts;
 import ee.tuleva.onboarding.banking.event.BankMessageEvents.FetchSebCurrentDayTransactionsRequested;
 import ee.tuleva.onboarding.banking.event.BankMessageEvents.FetchSebEodTransactionsRequested;
 import java.util.List;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -27,16 +29,21 @@ class SebStatementFetchingSchedulerTest {
           new BankAccount("EE001234567890123457", WITHDRAWAL_EUR, TKF100, "gw-test"),
           new BankAccount("EE001234567890123458", FUND_INVESTMENT_EUR, TKF100, "gw-test"));
 
+  private static final List<BankAccount> ALL_ACCOUNTS =
+      List.of(
+          SAVINGS_FUND_ACCOUNTS.get(0),
+          SAVINGS_FUND_ACCOUNTS.get(1),
+          SAVINGS_FUND_ACCOUNTS.get(2),
+          new BankAccount("EE001234567890123459", FUND_INVESTMENT_EUR, TUK75, "gw-test-tuk75"),
+          new BankAccount("EE001234567890123460", FUND_INVESTMENT_EUR, TUK00, "gw-test-tuk00"),
+          new BankAccount("EE001234567890123461", FUND_INVESTMENT_EUR, TUV100, "gw-test-tuv100"));
+
   @Mock private ApplicationEventPublisher eventPublisher;
   @Mock private BankAccounts bankAccounts;
 
-  @BeforeEach
-  void setUp() {
-    when(bankAccounts.findAll(TKF100)).thenReturn(SAVINGS_FUND_ACCOUNTS);
-  }
-
   @Test
   void fetchCurrentDayTransactions_publishesEventsOnlyForSavingsFundAccounts() {
+    when(bankAccounts.findAll(TKF100)).thenReturn(SAVINGS_FUND_ACCOUNTS);
     var scheduler = new SebStatementFetchingScheduler(eventPublisher, bankAccounts);
 
     scheduler.fetchCurrentDayTransactions();
@@ -50,6 +57,7 @@ class SebStatementFetchingSchedulerTest {
 
   @Test
   void fetchCurrentDayTransactions_continuesOnError() {
+    when(bankAccounts.findAll(TKF100)).thenReturn(SAVINGS_FUND_ACCOUNTS);
     var scheduler = new SebStatementFetchingScheduler(eventPublisher, bankAccounts);
 
     doThrow(new RuntimeException("Error"))
@@ -65,20 +73,22 @@ class SebStatementFetchingSchedulerTest {
   }
 
   @Test
-  void fetchEodTransactions_publishesEventsForSavingsFundAccounts() {
+  void fetchEodTransactions_publishesEventsForEveryConfiguredAccountIncludingPensionFunds() {
+    when(bankAccounts.findAll()).thenReturn(ALL_ACCOUNTS);
     var scheduler = new SebStatementFetchingScheduler(eventPublisher, bankAccounts);
 
     scheduler.fetchEodTransactions();
 
     var captor = ArgumentCaptor.forClass(FetchSebEodTransactionsRequested.class);
-    verify(eventPublisher, times(SAVINGS_FUND_ACCOUNTS.size())).publishEvent(captor.capture());
+    verify(eventPublisher, times(ALL_ACCOUNTS.size())).publishEvent(captor.capture());
     assertThat(captor.getAllValues())
         .extracting(FetchSebEodTransactionsRequested::account)
-        .containsExactlyElementsOf(SAVINGS_FUND_ACCOUNTS);
+        .containsExactlyElementsOf(ALL_ACCOUNTS);
   }
 
   @Test
   void fetchEodTransactions_continuesOnError_andPublishesFailureEvent() {
+    when(bankAccounts.findAll()).thenReturn(ALL_ACCOUNTS);
     var scheduler = new SebStatementFetchingScheduler(eventPublisher, bankAccounts);
 
     doThrow(new RuntimeException("404 LBR_EOD_STATEMENT_NOT_GENERATED"))
@@ -87,7 +97,7 @@ class SebStatementFetchingSchedulerTest {
 
     scheduler.fetchEodTransactions();
 
-    for (BankAccount account : SAVINGS_FUND_ACCOUNTS) {
+    for (BankAccount account : ALL_ACCOUNTS) {
       verify(eventPublisher)
           .publishEvent(new SebEodFetchFailedEvent(account, "404 LBR_EOD_STATEMENT_NOT_GENERATED"));
     }


### PR DESCRIPTION
The Feb–Aug 2026 backfill for TUK75, TUK00, and TUV100 is complete and verified: every month-end ledger balance reconciles against the bank statement, with zero unresolved suspense entries. This flips the last switch — the pension fund accounts join the nightly end-of-day statement fetch, so their ledgers stay current going forward.

- The EOD scheduler loop now iterates every configured bank account (`bankAccounts.findAll()`) instead of only the savings fund's three.
- Intraday fetching stays scoped to TKF100 — pension accounts are EOD-only by design.
- Per-account error isolation and the EOD-failure event are unchanged and covered for all six accounts.

Follow-up from PR #1868 (M8 in the plan).