### PR TITLE
Only check carried-forward closes for rows inside the requested range

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/comparisons/fundvalue/retrieval/EODHDValueRetriever.java
+++ b/src/main/java/ee/tuleva/onboarding/comparisons/fundvalue/retrieval/EODHDValueRetriever.java
@@ -121,7 +121,7 @@ public class EODHDValueRetriever implements ComparisonIndexRetriever {
 
     List<FundValue> freshValues =
         isEuronextParisTicker(ticker)
-            ? dropCarriedForwardCloses(ticker, nonZeroValues)
+            ? dropCarriedForwardCloses(ticker, nonZeroValues, startDate)
             : nonZeroValues;
 
     return freshValues.stream()
@@ -140,11 +140,15 @@ public class EODHDValueRetriever implements ComparisonIndexRetriever {
     return ticker.endsWith(".PA." + PROVIDER);
   }
 
-  private List<FundValue> dropCarriedForwardCloses(String ticker, List<FundValue> values) {
+  private List<FundValue> dropCarriedForwardCloses(
+      String ticker, List<FundValue> values, LocalDate startDate) {
     List<FundValue> sorted = values.stream().sorted(comparing(FundValue::date)).toList();
     return IntStream.range(0, sorted.size())
         .filter(
-            index -> index == 0 || isFreshClose(ticker, sorted.get(index), sorted.get(index - 1)))
+            index ->
+                index == 0
+                    || sorted.get(index).date().isBefore(startDate)
+                    || isFreshClose(ticker, sorted.get(index), sorted.get(index - 1)))
         .mapToObj(sorted::get)
         .toList();
   }

--- a/src/test/groovy/ee/tuleva/onboarding/comparisons/fundvalue/retrieval/EODHDValueRetrieverTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/comparisons/fundvalue/retrieval/EODHDValueRetrieverTest.java
@@ -5,6 +5,7 @@ import static java.time.ZoneOffset.UTC;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withServerError;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
@@ -504,6 +505,33 @@ class EODHDValueRetrieverTest {
     assertThat(xetraValues)
         .extracting(FundValue::date)
         .containsExactly(LocalDate.of(2026, 8, 18), LocalDate.of(2026, 8, 19));
+  }
+
+  @Test
+  void doesNotCheckBaselineRowsBeforeRequestedRange() {
+    ClockHolder.setClock(Clock.fixed(Instant.parse("2026-08-20T12:00:00Z"), UTC));
+
+    var mockResponse =
+        """
+        [
+          {"date": "2026-08-13", "open": 5.085, "high": 5.085, "low": 5.085, "close": 5.085, "adjusted_close": 5.085, "volume": 65429},
+          {"date": "2026-08-14", "open": 5.113, "high": 5.113, "low": 5.113, "close": 5.113, "adjusted_close": 5.085, "volume": 0},
+          {"date": "2026-08-18", "open": 5.05, "high": 5.05, "low": 5.025, "close": 5.025, "adjusted_close": 5.025, "volume": 121},
+          {"date": "2026-08-19", "open": 4.9975, "high": 5.00, "low": 4.9975, "close": 5.00, "adjusted_close": 4.993, "volume": 1049}
+        ]
+        """;
+
+    expectRequests(
+        "USAS.PA.EODHD", mockResponse, LocalDate.of(2026, 8, 19), LocalDate.of(2026, 8, 19));
+
+    var result =
+        retriever.retrieveValuesForRange(LocalDate.of(2026, 8, 19), LocalDate.of(2026, 8, 19));
+
+    var parisValues = result.stream().filter(fv -> fv.key().equals("USAS.PA.EODHD")).toList();
+    assertThat(parisValues)
+        .extracting(FundValue::date, FundValue::value)
+        .containsExactly(tuple(LocalDate.of(2026, 8, 19), new BigDecimal("4.993")));
+    then(fundValueProvider).shouldHaveNoInteractions();
   }
 
   private void expectRequests(


### PR DESCRIPTION
Follow-up to #1875. The 7-day baseline rows fetched for Paris tickers exist only to give the repeat-detection a predecessor to compare against — they are filtered out before insert. But the carried-forward check still ran on them, so a historical divergence (WLSC.PA 2026-08-14: EODHD 5.085 vs Euronext 5.086) paged Sentry at error level on every hourly indexing run right after the deploy, even though nothing could or should be done about a week-old date.

Now rows before `startDate` pass through unchecked (they are dropped by the existing range filter anyway) and still serve as comparison baselines; the repeat check and its alerts fire only for dates that are actually candidates for insertion.