### PR TITLE
Drop carried-forward EODHD closes for Euronext Paris tickers

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/comparisons/fundvalue/retrieval/EODHDValueRetriever.java
+++ b/src/main/java/ee/tuleva/onboarding/comparisons/fundvalue/retrieval/EODHDValueRetriever.java
@@ -17,6 +17,7 @@ import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
@@ -35,6 +36,7 @@ public class EODHDValueRetriever implements ComparisonIndexRetriever {
   private static final List<String> FOREX_TICKERS = List.of("EURUSD.FOREX");
   private static final ZoneId EUROPE_BERLIN = ZoneId.of("Europe/Berlin");
   private static final LocalTime CLOSING_PRICE_FINALIZED_TIME = LocalTime.of(6, 0);
+  private static final int EURONEXT_PARIS_BASELINE_DAYS = 7;
 
   private final RestClient restClient;
   private final Clock clock;
@@ -75,7 +77,7 @@ public class EODHDValueRetriever implements ComparisonIndexRetriever {
   private List<FundValue> retrieveValuesForTicker(
       String ticker, LocalDate startDate, LocalDate endDate) {
     var apiTicker = stripProviderSuffix(ticker);
-    var uri = buildUri(apiTicker, startDate, endDate);
+    var uri = buildUri(apiTicker, fetchStartDate(ticker, startDate), endDate);
 
     EODHDResponse[] response;
     try {
@@ -112,7 +114,46 @@ public class EODHDValueRetriever implements ComparisonIndexRetriever {
     ZonedDateTime nowInCET = ZonedDateTime.now(clock).withZoneSameInstant(EUROPE_BERLIN);
     LocalDate cutoff = latestFinalizedDate(nowInCET);
 
-    return nonZeroValues.stream().filter(fundValue -> !fundValue.date().isAfter(cutoff)).toList();
+    List<FundValue> freshValues =
+        isEuronextParisTicker(ticker)
+            ? dropCarriedForwardCloses(ticker, nonZeroValues)
+            : nonZeroValues;
+
+    return freshValues.stream()
+        .filter(fundValue -> !fundValue.date().isAfter(cutoff))
+        .filter(fundValue -> !fundValue.date().isBefore(startDate))
+        .toList();
+  }
+
+  private LocalDate fetchStartDate(String ticker, LocalDate startDate) {
+    return isEuronextParisTicker(ticker)
+        ? startDate.minusDays(EURONEXT_PARIS_BASELINE_DAYS)
+        : startDate;
+  }
+
+  private boolean isEuronextParisTicker(String ticker) {
+    return ticker.endsWith(".PA." + PROVIDER);
+  }
+
+  private List<FundValue> dropCarriedForwardCloses(String ticker, List<FundValue> values) {
+    List<FundValue> sorted = values.stream().sorted(comparing(FundValue::date)).toList();
+    return IntStream.range(0, sorted.size())
+        .filter(
+            index -> index == 0 || isFreshClose(ticker, sorted.get(index), sorted.get(index - 1)))
+        .mapToObj(sorted::get)
+        .toList();
+  }
+
+  private boolean isFreshClose(String ticker, FundValue current, FundValue previous) {
+    boolean carriedForward = current.value().compareTo(previous.value()) == 0;
+    if (carriedForward) {
+      log.warn(
+          "Skipping carried-forward EODHD close: ticker={}, date={}, value={}",
+          ticker,
+          current.date(),
+          current.value());
+    }
+    return !carriedForward;
   }
 
   private String stripProviderSuffix(String ticker) {

--- a/src/main/java/ee/tuleva/onboarding/comparisons/fundvalue/retrieval/EODHDValueRetriever.java
+++ b/src/main/java/ee/tuleva/onboarding/comparisons/fundvalue/retrieval/EODHDValueRetriever.java
@@ -7,6 +7,7 @@ import static org.springframework.http.MediaType.APPLICATION_JSON;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import ee.tuleva.onboarding.comparisons.fundvalue.FundValue;
+import ee.tuleva.onboarding.comparisons.fundvalue.FundValueProvider;
 import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.Instant;
@@ -41,14 +42,17 @@ public class EODHDValueRetriever implements ComparisonIndexRetriever {
   private final RestClient restClient;
   private final Clock clock;
   private final String apiToken;
+  private final FundValueProvider fundValueProvider;
 
   public EODHDValueRetriever(
       RestClient.Builder restClientBuilder,
       Clock clock,
-      @Value("${eodhd.api-token:}") String apiToken) {
+      @Value("${eodhd.api-token:}") String apiToken,
+      FundValueProvider fundValueProvider) {
     this.restClient = restClientBuilder.build();
     this.clock = clock;
     this.apiToken = apiToken;
+    this.fundValueProvider = fundValueProvider;
   }
 
   @Override
@@ -145,15 +149,27 @@ public class EODHDValueRetriever implements ComparisonIndexRetriever {
   }
 
   private boolean isFreshClose(String ticker, FundValue current, FundValue previous) {
-    boolean carriedForward = current.value().compareTo(previous.value()) == 0;
-    if (carriedForward) {
-      log.warn(
-          "Skipping carried-forward EODHD close: ticker={}, date={}, value={}",
-          ticker,
-          current.date(),
-          current.value());
+    if (current.value().compareTo(previous.value()) != 0) {
+      return true;
     }
-    return !carriedForward;
+    if (euronextConfirmsValue(ticker, current)) {
+      return true;
+    }
+    log.warn(
+        "Skipping carried-forward EODHD close: ticker={}, date={}, value={}",
+        ticker,
+        current.date(),
+        current.value());
+    return false;
+  }
+
+  private boolean euronextConfirmsValue(String ticker, FundValue fundValue) {
+    return FundTicker.findByEodhdTicker(ticker)
+        .flatMap(FundTicker::getEuronextParisStorageKey)
+        .flatMap(storageKey -> fundValueProvider.getLatestValue(storageKey, fundValue.date()))
+        .filter(euronextValue -> euronextValue.date().equals(fundValue.date()))
+        .filter(euronextValue -> euronextValue.value().compareTo(fundValue.value()) == 0)
+        .isPresent();
   }
 
   private String stripProviderSuffix(String ticker) {

--- a/src/main/java/ee/tuleva/onboarding/comparisons/fundvalue/retrieval/EODHDValueRetriever.java
+++ b/src/main/java/ee/tuleva/onboarding/comparisons/fundvalue/retrieval/EODHDValueRetriever.java
@@ -17,6 +17,7 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -152,24 +153,32 @@ public class EODHDValueRetriever implements ComparisonIndexRetriever {
     if (current.value().compareTo(previous.value()) != 0) {
       return true;
     }
-    if (euronextConfirmsValue(ticker, current)) {
+    Optional<FundValue> euronextValue = euronextValueOn(ticker, current.date());
+    if (euronextValue.isEmpty()) {
+      log.warn(
+          "Skipping repeated EODHD close, no Euronext value to confirm it yet: ticker={}, date={}, value={}",
+          ticker,
+          current.date(),
+          current.value());
+      return false;
+    }
+    if (euronextValue.get().value().compareTo(current.value()) == 0) {
       return true;
     }
-    log.warn(
-        "Skipping carried-forward EODHD close: ticker={}, date={}, value={}",
+    log.error(
+        "Skipping stale carried-forward EODHD close contradicted by Euronext: ticker={}, date={}, eodhdValue={}, euronextValue={}",
         ticker,
         current.date(),
-        current.value());
+        current.value(),
+        euronextValue.get().value());
     return false;
   }
 
-  private boolean euronextConfirmsValue(String ticker, FundValue fundValue) {
+  private Optional<FundValue> euronextValueOn(String ticker, LocalDate date) {
     return FundTicker.findByEodhdTicker(ticker)
         .flatMap(FundTicker::getEuronextParisStorageKey)
-        .flatMap(storageKey -> fundValueProvider.getLatestValue(storageKey, fundValue.date()))
-        .filter(euronextValue -> euronextValue.date().equals(fundValue.date()))
-        .filter(euronextValue -> euronextValue.value().compareTo(fundValue.value()) == 0)
-        .isPresent();
+        .flatMap(storageKey -> fundValueProvider.getLatestValue(storageKey, date))
+        .filter(euronextValue -> euronextValue.date().equals(date));
   }
 
   private String stripProviderSuffix(String ticker) {

--- a/src/main/java/ee/tuleva/onboarding/comparisons/fundvalue/retrieval/FundTicker.java
+++ b/src/main/java/ee/tuleva/onboarding/comparisons/fundvalue/retrieval/FundTicker.java
@@ -337,6 +337,12 @@ public enum FundTicker {
         .findFirst();
   }
 
+  public static Optional<FundTicker> findByEodhdTicker(String eodhdTicker) {
+    return Arrays.stream(values())
+        .filter(fundTicker -> fundTicker.getEodhdTicker().equals(eodhdTicker))
+        .findFirst();
+  }
+
   public static Optional<FundTicker> findByBloombergTicker(String bloombergTicker) {
     return Arrays.stream(values())
         .filter(fundTicker -> bloombergTicker.equals(fundTicker.getBloombergTicker()))

--- a/src/test/groovy/ee/tuleva/onboarding/comparisons/fundvalue/retrieval/EODHDValueRetrieverTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/comparisons/fundvalue/retrieval/EODHDValueRetrieverTest.java
@@ -4,11 +4,13 @@ import static java.math.BigDecimal.ZERO;
 import static java.time.ZoneOffset.UTC;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
+import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withServerError;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 
 import ee.tuleva.onboarding.comparisons.fundvalue.FundValue;
+import ee.tuleva.onboarding.comparisons.fundvalue.FundValueProvider;
 import ee.tuleva.onboarding.time.ClockConfig;
 import ee.tuleva.onboarding.time.ClockHolder;
 import java.math.BigDecimal;
@@ -16,6 +18,7 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,6 +26,7 @@ import org.springframework.boot.restclient.test.autoconfigure.RestClientTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.client.MockRestServiceServer;
 
 @RestClientTest(EODHDValueRetriever.class)
@@ -33,6 +37,8 @@ class EODHDValueRetrieverTest {
   @Autowired EODHDValueRetriever retriever;
 
   @Autowired MockRestServiceServer server;
+
+  @MockitoBean FundValueProvider fundValueProvider;
 
   @AfterEach
   void cleanup() {
@@ -326,6 +332,81 @@ class EODHDValueRetrieverTest {
         ]
         """;
 
+    given(fundValueProvider.getLatestValue("IE000F60HVH9.XPAR", LocalDate.of(2026, 8, 19)))
+        .willReturn(
+            Optional.of(
+                new FundValue(
+                    "IE000F60HVH9.XPAR",
+                    LocalDate.of(2026, 8, 19),
+                    new BigDecimal("4.993"),
+                    "EURONEXT",
+                    null)));
+
+    expectRequests(
+        "USAS.PA.EODHD", mockResponse, LocalDate.of(2026, 8, 19), LocalDate.of(2026, 8, 19));
+
+    var result =
+        retriever.retrieveValuesForRange(LocalDate.of(2026, 8, 19), LocalDate.of(2026, 8, 19));
+
+    assertThat(result).noneMatch(fv -> fv.key().equals("USAS.PA.EODHD"));
+  }
+
+  @Test
+  void keepsRepeatedCloseConfirmedByEuronext() {
+    ClockHolder.setClock(Clock.fixed(Instant.parse("2026-08-20T12:00:00Z"), UTC));
+
+    var mockResponse =
+        """
+        [
+          {"date": "2026-08-18", "open": 5.027, "high": 5.027, "low": 5.02, "close": 5.02, "adjusted_close": 5.007, "volume": 1042},
+          {"date": "2026-08-19", "open": 5.007, "high": 5.007, "low": 5.007, "close": 5.007, "adjusted_close": 5.007, "volume": 1049}
+        ]
+        """;
+
+    given(fundValueProvider.getLatestValue("IE000F60HVH9.XPAR", LocalDate.of(2026, 8, 19)))
+        .willReturn(
+            Optional.of(
+                new FundValue(
+                    "IE000F60HVH9.XPAR",
+                    LocalDate.of(2026, 8, 19),
+                    new BigDecimal("5.007"),
+                    "EURONEXT",
+                    null)));
+
+    expectRequests(
+        "USAS.PA.EODHD", mockResponse, LocalDate.of(2026, 8, 19), LocalDate.of(2026, 8, 19));
+
+    var result =
+        retriever.retrieveValuesForRange(LocalDate.of(2026, 8, 19), LocalDate.of(2026, 8, 19));
+
+    var parisValues = result.stream().filter(fv -> fv.key().equals("USAS.PA.EODHD")).toList();
+    assertThat(parisValues)
+        .extracting(FundValue::date, FundValue::value)
+        .containsExactly(tuple(LocalDate.of(2026, 8, 19), new BigDecimal("5.007")));
+  }
+
+  @Test
+  void dropsRepeatedCloseWhenEuronextHasNoSameDateValue() {
+    ClockHolder.setClock(Clock.fixed(Instant.parse("2026-08-20T12:00:00Z"), UTC));
+
+    var mockResponse =
+        """
+        [
+          {"date": "2026-08-18", "open": 5.027, "high": 5.027, "low": 5.02, "close": 5.02, "adjusted_close": 5.007, "volume": 1042},
+          {"date": "2026-08-19", "open": 5.007, "high": 5.007, "low": 5.007, "close": 5.007, "adjusted_close": 5.007, "volume": 1049}
+        ]
+        """;
+
+    given(fundValueProvider.getLatestValue("IE000F60HVH9.XPAR", LocalDate.of(2026, 8, 19)))
+        .willReturn(
+            Optional.of(
+                new FundValue(
+                    "IE000F60HVH9.XPAR",
+                    LocalDate.of(2026, 8, 18),
+                    new BigDecimal("5.007"),
+                    "EURONEXT",
+                    null)));
+
     expectRequests(
         "USAS.PA.EODHD", mockResponse, LocalDate.of(2026, 8, 19), LocalDate.of(2026, 8, 19));
 
@@ -372,6 +453,25 @@ class EODHDValueRetrieverTest {
           {"date": "2026-08-19", "open": 48.875, "high": 48.875, "low": 48.875, "close": 48.875, "adjusted_close": 48.875, "volume": 2660}
         ]
         """;
+
+    given(fundValueProvider.getLatestValue("LU1708330318.XPAR", LocalDate.of(2026, 8, 18)))
+        .willReturn(
+            Optional.of(
+                new FundValue(
+                    "LU1708330318.XPAR",
+                    LocalDate.of(2026, 8, 18),
+                    new BigDecimal("48.795"),
+                    "EURONEXT",
+                    null)));
+    given(fundValueProvider.getLatestValue("LU1708330318.XPAR", LocalDate.of(2026, 8, 19)))
+        .willReturn(
+            Optional.of(
+                new FundValue(
+                    "LU1708330318.XPAR",
+                    LocalDate.of(2026, 8, 19),
+                    new BigDecimal("48.89"),
+                    "EURONEXT",
+                    null)));
 
     expectRequests(
         "GAGH.PA.EODHD", mockResponse, LocalDate.of(2026, 8, 18), LocalDate.of(2026, 8, 19));

--- a/src/test/groovy/ee/tuleva/onboarding/comparisons/fundvalue/retrieval/EODHDValueRetrieverTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/comparisons/fundvalue/retrieval/EODHDValueRetrieverTest.java
@@ -3,6 +3,7 @@ package ee.tuleva.onboarding.comparisons.fundvalue.retrieval;
 import static java.math.BigDecimal.ZERO;
 import static java.time.ZoneOffset.UTC;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withServerError;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
@@ -66,9 +67,8 @@ class EODHDValueRetrieverTest {
                 server
                     .expect(
                         requestTo(
-                            "https://eodhd.com/api/eod/"
-                                + expectedApiTicker(ticker)
-                                + "?api_token=test-token&fmt=json&from=2024-01-02&to=2024-01-02"))
+                            expectedUri(
+                                ticker, LocalDate.of(2024, 1, 2), LocalDate.of(2024, 1, 2))))
                     .andRespond(withSuccess(mockResponse, MediaType.APPLICATION_JSON)));
 
     server
@@ -103,9 +103,8 @@ class EODHDValueRetrieverTest {
                 server
                     .expect(
                         requestTo(
-                            "https://eodhd.com/api/eod/"
-                                + expectedApiTicker(ticker)
-                                + "?api_token=test-token&fmt=json&from=2024-01-02&to=2024-01-04"))
+                            expectedUri(
+                                ticker, LocalDate.of(2024, 1, 2), LocalDate.of(2024, 1, 4))))
                     .andRespond(withSuccess("[]", MediaType.APPLICATION_JSON)));
 
     server
@@ -148,9 +147,8 @@ class EODHDValueRetrieverTest {
                 server
                     .expect(
                         requestTo(
-                            "https://eodhd.com/api/eod/"
-                                + expectedApiTicker(ticker)
-                                + "?api_token=test-token&fmt=json&from=2024-01-02&to=2024-01-04"))
+                            expectedUri(
+                                ticker, LocalDate.of(2024, 1, 2), LocalDate.of(2024, 1, 4))))
                     .andRespond(withSuccess(mockResponse, MediaType.APPLICATION_JSON)));
 
     server
@@ -186,9 +184,8 @@ class EODHDValueRetrieverTest {
                 server
                     .expect(
                         requestTo(
-                            "https://eodhd.com/api/eod/"
-                                + expectedApiTicker(ticker)
-                                + "?api_token=test-token&fmt=json&from=2024-01-02&to=2024-01-04"))
+                            expectedUri(
+                                ticker, LocalDate.of(2024, 1, 2), LocalDate.of(2024, 1, 4))))
                     .andRespond(withSuccess(mockResponseWithZeros, MediaType.APPLICATION_JSON)));
 
     server
@@ -218,10 +215,7 @@ class EODHDValueRetrieverTest {
     var firstTicker = FundTicker.getEodhdTickers().getFirst();
     server
         .expect(
-            requestTo(
-                "https://eodhd.com/api/eod/"
-                    + expectedApiTicker(firstTicker)
-                    + "?api_token=test-token&fmt=json&from=2024-01-02&to=2024-01-02"))
+            requestTo(expectedUri(firstTicker, LocalDate.of(2024, 1, 2), LocalDate.of(2024, 1, 2))))
         .andRespond(withSuccess(mockResponse, MediaType.APPLICATION_JSON));
 
     FundTicker.getEodhdTickers().stream()
@@ -231,9 +225,8 @@ class EODHDValueRetrieverTest {
                 server
                     .expect(
                         requestTo(
-                            "https://eodhd.com/api/eod/"
-                                + expectedApiTicker(ticker)
-                                + "?api_token=test-token&fmt=json&from=2024-01-02&to=2024-01-02"))
+                            expectedUri(
+                                ticker, LocalDate.of(2024, 1, 2), LocalDate.of(2024, 1, 2))))
                     .andRespond(withSuccess("[]", MediaType.APPLICATION_JSON)));
 
     server
@@ -261,9 +254,8 @@ class EODHDValueRetrieverTest {
                 server
                     .expect(
                         requestTo(
-                            "https://eodhd.com/api/eod/"
-                                + expectedApiTicker(ticker)
-                                + "?api_token=test-token&fmt=json&from=2024-01-02&to=2024-01-04"))
+                            expectedUri(
+                                ticker, LocalDate.of(2024, 1, 2), LocalDate.of(2024, 1, 4))))
                     .andRespond(withServerError()));
 
     server
@@ -298,9 +290,8 @@ class EODHDValueRetrieverTest {
                 server
                     .expect(
                         requestTo(
-                            "https://eodhd.com/api/eod/"
-                                + expectedApiTicker(ticker)
-                                + "?api_token=test-token&fmt=json&from=2024-01-02&to=2024-01-04"))
+                            expectedUri(
+                                ticker, LocalDate.of(2024, 1, 2), LocalDate.of(2024, 1, 4))))
                     .andRespond(withSuccess(mockResponse, MediaType.APPLICATION_JSON)));
 
     server
@@ -319,6 +310,130 @@ class EODHDValueRetrieverTest {
         .anyMatch(fundValue -> fundValue.date().equals(LocalDate.of(2024, 1, 2)))
         .anyMatch(fundValue -> fundValue.date().equals(LocalDate.of(2024, 1, 3)))
         .noneMatch(fundValue -> fundValue.date().equals(LocalDate.of(2024, 1, 4)));
+  }
+
+  @Test
+  void dropsCarriedForwardClosesForEuronextParisTickers() {
+    // 2026-08-20 12:00 UTC = 14:00 CET, so the cutoff is 2026-08-19
+    ClockHolder.setClock(Clock.fixed(Instant.parse("2026-08-20T12:00:00Z"), UTC));
+
+    var mockResponse =
+        """
+        [
+          {"date": "2026-08-17", "open": 5.073, "high": 5.073, "low": 5.06, "close": 5.06, "adjusted_close": 5.063, "volume": 1035},
+          {"date": "2026-08-18", "open": 5.027, "high": 5.027, "low": 5.02, "close": 5.02, "adjusted_close": 5.007, "volume": 1042},
+          {"date": "2026-08-19", "open": 5.007, "high": 5.007, "low": 5.007, "close": 5.007, "adjusted_close": 5.007, "volume": 1049}
+        ]
+        """;
+
+    expectRequests(
+        "USAS.PA.EODHD", mockResponse, LocalDate.of(2026, 8, 19), LocalDate.of(2026, 8, 19));
+
+    var result =
+        retriever.retrieveValuesForRange(LocalDate.of(2026, 8, 19), LocalDate.of(2026, 8, 19));
+
+    assertThat(result).noneMatch(fv -> fv.key().equals("USAS.PA.EODHD"));
+  }
+
+  @Test
+  void keepsChangedClosesForEuronextParisTickers() {
+    ClockHolder.setClock(Clock.fixed(Instant.parse("2026-08-20T12:00:00Z"), UTC));
+
+    var mockResponse =
+        """
+        [
+          {"date": "2026-08-17", "open": 5.073, "high": 5.073, "low": 5.06, "close": 5.06, "adjusted_close": 5.063, "volume": 1035},
+          {"date": "2026-08-18", "open": 5.027, "high": 5.027, "low": 5.02, "close": 5.02, "adjusted_close": 5.007, "volume": 1042},
+          {"date": "2026-08-19", "open": 4.9975, "high": 5.00, "low": 4.9975, "close": 5.00, "adjusted_close": 4.993, "volume": 1049}
+        ]
+        """;
+
+    expectRequests(
+        "USAS.PA.EODHD", mockResponse, LocalDate.of(2026, 8, 19), LocalDate.of(2026, 8, 19));
+
+    var result =
+        retriever.retrieveValuesForRange(LocalDate.of(2026, 8, 19), LocalDate.of(2026, 8, 19));
+
+    var parisValues = result.stream().filter(fv -> fv.key().equals("USAS.PA.EODHD")).toList();
+    assertThat(parisValues)
+        .extracting(FundValue::date, FundValue::value)
+        .containsExactly(tuple(LocalDate.of(2026, 8, 19), new BigDecimal("4.993")));
+  }
+
+  @Test
+  void dropsConsecutiveCarriedForwardClosesForEuronextParisTickers() {
+    ClockHolder.setClock(Clock.fixed(Instant.parse("2026-08-20T12:00:00Z"), UTC));
+
+    var mockResponse =
+        """
+        [
+          {"date": "2026-08-17", "open": 48.875, "high": 48.875, "low": 48.875, "close": 48.875, "adjusted_close": 48.875, "volume": 28},
+          {"date": "2026-08-18", "open": 48.875, "high": 48.875, "low": 48.875, "close": 48.875, "adjusted_close": 48.875, "volume": 29},
+          {"date": "2026-08-19", "open": 48.875, "high": 48.875, "low": 48.875, "close": 48.875, "adjusted_close": 48.875, "volume": 2660}
+        ]
+        """;
+
+    expectRequests(
+        "GAGH.PA.EODHD", mockResponse, LocalDate.of(2026, 8, 18), LocalDate.of(2026, 8, 19));
+
+    var result =
+        retriever.retrieveValuesForRange(LocalDate.of(2026, 8, 18), LocalDate.of(2026, 8, 19));
+
+    assertThat(result).noneMatch(fv -> fv.key().equals("GAGH.PA.EODHD"));
+  }
+
+  @Test
+  void keepsRepeatedClosesForNonParisTickers() {
+    ClockHolder.setClock(Clock.fixed(Instant.parse("2026-08-20T12:00:00Z"), UTC));
+
+    var mockResponse =
+        """
+        [
+          {"date": "2026-08-18", "open": 13.85, "high": 13.85, "low": 13.84, "close": 13.844, "adjusted_close": 13.844, "volume": 280524},
+          {"date": "2026-08-19", "open": 13.84, "high": 13.85, "low": 13.84, "close": 13.844, "adjusted_close": 13.844, "volume": 309691}
+        ]
+        """;
+
+    expectRequests(
+        "SGAS.XETRA", mockResponse, LocalDate.of(2026, 8, 18), LocalDate.of(2026, 8, 19));
+
+    var result =
+        retriever.retrieveValuesForRange(LocalDate.of(2026, 8, 18), LocalDate.of(2026, 8, 19));
+
+    var xetraValues = result.stream().filter(fv -> fv.key().equals("SGAS.XETRA")).toList();
+    assertThat(xetraValues)
+        .extracting(FundValue::date)
+        .containsExactly(LocalDate.of(2026, 8, 18), LocalDate.of(2026, 8, 19));
+  }
+
+  private void expectRequests(
+      String targetTicker, String targetResponse, LocalDate startDate, LocalDate endDate) {
+    FundTicker.getEodhdTickers()
+        .forEach(
+            ticker ->
+                server
+                    .expect(requestTo(expectedUri(ticker, startDate, endDate)))
+                    .andRespond(
+                        withSuccess(
+                            ticker.equals(targetTicker) ? targetResponse : "[]",
+                            MediaType.APPLICATION_JSON)));
+
+    server
+        .expect(requestTo(expectedUri("EURUSD.FOREX", startDate, endDate)))
+        .andRespond(withSuccess("[]", MediaType.APPLICATION_JSON));
+  }
+
+  private String expectedUri(String storageTicker, LocalDate startDate, LocalDate endDate) {
+    return "https://eodhd.com/api/eod/"
+        + expectedApiTicker(storageTicker)
+        + "?api_token=test-token&fmt=json&from="
+        + expectedFromDate(storageTicker, startDate)
+        + "&to="
+        + endDate;
+  }
+
+  private LocalDate expectedFromDate(String storageTicker, LocalDate startDate) {
+    return storageTicker.endsWith(".PA.EODHD") ? startDate.minusDays(7) : startDate;
   }
 
   private String expectedApiTicker(String storageTicker) {


### PR DESCRIPTION
## Problem

On 2026-08-19 EODHD served **carried-forward (stale) closes** for all three Euronext Paris ETF listings (USAS.PA, WLSC.PA, GAGH.PA) — repeating the previous day's close instead of the official exchange close. The rows carried plausible non-zero volumes (USAS showed the real Euronext trade count), so the staleness is undetectable from the EODHD payload alone. This has happened repeatedly on low-activity Paris trading days.

Because `PriorityPriceProvider` ranks EODHD above Euronext at the same date, the stale row shadowed the correct exchange close and would have overstated the TKF100 NAV by ~0.05% (TKF100 holds 528,951 units of USAS; 5.007 stale vs 4.993 official). Manual intervention (deleting the rows in prod) was needed — see the Fund Value Integrity Check alerts from 2026-08-21.

## Fix

In `EODHDValueRetriever`, for `.PA.EODHD` tickers only:

1. Extend each fetch 7 days back to establish a baseline close before the requested range.
2. Treat a row whose adjusted close **exactly repeats the previous day's** as suspect.
3. Cross-check the suspect row against the **same-date Euronext official close already stored in `index_values`** (`ISIN.XPAR`):
   - Euronext agrees → genuine repeat → row kept
   - Euronext disagrees → confirmed stale → row skipped (warn log)
   - No same-date Euronext row yet (it is fetched after EODHD in the same indexing cycle) → skipped conservatively; the next hourly cycle refetches the date (the indexing job resumes from `min(latest across EODHD keys)+1`) and inserts it once confirmed — self-healing, at most one cycle of delay

While an EODHD row is skipped, price resolution falls through to the same-date Euronext row by date priority, so NAV correctness is never affected. XETRA, EUFUND, and forex series are untouched.

This would have caught all three stale rows from 2026-08-19 (a volume-based check would have caught none — EODHD reported fake non-zero volumes on the stale rows).

## Notes

- EODHD support confirmed and fixed the 2026-08-19 data after we reported it, but the fix only came after a support ticket — hence guarding at ingest.
- `index_values` is append-only, so a stale insert can never be corrected later; per the module's CLAUDE.md the retriever must not insert bad data in the first place.