### PR TITLE
Match the R17 operator column exactly, now that the real header is known

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/investment/epis/parser/R17ReportParser.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/epis/parser/R17ReportParser.java
@@ -180,12 +180,6 @@ public class R17ReportParser {
         return;
       }
 
-      // "PF valitseja/PIK" is the real column name, verified against a genuine EPIS R17 export
-      // (Seisuga 23.08.2026). It must come first: the report ALSO carries "Summa (PF valitseja)",
-      // and both contain "pf valitseja", so a contains-match picks whichever column comes first.
-      // That happens to be the right one today only because the amount column sits to its right —
-      // a reordered export would silently classify PIK redemptions as switching flows, and the
-      // units-vs-amount cross-check cannot catch it because the row's units are unchanged.
       String pfType = lowerCase(findValue(row, "pf valitseja/pik", "pf valitseja", "pfvalitseja"));
       BigDecimal units = requiredUnits(row, fundRaw, toiming).abs();
       if (units.signum() == 0) {

--- a/src/main/java/ee/tuleva/onboarding/investment/epis/parser/R17ReportParser.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/epis/parser/R17ReportParser.java
@@ -157,6 +157,15 @@ public class R17ReportParser {
     return requireNonNullElse(feeBearingUnits, ZERO).add(requireNonNullElse(feeFreeUnits, ZERO));
   }
 
+  private static String requiredPfType(Map<String, String> row, String fund, String toiming) {
+    String pfType = findValue(row, "pf valitseja/pik");
+    if (pfType == null) {
+      throw new IllegalArgumentException(
+          "R17 operator column missing: fund=" + fund + ", toiming=" + toiming);
+    }
+    return lowerCase(pfType);
+  }
+
   private static String trimmed(@Nullable String value) {
     return value == null ? "" : value.trim();
   }
@@ -180,7 +189,7 @@ public class R17ReportParser {
         return;
       }
 
-      String pfType = lowerCase(findValue(row, "pf valitseja/pik", "pf valitseja", "pfvalitseja"));
+      String pfType = requiredPfType(row, fundRaw, toiming);
       BigDecimal units = requiredUnits(row, fundRaw, toiming).abs();
       if (units.signum() == 0) {
         return;

--- a/src/main/java/ee/tuleva/onboarding/investment/epis/parser/R17ReportParser.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/epis/parser/R17ReportParser.java
@@ -157,13 +157,13 @@ public class R17ReportParser {
     return requireNonNullElse(feeBearingUnits, ZERO).add(requireNonNullElse(feeFreeUnits, ZERO));
   }
 
-  private static String requiredPfType(Map<String, String> row, String fund, String toiming) {
-    String pfType = findValue(row, "pf valitseja/pik");
-    if (pfType == null) {
+  private static String requiredOperatorType(Map<String, String> row, String fund, String toiming) {
+    String operatorType = lowerCase(findValue(row, "pf valitseja/pik"));
+    if (operatorType.isEmpty()) {
       throw new IllegalArgumentException(
-          "R17 operator column missing: fund=" + fund + ", toiming=" + toiming);
+          "R17 operator column missing or blank: fund=" + fund + ", toiming=" + toiming);
     }
-    return lowerCase(pfType);
+    return operatorType;
   }
 
   private static String trimmed(@Nullable String value) {
@@ -189,7 +189,7 @@ public class R17ReportParser {
         return;
       }
 
-      String pfType = requiredPfType(row, fundRaw, toiming);
+      String operatorType = requiredOperatorType(row, fundRaw, toiming);
       BigDecimal units = requiredUnits(row, fundRaw, toiming).abs();
       if (units.signum() == 0) {
         return;
@@ -202,14 +202,14 @@ public class R17ReportParser {
 
       UnitAccumulator accumulator =
           accumulators.computeIfAbsent(fund.get().getCode(), code -> new UnitAccumulator());
-      applyToiming(accumulator, toiming, pfType, units);
+      applyToiming(accumulator, toiming, operatorType, units);
     }
 
     private static void applyToiming(
-        UnitAccumulator accumulator, String toiming, String pfType, BigDecimal units) {
+        UnitAccumulator accumulator, String toiming, String operatorType, BigDecimal units) {
       boolean isTagasivott = toiming.contains("tagasivõtt") || toiming.contains("tagasivott");
       boolean isValjalase = toiming.contains("väljalase") || toiming.contains("valjalase");
-      boolean isPik = pfType.contains("pik");
+      boolean isPik = operatorType.contains("pik");
 
       if (isTagasivott && isPik) {
         accumulator.pikUnits = accumulator.pikUnits.add(units);

--- a/src/main/java/ee/tuleva/onboarding/investment/epis/parser/R17ReportParser.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/epis/parser/R17ReportParser.java
@@ -180,7 +180,13 @@ public class R17ReportParser {
         return;
       }
 
-      String pfType = lowerCase(findValue(row, "pf valitseja", "pfvalitseja"));
+      // "PF valitseja/PIK" is the real column name, verified against a genuine EPIS R17 export
+      // (Seisuga 23.08.2026). It must come first: the report ALSO carries "Summa (PF valitseja)",
+      // and both contain "pf valitseja", so a contains-match picks whichever column comes first.
+      // That happens to be the right one today only because the amount column sits to its right —
+      // a reordered export would silently classify PIK redemptions as switching flows, and the
+      // units-vs-amount cross-check cannot catch it because the row's units are unchanged.
+      String pfType = lowerCase(findValue(row, "pf valitseja/pik", "pf valitseja", "pfvalitseja"));
       BigDecimal units = requiredUnits(row, fundRaw, toiming).abs();
       if (units.signum() == 0) {
         return;

--- a/src/test/groovy/ee/tuleva/onboarding/investment/epis/parser/R17ReportParserTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/epis/parser/R17ReportParserTest.java
@@ -528,4 +528,24 @@ class R17ReportParserTest {
     assertThat(result.get("TUK75").pikUnits()).isEqualByComparingTo("100.000");
     assertThat(result.get("TUK75").switchingNetUnits()).isEqualByComparingTo("0");
   }
+
+  // Without the operator column the row cannot be classified at all, and an empty operator type
+  // reads as "not PIK" — so the units would land in the switching total and the number would look
+  // finished while meaning something else.
+  @Test
+  void refusesARowWithNoOperatorColumnRatherThanCallingItSwitching() {
+    String headerWithoutOperator =
+        "Väärtpaber;NAV;Toiming;Hind;Osakud (teenustasuta);Osakud (teenustasuga);Summa";
+    String csv =
+        """
+        Staatus;;;;Seisuga;;Valuuta
+        Netitud;;;;15.04.2026;;EUR
+        %s
+        Tuleva Maailma Aktsiate Pensionifond;0.80;Tagasivõtt;0.80;40.000;60.000;80.00
+        """
+            .formatted(headerWithoutOperator);
+
+    assertThatThrownBy(() -> parser.parse(csv, LOCK_DATE, EXEC_DATE))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/investment/epis/parser/R17ReportParserTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/epis/parser/R17ReportParserTest.java
@@ -502,4 +502,29 @@ class R17ReportParserTest {
 
     assertThat(result.get("TUK75").switchingNetUnits()).isEqualByComparingTo("100.000");
   }
+
+  @Test
+  void classifiesPikByTheOperatorColumnEvenWhenTheAmountColumnComesFirst() {
+    // "Summa (PF valitseja)" also contains "pf valitseja". While it sits to the RIGHT of
+    // "PF valitseja/PIK" a contains-match lands on the right column by luck of column order; move
+    // it
+    // left and the operator type would read "0.00", which contains no "pik", so a PIK redemption
+    // would be booked as a switching outflow instead. The units on the row are unchanged, so the
+    // units-vs-amount cross-check cannot catch it — only an exact column match can.
+    String reorderedHeader =
+        "Väärtpaber;NAV;Toiming;Summa (PF valitseja);Hind;Osakud (teenustasuta);Osakud (teenustasuga);Summa;PF valitseja/PIK";
+    String csv =
+        """
+        Staatus;;;;Seisuga;;Valuuta;;
+        Netitud;;;;15.04.2026;;EUR;;
+        %s
+        Tuleva Maailma Aktsiate Pensionifond;0.80;Tagasivõtt;0.00;0.80;40.000;60.000;80.00;PIK
+        """
+            .formatted(reorderedHeader);
+
+    Map<String, R17Result> result = parser.parse(csv, LOCK_DATE, EXEC_DATE);
+
+    assertThat(result.get("TUK75").pikUnits()).isEqualByComparingTo("100.000");
+    assertThat(result.get("TUK75").switchingNetUnits()).isEqualByComparingTo("0");
+  }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/investment/epis/parser/R17ReportParserTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/epis/parser/R17ReportParserTest.java
@@ -505,12 +505,13 @@ class R17ReportParserTest {
 
   @Test
   void classifiesPikByTheOperatorColumnEvenWhenTheAmountColumnComesFirst() {
-    // "Summa (PF valitseja)" also contains "pf valitseja". While it sits to the RIGHT of
-    // "PF valitseja/PIK" a contains-match lands on the right column by luck of column order; move
-    // it
-    // left and the operator type would read "0.00", which contains no "pik", so a PIK redemption
-    // would be booked as a switching outflow instead. The units on the row are unchanged, so the
-    // units-vs-amount cross-check cannot catch it — only an exact column match can.
+    // "Summa (PF valitseja)" also contains "pf valitseja", so the bare contains-match lands on
+    // whichever of the two columns the export puts first. In the real export the amount column
+    // sits to the right, which made the old lookup right by luck of column order rather than by
+    // rule. This header moves it left, and without the "pf valitseja/pik" candidate the operator
+    // type would read "0.00" — no "pik" in it, so a PIK redemption would be booked as a switching
+    // outflow. The row's units are unchanged either way, so the units-vs-amount cross-check cannot
+    // catch it.
     String reorderedHeader =
         "Väärtpaber;NAV;Toiming;Summa (PF valitseja);Hind;Osakud (teenustasuta);Osakud (teenustasuga);Summa;PF valitseja/PIK";
     String csv =

--- a/src/test/groovy/ee/tuleva/onboarding/investment/epis/parser/R17ReportParserTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/epis/parser/R17ReportParserTest.java
@@ -503,15 +503,12 @@ class R17ReportParserTest {
     assertThat(result.get("TUK75").switchingNetUnits()).isEqualByComparingTo("100.000");
   }
 
+  // "Summa (PF valitseja)" also contains "pf valitseja", so the old contains-match landed on
+  // whichever of the two columns the export put first. Moving the amount column left makes the
+  // operator type read "0.00" — no "pik" in it, so the PIK redemption would be booked as a
+  // switching outflow, and the row's units are the same either way so no cross-check can see it.
   @Test
   void classifiesPikByTheOperatorColumnEvenWhenTheAmountColumnComesFirst() {
-    // "Summa (PF valitseja)" also contains "pf valitseja", so the bare contains-match lands on
-    // whichever of the two columns the export puts first. In the real export the amount column
-    // sits to the right, which made the old lookup right by luck of column order rather than by
-    // rule. This header moves it left, and without the "pf valitseja/pik" candidate the operator
-    // type would read "0.00" — no "pik" in it, so a PIK redemption would be booked as a switching
-    // outflow. The row's units are unchanged either way, so the units-vs-amount cross-check cannot
-    // catch it.
     String reorderedHeader =
         "Väärtpaber;NAV;Toiming;Summa (PF valitseja);Hind;Osakud (teenustasuta);Osakud (teenustasuga);Summa;PF valitseja/PIK";
     String csv =
@@ -529,9 +526,8 @@ class R17ReportParserTest {
     assertThat(result.get("TUK75").switchingNetUnits()).isEqualByComparingTo("0");
   }
 
-  // Without the operator column the row cannot be classified at all, and an empty operator type
-  // reads as "not PIK" — so the units would land in the switching total and the number would look
-  // finished while meaning something else.
+  // An unreadable operator type would read as "not PIK", so the units would land in the switching
+  // total and the number would look finished while meaning something else.
   @Test
   void refusesARowWithNoOperatorColumnRatherThanCallingItSwitching() {
     String headerWithoutOperator =
@@ -544,6 +540,21 @@ class R17ReportParserTest {
         Tuleva Maailma Aktsiate Pensionifond;0.80;Tagasivõtt;0.80;40.000;60.000;80.00
         """
             .formatted(headerWithoutOperator);
+
+    assertThatThrownBy(() -> parser.parse(csv, LOCK_DATE, EXEC_DATE))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void refusesARowWhoseOperatorCellIsBlankRatherThanCallingItSwitching() {
+    String csv =
+        """
+        Staatus;;;;Seisuga;;Valuuta;;
+        Netitud;;;;15.04.2026;;EUR;;
+        %s
+        Tuleva Maailma Aktsiate Pensionifond;0.80;Tagasivõtt;;0.80;40.000;60.000;80.00;0.00
+        """
+            .formatted(HEADER_ROW);
 
     assertThatThrownBy(() -> parser.parse(csv, LOCK_DATE, EXEC_DATE))
         .isInstanceOf(IllegalArgumentException.class);


### PR DESCRIPTION
#1865 shipped with one limitation stated openly: the R17 column names came from
fixtures, not from a genuine EPIS export, and `pfvalitseja` was still resolved
by column order. A real export (Seisuga 23.08.2026) settles both.

**The guessed header was right.** The real row is:

```
Väärtpaber;NAV;Toiming;PF valitseja/PIK;Hind;Osakud (teenustasuta);Osakud (teenustasuga);Summa;Summa (PF valitseja)
```

byte-for-byte what `R17ReportParserTest.HEADER_ROW` already used. Both unit
column names resolve as EXACT matches, so the two-column sum #1865 introduced
was reading the right columns all along, and `Summa` matches exactly rather than
colliding with `Summa (PF valitseja)`.

**The operator lookup was the real gap.** No header equals `pf valitseja`, so it
fell through to the contains pass, where BOTH `PF valitseja/PIK` and
`Summa (PF valitseja)` match. It picked the right one only because that column
sits to the left — iteration order is column order. Reorder the export and
`pfType` reads `"0.00"`, which contains no `"pik"`, so a **PIK redemption is
booked as a switching outflow**. The units on the row are identical either way,
so the units-vs-amount cross-check cannot see it.

Fix: the lookup asks for `"pf valitseja/pik"` and nothing else, so it can only
resolve as an exact match. The old `pf valitseja` / `pfvalitseja` keywords are
gone rather than kept as fallbacks — every export shape in the fixtures, the
short four-column one included, already carries the full column name, so a
fallback would only re-open the collision it is there to avoid.

A blank cell is refused too. `findValue` returns `""` for an empty cell, which
passed a bare null check and then read as "not PIK" — the same
misclassification through a different door.

**Verified against the real file, not just fixtures.** Replaying all 10 rows
through the same normalisation the parser uses: every unit column resolves
EXACT; `units × Hind == Summa` holds on all 10 rows, with the largest divergence
0.14 EUR against a half-price-step tolerance of 7.43 for that row — the
tolerance is comfortably wide for real rounding and still far tighter than the
hundreds of thousands a dropped unit column would produce.

Test: `classifiesPikByTheOperatorColumnEvenWhenTheAmountColumnComesFirst` moves
`Summa (PF valitseja)` to the left of `PF valitseja/PIK`. Red before green —
without the fix it books the PIK row as switching (31 tests, 1 failed); with it,
`pikUnits = 100.000` and `switchingNetUnits = 0`.

No real report data is added to this repo — the header row is structural and was
already present; all values in the fixtures stay synthetic.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

Closes the one open limitation stated in #1865.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
