### PR TITLE
Expose unverified related persons as structured data on the KYC error

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/kyb/survey/KybSurveyService.java
+++ b/src/main/java/ee/tuleva/onboarding/kyb/survey/KybSurveyService.java
@@ -85,6 +85,11 @@ class KybSurveyService {
     return new FieldError(field, new ValidationError(code, message));
   }
 
+  private static FieldError fieldError(
+      String field, String code, String message, List<RelatedPersonData> persons) {
+    return new FieldError(field, new ValidationError(code, message, persons));
+  }
+
   private static Stream<FieldError> relatedPersonsKycErrors(
       KybCheck check, String userPersonalCode, List<RelatedPersonData> relatedPersons) {
     var incompletePersonalCodes = RelatedPersonsKycMetadata.incompletePersonalCodes(check);
@@ -101,7 +106,8 @@ class KybSurveyService {
           fieldError(
               "relatedPersons",
               "OTHER_RELATED_PERSONS_KYC",
-              kycMessageWithNames(otherPersonalCodes, relatedPersons)));
+              KYC_MESSAGE,
+              personsFor(otherPersonalCodes, relatedPersons)));
     }
     if (errors.isEmpty()) {
       errors.add(fieldError("relatedPersons", "OTHER_RELATED_PERSONS_KYC", KYC_MESSAGE));
@@ -109,18 +115,19 @@ class KybSurveyService {
     return errors.stream();
   }
 
-  private static String kycMessageWithNames(
+  private static List<RelatedPersonData> personsFor(
       List<String> personalCodes, List<RelatedPersonData> relatedPersons) {
-    var namesByPersonalCode =
+    var personsByPersonalCode =
         relatedPersons.stream()
-            .filter(person -> person.personalCode() != null && person.name() != null)
-            .collect(toMap(RelatedPersonData::personalCode, RelatedPersonData::name, (a, b) -> a));
-    var names =
-        personalCodes.stream()
-            .map(personalCode -> namesByPersonalCode.getOrDefault(personalCode, personalCode))
-            .distinct()
-            .collect(joining(", "));
-    return names.isBlank() ? KYC_MESSAGE : KYC_MESSAGE + ": " + names;
+            .filter(person -> person.personalCode() != null)
+            .collect(toMap(RelatedPersonData::personalCode, identity(), (a, b) -> a));
+    return personalCodes.stream()
+        .distinct()
+        .map(
+            personalCode ->
+                personsByPersonalCode.getOrDefault(
+                    personalCode, new RelatedPersonData(personalCode, null)))
+        .toList();
   }
 
   private static ValidationError blockedReasonError(BlockedReason reason) {

--- a/src/main/java/ee/tuleva/onboarding/kyb/survey/RelatedPersonData.java
+++ b/src/main/java/ee/tuleva/onboarding/kyb/survey/RelatedPersonData.java
@@ -1,3 +1,7 @@
 package ee.tuleva.onboarding.kyb.survey;
 
-record RelatedPersonData(String personalCode, String name) {}
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+@NullMarked
+record RelatedPersonData(String personalCode, @Nullable String name) {}

--- a/src/main/java/ee/tuleva/onboarding/kyb/survey/ValidationError.java
+++ b/src/main/java/ee/tuleva/onboarding/kyb/survey/ValidationError.java
@@ -1,3 +1,16 @@
 package ee.tuleva.onboarding.kyb.survey;
 
-record ValidationError(String code, String message) {}
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_EMPTY;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.util.List;
+import org.jspecify.annotations.NullMarked;
+
+@NullMarked
+record ValidationError(
+    String code, String message, @JsonInclude(NON_EMPTY) List<RelatedPersonData> persons) {
+
+  ValidationError(String code, String message) {
+    this(code, message, List.of());
+  }
+}

--- a/src/test/groovy/ee/tuleva/onboarding/kyb/survey/KybSurveyControllerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyb/survey/KybSurveyControllerTest.java
@@ -2,6 +2,7 @@ package ee.tuleva.onboarding.kyb.survey;
 
 import static ee.tuleva.onboarding.auth.authority.Authority.USER;
 import static ee.tuleva.onboarding.auth.role.RoleType.PERSON;
+import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.willThrow;
@@ -11,6 +12,7 @@ import static org.springframework.security.test.web.servlet.request.SecurityMock
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import ee.tuleva.onboarding.auth.principal.AuthenticatedPerson;
@@ -103,7 +105,81 @@ class KybSurveyControllerTest {
             content()
                 .json(
                     "{\"relatedPersons\":{\"errors\":[{\"code\":\"USER_KYC\","
-                        + "\"message\":\"Sinu isikusamasuse tuvastamine on lõpetamata\"}]}}"));
+                        + "\"message\":\"Sinu isikusamasuse tuvastamine on lõpetamata\"}]}}"))
+        .andExpect(jsonPath("$.relatedPersons.errors[0].persons").doesNotExist());
+  }
+
+  @Test
+  void initialValidation_serializesUnverifiedRelatedPersonsAsStructuredData() throws Exception {
+    var data =
+        new LegalEntityData(
+            ValidatedField.valid("Test OÜ"),
+            ValidatedField.valid(REGISTRY_CODE),
+            ValidatedField.valid("OÜ"),
+            ValidatedField.valid(LocalDate.of(2020, 1, 15)),
+            ValidatedField.valid(LegalEntityStatus.REGISTERED),
+            ValidatedField.valid(
+                new LegalEntityAddress(
+                    "Pärnu mnt 123, 11313 Tallinn", "Pärnu mnt 123", "Tallinn", "11313", "EST")),
+            ValidatedField.valid("Fondide valitsemine"),
+            ValidatedField.valid("6630"),
+            ValidatedField.withErrors(
+                List.of(),
+                List.of(
+                    new ValidationError(
+                        "OTHER_RELATED_PERSONS_KYC",
+                        "Isikusamasuse tuvastamine on lõpetamata",
+                        List.of(
+                            new RelatedPersonData("38501010003", "Mari Maasikas"),
+                            new RelatedPersonData("38501010004", "Peeter Kask"))))));
+    when(kybSurveyService.initialValidation(REGISTRY_CODE, PERSONAL_CODE)).thenReturn(data);
+
+    mvc.perform(
+            get("/v1/kyb/surveys/initial-validation")
+                .param("registry-code", REGISTRY_CODE)
+                .with(authentication(personAuth())))
+        .andExpect(status().isOk())
+        .andExpect(
+            content()
+                .json(
+                    "{\"relatedPersons\":{\"errors\":[{\"code\":\"OTHER_RELATED_PERSONS_KYC\","
+                        + "\"message\":\"Isikusamasuse tuvastamine on lõpetamata\","
+                        + "\"persons\":[{\"personalCode\":\"38501010003\",\"name\":\"Mari Maasikas\"},"
+                        + "{\"personalCode\":\"38501010004\",\"name\":\"Peeter Kask\"}]}]}}"));
+  }
+
+  @Test
+  void initialValidation_serializesPersonWithoutNameAsExplicitNull() throws Exception {
+    var data =
+        new LegalEntityData(
+            ValidatedField.valid("Test OÜ"),
+            ValidatedField.valid(REGISTRY_CODE),
+            ValidatedField.valid("OÜ"),
+            ValidatedField.valid(LocalDate.of(2020, 1, 15)),
+            ValidatedField.valid(LegalEntityStatus.REGISTERED),
+            ValidatedField.valid(
+                new LegalEntityAddress(
+                    "Pärnu mnt 123, 11313 Tallinn", "Pärnu mnt 123", "Tallinn", "11313", "EST")),
+            ValidatedField.valid("Fondide valitsemine"),
+            ValidatedField.valid("6630"),
+            ValidatedField.withErrors(
+                List.of(),
+                List.of(
+                    new ValidationError(
+                        "OTHER_RELATED_PERSONS_KYC",
+                        "Isikusamasuse tuvastamine on lõpetamata",
+                        List.of(new RelatedPersonData("38501010005", null))))));
+    when(kybSurveyService.initialValidation(REGISTRY_CODE, PERSONAL_CODE)).thenReturn(data);
+
+    mvc.perform(
+            get("/v1/kyb/surveys/initial-validation")
+                .param("registry-code", REGISTRY_CODE)
+                .with(authentication(personAuth())))
+        .andExpect(status().isOk())
+        .andExpect(
+            jsonPath("$.relatedPersons.errors[0].persons[0].personalCode").value("38501010005"))
+        .andExpect(jsonPath("$.relatedPersons.errors[0].persons[0].name").hasJsonPath())
+        .andExpect(jsonPath("$.relatedPersons.errors[0].persons[0].name").value(nullValue()));
   }
 
   @Test

--- a/src/test/groovy/ee/tuleva/onboarding/kyb/survey/KybSurveyServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/kyb/survey/KybSurveyServiceTest.java
@@ -128,7 +128,7 @@ class KybSurveyServiceTest {
   }
 
   @Test
-  void initialValidation_codesOtherRelatedPersonsKycAndNamesThem() {
+  void initialValidation_codesOtherRelatedPersonsKycWithPersons() {
     stubInitialValidation(
         boardMemberWithTwoOwners(),
         sampleDetail(),
@@ -149,7 +149,34 @@ class KybSurveyServiceTest {
         .containsExactly(
             new ValidationError(
                 "OTHER_RELATED_PERSONS_KYC",
-                "Isikusamasuse tuvastamine on lõpetamata: Mari Maasikas, Peeter Kask"));
+                "Isikusamasuse tuvastamine on lõpetamata",
+                List.of(
+                    new RelatedPersonData("38501010003", "Mari Maasikas"),
+                    new RelatedPersonData("38501010004", "Peeter Kask"))));
+  }
+
+  @Test
+  void initialValidation_codesOtherRelatedPersonsKycWithoutNameWhenPersonNotInRelatedPersons() {
+    stubInitialValidation(
+        sampleRelationships(),
+        sampleDetail(),
+        List.of(
+            new KybCheck(COMPANY_ACTIVE, true, Map.of()),
+            new KybCheck(
+                RELATED_PERSONS_KYC,
+                false,
+                Map.of(
+                    "incompletePersons",
+                    List.of(Map.of("personalCode", "38501010005", "kycStatus", "PENDING"))))));
+
+    var result = service.initialValidation(REGISTRY_CODE, PERSONAL_CODE);
+
+    assertThat(result.relatedPersons().errors())
+        .containsExactly(
+            new ValidationError(
+                "OTHER_RELATED_PERSONS_KYC",
+                "Isikusamasuse tuvastamine on lõpetamata",
+                List.of(new RelatedPersonData("38501010005", null))));
   }
 
   @Test
@@ -197,7 +224,10 @@ class KybSurveyServiceTest {
             new ValidationError("USER_KYC", "Sinu isikusamasuse tuvastamine on lõpetamata"),
             new ValidationError(
                 "OTHER_RELATED_PERSONS_KYC",
-                "Isikusamasuse tuvastamine on lõpetamata: Mari Maasikas, Peeter Kask"));
+                "Isikusamasuse tuvastamine on lõpetamata",
+                List.of(
+                    new RelatedPersonData("38501010003", "Mari Maasikas"),
+                    new RelatedPersonData("38501010004", "Peeter Kask"))));
   }
 
   private List<CompanyRelationship> boardMemberWithTwoOwners() {


### PR DESCRIPTION
The client had to parse names out of the OTHER_RELATED_PERSONS_KYC message tail. The error now carries a persons list (personalCode + name) and the message reverts to plain "Isikusamasuse tuvastamine on lõpetamata". persons is omitted from JSON when empty, so all other errors keep their wire shape.