### PR TITLE
Add per-order execution basis (MOC/NAV/RISK) to transaction orders

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/OrderType.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/OrderType.java
@@ -1,0 +1,7 @@
+package ee.tuleva.onboarding.investment.transaction;
+
+public enum OrderType {
+  MOC,
+  NAV,
+  RISK
+}

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/SetOrderTypeRequest.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/SetOrderTypeRequest.java
@@ -1,0 +1,7 @@
+package ee.tuleva.onboarding.investment.transaction;
+
+import jakarta.validation.constraints.NotNull;
+import org.jspecify.annotations.NullMarked;
+
+@NullMarked
+public record SetOrderTypeRequest(@NotNull OrderType orderType) {}

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/SetTransactionOrderTypeRequest.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/SetTransactionOrderTypeRequest.java
@@ -4,4 +4,4 @@ import jakarta.validation.constraints.NotNull;
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked
-public record SetOrderTypeRequest(@NotNull OrderType orderType) {}
+public record SetTransactionOrderTypeRequest(@NotNull OrderType orderType) {}

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionAdminService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionAdminService.java
@@ -268,6 +268,47 @@ class TransactionAdminService {
     return TransactionOrderResponse.from(order);
   }
 
+  @Transactional
+  TransactionOrderResponse setOrderType(Long orderId, OrderType orderType, String actor) {
+    TransactionOrder order =
+        orderRepository
+            .findById(orderId)
+            .orElseThrow(
+                () ->
+                    new ResponseStatusException(
+                        NOT_FOUND, "Transaction order not found: id=" + orderId));
+    if (order.getOrderStatus() != OrderStatus.DRAFT) {
+      throw new ResponseStatusException(
+          CONFLICT,
+          "Only DRAFT orders can change order type: id="
+              + orderId
+              + ", status="
+              + order.getOrderStatus());
+    }
+    OrderType previousOrderType = order.getOrderType();
+    Instant now = Instant.now(clock);
+    log.info(
+        "Admin changed transaction order type: id={}, actor={}, from={}, to={}",
+        orderId,
+        actor,
+        previousOrderType,
+        orderType);
+    order.setOrderType(orderType);
+    orderRepository.save(order);
+
+    auditEventRepository.save(
+        TransactionAuditEvent.builder()
+            .orderId(order.getId())
+            .eventType("ORDER_TYPE_CHANGED")
+            .actor(actor)
+            .createdAt(now)
+            .payload(
+                Map.of("from", previousOrderType.name(), "to", orderType.name(), "actor", actor))
+            .build());
+
+    return TransactionOrderResponse.from(order);
+  }
+
   private static boolean isInMarket(TransactionOrder order) {
     return order.getOrderStatus() == OrderStatus.EXECUTED
         || order.getOrderStatus() == OrderStatus.SETTLED;

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionCommandController.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionCommandController.java
@@ -163,7 +163,7 @@ public class TransactionCommandController {
   public TransactionOrderResponse setOrderType(
       @RequestHeader("X-Admin-Token") String token,
       @PathVariable Long id,
-      @Valid @RequestBody SetOrderTypeRequest request) {
+      @Valid @RequestBody SetTransactionOrderTypeRequest request) {
 
     var actor = authenticator.resolveActor(token);
 

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionCommandController.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionCommandController.java
@@ -159,6 +159,23 @@ public class TransactionCommandController {
     return adminService.cancelOrder(id, request.reason(), actor);
   }
 
+  @PostMapping("/transaction-orders/{id}/order-type")
+  public TransactionOrderResponse setOrderType(
+      @RequestHeader("X-Admin-Token") String token,
+      @PathVariable Long id,
+      @Valid @RequestBody SetOrderTypeRequest request) {
+
+    var actor = authenticator.resolveActor(token);
+
+    log.info(
+        "Admin triggered transaction order type change: id={}, actor={}, orderType={}",
+        id,
+        actor,
+        request.orderType());
+
+    return adminService.setOrderType(id, request.orderType(), actor);
+  }
+
   @GetMapping("/transaction-batches/{id}/exports/{type}")
   public ResponseEntity<byte[]> downloadExport(
       @RequestHeader("X-Admin-Token") String token,

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionOrder.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionOrder.java
@@ -72,7 +72,10 @@ public class TransactionOrder {
   @Builder.Default
   private OrderStatus orderStatus = OrderStatus.DRAFT;
 
-  @NotNull @Builder.Default private String orderType = "MOC";
+  @NotNull
+  @Enumerated(STRING)
+  @Builder.Default
+  private OrderType orderType = OrderType.MOC;
 
   private Instant orderTimestamp;
 

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionOrderResponse.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionOrderResponse.java
@@ -16,6 +16,7 @@ public record TransactionOrderResponse(
     @Nullable BigDecimal orderQuantity,
     OrderVenue orderVenue,
     OrderStatus orderStatus,
+    OrderType orderType,
     UUID orderUuid,
     @Nullable LocalDate expectedSettlementDate,
     @Nullable String comment) {
@@ -30,6 +31,7 @@ public record TransactionOrderResponse(
         order.getOrderQuantity(),
         order.getOrderVenue(),
         order.getOrderStatus(),
+        order.getOrderType(),
         order.getOrderUuid(),
         order.getExpectedSettlementDate(),
         order.getComment());

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/export/TransactionExportService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/export/TransactionExportService.java
@@ -177,7 +177,7 @@ public class TransactionExportService {
         row.createCell(1).setCellValue(fundAccounts.securitiesAccount(order.getFund()));
         row.createCell(2).setCellValue(order.getInstrumentIsin());
         row.createCell(3).setCellValue(ricByIsin.getOrDefault(order.getInstrumentIsin(), ""));
-        row.createCell(4).setCellValue("MOC");
+        row.createCell(4).setCellValue(order.getOrderType().name());
         if (order.getOrderQuantity() != null) {
           row.createCell(6).setCellValue(order.getOrderQuantity().doubleValue());
         }

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionAdminServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionAdminServiceTest.java
@@ -682,6 +682,56 @@ class TransactionAdminServiceTest {
   }
 
   @Test
+  void setOrderType_draftOrder_updatesTypeAndWritesOrderScopedAudit() {
+    TransactionOrder order = order(100L, batch(10L, DRAFT));
+    order.setOrderStatus(OrderStatus.DRAFT);
+    given(orderRepository.findById(100L)).willReturn(Optional.of(order));
+
+    TransactionOrderResponse response = service.setOrderType(100L, OrderType.NAV, "operator-7");
+
+    assertThat(response.orderType()).isEqualTo(OrderType.NAV);
+    assertThat(order.getOrderType()).isEqualTo(OrderType.NAV);
+
+    then(orderRepository).should().save(order);
+    then(auditEventRepository)
+        .should()
+        .save(
+            TransactionAuditEvent.builder()
+                .orderId(100L)
+                .eventType("ORDER_TYPE_CHANGED")
+                .actor("operator-7")
+                .createdAt(Instant.parse("2026-06-11T09:00:00Z"))
+                .payload(Map.of("from", "MOC", "to", "NAV", "actor", "operator-7"))
+                .build());
+  }
+
+  @Test
+  void setOrderType_sentOrder_throwsConflictAndMutatesNothing() {
+    TransactionOrder order = order(100L, batch(10L, BatchStatus.SENT));
+    order.setOrderStatus(OrderStatus.SENT);
+    given(orderRepository.findById(100L)).willReturn(Optional.of(order));
+
+    assertThatThrownBy(() -> service.setOrderType(100L, OrderType.NAV, "operator-7"))
+        .isInstanceOf(ResponseStatusException.class)
+        .extracting(e -> ((ResponseStatusException) e).getStatusCode().value())
+        .isEqualTo(409);
+
+    assertThat(order.getOrderType()).isEqualTo(OrderType.MOC);
+    then(orderRepository).should(never()).save(any());
+    then(auditEventRepository).shouldHaveNoInteractions();
+  }
+
+  @Test
+  void setOrderType_unknownOrder_throwsNotFound() {
+    given(orderRepository.findById(999L)).willReturn(Optional.empty());
+
+    assertThatThrownBy(() -> service.setOrderType(999L, OrderType.NAV, "admin"))
+        .isInstanceOf(ResponseStatusException.class)
+        .extracting(e -> ((ResponseStatusException) e).getStatusCode().value())
+        .isEqualTo(404);
+  }
+
+  @Test
   void exportFile_decodesStoredBase64Export() {
     byte[] xlsx = {1, 2, 3};
     TransactionBatch batch = batch(10L, BatchStatus.SENT);

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionCommandControllerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionCommandControllerTest.java
@@ -66,6 +66,7 @@ class TransactionCommandControllerTest {
         new BigDecimal("8.500000"),
         SEB,
         DRAFT,
+        OrderType.MOC,
         ORDER_UUID,
         null,
         "operator note");

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionCommandControllerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionCommandControllerTest.java
@@ -57,6 +57,10 @@ class TransactionCommandControllerTest {
   @MockitoBean private TransactionAdminService adminService;
 
   private static TransactionOrderResponse orderResponse() {
+    return orderResponse(OrderType.MOC);
+  }
+
+  private static TransactionOrderResponse orderResponse(OrderType orderType) {
     return new TransactionOrderResponse(
         100L,
         "IE00BFG1TM61",
@@ -66,7 +70,7 @@ class TransactionCommandControllerTest {
         new BigDecimal("8.500000"),
         SEB,
         DRAFT,
-        OrderType.MOC,
+        orderType,
         ORDER_UUID,
         null,
         "operator note");
@@ -561,7 +565,8 @@ class TransactionCommandControllerTest {
 
   @Test
   void setOrderType_validType_invokesServiceAndReturnsOrder() throws Exception {
-    given(adminService.setOrderType(100L, OrderType.NAV, "operator-7")).willReturn(orderResponse());
+    given(adminService.setOrderType(100L, OrderType.NAV, "operator-7"))
+        .willReturn(orderResponse(OrderType.NAV));
 
     mockMvc
         .perform(
@@ -575,7 +580,7 @@ class TransactionCommandControllerTest {
                     """))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.id").value(100))
-        .andExpect(jsonPath("$.orderType").value("MOC"));
+        .andExpect(jsonPath("$.orderType").value("NAV"));
 
     then(adminService).should().setOrderType(100L, OrderType.NAV, "operator-7");
   }
@@ -583,7 +588,7 @@ class TransactionCommandControllerTest {
   @Test
   void setOrderType_withoutActor_defaultsToAdmin() throws Exception {
     given(adminService.setOrderType(100L, OrderType.RISK, "shared-admin-token"))
-        .willReturn(orderResponse());
+        .willReturn(orderResponse(OrderType.RISK));
 
     mockMvc
         .perform(

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionCommandControllerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionCommandControllerTest.java
@@ -560,6 +560,97 @@ class TransactionCommandControllerTest {
   }
 
   @Test
+  void setOrderType_validType_invokesServiceAndReturnsOrder() throws Exception {
+    given(adminService.setOrderType(100L, OrderType.NAV, "operator-7")).willReturn(orderResponse());
+
+    mockMvc
+        .perform(
+            post("/admin/transaction-orders/100/order-type")
+                .with(csrf())
+                .header("X-Admin-Token", "operator-7-token")
+                .contentType(APPLICATION_JSON)
+                .content(
+                    """
+                    {"orderType": "NAV"}
+                    """))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").value(100))
+        .andExpect(jsonPath("$.orderType").value("MOC"));
+
+    then(adminService).should().setOrderType(100L, OrderType.NAV, "operator-7");
+  }
+
+  @Test
+  void setOrderType_withoutActor_defaultsToAdmin() throws Exception {
+    given(adminService.setOrderType(100L, OrderType.RISK, "shared-admin-token"))
+        .willReturn(orderResponse());
+
+    mockMvc
+        .perform(
+            post("/admin/transaction-orders/100/order-type")
+                .with(csrf())
+                .header("X-Admin-Token", "valid-token")
+                .contentType(APPLICATION_JSON)
+                .content(
+                    """
+                    {"orderType": "RISK"}
+                    """))
+        .andExpect(status().isOk());
+
+    then(adminService).should().setOrderType(100L, OrderType.RISK, "shared-admin-token");
+  }
+
+  @Test
+  void setOrderType_unknownType_returnsBadRequest() throws Exception {
+    mockMvc
+        .perform(
+            post("/admin/transaction-orders/100/order-type")
+                .with(csrf())
+                .header("X-Admin-Token", "valid-token")
+                .contentType(APPLICATION_JSON)
+                .content(
+                    """
+                    {"orderType": "VWAP"}
+                    """))
+        .andExpect(status().isBadRequest());
+
+    then(adminService).shouldHaveNoInteractions();
+  }
+
+  @Test
+  void setOrderType_missingType_returnsBadRequest() throws Exception {
+    mockMvc
+        .perform(
+            post("/admin/transaction-orders/100/order-type")
+                .with(csrf())
+                .header("X-Admin-Token", "valid-token")
+                .contentType(APPLICATION_JSON)
+                .content("{}"))
+        .andExpect(status().isBadRequest());
+
+    then(adminService).shouldHaveNoInteractions();
+  }
+
+  @Test
+  void setOrderType_notDraftOrder_returnsConflict() throws Exception {
+    given(adminService.setOrderType(100L, OrderType.NAV, "shared-admin-token"))
+        .willThrow(
+            new ResponseStatusException(CONFLICT, "Only DRAFT orders can change order type"));
+
+    mockMvc
+        .perform(
+            post("/admin/transaction-orders/100/order-type")
+                .with(csrf())
+                .header("X-Admin-Token", "valid-token")
+                .contentType(APPLICATION_JSON)
+                .content(
+                    """
+                    {"orderType": "NAV"}
+                    """))
+        .andExpect(status().isConflict());
+  }
+
+  @Test
   void cancelOrder_blankReason_returnsBadRequest() throws Exception {
     mockMvc
         .perform(

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionOrderRepositoryIT.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionOrderRepositoryIT.java
@@ -7,6 +7,8 @@ import static ee.tuleva.onboarding.investment.transaction.OrderStatus.CANCELLED;
 import static ee.tuleva.onboarding.investment.transaction.OrderStatus.EXECUTED;
 import static ee.tuleva.onboarding.investment.transaction.OrderStatus.SENT;
 import static ee.tuleva.onboarding.investment.transaction.OrderStatus.SETTLED;
+import static ee.tuleva.onboarding.investment.transaction.OrderType.MOC;
+import static ee.tuleva.onboarding.investment.transaction.OrderType.NAV;
 import static ee.tuleva.onboarding.investment.transaction.OrderVenue.SEB;
 import static ee.tuleva.onboarding.investment.transaction.TransactionType.BUY;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -41,6 +43,32 @@ class TransactionOrderRepositoryIT {
     TransactionOrder loaded = orderRepository.findById(order.getId()).orElseThrow();
 
     assertThat(loaded.getComment()).isEqualTo("operator note: partial fill expected");
+  }
+
+  @Test
+  void save_defaultsOrderTypeToMarketOnClose() {
+    TransactionOrder order = persistOrder(TUK75);
+
+    entityManager.flush();
+    entityManager.clear();
+
+    TransactionOrder loaded = orderRepository.findById(order.getId()).orElseThrow();
+
+    assertThat(loaded.getOrderType()).isEqualTo(MOC);
+  }
+
+  @Test
+  void save_roundTripsOrderType() {
+    TransactionOrder order = persistOrder(TUK75);
+    order.setOrderType(NAV);
+    orderRepository.save(order);
+
+    entityManager.flush();
+    entityManager.clear();
+
+    TransactionOrder loaded = orderRepository.findById(order.getId()).orElseThrow();
+
+    assertThat(loaded.getOrderType()).isEqualTo(NAV);
   }
 
   @Test

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/export/TransactionExportServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/export/TransactionExportServiceTest.java
@@ -3,6 +3,8 @@ package ee.tuleva.onboarding.investment.transaction.export;
 import static ee.tuleva.onboarding.fund.TulevaFund.*;
 import static ee.tuleva.onboarding.investment.transaction.InstrumentType.ETF;
 import static ee.tuleva.onboarding.investment.transaction.InstrumentType.FUND;
+import static ee.tuleva.onboarding.investment.transaction.OrderType.NAV;
+import static ee.tuleva.onboarding.investment.transaction.OrderType.RISK;
 import static ee.tuleva.onboarding.investment.transaction.OrderVenue.FT;
 import static ee.tuleva.onboarding.investment.transaction.OrderVenue.SEB;
 import static ee.tuleva.onboarding.investment.transaction.TransactionType.BUY;
@@ -227,6 +229,30 @@ class TransactionExportServiceTest {
       assertThat(dataRow.getCell(7).getStringCellValue()).isEqualTo("Buy");
 
       assertThat(sheet.getPhysicalNumberOfRows()).isEqualTo(2);
+    }
+  }
+
+  @Test
+  void generateSebEtfExport_writesEachOrdersOwnOrderTypeAsInstructionType() throws Exception {
+    var batch = buildBatch();
+
+    var navOrder =
+        buildOrder(batch, TKF100, "IE00NAV", BUY, ETF, SEB, new BigDecimal("100000"), 500L);
+    navOrder.setOrderType(NAV);
+    var riskOrder =
+        buildOrder(batch, TKF100, "IE00RISK", BUY, ETF, SEB, new BigDecimal("200000"), 1000L);
+    riskOrder.setOrderType(RISK);
+    var mocOrder =
+        buildOrder(batch, TKF100, "IE00MOC", BUY, ETF, SEB, new BigDecimal("300000"), 1500L);
+
+    byte[] xlsx = service.generateSebEtfExport(List.of(navOrder, riskOrder, mocOrder), Map.of());
+
+    try (var workbook = WorkbookFactory.create(new ByteArrayInputStream(xlsx))) {
+      var sheet = workbook.getSheetAt(0);
+
+      assertThat(sheet.getRow(1).getCell(4).getStringCellValue()).isEqualTo("NAV");
+      assertThat(sheet.getRow(2).getCell(4).getStringCellValue()).isEqualTo("RISK");
+      assertThat(sheet.getRow(3).getCell(4).getStringCellValue()).isEqualTo("MOC");
     }
   }
 


### PR DESCRIPTION
## What

ETF orders can now carry an execution basis: `MOC` (market-on-close), `NAV` (executed at the ETF's end-of-day NAV) or `RISK` (market maker's firm principal price). `MOC` stays the default; the basis is changed per order.

## Why

`order_type` existed as a `text not null default 'MOC'` column and a `String` field, but nothing ever read or wrote it — `TransactionExportService` wrote the literal `"MOC"` into the SEB ETF sheet without consulting the field. So the column could only ever say `MOC`, and every row in it does.

## Changes

- `OrderType` enum — `MOC`, `NAV`, `RISK`
- `TransactionOrder.orderType` is now `@Enumerated(STRING) OrderType`, defaulting to `MOC`
- SEB ETF export writes `order.getOrderType().name()` instead of the hardcoded literal
- `POST /admin/transaction-orders/{id}/order-type` sets the basis per order, with an `ORDER_TYPE_CHANGED` audit event recording `from`, `to` and actor
- `TransactionOrderResponse` exposes `orderType`

## DRAFT-only, deliberately

The endpoint 409s on anything past `DRAFT`. `finalizeConfirmedBatch` generates all five broker files, base64s them into batch metadata, uploads them to Drive and flips orders `DRAFT` → `SENT` in one transaction. Once that has run, the file the broker holds is fixed — letting the type change afterwards would only make the DB disagree with what was actually sent.

Operator flow: create command → read `calculationSnapshot` → flip any non-`MOC` trades → confirm.

## No migration

The column is already `text not null default 'MOC'`, which is exactly what `@Enumerated(STRING)` writes. Views `V1_211`/`V1_236` keep selecting it as text, unchanged. No CHECK constraint — H2 breaks on ALTER-added ones, so the enum plus `TransactionOrderRepositoryIT` carry the invariant.

## Before deploy

Worth confirming `select distinct order_type from investment_transaction_order` returns only `MOC` — Hibernate will now reject a row holding anything outside the three. It should be clean, since no code ever wrote the column, but that is an inference rather than a check.

## Tests

9 added: enum default and round-trip through the DB, all three types exporting distinctly, and the endpoint's DRAFT / non-DRAFT / not-found paths. Full suite green.

## Docs

Companion PR on the tuleva monorepo updates the A2 column spec and the admin endpoint table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
