### PR TITLE
Split the savings fund tax report by investment account

### DIFF
--- a/.githooks/pii-iban-allow
+++ b/.githooks/pii-iban-allow
@@ -6,6 +6,11 @@
 # Never add a person's account, and never add a live pension fund account -
 # those belong in the gitignored terraform tfvars, not in code.
 # One IBAN per line; anything else is ignored.
+#
+# Repo-invented savings-fund test fixtures, long public in this repository's
+# test files (Juri Tamm demo persona's account and the deposit-account fixture):
+EE157700771001802057
+EE442200221092874625
 EE861010220306591229
 EE651010220306497226
 EE241010220306719221

--- a/src/main/java/ee/tuleva/onboarding/account/transaction/Transaction.java
+++ b/src/main/java/ee/tuleva/onboarding/account/transaction/Transaction.java
@@ -25,7 +25,8 @@ public record Transaction(
     String isin,
     CashFlow.Type type,
     BigDecimal units,
-    BigDecimal nav)
+    BigDecimal nav,
+    String counterpartyIban)
     implements Comparable<Transaction> {
 
   public Transaction {

--- a/src/main/java/ee/tuleva/onboarding/account/transaction/Transaction.java
+++ b/src/main/java/ee/tuleva/onboarding/account/transaction/Transaction.java
@@ -25,8 +25,7 @@ public record Transaction(
     String isin,
     CashFlow.Type type,
     BigDecimal units,
-    BigDecimal nav,
-    String counterpartyIban)
+    BigDecimal nav)
     implements Comparable<Transaction> {
 
   public Transaction {

--- a/src/main/java/ee/tuleva/onboarding/capital/transfer/iban/IbanValidator.java
+++ b/src/main/java/ee/tuleva/onboarding/capital/transfer/iban/IbanValidator.java
@@ -143,7 +143,8 @@ public class IbanValidator implements ConstraintValidator<ValidIban, String> {
       }
     }
     boolean ok = mod == 1;
-    if (!ok && log.isDebugEnabled()) log.debug("IBAN failed checksum: {}", iban);
+    if (!ok && log.isDebugEnabled())
+      log.debug("IBAN failed checksum: country={}, length={}", cc, len);
     return ok;
   }
 }

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/SavingFundPaymentRepository.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/SavingFundPaymentRepository.java
@@ -31,6 +31,16 @@ public class SavingFundPaymentRepository {
     return result.isEmpty() ? Optional.empty() : Optional.of(result.getFirst());
   }
 
+  public List<SavingFundPayment> findAllById(Collection<UUID> ids) {
+    if (ids.isEmpty()) {
+      return List.of();
+    }
+    return jdbcTemplate.query(
+        "select * from saving_fund_payment where id in (:ids)",
+        Map.of("ids", ids),
+        this::rowMapper);
+  }
+
   public UUID savePaymentData(SavingFundPayment payment) {
     var id = UUID.randomUUID();
     var parameters =

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/SavingsFundTransactionService.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/SavingsFundTransactionService.java
@@ -48,35 +48,80 @@ public class SavingsFundTransactionService {
 
   @Transactional
   public List<Transaction> getTransactions(AuthenticatedPerson person) {
-    String ownerCode = person.getRoleCode();
-    PartyType partyType = PartyType.from(person.getRoleType());
+    return transactionSources(person).transactions();
+  }
 
+  @Transactional
+  public TransactionsWithCounterparties getTransactionsWithCounterpartyIbans(
+      AuthenticatedPerson person) {
+    TransactionSources sources = transactionSources(person);
+    return new TransactionsWithCounterparties(
+        sources.transactions(), counterpartyIbans(sources, person.toPartyId()));
+  }
+
+  private record TransactionSources(
+      List<Transaction> transactions,
+      List<LedgerEntry> subscriptionEntries,
+      List<LedgerEntry> redemptionEntries,
+      List<RedemptionRequest> redemptionRequests) {
+
+    static TransactionSources empty() {
+      return new TransactionSources(List.of(), List.of(), List.of(), List.of());
+    }
+  }
+
+  private TransactionSources transactionSources(AuthenticatedPerson person) {
     if (!savingsFundOnboardingService.isOnboardingCompleted(person.toPartyId())) {
-      return List.of();
+      return TransactionSources.empty();
     }
 
+    String ownerCode = person.getRoleCode();
+    PartyType partyType = PartyType.from(person.getRoleType());
     String isin = savingsFundConfiguration.getIsin();
 
     List<LedgerEntry> subscriptionEntries = entries(ownerCode, partyType, SUBSCRIPTIONS);
-    Map<UUID, String> payerIbans = payerIbans(subscriptionEntries, person.toPartyId());
-    List<Transaction> subscriptions =
-        subscriptionEntries.stream()
-            .map(entry -> toTransaction(entry, CONTRIBUTION_CASH, isin, Map.of(), payerIbans))
-            .toList();
-
     List<LedgerEntry> redemptionEntries = entries(ownerCode, partyType, REDEMPTIONS);
     List<RedemptionRequest> redemptionRequests =
         redemptionRequests(redemptionEntries, person.toPartyId());
     Map<UUID, Instant> payoutTimes = payoutTimes(redemptionRequests);
-    Map<UUID, String> payoutIbans = payoutIbans(redemptionRequests);
-    List<Transaction> redemptions =
-        redemptionEntries.stream()
-            .map(entry -> toTransaction(entry, SUBTRACTION, isin, payoutTimes, payoutIbans))
+
+    List<Transaction> transactions =
+        Stream.concat(
+                subscriptionEntries.stream()
+                    .map(entry -> toTransaction(entry, CONTRIBUTION_CASH, isin, Map.of())),
+                redemptionEntries.stream()
+                    .map(entry -> toTransaction(entry, SUBTRACTION, isin, payoutTimes)))
+            .sorted(reverseOrder())
             .toList();
 
-    return Stream.concat(subscriptions.stream(), redemptions.stream())
-        .sorted(reverseOrder())
-        .toList();
+    return new TransactionSources(
+        transactions, subscriptionEntries, redemptionEntries, redemptionRequests);
+  }
+
+  private Map<UUID, String> counterpartyIbans(TransactionSources sources, PartyId partyId) {
+    Map<UUID, String> byTransactionId = new HashMap<>();
+    byTransactionId.putAll(
+        byTransactionId(
+            sources.subscriptionEntries(), payerIbans(sources.subscriptionEntries(), partyId)));
+    byTransactionId.putAll(
+        byTransactionId(sources.redemptionEntries(), payoutIbans(sources.redemptionRequests())));
+    return Map.copyOf(byTransactionId);
+  }
+
+  private static Map<UUID, String> byTransactionId(
+      List<LedgerEntry> entries, Map<UUID, String> byExternalReference) {
+    Map<UUID, String> byTransactionId = new HashMap<>();
+    entries.forEach(
+        entry -> {
+          LedgerTransaction ledgerTransaction = entry.getTransaction();
+          UUID externalReference = ledgerTransaction.getExternalReference();
+          String iban =
+              externalReference == null ? null : byExternalReference.get(externalReference);
+          if (iban != null) {
+            byTransactionId.put(ledgerTransaction.getId(), iban);
+          }
+        });
+    return byTransactionId;
   }
 
   private List<LedgerEntry> entries(
@@ -157,11 +202,7 @@ public class SavingsFundTransactionService {
   }
 
   private Transaction toTransaction(
-      LedgerEntry entry,
-      CashFlow.Type type,
-      String isin,
-      Map<UUID, Instant> payoutTimes,
-      Map<UUID, String> counterpartyIbans) {
+      LedgerEntry entry, CashFlow.Type type, String isin, Map<UUID, Instant> payoutTimes) {
     LedgerTransaction ledgerTransaction = entry.getTransaction();
     UUID externalReference = ledgerTransaction.getExternalReference();
 
@@ -172,8 +213,6 @@ public class SavingsFundTransactionService {
         .time(ledgerTransaction.getTransactionDate())
         .priceTime(ledgerTransaction.getTransactionDate())
         .settledTime(externalReference == null ? null : payoutTimes.get(externalReference))
-        .counterpartyIban(
-            externalReference == null ? null : counterpartyIbans.get(externalReference))
         .isin(isin)
         .type(type)
         .units(require(ledgerTransaction.findUserFundUnits(), "fundUnits", ledgerTransaction))

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/SavingsFundTransactionService.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/SavingsFundTransactionService.java
@@ -178,16 +178,18 @@ public class SavingsFundTransactionService {
   }
 
   private Map<UUID, String> payerIbans(List<LedgerEntry> subscriptionEntries, PartyId partyId) {
-    if (externalReferences(subscriptionEntries).isEmpty()) {
+    Set<UUID> paymentIds = externalReferences(subscriptionEntries);
+
+    if (paymentIds.isEmpty()) {
       return Map.of();
     }
 
     Map<UUID, String> byPaymentId = new HashMap<>();
     savingFundPaymentRepository
-        .findPayments(partyId)
+        .findAllById(paymentIds)
         .forEach(
             payment -> {
-              if (payment.getId() != null && payment.getRemitterIban() != null) {
+              if (partyId.equals(payment.getPartyId()) && payment.getRemitterIban() != null) {
                 byPaymentId.put(payment.getId(), payment.getRemitterIban());
               }
             });

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/SavingsFundTransactionService.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/SavingsFundTransactionService.java
@@ -18,9 +18,12 @@ import ee.tuleva.onboarding.ledger.LedgerParty.PartyType;
 import ee.tuleva.onboarding.ledger.LedgerService;
 import ee.tuleva.onboarding.ledger.LedgerTransaction;
 import ee.tuleva.onboarding.ledger.UserAccount;
+import ee.tuleva.onboarding.party.PartyId;
+import ee.tuleva.onboarding.savings.fund.redemption.RedemptionRequest;
 import ee.tuleva.onboarding.savings.fund.redemption.RedemptionRequestRepository;
 import java.math.BigDecimal;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -41,6 +44,7 @@ public class SavingsFundTransactionService {
   private final SavingsFundOnboardingService savingsFundOnboardingService;
   private final SavingsFundConfiguration savingsFundConfiguration;
   private final RedemptionRequestRepository redemptionRequestRepository;
+  private final SavingFundPaymentRepository savingFundPaymentRepository;
 
   @Transactional
   public List<Transaction> getTransactions(AuthenticatedPerson person) {
@@ -53,16 +57,20 @@ public class SavingsFundTransactionService {
 
     String isin = savingsFundConfiguration.getIsin();
 
+    List<LedgerEntry> subscriptionEntries = entries(ownerCode, partyType, SUBSCRIPTIONS);
+    Map<UUID, String> payerIbans = payerIbans(subscriptionEntries, person.toPartyId());
     List<Transaction> subscriptions =
-        entries(ownerCode, partyType, SUBSCRIPTIONS).stream()
-            .map(entry -> toTransaction(entry, CONTRIBUTION_CASH, isin, Map.of()))
+        subscriptionEntries.stream()
+            .map(entry -> toTransaction(entry, CONTRIBUTION_CASH, isin, Map.of(), payerIbans))
             .toList();
 
     List<LedgerEntry> redemptionEntries = entries(ownerCode, partyType, REDEMPTIONS);
-    Map<UUID, Instant> payoutTimes = payoutTimes(redemptionEntries);
+    List<RedemptionRequest> redemptionRequests = redemptionRequests(redemptionEntries);
+    Map<UUID, Instant> payoutTimes = payoutTimes(redemptionRequests);
+    Map<UUID, String> payoutIbans = payoutIbans(redemptionRequests);
     List<Transaction> redemptions =
         redemptionEntries.stream()
-            .map(entry -> toTransaction(entry, SUBTRACTION, isin, payoutTimes))
+            .map(entry -> toTransaction(entry, SUBTRACTION, isin, payoutTimes, payoutIbans))
             .toList();
 
     return Stream.concat(subscriptions.stream(), redemptions.stream())
@@ -76,31 +84,70 @@ public class SavingsFundTransactionService {
         ledgerService.getPartyAccount(ownerCode, partyType, userAccount).getEntries());
   }
 
-  private Map<UUID, Instant> payoutTimes(List<LedgerEntry> redemptionEntries) {
-    Set<UUID> requestIds =
-        redemptionEntries.stream()
-            .map(entry -> entry.getTransaction().getExternalReference())
-            .filter(Objects::nonNull)
-            .collect(toSet());
+  private List<RedemptionRequest> redemptionRequests(List<LedgerEntry> redemptionEntries) {
+    Set<UUID> requestIds = externalReferences(redemptionEntries);
 
     if (requestIds.isEmpty()) {
-      return Map.of();
+      return List.of();
     }
 
+    List<RedemptionRequest> requests = new ArrayList<>();
+    redemptionRequestRepository.findAllById(requestIds).forEach(requests::add);
+    return List.copyOf(requests);
+  }
+
+  private static Map<UUID, Instant> payoutTimes(List<RedemptionRequest> redemptionRequests) {
     Map<UUID, Instant> byRequestId = new HashMap<>();
-    redemptionRequestRepository
-        .findAllById(requestIds)
-        .forEach(
-            request -> {
-              if (request.getProcessedAt() != null) {
-                byRequestId.put(request.getId(), request.getProcessedAt());
-              }
-            });
+    redemptionRequests.forEach(
+        request -> {
+          if (request.getProcessedAt() != null) {
+            byRequestId.put(request.getId(), request.getProcessedAt());
+          }
+        });
     return Map.copyOf(byRequestId);
   }
 
+  private static Map<UUID, String> payoutIbans(List<RedemptionRequest> redemptionRequests) {
+    Map<UUID, String> byRequestId = new HashMap<>();
+    redemptionRequests.forEach(
+        request -> {
+          if (request.getCustomerIban() != null) {
+            byRequestId.put(request.getId(), request.getCustomerIban());
+          }
+        });
+    return Map.copyOf(byRequestId);
+  }
+
+  private Map<UUID, String> payerIbans(List<LedgerEntry> subscriptionEntries, PartyId partyId) {
+    if (externalReferences(subscriptionEntries).isEmpty()) {
+      return Map.of();
+    }
+
+    Map<UUID, String> byPaymentId = new HashMap<>();
+    savingFundPaymentRepository
+        .findPayments(partyId)
+        .forEach(
+            payment -> {
+              if (payment.getId() != null && payment.getRemitterIban() != null) {
+                byPaymentId.put(payment.getId(), payment.getRemitterIban());
+              }
+            });
+    return Map.copyOf(byPaymentId);
+  }
+
+  private static Set<UUID> externalReferences(List<LedgerEntry> entries) {
+    return entries.stream()
+        .map(entry -> entry.getTransaction().getExternalReference())
+        .filter(Objects::nonNull)
+        .collect(toSet());
+  }
+
   private Transaction toTransaction(
-      LedgerEntry entry, CashFlow.Type type, String isin, Map<UUID, Instant> payoutTimes) {
+      LedgerEntry entry,
+      CashFlow.Type type,
+      String isin,
+      Map<UUID, Instant> payoutTimes,
+      Map<UUID, String> counterpartyIbans) {
     LedgerTransaction ledgerTransaction = entry.getTransaction();
     UUID externalReference = ledgerTransaction.getExternalReference();
 
@@ -111,6 +158,8 @@ public class SavingsFundTransactionService {
         .time(ledgerTransaction.getTransactionDate())
         .priceTime(ledgerTransaction.getTransactionDate())
         .settledTime(externalReference == null ? null : payoutTimes.get(externalReference))
+        .counterpartyIban(
+            externalReference == null ? null : counterpartyIbans.get(externalReference))
         .isin(isin)
         .type(type)
         .units(require(ledgerTransaction.findUserFundUnits(), "fundUnits", ledgerTransaction))

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/SavingsFundTransactionService.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/SavingsFundTransactionService.java
@@ -65,7 +65,8 @@ public class SavingsFundTransactionService {
             .toList();
 
     List<LedgerEntry> redemptionEntries = entries(ownerCode, partyType, REDEMPTIONS);
-    List<RedemptionRequest> redemptionRequests = redemptionRequests(redemptionEntries);
+    List<RedemptionRequest> redemptionRequests =
+        redemptionRequests(redemptionEntries, person.toPartyId());
     Map<UUID, Instant> payoutTimes = payoutTimes(redemptionRequests);
     Map<UUID, String> payoutIbans = payoutIbans(redemptionRequests);
     List<Transaction> redemptions =
@@ -84,7 +85,8 @@ public class SavingsFundTransactionService {
         ledgerService.getPartyAccount(ownerCode, partyType, userAccount).getEntries());
   }
 
-  private List<RedemptionRequest> redemptionRequests(List<LedgerEntry> redemptionEntries) {
+  private List<RedemptionRequest> redemptionRequests(
+      List<LedgerEntry> redemptionEntries, PartyId partyId) {
     Set<UUID> requestIds = externalReferences(redemptionEntries);
 
     if (requestIds.isEmpty()) {
@@ -92,8 +94,20 @@ public class SavingsFundTransactionService {
     }
 
     List<RedemptionRequest> requests = new ArrayList<>();
-    redemptionRequestRepository.findAllById(requestIds).forEach(requests::add);
+    redemptionRequestRepository
+        .findAllById(requestIds)
+        .forEach(
+            request -> {
+              if (belongsTo(request, partyId)) {
+                requests.add(request);
+              }
+            });
     return List.copyOf(requests);
+  }
+
+  private static boolean belongsTo(RedemptionRequest request, PartyId partyId) {
+    return partyId.type() == request.getPartyType()
+        && partyId.code().equals(request.getPartyCode());
   }
 
   private static Map<UUID, Instant> payoutTimes(List<RedemptionRequest> redemptionRequests) {

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/TransactionsWithCounterparties.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/TransactionsWithCounterparties.java
@@ -1,0 +1,9 @@
+package ee.tuleva.onboarding.savings.fund;
+
+import ee.tuleva.onboarding.account.transaction.Transaction;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+public record TransactionsWithCounterparties(
+    List<Transaction> transactions, Map<UUID, String> counterpartyIbans) {}

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/taxreport/InvestmentAccount.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/taxreport/InvestmentAccount.java
@@ -5,7 +5,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
-import java.time.Instant;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -27,12 +26,4 @@ public class InvestmentAccount {
   @NotNull
   @Column(nullable = false)
   private String iban;
-
-  @NotNull
-  @Column(nullable = false, updatable = false)
-  private Instant createdAt;
-
-  @NotNull
-  @Column(nullable = false)
-  private Instant updatedAt;
 }

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/taxreport/InvestmentAccount.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/taxreport/InvestmentAccount.java
@@ -1,0 +1,38 @@
+package ee.tuleva.onboarding.savings.fund.taxreport;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import java.time.Instant;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "investment_account")
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Data
+public class InvestmentAccount {
+
+  @Id
+  @NotNull
+  @Column(nullable = false, updatable = false)
+  private String personalCode;
+
+  @NotNull
+  @Column(nullable = false)
+  private String iban;
+
+  @NotNull
+  @Column(nullable = false, updatable = false)
+  private Instant createdAt;
+
+  @NotNull
+  @Column(nullable = false)
+  private Instant updatedAt;
+}

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/taxreport/InvestmentAccountCommand.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/taxreport/InvestmentAccountCommand.java
@@ -1,0 +1,5 @@
+package ee.tuleva.onboarding.savings.fund.taxreport;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record InvestmentAccountCommand(@NotBlank String iban) {}

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/taxreport/InvestmentAccountCommand.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/taxreport/InvestmentAccountCommand.java
@@ -1,5 +1,5 @@
 package ee.tuleva.onboarding.savings.fund.taxreport;
 
-import jakarta.validation.constraints.NotBlank;
+import ee.tuleva.onboarding.capital.transfer.iban.ValidIban;
 
-public record InvestmentAccountCommand(@NotBlank String iban) {}
+public record InvestmentAccountCommand(@ValidIban String iban) {}

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/taxreport/InvestmentAccountController.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/taxreport/InvestmentAccountController.java
@@ -7,7 +7,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -38,14 +37,6 @@ public class InvestmentAccountController {
       @Valid @RequestBody InvestmentAccountCommand command) {
     return new InvestmentAccountResponse(
         investmentAccountService.declare(naturalPersonCodeOf(person), command.iban()).getIban());
-  }
-
-  @Operation(summary = "Take back a declared investment account")
-  @DeleteMapping("/savings-fund/investment-account")
-  public InvestmentAccountResponse forgetInvestmentAccount(
-      @AuthenticationPrincipal AuthenticatedPerson person) {
-    investmentAccountService.forget(naturalPersonCodeOf(person));
-    return new InvestmentAccountResponse(null);
   }
 
   private static String naturalPersonCodeOf(AuthenticatedPerson person) {

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/taxreport/InvestmentAccountController.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/taxreport/InvestmentAccountController.java
@@ -1,0 +1,59 @@
+package ee.tuleva.onboarding.savings.fund.taxreport;
+
+import ee.tuleva.onboarding.auth.principal.AuthenticatedPerson;
+import ee.tuleva.onboarding.error.exception.ErrorsResponseException;
+import ee.tuleva.onboarding.error.response.ErrorsResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/v1")
+@RequiredArgsConstructor
+public class InvestmentAccountController {
+
+  private static final String NOT_A_NATURAL_PERSON = "investmentAccount.naturalPersonOnly";
+
+  private final InvestmentAccountService investmentAccountService;
+
+  @Operation(summary = "Get the investment account someone has declared to us")
+  @GetMapping("/savings-fund/investment-account")
+  public InvestmentAccountResponse getInvestmentAccount(
+      @AuthenticationPrincipal AuthenticatedPerson person) {
+    return new InvestmentAccountResponse(
+        investmentAccountService.declaredIban(naturalPersonCodeOf(person)).orElse(null));
+  }
+
+  @Operation(summary = "Declare which account is an investment account")
+  @PutMapping("/savings-fund/investment-account")
+  public InvestmentAccountResponse declareInvestmentAccount(
+      @AuthenticationPrincipal AuthenticatedPerson person,
+      @Valid @RequestBody InvestmentAccountCommand command) {
+    return new InvestmentAccountResponse(
+        investmentAccountService.declare(naturalPersonCodeOf(person), command.iban()).getIban());
+  }
+
+  @Operation(summary = "Take back a declared investment account")
+  @DeleteMapping("/savings-fund/investment-account")
+  public InvestmentAccountResponse forgetInvestmentAccount(
+      @AuthenticationPrincipal AuthenticatedPerson person) {
+    investmentAccountService.forget(naturalPersonCodeOf(person));
+    return new InvestmentAccountResponse(null);
+  }
+
+  private static String naturalPersonCodeOf(AuthenticatedPerson person) {
+    if (person.isLegalEntity()) {
+      throw new ErrorsResponseException(
+          ErrorsResponse.ofSingleError(
+              NOT_A_NATURAL_PERSON, "Only a natural person can hold an investment account"));
+    }
+    return person.getRoleCode();
+  }
+}

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/taxreport/InvestmentAccountGains.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/taxreport/InvestmentAccountGains.java
@@ -3,12 +3,10 @@ package ee.tuleva.onboarding.savings.fund.taxreport;
 import java.math.BigDecimal;
 import java.util.List;
 import lombok.Builder;
-import org.jspecify.annotations.Nullable;
 
 @Builder
-public record SavingsFundTaxReport(
-    int year,
-    CostBasisMethod method,
+public record InvestmentAccountGains(
+    String iban,
     BigDecimal totalGain,
     List<RealisedGain> redemptions,
-    @Nullable InvestmentAccountGains investmentAccount) {}
+    boolean redeemedOutsideTheAccount) {}

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/taxreport/InvestmentAccountGains.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/taxreport/InvestmentAccountGains.java
@@ -1,12 +1,8 @@
 package ee.tuleva.onboarding.savings.fund.taxreport;
 
 import java.math.BigDecimal;
-import java.util.List;
 import lombok.Builder;
+import org.jspecify.annotations.Nullable;
 
 @Builder
-public record InvestmentAccountGains(
-    String iban,
-    BigDecimal totalGain,
-    List<RealisedGain> redemptions,
-    boolean redeemedOutsideTheAccount) {}
+public record InvestmentAccountGains(@Nullable BigDecimal totalGain) {}

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/taxreport/InvestmentAccountRepository.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/taxreport/InvestmentAccountRepository.java
@@ -1,0 +1,9 @@
+package ee.tuleva.onboarding.savings.fund.taxreport;
+
+import java.util.Optional;
+import org.springframework.data.repository.CrudRepository;
+
+interface InvestmentAccountRepository extends CrudRepository<InvestmentAccount, String> {
+
+  Optional<InvestmentAccount> findByPersonalCode(String personalCode);
+}

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/taxreport/InvestmentAccountRepository.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/taxreport/InvestmentAccountRepository.java
@@ -1,9 +1,5 @@
 package ee.tuleva.onboarding.savings.fund.taxreport;
 
-import java.util.Optional;
 import org.springframework.data.repository.CrudRepository;
 
-interface InvestmentAccountRepository extends CrudRepository<InvestmentAccount, String> {
-
-  Optional<InvestmentAccount> findByPersonalCode(String personalCode);
-}
+interface InvestmentAccountRepository extends CrudRepository<InvestmentAccount, String> {}

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/taxreport/InvestmentAccountRepository.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/taxreport/InvestmentAccountRepository.java
@@ -1,5 +1,36 @@
 package ee.tuleva.onboarding.savings.fund.taxreport;
 
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
-interface InvestmentAccountRepository extends CrudRepository<InvestmentAccount, String> {}
+interface InvestmentAccountRepository extends CrudRepository<InvestmentAccount, String> {
+
+  @Transactional
+  default void declareIban(String personalCode, String iban) {
+    if (updateIban(personalCode, iban) == 0 && insertIfAbsent(personalCode, iban) == 0) {
+      updateIban(personalCode, iban);
+    }
+  }
+
+  @Transactional
+  @Modifying(clearAutomatically = true, flushAutomatically = true)
+  @Query(
+      value = "UPDATE investment_account SET iban = :iban WHERE personal_code = :personalCode",
+      nativeQuery = true)
+  int updateIban(@Param("personalCode") String personalCode, @Param("iban") String iban);
+
+  @Transactional
+  @Modifying(clearAutomatically = true, flushAutomatically = true)
+  @Query(
+      value =
+          """
+          INSERT INTO investment_account (personal_code, iban)
+          VALUES (:personalCode, :iban)
+          ON CONFLICT DO NOTHING
+          """,
+      nativeQuery = true)
+  int insertIfAbsent(@Param("personalCode") String personalCode, @Param("iban") String iban);
+}

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/taxreport/InvestmentAccountResponse.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/taxreport/InvestmentAccountResponse.java
@@ -1,0 +1,5 @@
+package ee.tuleva.onboarding.savings.fund.taxreport;
+
+import org.jspecify.annotations.Nullable;
+
+public record InvestmentAccountResponse(@Nullable String iban) {}

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/taxreport/InvestmentAccountService.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/taxreport/InvestmentAccountService.java
@@ -3,8 +3,6 @@ package ee.tuleva.onboarding.savings.fund.taxreport;
 import ee.tuleva.onboarding.capital.transfer.iban.IbanValidator;
 import ee.tuleva.onboarding.error.exception.ErrorsResponseException;
 import ee.tuleva.onboarding.error.response.ErrorsResponse;
-import java.time.Clock;
-import java.time.Instant;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -17,12 +15,9 @@ public class InvestmentAccountService {
   private static final String INVALID_IBAN = "investmentAccount.iban.invalid";
 
   private final InvestmentAccountRepository investmentAccountRepository;
-  private final Clock clock;
 
   public Optional<String> declaredIban(String personalCode) {
-    return investmentAccountRepository
-        .findByPersonalCode(personalCode)
-        .map(InvestmentAccount::getIban);
+    return investmentAccountRepository.findById(personalCode).map(InvestmentAccount::getIban);
   }
 
   @Transactional
@@ -34,24 +29,6 @@ public class InvestmentAccountService {
           ErrorsResponse.ofSingleError(INVALID_IBAN, "Not a valid IBAN"));
     }
 
-    Instant now = clock.instant();
-    InvestmentAccount account =
-        investmentAccountRepository
-            .findByPersonalCode(personalCode)
-            .orElseGet(
-                () ->
-                    InvestmentAccount.builder().personalCode(personalCode).createdAt(now).build());
-
-    account.setIban(canonicalIban);
-    account.setUpdatedAt(now);
-
-    return investmentAccountRepository.save(account);
-  }
-
-  @Transactional
-  public void forget(String personalCode) {
-    investmentAccountRepository
-        .findByPersonalCode(personalCode)
-        .ifPresent(investmentAccountRepository::delete);
+    return investmentAccountRepository.save(new InvestmentAccount(personalCode, canonicalIban));
   }
 }

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/taxreport/InvestmentAccountService.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/taxreport/InvestmentAccountService.java
@@ -18,6 +18,9 @@ public class InvestmentAccountService {
 
   @Transactional
   public InvestmentAccount declare(String personalCode, String iban) {
+    if (!IbanValidator.isValid(iban)) {
+      throw new IllegalArgumentException("Invalid investment account iban");
+    }
     String canonicalIban = IbanValidator.canonicalize(iban);
     investmentAccountRepository.declareIban(personalCode, canonicalIban);
     return new InvestmentAccount(personalCode, canonicalIban);

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/taxreport/InvestmentAccountService.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/taxreport/InvestmentAccountService.java
@@ -1,8 +1,6 @@
 package ee.tuleva.onboarding.savings.fund.taxreport;
 
 import ee.tuleva.onboarding.capital.transfer.iban.IbanValidator;
-import ee.tuleva.onboarding.error.exception.ErrorsResponseException;
-import ee.tuleva.onboarding.error.response.ErrorsResponse;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -12,8 +10,6 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class InvestmentAccountService {
 
-  private static final String INVALID_IBAN = "investmentAccount.iban.invalid";
-
   private final InvestmentAccountRepository investmentAccountRepository;
 
   public Optional<String> declaredIban(String personalCode) {
@@ -22,13 +18,7 @@ public class InvestmentAccountService {
 
   @Transactional
   public InvestmentAccount declare(String personalCode, String iban) {
-    String canonicalIban = IbanValidator.canonicalize(iban);
-
-    if (!IbanValidator.isValid(canonicalIban)) {
-      throw new ErrorsResponseException(
-          ErrorsResponse.ofSingleError(INVALID_IBAN, "Not a valid IBAN"));
-    }
-
-    return investmentAccountRepository.save(new InvestmentAccount(personalCode, canonicalIban));
+    return investmentAccountRepository.save(
+        new InvestmentAccount(personalCode, IbanValidator.canonicalize(iban)));
   }
 }

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/taxreport/InvestmentAccountService.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/taxreport/InvestmentAccountService.java
@@ -18,7 +18,8 @@ public class InvestmentAccountService {
 
   @Transactional
   public InvestmentAccount declare(String personalCode, String iban) {
-    return investmentAccountRepository.save(
-        new InvestmentAccount(personalCode, IbanValidator.canonicalize(iban)));
+    String canonicalIban = IbanValidator.canonicalize(iban);
+    investmentAccountRepository.declareIban(personalCode, canonicalIban);
+    return new InvestmentAccount(personalCode, canonicalIban);
   }
 }

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/taxreport/InvestmentAccountService.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/taxreport/InvestmentAccountService.java
@@ -1,0 +1,57 @@
+package ee.tuleva.onboarding.savings.fund.taxreport;
+
+import ee.tuleva.onboarding.capital.transfer.iban.IbanValidator;
+import ee.tuleva.onboarding.error.exception.ErrorsResponseException;
+import ee.tuleva.onboarding.error.response.ErrorsResponse;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class InvestmentAccountService {
+
+  private static final String INVALID_IBAN = "investmentAccount.iban.invalid";
+
+  private final InvestmentAccountRepository investmentAccountRepository;
+  private final Clock clock;
+
+  public Optional<String> declaredIban(String personalCode) {
+    return investmentAccountRepository
+        .findByPersonalCode(personalCode)
+        .map(InvestmentAccount::getIban);
+  }
+
+  @Transactional
+  public InvestmentAccount declare(String personalCode, String iban) {
+    String canonicalIban = IbanValidator.canonicalize(iban);
+
+    if (!IbanValidator.isValid(canonicalIban)) {
+      throw new ErrorsResponseException(
+          ErrorsResponse.ofSingleError(INVALID_IBAN, "Not a valid IBAN"));
+    }
+
+    Instant now = clock.instant();
+    InvestmentAccount account =
+        investmentAccountRepository
+            .findByPersonalCode(personalCode)
+            .orElseGet(
+                () ->
+                    InvestmentAccount.builder().personalCode(personalCode).createdAt(now).build());
+
+    account.setIban(canonicalIban);
+    account.setUpdatedAt(now);
+
+    return investmentAccountRepository.save(account);
+  }
+
+  @Transactional
+  public void forget(String personalCode) {
+    investmentAccountRepository
+        .findByPersonalCode(personalCode)
+        .ifPresent(investmentAccountRepository::delete);
+  }
+}

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/taxreport/SavingsFundCostBasisCalculator.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/taxreport/SavingsFundCostBasisCalculator.java
@@ -1,8 +1,8 @@
 package ee.tuleva.onboarding.savings.fund.taxreport;
 
 import static ee.tuleva.onboarding.savings.fund.taxreport.CostBasisMethod.WEIGHTED_AVERAGE;
+import static ee.tuleva.onboarding.savings.fund.taxreport.TransactionOrder.ACQUISITIONS_FIRST_WITHIN_AN_INSTANT;
 import static java.math.RoundingMode.HALF_UP;
-import static java.util.Comparator.comparing;
 
 import ee.tuleva.onboarding.account.transaction.Transaction;
 import java.math.BigDecimal;
@@ -40,7 +40,7 @@ public class SavingsFundCostBasisCalculator {
 
     transactions.stream()
         .filter(transaction -> !dayOf(transaction.time()).isAfter(to))
-        .sorted(comparing(Transaction::time))
+        .sorted(ACQUISITIONS_FIRST_WITHIN_AN_INSTANT)
         .forEach(
             transaction -> {
               BigDecimal units = requireUnits(transaction);

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/taxreport/SavingsFundTaxReportService.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/taxreport/SavingsFundTaxReportService.java
@@ -105,9 +105,14 @@ public class SavingsFundTaxReportService {
       List<Transaction> ordinary,
       LocalDate to) {
     return transactions.stream()
+            .filter(transaction -> happenedBy(transaction, to))
             .allMatch(transaction -> counterpartyIbans.containsKey(transaction.id()))
         && holdsEnoughUnits(fromTheAccount, to)
         && holdsEnoughUnits(ordinary, to);
+  }
+
+  private static boolean happenedBy(Transaction transaction, LocalDate to) {
+    return !transaction.time().atZone(ESTONIAN_ZONE).toLocalDate().isAfter(to);
   }
 
   private static boolean holdsEnoughUnits(List<Transaction> transactions, LocalDate to) {
@@ -115,7 +120,7 @@ public class SavingsFundTaxReportService {
 
     for (Transaction transaction :
         transactions.stream().sorted(comparing(Transaction::time)).toList()) {
-      if (transaction.time().atZone(ESTONIAN_ZONE).toLocalDate().isAfter(to)) {
+      if (!happenedBy(transaction, to)) {
         continue;
       }
       BigDecimal units = requireUnits(transaction).abs();

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/taxreport/SavingsFundTaxReportService.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/taxreport/SavingsFundTaxReportService.java
@@ -5,12 +5,14 @@ import static java.util.Comparator.comparing;
 
 import ee.tuleva.onboarding.account.transaction.Transaction;
 import ee.tuleva.onboarding.auth.principal.AuthenticatedPerson;
+import ee.tuleva.onboarding.capital.transfer.iban.IbanValidator;
 import ee.tuleva.onboarding.savings.fund.SavingsFundTransactionService;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.Nullable;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -33,7 +35,7 @@ public class SavingsFundTaxReportService {
       return report(year, method, gainsOf(transactions, from, to, method), null);
     }
 
-    String iban = declaredIban.get();
+    String iban = IbanValidator.canonicalize(declaredIban.get());
     List<Transaction> investmentAccountTransactions = fundedFrom(transactions, iban, true);
     List<Transaction> ordinaryTransactions = fundedFrom(transactions, iban, false);
 
@@ -75,7 +77,7 @@ public class SavingsFundTaxReportService {
       int year,
       CostBasisMethod method,
       List<RealisedGain> redemptions,
-      InvestmentAccountGains investmentAccount) {
+      @Nullable InvestmentAccountGains investmentAccount) {
     return SavingsFundTaxReport.builder()
         .year(year)
         .method(method)
@@ -88,8 +90,14 @@ public class SavingsFundTaxReportService {
   private static List<Transaction> fundedFrom(
       List<Transaction> transactions, String iban, boolean fromTheAccount) {
     return transactions.stream()
-        .filter(transaction -> iban.equals(transaction.counterpartyIban()) == fromTheAccount)
+        .filter(transaction -> facedTheAccount(transaction, iban) == fromTheAccount)
         .toList();
+  }
+
+  private static boolean facedTheAccount(Transaction transaction, String canonicalIban) {
+    String counterpartyIban = transaction.counterpartyIban();
+    return counterpartyIban != null
+        && canonicalIban.equals(IbanValidator.canonicalize(counterpartyIban));
   }
 
   private static boolean holdsEnoughUnits(List<Transaction> transactions) {

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/taxreport/SavingsFundTaxReportService.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/taxreport/SavingsFundTaxReportService.java
@@ -7,11 +7,14 @@ import ee.tuleva.onboarding.account.transaction.Transaction;
 import ee.tuleva.onboarding.auth.principal.AuthenticatedPerson;
 import ee.tuleva.onboarding.capital.transfer.iban.IbanValidator;
 import ee.tuleva.onboarding.savings.fund.SavingsFundTransactionService;
+import ee.tuleva.onboarding.savings.fund.TransactionsWithCounterparties;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.jspecify.annotations.Nullable;
 import org.springframework.stereotype.Service;
@@ -30,7 +33,10 @@ public class SavingsFundTaxReportService {
   @Transactional(readOnly = true)
   public SavingsFundTaxReport getTaxReport(
       AuthenticatedPerson person, int year, CostBasisMethod method) {
-    List<Transaction> transactions = savingsFundTransactionService.getTransactions(person);
+    TransactionsWithCounterparties withCounterparties =
+        savingsFundTransactionService.getTransactionsWithCounterpartyIbans(person);
+    List<Transaction> transactions = withCounterparties.transactions();
+    Map<UUID, String> counterpartyIbans = withCounterparties.counterpartyIbans();
     LocalDate from = LocalDate.of(year, 1, 1);
     LocalDate to = LocalDate.of(year, 12, 31);
 
@@ -46,11 +52,15 @@ public class SavingsFundTaxReportService {
 
     String iban = IbanValidator.canonicalize(declared.get());
     List<Transaction> fromTheAccount =
-        transactions.stream().filter(transaction -> facedTheAccount(transaction, iban)).toList();
+        transactions.stream()
+            .filter(transaction -> facedTheAccount(transaction, iban, counterpartyIbans))
+            .toList();
     List<Transaction> ordinary =
-        transactions.stream().filter(transaction -> !facedTheAccount(transaction, iban)).toList();
+        transactions.stream()
+            .filter(transaction -> !facedTheAccount(transaction, iban, counterpartyIbans))
+            .toList();
 
-    if (!canBeSplit(transactions, fromTheAccount, ordinary, to)) {
+    if (!canBeSplit(transactions, counterpartyIbans, fromTheAccount, ordinary, to)) {
       return report(
           year,
           method,
@@ -82,17 +92,20 @@ public class SavingsFundTaxReportService {
         .build();
   }
 
-  private static boolean facedTheAccount(Transaction transaction, String iban) {
-    String counterpartyIban = transaction.counterpartyIban();
+  private static boolean facedTheAccount(
+      Transaction transaction, String iban, Map<UUID, String> counterpartyIbans) {
+    String counterpartyIban = counterpartyIbans.get(transaction.id());
     return counterpartyIban != null && iban.equals(IbanValidator.canonicalize(counterpartyIban));
   }
 
   private static boolean canBeSplit(
       List<Transaction> transactions,
+      Map<UUID, String> counterpartyIbans,
       List<Transaction> fromTheAccount,
       List<Transaction> ordinary,
       LocalDate to) {
-    return transactions.stream().allMatch(transaction -> transaction.counterpartyIban() != null)
+    return transactions.stream()
+            .allMatch(transaction -> counterpartyIbans.containsKey(transaction.id()))
         && holdsEnoughUnits(fromTheAccount, to)
         && holdsEnoughUnits(ordinary, to);
   }

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/taxreport/SavingsFundTaxReportService.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/taxreport/SavingsFundTaxReportService.java
@@ -8,6 +8,7 @@ import ee.tuleva.onboarding.savings.fund.SavingsFundTransactionService;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -17,20 +18,95 @@ public class SavingsFundTaxReportService {
 
   private final SavingsFundTransactionService savingsFundTransactionService;
   private final SavingsFundCostBasisCalculator costBasisCalculator;
+  private final InvestmentAccountService investmentAccountService;
 
   public SavingsFundTaxReport getTaxReport(
       AuthenticatedPerson person, int year, CostBasisMethod method) {
     List<Transaction> transactions = savingsFundTransactionService.getTransactions(person);
-    List<RealisedGain> redemptions =
-        costBasisCalculator.realisedGainsBetween(
-            transactions, LocalDate.of(year, 1, 1), LocalDate.of(year, 12, 31), method);
+    LocalDate from = LocalDate.of(year, 1, 1);
+    LocalDate to = LocalDate.of(year, 12, 31);
 
+    Optional<String> declaredIban = investmentAccountService.declaredIban(person.getRoleCode());
+
+    if (declaredIban.isEmpty()) {
+      return report(year, method, gainsOf(transactions, from, to, method), null);
+    }
+
+    String iban = declaredIban.get();
+    List<Transaction> investmentAccountTransactions = fundedFrom(transactions, iban, true);
+    List<Transaction> ordinaryTransactions = fundedFrom(transactions, iban, false);
+
+    if (!holdsEnoughUnits(investmentAccountTransactions)
+        || !holdsEnoughUnits(ordinaryTransactions)) {
+      return report(
+          year,
+          method,
+          gainsOf(transactions, from, to, method),
+          InvestmentAccountGains.builder()
+              .iban(iban)
+              .totalGain(BigDecimal.ZERO.setScale(2, HALF_UP))
+              .redemptions(List.of())
+              .redeemedOutsideTheAccount(true)
+              .build());
+    }
+
+    List<RealisedGain> investmentAccountGains =
+        gainsOf(investmentAccountTransactions, from, to, method);
+
+    return report(
+        year,
+        method,
+        gainsOf(ordinaryTransactions, from, to, method),
+        InvestmentAccountGains.builder()
+            .iban(iban)
+            .totalGain(sumOfGains(investmentAccountGains))
+            .redemptions(investmentAccountGains)
+            .redeemedOutsideTheAccount(false)
+            .build());
+  }
+
+  private List<RealisedGain> gainsOf(
+      List<Transaction> transactions, LocalDate from, LocalDate to, CostBasisMethod method) {
+    return costBasisCalculator.realisedGainsBetween(transactions, from, to, method);
+  }
+
+  private static SavingsFundTaxReport report(
+      int year,
+      CostBasisMethod method,
+      List<RealisedGain> redemptions,
+      InvestmentAccountGains investmentAccount) {
     return SavingsFundTaxReport.builder()
         .year(year)
         .method(method)
         .totalGain(sumOfGains(redemptions))
         .redemptions(redemptions)
+        .investmentAccount(investmentAccount)
         .build();
+  }
+
+  private static List<Transaction> fundedFrom(
+      List<Transaction> transactions, String iban, boolean fromTheAccount) {
+    return transactions.stream()
+        .filter(transaction -> iban.equals(transaction.counterpartyIban()) == fromTheAccount)
+        .toList();
+  }
+
+  private static boolean holdsEnoughUnits(List<Transaction> transactions) {
+    BigDecimal held = BigDecimal.ZERO;
+
+    for (Transaction transaction :
+        transactions.stream().sorted(java.util.Comparator.comparing(Transaction::time)).toList()) {
+      BigDecimal units = transaction.units();
+      if (units == null) {
+        return false;
+      }
+      held = transaction.isAcquisition() ? held.add(units.abs()) : held.subtract(units.abs());
+      if (held.signum() < 0) {
+        return false;
+      }
+    }
+
+    return true;
   }
 
   private static BigDecimal sumOfGains(List<RealisedGain> redemptions) {

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/taxreport/SavingsFundTaxReportService.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/taxreport/SavingsFundTaxReportService.java
@@ -1,7 +1,7 @@
 package ee.tuleva.onboarding.savings.fund.taxreport;
 
+import static ee.tuleva.onboarding.savings.fund.taxreport.TransactionOrder.ACQUISITIONS_FIRST_WITHIN_AN_INSTANT;
 import static java.math.RoundingMode.HALF_UP;
-import static java.util.Comparator.comparing;
 
 import ee.tuleva.onboarding.account.transaction.Transaction;
 import ee.tuleva.onboarding.auth.principal.AuthenticatedPerson;
@@ -119,7 +119,7 @@ public class SavingsFundTaxReportService {
     BigDecimal held = BigDecimal.ZERO;
 
     for (Transaction transaction :
-        transactions.stream().sorted(comparing(Transaction::time)).toList()) {
+        transactions.stream().sorted(ACQUISITIONS_FIRST_WITHIN_AN_INSTANT).toList()) {
       if (!happenedBy(transaction, to)) {
         continue;
       }

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/taxreport/SavingsFundTaxReportService.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/taxreport/SavingsFundTaxReportService.java
@@ -1,6 +1,7 @@
 package ee.tuleva.onboarding.savings.fund.taxreport;
 
 import static java.math.RoundingMode.HALF_UP;
+import static java.util.Comparator.comparing;
 
 import ee.tuleva.onboarding.account.transaction.Transaction;
 import ee.tuleva.onboarding.auth.principal.AuthenticatedPerson;
@@ -95,11 +96,8 @@ public class SavingsFundTaxReportService {
     BigDecimal held = BigDecimal.ZERO;
 
     for (Transaction transaction :
-        transactions.stream().sorted(java.util.Comparator.comparing(Transaction::time)).toList()) {
-      BigDecimal units = transaction.units();
-      if (units == null) {
-        return false;
-      }
+        transactions.stream().sorted(comparing(Transaction::time)).toList()) {
+      BigDecimal units = requireUnits(transaction);
       held = transaction.isAcquisition() ? held.add(units.abs()) : held.subtract(units.abs());
       if (held.signum() < 0) {
         return false;
@@ -107,6 +105,18 @@ public class SavingsFundTaxReportService {
     }
 
     return true;
+  }
+
+  private static BigDecimal requireUnits(Transaction transaction) {
+    BigDecimal units = transaction.units();
+
+    if (units == null) {
+      throw new IllegalStateException(
+          "Savings fund transaction missing units: id=%s, time=%s"
+              .formatted(transaction.id(), transaction.time()));
+    }
+
+    return units;
   }
 
   private static BigDecimal sumOfGains(List<RealisedGain> redemptions) {

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/taxreport/SavingsFundTaxReportService.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/taxreport/SavingsFundTaxReportService.java
@@ -8,21 +8,27 @@ import ee.tuleva.onboarding.auth.principal.AuthenticatedPerson;
 import ee.tuleva.onboarding.capital.transfer.iban.IbanValidator;
 import ee.tuleva.onboarding.savings.fund.SavingsFundTransactionService;
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.jspecify.annotations.Nullable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class SavingsFundTaxReportService {
 
+  private static final ZoneId ESTONIAN_ZONE = ZoneId.of("Europe/Tallinn");
+
   private final SavingsFundTransactionService savingsFundTransactionService;
   private final SavingsFundCostBasisCalculator costBasisCalculator;
   private final InvestmentAccountService investmentAccountService;
 
+  @Transactional(readOnly = true)
   public SavingsFundTaxReport getTaxReport(
       AuthenticatedPerson person, int year, CostBasisMethod method) {
     List<Transaction> transactions = savingsFundTransactionService.getTransactions(person);
@@ -39,8 +45,7 @@ public class SavingsFundTaxReportService {
     List<Transaction> investmentAccountTransactions = fundedFrom(transactions, iban, true);
     List<Transaction> ordinaryTransactions = fundedFrom(transactions, iban, false);
 
-    if (!holdsEnoughUnits(investmentAccountTransactions)
-        || !holdsEnoughUnits(ordinaryTransactions)) {
+    if (!canBeSplit(transactions, investmentAccountTransactions, ordinaryTransactions, to)) {
       return report(
           year,
           method,
@@ -98,6 +103,26 @@ public class SavingsFundTaxReportService {
     String counterpartyIban = transaction.counterpartyIban();
     return counterpartyIban != null
         && canonicalIban.equals(IbanValidator.canonicalize(counterpartyIban));
+  }
+
+  private static boolean canBeSplit(
+      List<Transaction> transactions,
+      List<Transaction> investmentAccountTransactions,
+      List<Transaction> ordinaryTransactions,
+      LocalDate to) {
+    return transactions.stream().noneMatch(transaction -> transaction.counterpartyIban() == null)
+        && holdsEnoughUnits(upTo(investmentAccountTransactions, to))
+        && holdsEnoughUnits(upTo(ordinaryTransactions, to));
+  }
+
+  private static List<Transaction> upTo(List<Transaction> transactions, LocalDate to) {
+    return transactions.stream()
+        .filter(transaction -> !dayOf(transaction.time()).isAfter(to))
+        .toList();
+  }
+
+  private static LocalDate dayOf(Instant time) {
+    return time.atZone(ESTONIAN_ZONE).toLocalDate();
   }
 
   private static boolean holdsEnoughUnits(List<Transaction> transactions) {

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/taxreport/SavingsFundTaxReportService.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/taxreport/SavingsFundTaxReportService.java
@@ -33,10 +33,6 @@ public class SavingsFundTaxReportService {
   @Transactional(readOnly = true)
   public SavingsFundTaxReport getTaxReport(
       AuthenticatedPerson person, int year, CostBasisMethod method) {
-    TransactionsWithCounterparties withCounterparties =
-        savingsFundTransactionService.getTransactionsWithCounterpartyIbans(person);
-    List<Transaction> transactions = withCounterparties.transactions();
-    Map<UUID, String> counterpartyIbans = withCounterparties.counterpartyIbans();
     LocalDate from = LocalDate.of(year, 1, 1);
     LocalDate to = LocalDate.of(year, 12, 31);
 
@@ -46,9 +42,15 @@ public class SavingsFundTaxReportService {
       return report(
           year,
           method,
-          costBasisCalculator.realisedGainsBetween(transactions, from, to, method),
+          costBasisCalculator.realisedGainsBetween(
+              savingsFundTransactionService.getTransactions(person), from, to, method),
           null);
     }
+
+    TransactionsWithCounterparties withCounterparties =
+        savingsFundTransactionService.getTransactionsWithCounterpartyIbans(person);
+    List<Transaction> transactions = withCounterparties.transactions();
+    Map<UUID, String> counterpartyIbans = withCounterparties.counterpartyIbans();
 
     String iban = IbanValidator.canonicalize(declared.get());
     List<Transaction> fromTheAccount =
@@ -106,9 +108,15 @@ public class SavingsFundTaxReportService {
       LocalDate to) {
     return transactions.stream()
             .filter(transaction -> happenedBy(transaction, to))
-            .allMatch(transaction -> counterpartyIbans.containsKey(transaction.id()))
+            .allMatch(transaction -> cameFromAKnownAccount(transaction, counterpartyIbans))
         && holdsEnoughUnits(fromTheAccount, to)
         && holdsEnoughUnits(ordinary, to);
+  }
+
+  private static boolean cameFromAKnownAccount(
+      Transaction transaction, Map<UUID, String> counterpartyIbans) {
+    String counterpartyIban = counterpartyIbans.get(transaction.id());
+    return counterpartyIban != null && IbanValidator.isValid(counterpartyIban);
   }
 
   private static boolean happenedBy(Transaction transaction, LocalDate to) {

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/taxreport/SavingsFundTaxReportService.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/taxreport/SavingsFundTaxReportService.java
@@ -8,7 +8,6 @@ import ee.tuleva.onboarding.auth.principal.AuthenticatedPerson;
 import ee.tuleva.onboarding.capital.transfer.iban.IbanValidator;
 import ee.tuleva.onboarding.savings.fund.SavingsFundTransactionService;
 import java.math.BigDecimal;
-import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.List;
@@ -35,47 +34,38 @@ public class SavingsFundTaxReportService {
     LocalDate from = LocalDate.of(year, 1, 1);
     LocalDate to = LocalDate.of(year, 12, 31);
 
-    Optional<String> declaredIban = investmentAccountService.declaredIban(person.getRoleCode());
+    Optional<String> declared = investmentAccountService.declaredIban(person.getRoleCode());
 
-    if (declaredIban.isEmpty()) {
-      return report(year, method, gainsOf(transactions, from, to, method), null);
-    }
-
-    String iban = IbanValidator.canonicalize(declaredIban.get());
-    List<Transaction> investmentAccountTransactions = fundedFrom(transactions, iban, true);
-    List<Transaction> ordinaryTransactions = fundedFrom(transactions, iban, false);
-
-    if (!canBeSplit(transactions, investmentAccountTransactions, ordinaryTransactions, to)) {
+    if (declared.isEmpty()) {
       return report(
           year,
           method,
-          gainsOf(transactions, from, to, method),
-          InvestmentAccountGains.builder()
-              .iban(iban)
-              .totalGain(BigDecimal.ZERO.setScale(2, HALF_UP))
-              .redemptions(List.of())
-              .redeemedOutsideTheAccount(true)
-              .build());
+          costBasisCalculator.realisedGainsBetween(transactions, from, to, method),
+          null);
     }
 
-    List<RealisedGain> investmentAccountGains =
-        gainsOf(investmentAccountTransactions, from, to, method);
+    String iban = IbanValidator.canonicalize(declared.get());
+    List<Transaction> fromTheAccount =
+        transactions.stream().filter(transaction -> facedTheAccount(transaction, iban)).toList();
+    List<Transaction> ordinary =
+        transactions.stream().filter(transaction -> !facedTheAccount(transaction, iban)).toList();
+
+    if (!canBeSplit(transactions, fromTheAccount, ordinary, to)) {
+      return report(
+          year,
+          method,
+          costBasisCalculator.realisedGainsBetween(transactions, from, to, method),
+          InvestmentAccountGains.builder().build());
+    }
+
+    List<RealisedGain> gainsFromTheAccount =
+        costBasisCalculator.realisedGainsBetween(fromTheAccount, from, to, method);
 
     return report(
         year,
         method,
-        gainsOf(ordinaryTransactions, from, to, method),
-        InvestmentAccountGains.builder()
-            .iban(iban)
-            .totalGain(sumOfGains(investmentAccountGains))
-            .redemptions(investmentAccountGains)
-            .redeemedOutsideTheAccount(false)
-            .build());
-  }
-
-  private List<RealisedGain> gainsOf(
-      List<Transaction> transactions, LocalDate from, LocalDate to, CostBasisMethod method) {
-    return costBasisCalculator.realisedGainsBetween(transactions, from, to, method);
+        costBasisCalculator.realisedGainsBetween(ordinary, from, to, method),
+        InvestmentAccountGains.builder().totalGain(sumOfGains(gainsFromTheAccount)).build());
   }
 
   private static SavingsFundTaxReport report(
@@ -92,46 +82,31 @@ public class SavingsFundTaxReportService {
         .build();
   }
 
-  private static List<Transaction> fundedFrom(
-      List<Transaction> transactions, String iban, boolean fromTheAccount) {
-    return transactions.stream()
-        .filter(transaction -> facedTheAccount(transaction, iban) == fromTheAccount)
-        .toList();
-  }
-
-  private static boolean facedTheAccount(Transaction transaction, String canonicalIban) {
+  private static boolean facedTheAccount(Transaction transaction, String iban) {
     String counterpartyIban = transaction.counterpartyIban();
-    return counterpartyIban != null
-        && canonicalIban.equals(IbanValidator.canonicalize(counterpartyIban));
+    return counterpartyIban != null && iban.equals(IbanValidator.canonicalize(counterpartyIban));
   }
 
   private static boolean canBeSplit(
       List<Transaction> transactions,
-      List<Transaction> investmentAccountTransactions,
-      List<Transaction> ordinaryTransactions,
+      List<Transaction> fromTheAccount,
+      List<Transaction> ordinary,
       LocalDate to) {
-    return transactions.stream().noneMatch(transaction -> transaction.counterpartyIban() == null)
-        && holdsEnoughUnits(upTo(investmentAccountTransactions, to))
-        && holdsEnoughUnits(upTo(ordinaryTransactions, to));
+    return transactions.stream().allMatch(transaction -> transaction.counterpartyIban() != null)
+        && holdsEnoughUnits(fromTheAccount, to)
+        && holdsEnoughUnits(ordinary, to);
   }
 
-  private static List<Transaction> upTo(List<Transaction> transactions, LocalDate to) {
-    return transactions.stream()
-        .filter(transaction -> !dayOf(transaction.time()).isAfter(to))
-        .toList();
-  }
-
-  private static LocalDate dayOf(Instant time) {
-    return time.atZone(ESTONIAN_ZONE).toLocalDate();
-  }
-
-  private static boolean holdsEnoughUnits(List<Transaction> transactions) {
+  private static boolean holdsEnoughUnits(List<Transaction> transactions, LocalDate to) {
     BigDecimal held = BigDecimal.ZERO;
 
     for (Transaction transaction :
         transactions.stream().sorted(comparing(Transaction::time)).toList()) {
-      BigDecimal units = requireUnits(transaction);
-      held = transaction.isAcquisition() ? held.add(units.abs()) : held.subtract(units.abs());
+      if (transaction.time().atZone(ESTONIAN_ZONE).toLocalDate().isAfter(to)) {
+        continue;
+      }
+      BigDecimal units = requireUnits(transaction).abs();
+      held = transaction.isAcquisition() ? held.add(units) : held.subtract(units);
       if (held.signum() < 0) {
         return false;
       }

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/taxreport/TransactionOrder.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/taxreport/TransactionOrder.java
@@ -1,0 +1,15 @@
+package ee.tuleva.onboarding.savings.fund.taxreport;
+
+import static java.util.Comparator.comparing;
+
+import ee.tuleva.onboarding.account.transaction.Transaction;
+import java.util.Comparator;
+
+final class TransactionOrder {
+
+  static final Comparator<Transaction> ACQUISITIONS_FIRST_WITHIN_AN_INSTANT =
+      comparing(Transaction::time)
+          .thenComparing(transaction -> transaction.isAcquisition() ? 0 : 1);
+
+  private TransactionOrder() {}
+}

--- a/src/main/resources/db/migration/V1_249__create_investment_account.sql
+++ b/src/main/resources/db/migration/V1_249__create_investment_account.sql
@@ -1,8 +1,6 @@
 CREATE TABLE investment_account
 (
-    personal_code TEXT        NOT NULL,
-    iban          TEXT        NOT NULL,
-    created_at    TIMESTAMPTZ NOT NULL,
-    updated_at    TIMESTAMPTZ NOT NULL,
+    personal_code TEXT NOT NULL,
+    iban          TEXT NOT NULL,
     CONSTRAINT investment_account_pk PRIMARY KEY (personal_code)
 );

--- a/src/main/resources/db/migration/V1_249__create_investment_account.sql
+++ b/src/main/resources/db/migration/V1_249__create_investment_account.sql
@@ -1,0 +1,8 @@
+CREATE TABLE investment_account
+(
+    personal_code TEXT        NOT NULL,
+    iban          TEXT        NOT NULL,
+    created_at    TIMESTAMPTZ NOT NULL,
+    updated_at    TIMESTAMPTZ NOT NULL,
+    CONSTRAINT investment_account_pk PRIMARY KEY (personal_code)
+);

--- a/src/test/groovy/ee/tuleva/onboarding/account/transaction/TransactionControllerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/account/transaction/TransactionControllerTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.math.BigDecimal;
@@ -59,5 +60,27 @@ class TransactionControllerTest {
               "nav": 1.0000
             }]
             """));
+  }
+
+  @Test
+  void keepsTheCounterpartyAccountOutOfTheTransactionList() throws Exception {
+    var transaction =
+        Transaction.builder()
+            .id(UUID.fromString("550e8400-e29b-41d4-a716-446655440000"))
+            .amount(new BigDecimal("100.00"))
+            .currency(EUR)
+            .time(Instant.parse("2025-02-01T10:00:00Z"))
+            .isin("EE0000003283")
+            .type(CONTRIBUTION_CASH)
+            .units(new BigDecimal("10.00000"))
+            .nav(new BigDecimal("1.0000"))
+            .build();
+
+    when(transactionService.getTransactions(any())).thenReturn(List.of(transaction));
+
+    mockMvc
+        .perform(get("/v1/transactions"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0].counterpartyIban").doesNotExist());
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/ledger/LedgerAccountFixture.java
+++ b/src/test/groovy/ee/tuleva/onboarding/ledger/LedgerAccountFixture.java
@@ -325,6 +325,7 @@ public class LedgerAccountFixture {
                   .id(UUID.randomUUID())
                   .transactionType(FUND_SUBSCRIPTION)
                   .transactionDate(entry.transactionDate())
+                  .externalReference(entry.externalReference())
                   .metadata(Map.of("navPerUnit", navPerUnit))
                   .build();
           transaction.addEntry(account, entry.amount().negate());

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/SavingFundPaymentRepositoryTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/SavingFundPaymentRepositoryTest.java
@@ -333,6 +333,24 @@ class SavingFundPaymentRepositoryTest {
   }
 
   @Test
+  void findAllById() {
+    var id1 = repository.savePaymentData(createPayment().externalId("1").build());
+    var id2 = repository.savePaymentData(createPayment().externalId("2").build());
+    repository.savePaymentData(createPayment().externalId("3").build());
+
+    assertThat(repository.findAllById(List.of(id1, id2, UUID.randomUUID())))
+        .extracting("id")
+        .containsExactlyInAnyOrder(id1, id2);
+  }
+
+  @Test
+  void findAllByIdWithoutIds() {
+    repository.savePaymentData(createPayment().build());
+
+    assertThat(repository.findAllById(List.of())).isEmpty();
+  }
+
+  @Test
   void returnReason() {
     var id = repository.savePaymentData(createPayment().build());
 

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/SavingFundPaymentUpsertionServiceIntegrationTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/SavingFundPaymentUpsertionServiceIntegrationTest.java
@@ -5,6 +5,7 @@ import static ee.tuleva.onboarding.banking.seb.Seb.SEB_GATEWAY_TIME_ZONE;
 import static ee.tuleva.onboarding.fund.TulevaFund.TKF100;
 import static ee.tuleva.onboarding.ledger.SystemAccount.FUND_INVESTMENT_CASH_CLEARING;
 import static ee.tuleva.onboarding.ledger.SystemAccount.INCOMING_PAYMENTS_CLEARING;
+import static java.util.stream.Collectors.toSet;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import ee.tuleva.onboarding.banking.BankAccounts;
@@ -20,8 +21,8 @@ import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
-import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -97,11 +98,14 @@ class SavingFundPaymentUpsertionServiceIntegrationTest {
 
   @Test
   void endToEnd_processesXmlAndStoresPaymentsInDatabase() {
+    // given
+    var paymentIdsBefore = paymentIdsBeforeProcessing();
+
     // when
     processXmlMessage(XML_TEMPLATE);
 
     // then
-    var payments = paymentsUnderTest("2025100112345-1");
+    var payments = paymentsCreatedFromXml(paymentIdsBefore, "EE157700771001802057", "Test payment");
     assertThat(payments).hasSize(1);
     var savedPayment = payments.getFirst();
     assertThat(savedPayment.getAmount()).isEqualByComparingTo(new BigDecimal("100.50"));
@@ -144,6 +148,7 @@ class SavingFundPaymentUpsertionServiceIntegrationTest {
             .receivedAt(NOW)
             .build();
     var savedSuccessMessage = bankingMessageRepository.save(successMessage);
+    var paymentIdsBefore = paymentIdsBeforeProcessing();
 
     // when
     eventPublisher.publishEvent(new ProcessBankMessagesRequested());
@@ -161,7 +166,7 @@ class SavingFundPaymentUpsertionServiceIntegrationTest {
     assertThat(successMessageAfter.getFailedAt()).isNull();
 
     // and only one payment should be created from the successful message
-    var payments = paymentsUnderTest("2025100112345-1");
+    var payments = paymentsCreatedFromXml(paymentIdsBefore, "EE157700771001802057", "Test payment");
     assertThat(payments).hasSize(1);
     assertThat(payments.getFirst().getExternalId()).isEqualTo("2025100112345-1");
   }
@@ -207,11 +212,15 @@ class SavingFundPaymentUpsertionServiceIntegrationTest {
             + "</BkToCstmrAcctRpt> "
             + "</Document>";
 
+    // and
+    var paymentIdsBefore = paymentIdsBeforeProcessing();
+
     // when
     processXmlMessage(debitXml);
 
     // then
-    var payments = paymentsUnderTest("2025100112346-1");
+    var payments =
+        paymentsCreatedFromXml(paymentIdsBefore, "EE442200221092874625", "Outgoing payment");
     assertThat(payments).hasSize(1);
     var savedPayment = payments.getFirst();
     assertThat(savedPayment.getAmount()).isEqualByComparingTo(new BigDecimal("-50.00"));
@@ -266,11 +275,16 @@ class SavingFundPaymentUpsertionServiceIntegrationTest {
             + "</BkToCstmrAcctRpt> "
             + "</Document>";
 
+    // and
+    var paymentIdsBefore = paymentIdsBeforeProcessing();
+
     // when
     processXmlMessage(withdrawalAccountXml);
 
     // then - payment is created and directly goes to PROCESSED status
-    var payments = paymentsUnderTest("2025100112348-1");
+    var payments =
+        paymentsCreatedFromXml(
+            paymentIdsBefore, "EE111222333444555666", "Payment to withdrawal account");
     assertThat(payments).hasSize(1);
     var savedPayment = payments.getFirst();
     assertThat(savedPayment.getAmount()).isEqualByComparingTo(new BigDecimal("200.00"));
@@ -318,11 +332,14 @@ class SavingFundPaymentUpsertionServiceIntegrationTest {
             + "</BkToCstmrAcctRpt> "
             + "</Document>";
 
+    // and
+    var paymentIdsBefore = paymentIdsBeforeProcessing();
+
     // when
     processXmlMessage(zeroAmountXml);
 
     // then
-    var payments = paymentsUnderTest("2025100112347-1");
+    var payments = paymentsCreatedFromXml(paymentIdsBefore, "EE888888888888888888", "Zero payment");
     assertThat(payments).hasSize(1);
     var savedPayment = payments.getFirst();
     assertThat(savedPayment.getAmount()).isEqualByComparingTo(BigDecimal.ZERO);
@@ -383,12 +400,15 @@ class SavingFundPaymentUpsertionServiceIntegrationTest {
         ledgerService.getSystemAccount(FUND_INVESTMENT_CASH_CLEARING, TKF100);
     var incomingPaymentsBalanceBefore = incomingPaymentsAccount.getBalance();
     var fundInvestmentBalanceBefore = fundInvestmentAccount.getBalance();
+    var paymentIdsBefore = paymentIdsBeforeProcessing();
 
     // when
     processXmlMessage(outgoingToInvestmentXml);
 
     // then - payment is created and marked as PROCESSED
-    var payments = paymentsUnderTest("2025100112350-1");
+    var payments =
+        paymentsCreatedFromXml(
+            paymentIdsBefore, "EE442200221092874625", "Transfer to investment account");
     assertThat(payments).hasSize(1);
     var savedPayment = payments.getFirst();
     assertThat(savedPayment.getAmount()).isEqualByComparingTo(new BigDecimal("-100.50"));
@@ -419,14 +439,15 @@ class SavingFundPaymentUpsertionServiceIntegrationTest {
               .externalId(null) // Montonio payment doesn't have externalId
               .build();
       var existingId = repository.savePaymentData(existingPayment);
+      var paymentIdsBefore = paymentIdsBeforeProcessing();
 
       // when - XML with same IBAN+description but with externalId
       processXmlMessage(XML_TEMPLATE);
 
       // then - existing payment is updated with externalId, not a new one created
-      var payments = paymentsUnderTest("2025100112345-1", existingId);
-      assertThat(payments).hasSize(1);
-      var updated = payments.getFirst();
+      assertThat(paymentsCreatedFromXml(paymentIdsBefore, "EE157700771001802057", "Test payment"))
+          .isEmpty();
+      var updated = repository.findByExternalId("2025100112345-1").orElseThrow();
       assertThat(updated.getId()).isEqualTo(existingId);
       assertThat(updated.getExternalId()).isEqualTo("2025100112345-1");
       assertThat(updated.getDescription()).isEqualTo("Test payment");
@@ -446,12 +467,14 @@ class SavingFundPaymentUpsertionServiceIntegrationTest {
               .build();
       var existingId = repository.savePaymentData(existingPayment);
       repository.changeStatus(existingId, SavingFundPayment.Status.RECEIVED);
+      var paymentIdsBefore = paymentIdsBeforeProcessing();
 
       // when - same XML arrives again (duplicate bank statement)
       processXmlMessage(XML_TEMPLATE);
 
       // then - no new payment is created, no update is performed (aborts early)
-      assertThat(paymentsUnderTest("2025100112345-1", existingId)).hasSize(1);
+      assertThat(paymentsCreatedFromXml(paymentIdsBefore, "EE157700771001802057", "Test payment"))
+          .isEmpty();
       var payment = repository.findByExternalId("2025100112345-1");
       assertThat(payment).isPresent();
       assertThat(payment.get().getId()).isEqualTo(existingId);
@@ -465,13 +488,15 @@ class SavingFundPaymentUpsertionServiceIntegrationTest {
       // given - existing payment with different IBAN but same description
       var existingPayment =
           paymentMatchingXmlTemplate().externalId(null).remitterIban("EE999DIFFERENT").build();
-      var existingId = repository.savePaymentData(existingPayment);
+      repository.savePaymentData(existingPayment);
+      var paymentIdsBefore = paymentIdsBeforeProcessing();
 
       // when - XML arrives with EE157700771001802057
       var messageId = processXmlMessage(XML_TEMPLATE);
 
       // then - new payment is created and message is processed
-      assertThat(paymentsUnderTest("2025100112345-1", existingId)).hasSize(2);
+      assertThat(paymentsCreatedFromXml(paymentIdsBefore, "EE157700771001802057", "Test payment"))
+          .hasSize(1);
       var message = bankingMessageRepository.findById(messageId).orElseThrow();
       assertThat(message.getProcessedAt()).isNotNull();
     }
@@ -484,13 +509,15 @@ class SavingFundPaymentUpsertionServiceIntegrationTest {
               .externalId(null)
               .description("Different description")
               .build();
-      var existingId = repository.savePaymentData(existingPayment);
+      repository.savePaymentData(existingPayment);
+      var paymentIdsBefore = paymentIdsBeforeProcessing();
 
       // when - XML arrives with "Test payment"
       processXmlMessage(XML_TEMPLATE);
 
       // then - new payment is created
-      assertThat(paymentsUnderTest("2025100112345-1", existingId)).hasSize(2);
+      assertThat(paymentsCreatedFromXml(paymentIdsBefore, "EE157700771001802057", "Test payment"))
+          .hasSize(1);
     }
 
     @Test
@@ -507,13 +534,15 @@ class SavingFundPaymentUpsertionServiceIntegrationTest {
               .externalId("existing-ext-id")
               .receivedBefore(Instant.parse("2025-09-30T10:00:00Z"))
               .build();
-      var existingId = repository.savePaymentData(existingPayment);
+      repository.savePaymentData(existingPayment);
+      var paymentIdsBefore = paymentIdsBeforeProcessing();
 
       // when - XML arrives
       processXmlMessage(XML_TEMPLATE);
 
       // then - new payment is created (existing one cannot be matched)
-      assertThat(paymentsUnderTest("2025100112345-1", existingId)).hasSize(2);
+      assertThat(paymentsCreatedFromXml(paymentIdsBefore, "EE157700771001802057", "Test payment"))
+          .hasSize(1);
     }
 
     @Test
@@ -521,13 +550,15 @@ class SavingFundPaymentUpsertionServiceIntegrationTest {
       // given - existing payment with different amount but same description
       var existingPayment =
           paymentMatchingXmlTemplate().externalId(null).amount(new BigDecimal("50.00")).build();
-      var existingId = repository.savePaymentData(existingPayment);
+      repository.savePaymentData(existingPayment);
+      var paymentIdsBefore = paymentIdsBeforeProcessing();
 
       // when - XML arrives with 100.50
       var messageId = processXmlMessage(XML_TEMPLATE);
 
       // then - new payment is created and message is processed
-      assertThat(paymentsUnderTest("2025100112345-1", existingId)).hasSize(2);
+      assertThat(paymentsCreatedFromXml(paymentIdsBefore, "EE157700771001802057", "Test payment"))
+          .hasSize(1);
       var message = bankingMessageRepository.findById(messageId).orElseThrow();
       assertThat(message.getProcessedAt()).isNotNull();
     }
@@ -538,14 +569,15 @@ class SavingFundPaymentUpsertionServiceIntegrationTest {
       var existingPayment =
           paymentMatchingXmlTemplate().externalId(null).remitterName("Kati Karu").build();
       var existingId = repository.savePaymentData(existingPayment);
+      var paymentIdsBefore = paymentIdsBeforeProcessing();
 
       // when - XML arrives with different remitterName
       var messageId = processXmlMessage(XML_TEMPLATE);
 
       // then - the bank statement name wins and the message is processed
-      var payments = paymentsUnderTest("2025100112345-1", existingId);
-      assertThat(payments).hasSize(1);
-      var updated = payments.getFirst();
+      assertThat(paymentsCreatedFromXml(paymentIdsBefore, "EE157700771001802057", "Test payment"))
+          .isEmpty();
+      var updated = repository.findByExternalId("2025100112345-1").orElseThrow();
       assertThat(updated.getId()).isEqualTo(existingId);
       assertThat(updated.getRemitterName()).isEqualTo("Jüri Tamm");
       var message = bankingMessageRepository.findById(messageId).orElseThrow();
@@ -583,12 +615,19 @@ class SavingFundPaymentUpsertionServiceIntegrationTest {
     }
   }
 
-  // Scopes assertions to the rows this test created, ignoring rows committed by other test classes
-  // sharing the database
-  private List<SavingFundPayment> paymentsUnderTest(String externalId, UUID... existingPaymentIds) {
-    var ids = new LinkedHashSet<>(List.of(existingPaymentIds));
-    repository.findByExternalId(externalId).map(SavingFundPayment::getId).ifPresent(ids::add);
-    return repository.findAllById(ids);
+  private Set<UUID> paymentIdsBeforeProcessing() {
+    return repository.findAll().stream().map(SavingFundPayment::getId).collect(toSet());
+  }
+
+  // Scopes assertions to the rows processing created from this test's XML entry, ignoring rows
+  // committed by other test classes sharing the database
+  private List<SavingFundPayment> paymentsCreatedFromXml(
+      Set<UUID> paymentIdsBeforeProcessing, String remitterIban, String description) {
+    return repository.findAll().stream()
+        .filter(payment -> !paymentIdsBeforeProcessing.contains(payment.getId()))
+        .filter(payment -> remitterIban.equals(payment.getRemitterIban()))
+        .filter(payment -> description.equals(payment.getDescription()))
+        .toList();
   }
 
   // Returns a builder with all fields matching XML_TEMPLATE

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/SavingFundPaymentUpsertionServiceIntegrationTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/SavingFundPaymentUpsertionServiceIntegrationTest.java
@@ -20,6 +20,8 @@ import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
+import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -99,8 +101,9 @@ class SavingFundPaymentUpsertionServiceIntegrationTest {
     processXmlMessage(XML_TEMPLATE);
 
     // then
-    assertThat(repository.findAll()).hasSize(1);
-    var savedPayment = repository.findAll().iterator().next();
+    var payments = paymentsUnderTest("2025100112345-1");
+    assertThat(payments).hasSize(1);
+    var savedPayment = payments.getFirst();
     assertThat(savedPayment.getAmount()).isEqualByComparingTo(new BigDecimal("100.50"));
     assertThat(savedPayment.getCurrency()).isEqualTo(Currency.EUR);
     assertThat(savedPayment.getDescription()).isEqualTo("Test payment");
@@ -158,9 +161,9 @@ class SavingFundPaymentUpsertionServiceIntegrationTest {
     assertThat(successMessageAfter.getFailedAt()).isNull();
 
     // and only one payment should be created from the successful message
-    assertThat(repository.findAll()).hasSize(1);
-    var savedPayment = repository.findAll().iterator().next();
-    assertThat(savedPayment.getExternalId()).isEqualTo("2025100112345-1");
+    var payments = paymentsUnderTest("2025100112345-1");
+    assertThat(payments).hasSize(1);
+    assertThat(payments.getFirst().getExternalId()).isEqualTo("2025100112345-1");
   }
 
   @Test
@@ -208,8 +211,9 @@ class SavingFundPaymentUpsertionServiceIntegrationTest {
     processXmlMessage(debitXml);
 
     // then
-    assertThat(repository.findAll()).hasSize(1);
-    var savedPayment = repository.findAll().iterator().next();
+    var payments = paymentsUnderTest("2025100112346-1");
+    assertThat(payments).hasSize(1);
+    var savedPayment = payments.getFirst();
     assertThat(savedPayment.getAmount()).isEqualByComparingTo(new BigDecimal("-50.00"));
     assertThat(savedPayment.getStatus()).isEqualTo(SavingFundPayment.Status.PROCESSED);
     assertThat(savedPayment.getDescription()).isEqualTo("Outgoing payment");
@@ -266,8 +270,9 @@ class SavingFundPaymentUpsertionServiceIntegrationTest {
     processXmlMessage(withdrawalAccountXml);
 
     // then - payment is created and directly goes to PROCESSED status
-    assertThat(repository.findAll()).hasSize(1);
-    var savedPayment = repository.findAll().iterator().next();
+    var payments = paymentsUnderTest("2025100112348-1");
+    assertThat(payments).hasSize(1);
+    var savedPayment = payments.getFirst();
     assertThat(savedPayment.getAmount()).isEqualByComparingTo(new BigDecimal("200.00"));
     assertThat(savedPayment.getStatus()).isEqualTo(SavingFundPayment.Status.PROCESSED);
   }
@@ -317,8 +322,9 @@ class SavingFundPaymentUpsertionServiceIntegrationTest {
     processXmlMessage(zeroAmountXml);
 
     // then
-    assertThat(repository.findAll()).hasSize(1);
-    var savedPayment = repository.findAll().iterator().next();
+    var payments = paymentsUnderTest("2025100112347-1");
+    assertThat(payments).hasSize(1);
+    var savedPayment = payments.getFirst();
     assertThat(savedPayment.getAmount()).isEqualByComparingTo(BigDecimal.ZERO);
     assertThat(savedPayment.getStatus()).isEqualTo(SavingFundPayment.Status.PROCESSED);
     assertThat(savedPayment.getDescription()).isEqualTo("Zero payment");
@@ -370,26 +376,31 @@ class SavingFundPaymentUpsertionServiceIntegrationTest {
             + "</BkToCstmrAcctRpt> "
             + "</Document>";
 
+    // and - the ledger balances before this payment is processed
+    var incomingPaymentsAccount =
+        ledgerService.getSystemAccount(INCOMING_PAYMENTS_CLEARING, TKF100);
+    var fundInvestmentAccount =
+        ledgerService.getSystemAccount(FUND_INVESTMENT_CASH_CLEARING, TKF100);
+    var incomingPaymentsBalanceBefore = incomingPaymentsAccount.getBalance();
+    var fundInvestmentBalanceBefore = fundInvestmentAccount.getBalance();
+
     // when
     processXmlMessage(outgoingToInvestmentXml);
 
     // then - payment is created and marked as PROCESSED
-    assertThat(repository.findAll()).hasSize(1);
-    var savedPayment = repository.findAll().getFirst();
+    var payments = paymentsUnderTest("2025100112350-1");
+    assertThat(payments).hasSize(1);
+    var savedPayment = payments.getFirst();
     assertThat(savedPayment.getAmount()).isEqualByComparingTo(new BigDecimal("-100.50"));
     assertThat(savedPayment.getStatus()).isEqualTo(SavingFundPayment.Status.PROCESSED);
     assertThat(savedPayment.getBeneficiaryIban()).isEqualTo(investmentIban);
 
     // and - ledger entry is created: INCOMING_PAYMENTS_CLEARING decreases,
     // FUND_INVESTMENT_CASH_CLEARING increases
-    var incomingPaymentsAccount =
-        ledgerService.getSystemAccount(INCOMING_PAYMENTS_CLEARING, TKF100);
-    var fundInvestmentAccount =
-        ledgerService.getSystemAccount(FUND_INVESTMENT_CASH_CLEARING, TKF100);
-
     assertThat(incomingPaymentsAccount.getBalance())
-        .isEqualByComparingTo(new BigDecimal("-100.50"));
-    assertThat(fundInvestmentAccount.getBalance()).isEqualByComparingTo(new BigDecimal("100.50"));
+        .isEqualByComparingTo(incomingPaymentsBalanceBefore.subtract(new BigDecimal("100.50")));
+    assertThat(fundInvestmentAccount.getBalance())
+        .isEqualByComparingTo(fundInvestmentBalanceBefore.add(new BigDecimal("100.50")));
   }
 
   @Nested
@@ -413,8 +424,9 @@ class SavingFundPaymentUpsertionServiceIntegrationTest {
       processXmlMessage(XML_TEMPLATE);
 
       // then - existing payment is updated with externalId, not a new one created
-      assertThat(repository.findAll()).hasSize(1);
-      var updated = repository.findAll().iterator().next();
+      var payments = paymentsUnderTest("2025100112345-1", existingId);
+      assertThat(payments).hasSize(1);
+      var updated = payments.getFirst();
       assertThat(updated.getId()).isEqualTo(existingId);
       assertThat(updated.getExternalId()).isEqualTo("2025100112345-1");
       assertThat(updated.getDescription()).isEqualTo("Test payment");
@@ -439,7 +451,7 @@ class SavingFundPaymentUpsertionServiceIntegrationTest {
       processXmlMessage(XML_TEMPLATE);
 
       // then - no new payment is created, no update is performed (aborts early)
-      assertThat(repository.findAll()).hasSize(1);
+      assertThat(paymentsUnderTest("2025100112345-1", existingId)).hasSize(1);
       var payment = repository.findByExternalId("2025100112345-1");
       assertThat(payment).isPresent();
       assertThat(payment.get().getId()).isEqualTo(existingId);
@@ -453,13 +465,13 @@ class SavingFundPaymentUpsertionServiceIntegrationTest {
       // given - existing payment with different IBAN but same description
       var existingPayment =
           paymentMatchingXmlTemplate().externalId(null).remitterIban("EE999DIFFERENT").build();
-      repository.savePaymentData(existingPayment);
+      var existingId = repository.savePaymentData(existingPayment);
 
       // when - XML arrives with EE157700771001802057
       var messageId = processXmlMessage(XML_TEMPLATE);
 
       // then - new payment is created and message is processed
-      assertThat(repository.findAll()).hasSize(2);
+      assertThat(paymentsUnderTest("2025100112345-1", existingId)).hasSize(2);
       var message = bankingMessageRepository.findById(messageId).orElseThrow();
       assertThat(message.getProcessedAt()).isNotNull();
     }
@@ -472,13 +484,13 @@ class SavingFundPaymentUpsertionServiceIntegrationTest {
               .externalId(null)
               .description("Different description")
               .build();
-      repository.savePaymentData(existingPayment);
+      var existingId = repository.savePaymentData(existingPayment);
 
       // when - XML arrives with "Test payment"
       processXmlMessage(XML_TEMPLATE);
 
       // then - new payment is created
-      assertThat(repository.findAll().size()).isEqualTo(2);
+      assertThat(paymentsUnderTest("2025100112345-1", existingId)).hasSize(2);
     }
 
     @Test
@@ -495,13 +507,13 @@ class SavingFundPaymentUpsertionServiceIntegrationTest {
               .externalId("existing-ext-id")
               .receivedBefore(Instant.parse("2025-09-30T10:00:00Z"))
               .build();
-      repository.savePaymentData(existingPayment);
+      var existingId = repository.savePaymentData(existingPayment);
 
       // when - XML arrives
       processXmlMessage(XML_TEMPLATE);
 
       // then - new payment is created (existing one cannot be matched)
-      assertThat(repository.findAll().size()).isEqualTo(2);
+      assertThat(paymentsUnderTest("2025100112345-1", existingId)).hasSize(2);
     }
 
     @Test
@@ -509,13 +521,13 @@ class SavingFundPaymentUpsertionServiceIntegrationTest {
       // given - existing payment with different amount but same description
       var existingPayment =
           paymentMatchingXmlTemplate().externalId(null).amount(new BigDecimal("50.00")).build();
-      repository.savePaymentData(existingPayment);
+      var existingId = repository.savePaymentData(existingPayment);
 
       // when - XML arrives with 100.50
       var messageId = processXmlMessage(XML_TEMPLATE);
 
       // then - new payment is created and message is processed
-      assertThat(repository.findAll()).hasSize(2);
+      assertThat(paymentsUnderTest("2025100112345-1", existingId)).hasSize(2);
       var message = bankingMessageRepository.findById(messageId).orElseThrow();
       assertThat(message.getProcessedAt()).isNotNull();
     }
@@ -531,8 +543,9 @@ class SavingFundPaymentUpsertionServiceIntegrationTest {
       var messageId = processXmlMessage(XML_TEMPLATE);
 
       // then - the bank statement name wins and the message is processed
-      assertThat(repository.findAll()).hasSize(1);
-      var updated = repository.findAll().iterator().next();
+      var payments = paymentsUnderTest("2025100112345-1", existingId);
+      assertThat(payments).hasSize(1);
+      var updated = payments.getFirst();
       assertThat(updated.getId()).isEqualTo(existingId);
       assertThat(updated.getRemitterName()).isEqualTo("Jüri Tamm");
       var message = bankingMessageRepository.findById(messageId).orElseThrow();
@@ -568,6 +581,14 @@ class SavingFundPaymentUpsertionServiceIntegrationTest {
       eventPublisher.publishEvent(new ProcessBankMessagesRequested());
       return saved.getId();
     }
+  }
+
+  // Scopes assertions to the rows this test created, ignoring rows committed by other test classes
+  // sharing the database
+  private List<SavingFundPayment> paymentsUnderTest(String externalId, UUID... existingPaymentIds) {
+    var ids = new LinkedHashSet<>(List.of(existingPaymentIds));
+    repository.findByExternalId(externalId).map(SavingFundPayment::getId).ifPresent(ids::add);
+    return repository.findAllById(ids);
   }
 
   // Returns a builder with all fields matching XML_TEMPLATE

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/SavingsFundTransactionServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/SavingsFundTransactionServiceTest.java
@@ -12,8 +12,10 @@ import static ee.tuleva.onboarding.ledger.UserAccount.REDEMPTIONS;
 import static ee.tuleva.onboarding.ledger.UserAccount.SUBSCRIPTIONS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.entry;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import ee.tuleva.onboarding.account.transaction.Transaction;
@@ -208,11 +210,11 @@ class SavingsFundTransactionServiceTest {
                     .remitterIban("EE123456789012345678")
                     .build()));
 
-    List<Transaction> transactions = service.getTransactions(person);
+    TransactionsWithCounterparties result = service.getTransactionsWithCounterpartyIbans(person);
 
-    assertThat(transactions)
-        .extracting(Transaction::counterpartyIban)
-        .containsExactly("EE123456789012345678");
+    assertThat(result.transactions()).hasSize(1);
+    assertThat(result.counterpartyIbans())
+        .containsExactly(entry(result.transactions().getFirst().id(), "EE123456789012345678"));
   }
 
   @Test
@@ -241,11 +243,86 @@ class SavingsFundTransactionServiceTest {
                     .customerIban("EE111111111111111111")
                     .build()));
 
+    TransactionsWithCounterparties result = service.getTransactionsWithCounterpartyIbans(person);
+
+    assertThat(result.transactions()).hasSize(1);
+    assertThat(result.counterpartyIbans())
+        .containsExactly(entry(result.transactions().getFirst().id(), "EE111111111111111111"));
+  }
+
+  @Test
+  void leavesOutTheAccountOfATransactionWeCannotTraceToOne() {
+    UUID requestId = UUID.randomUUID();
+    Instant bookingTime = Instant.parse("2025-03-01T10:00:00Z");
+
+    when(savingsFundOnboardingService.isOnboardingCompleted(any(PartyId.class))).thenReturn(true);
+    when(savingsFundConfiguration.getIsin()).thenReturn("EE0000003283");
+    when(ledgerService.getPartyAccount(personalCode, PERSON, SUBSCRIPTIONS))
+        .thenReturn(subscriptionsAccountWithBalance(BigDecimal.ZERO));
+    when(ledgerService.getPartyAccount(personalCode, PERSON, REDEMPTIONS))
+        .thenReturn(
+            redemptionsAccountWithEntries(
+                List.of(
+                    new EntryFixture(
+                        new BigDecimal("25.00"), bookingTime, new BigDecimal("10.0"), requestId))));
+    when(redemptionRequestRepository.findAllById(Set.of(requestId)))
+        .thenReturn(
+            List.of(
+                RedemptionRequest.builder()
+                    .id(requestId)
+                    .partyType(PartyId.Type.PERSON)
+                    .partyCode(personalCode)
+                    .build()));
+
+    TransactionsWithCounterparties result = service.getTransactionsWithCounterpartyIbans(person);
+
+    assertThat(result.transactions()).hasSize(1);
+    assertThat(result.counterpartyIbans()).isEmpty();
+  }
+
+  @Test
+  void doesNotLookUpCounterpartyAccountsForThePlainTransactionList() {
+    UUID paymentId = UUID.randomUUID();
+    UUID requestId = UUID.randomUUID();
+    Instant bookingTime = Instant.parse("2025-03-01T10:00:00Z");
+    Instant processedAt = Instant.parse("2025-03-05T09:00:00Z");
+
+    when(savingsFundOnboardingService.isOnboardingCompleted(any(PartyId.class))).thenReturn(true);
+    when(savingsFundConfiguration.getIsin()).thenReturn("EE0000003283");
+    when(ledgerService.getPartyAccount(personalCode, PERSON, SUBSCRIPTIONS))
+        .thenReturn(
+            subscriptionsAccountWithEntries(
+                List.of(
+                    new EntryFixture(
+                        new BigDecimal("100.00"),
+                        bookingTime,
+                        new BigDecimal("10.0"),
+                        paymentId))));
+    when(ledgerService.getPartyAccount(personalCode, PERSON, REDEMPTIONS))
+        .thenReturn(
+            redemptionsAccountWithEntries(
+                List.of(
+                    new EntryFixture(
+                        new BigDecimal("25.00"), bookingTime, new BigDecimal("10.0"), requestId))));
+    when(redemptionRequestRepository.findAllById(Set.of(requestId)))
+        .thenReturn(
+            List.of(
+                RedemptionRequest.builder()
+                    .id(requestId)
+                    .partyType(PartyId.Type.PERSON)
+                    .partyCode(personalCode)
+                    .customerIban("EE111111111111111111")
+                    .processedAt(processedAt)
+                    .build()));
+
     List<Transaction> transactions = service.getTransactions(person);
 
     assertThat(transactions)
-        .extracting(Transaction::counterpartyIban)
-        .containsExactly("EE111111111111111111");
+        .extracting(Transaction::amount, Transaction::settledTime)
+        .containsExactly(
+            tuple(new BigDecimal("100.00"), bookingTime),
+            tuple(new BigDecimal("-25.00"), processedAt));
+    verifyNoInteractions(savingFundPaymentRepository);
   }
 
   @Test
@@ -276,6 +353,8 @@ class SavingsFundTransactionServiceTest {
         .thenReturn(
             subscriptionsAccountWithoutFundUnits(
                 new EntryFixture(new BigDecimal("100.00"), Instant.parse("2025-01-15T10:00:00Z"))));
+    when(ledgerService.getPartyAccount(personalCode, PERSON, REDEMPTIONS))
+        .thenReturn(redemptionsAccountWithBalance(BigDecimal.ZERO));
 
     assertThatThrownBy(() -> service.getTransactions(person))
         .isInstanceOf(IllegalStateException.class);
@@ -289,6 +368,8 @@ class SavingsFundTransactionServiceTest {
         .thenReturn(
             subscriptionsAccountWithoutNavPerUnit(
                 new EntryFixture(new BigDecimal("100.00"), Instant.parse("2025-01-15T10:00:00Z"))));
+    when(ledgerService.getPartyAccount(personalCode, PERSON, REDEMPTIONS))
+        .thenReturn(redemptionsAccountWithBalance(BigDecimal.ZERO));
 
     assertThatThrownBy(() -> service.getTransactions(person))
         .isInstanceOf(IllegalStateException.class);

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/SavingsFundTransactionServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/SavingsFundTransactionServiceTest.java
@@ -205,14 +205,14 @@ class SavingsFundTransactionServiceTest {
             List.of(
                 SavingFundPayment.builder()
                     .id(paymentId)
-                    .remitterIban("EE471000001020145685")
+                    .remitterIban("EE123456789012345678")
                     .build()));
 
     List<Transaction> transactions = service.getTransactions(person);
 
     assertThat(transactions)
         .extracting(Transaction::counterpartyIban)
-        .containsExactly("EE471000001020145685");
+        .containsExactly("EE123456789012345678");
   }
 
   @Test
@@ -238,14 +238,14 @@ class SavingsFundTransactionServiceTest {
                     .id(requestId)
                     .partyType(PartyId.Type.PERSON)
                     .partyCode(personalCode)
-                    .customerIban("EE342200221020145685")
+                    .customerIban("EE111111111111111111")
                     .build()));
 
     List<Transaction> transactions = service.getTransactions(person);
 
     assertThat(transactions)
         .extracting(Transaction::counterpartyIban)
-        .containsExactly("EE342200221020145685");
+        .containsExactly("EE111111111111111111");
   }
 
   @Test

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/SavingsFundTransactionServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/SavingsFundTransactionServiceTest.java
@@ -42,6 +42,7 @@ class SavingsFundTransactionServiceTest {
   @Mock private SavingsFundOnboardingService savingsFundOnboardingService;
   @Mock private SavingsFundConfiguration savingsFundConfiguration;
   @Mock private RedemptionRequestRepository redemptionRequestRepository;
+  @Mock private SavingFundPaymentRepository savingFundPaymentRepository;
 
   @InjectMocks private SavingsFundTransactionService service;
 
@@ -178,6 +179,73 @@ class SavingsFundTransactionServiceTest {
             tuple(new BigDecimal("-10.00"), bookingTimeB, bookingTimeB),
             tuple(new BigDecimal("-15.00"), bookingTimeC, bookingTimeC),
             tuple(new BigDecimal("-25.00"), bookingTimeA, processedAtA));
+  }
+
+  @Test
+  void carriesTheAccountAPaymentCameFrom() {
+    String isin = "EE0000003283";
+    UUID paymentId = UUID.randomUUID();
+    Instant bookingTime = Instant.parse("2025-03-01T10:00:00Z");
+
+    when(savingsFundOnboardingService.isOnboardingCompleted(any(PartyId.class))).thenReturn(true);
+    when(savingsFundConfiguration.getIsin()).thenReturn(isin);
+    when(ledgerService.getPartyAccount(personalCode, PERSON, SUBSCRIPTIONS))
+        .thenReturn(
+            subscriptionsAccountWithEntries(
+                List.of(
+                    new EntryFixture(
+                        new BigDecimal("-100.00"),
+                        bookingTime,
+                        new BigDecimal("10.0"),
+                        paymentId))));
+    when(ledgerService.getPartyAccount(personalCode, PERSON, REDEMPTIONS))
+        .thenReturn(redemptionsAccountWithEntries(List.of()));
+    when(savingFundPaymentRepository.findPayments(any(PartyId.class)))
+        .thenReturn(
+            List.of(
+                SavingFundPayment.builder()
+                    .id(paymentId)
+                    .remitterIban("EE471000001020145685")
+                    .build()));
+
+    List<Transaction> transactions = service.getTransactions(person);
+
+    assertThat(transactions)
+        .extracting(Transaction::counterpartyIban)
+        .containsExactly("EE471000001020145685");
+  }
+
+  @Test
+  void carriesTheAccountARedemptionWasPaidTo() {
+    String isin = "EE0000003283";
+    UUID requestId = UUID.randomUUID();
+    Instant bookingTime = Instant.parse("2025-03-01T10:00:00Z");
+
+    when(savingsFundOnboardingService.isOnboardingCompleted(any(PartyId.class))).thenReturn(true);
+    when(savingsFundConfiguration.getIsin()).thenReturn(isin);
+    when(ledgerService.getPartyAccount(personalCode, PERSON, SUBSCRIPTIONS))
+        .thenReturn(subscriptionsAccountWithBalance(BigDecimal.ZERO));
+    when(ledgerService.getPartyAccount(personalCode, PERSON, REDEMPTIONS))
+        .thenReturn(
+            redemptionsAccountWithEntries(
+                List.of(
+                    new EntryFixture(
+                        new BigDecimal("25.00"), bookingTime, new BigDecimal("10.0"), requestId))));
+    when(redemptionRequestRepository.findAllById(Set.of(requestId)))
+        .thenReturn(
+            List.of(
+                RedemptionRequest.builder()
+                    .id(requestId)
+                    .partyType(PartyId.Type.PERSON)
+                    .partyCode("38888888888")
+                    .customerIban("EE342200221020145685")
+                    .build()));
+
+    List<Transaction> transactions = service.getTransactions(person);
+
+    assertThat(transactions)
+        .extracting(Transaction::counterpartyIban)
+        .containsExactly("EE342200221020145685");
   }
 
   @Test

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/SavingsFundTransactionServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/SavingsFundTransactionServiceTest.java
@@ -159,14 +159,14 @@ class SavingsFundTransactionServiceTest {
         RedemptionRequest.builder()
             .id(refA)
             .partyType(PartyId.Type.PERSON)
-            .partyCode("38888888888")
+            .partyCode(personalCode)
             .processedAt(processedAtA)
             .build();
     RedemptionRequest requestB =
         RedemptionRequest.builder()
             .id(refB)
             .partyType(PartyId.Type.PERSON)
-            .partyCode("38888888888")
+            .partyCode(personalCode)
             .build();
     when(redemptionRequestRepository.findAllById(Set.of(refA, refB, danglingRef)))
         .thenReturn(List.of(requestA, requestB));
@@ -237,7 +237,7 @@ class SavingsFundTransactionServiceTest {
                 RedemptionRequest.builder()
                     .id(requestId)
                     .partyType(PartyId.Type.PERSON)
-                    .partyCode("38888888888")
+                    .partyCode(personalCode)
                     .customerIban("EE342200221020145685")
                     .build()));
 

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/SavingsFundTransactionServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/SavingsFundTransactionServiceTest.java
@@ -202,11 +202,12 @@ class SavingsFundTransactionServiceTest {
                         paymentId))));
     when(ledgerService.getPartyAccount(personalCode, PERSON, REDEMPTIONS))
         .thenReturn(redemptionsAccountWithEntries(List.of()));
-    when(savingFundPaymentRepository.findPayments(any(PartyId.class)))
+    when(savingFundPaymentRepository.findAllById(Set.of(paymentId)))
         .thenReturn(
             List.of(
                 SavingFundPayment.builder()
                     .id(paymentId)
+                    .partyId(person.toPartyId())
                     .remitterIban("EE123456789012345678")
                     .build()));
 
@@ -215,6 +216,59 @@ class SavingsFundTransactionServiceTest {
     assertThat(result.transactions()).hasSize(1);
     assertThat(result.counterpartyIbans())
         .containsExactly(entry(result.transactions().getFirst().id(), "EE123456789012345678"));
+  }
+
+  @Test
+  void leavesOutTheAccountOfAPaymentBelongingToAnotherParty() {
+    UUID paymentId = UUID.randomUUID();
+    Instant bookingTime = Instant.parse("2025-03-01T10:00:00Z");
+
+    when(savingsFundOnboardingService.isOnboardingCompleted(any(PartyId.class))).thenReturn(true);
+    when(savingsFundConfiguration.getIsin()).thenReturn("EE0000003283");
+    when(ledgerService.getPartyAccount(personalCode, PERSON, SUBSCRIPTIONS))
+        .thenReturn(
+            subscriptionsAccountWithEntries(
+                List.of(
+                    new EntryFixture(
+                        new BigDecimal("-100.00"),
+                        bookingTime,
+                        new BigDecimal("10.0"),
+                        paymentId))));
+    when(ledgerService.getPartyAccount(personalCode, PERSON, REDEMPTIONS))
+        .thenReturn(redemptionsAccountWithEntries(List.of()));
+    when(savingFundPaymentRepository.findAllById(Set.of(paymentId)))
+        .thenReturn(
+            List.of(
+                SavingFundPayment.builder()
+                    .id(paymentId)
+                    .partyId(new PartyId(PartyId.Type.PERSON, "38888888888"))
+                    .remitterIban("EE123456789012345678")
+                    .build()));
+
+    TransactionsWithCounterparties result = service.getTransactionsWithCounterpartyIbans(person);
+
+    assertThat(result.transactions()).hasSize(1);
+    assertThat(result.counterpartyIbans()).isEmpty();
+  }
+
+  @Test
+  void doesNotLookUpPaymentsWhenNoSubscriptionCarriesAReference() {
+    Instant bookingTime = Instant.parse("2025-03-01T10:00:00Z");
+
+    when(savingsFundOnboardingService.isOnboardingCompleted(any(PartyId.class))).thenReturn(true);
+    when(savingsFundConfiguration.getIsin()).thenReturn("EE0000003283");
+    when(ledgerService.getPartyAccount(personalCode, PERSON, SUBSCRIPTIONS))
+        .thenReturn(
+            subscriptionsAccountWithEntries(
+                List.of(new EntryFixture(new BigDecimal("-100.00"), bookingTime))));
+    when(ledgerService.getPartyAccount(personalCode, PERSON, REDEMPTIONS))
+        .thenReturn(redemptionsAccountWithEntries(List.of()));
+
+    TransactionsWithCounterparties result = service.getTransactionsWithCounterpartyIbans(person);
+
+    assertThat(result.transactions()).hasSize(1);
+    assertThat(result.counterpartyIbans()).isEmpty();
+    verifyNoInteractions(savingFundPaymentRepository);
   }
 
   @Test

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/taxreport/InvestmentAccountControllerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/taxreport/InvestmentAccountControllerTest.java
@@ -3,8 +3,8 @@ package ee.tuleva.onboarding.savings.fund.taxreport;
 import static ee.tuleva.onboarding.auth.AuthenticatedPersonFixture.sampleAuthenticatedPersonNonMember;
 import static ee.tuleva.onboarding.auth.authority.Authority.USER;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -43,8 +43,8 @@ class InvestmentAccountControllerTest {
 
   @Test
   void answersWithNothingWhenNoAccountWasDeclared() throws Exception {
-    when(investmentAccountService.declaredIban(eq(authPerson.getRoleCode())))
-        .thenReturn(Optional.empty());
+    given(investmentAccountService.declaredIban(eq(authPerson.getRoleCode())))
+        .willReturn(Optional.empty());
 
     mvc.perform(get("/v1/savings-fund/investment-account").with(authentication(authentication)))
         .andExpect(status().isOk())
@@ -53,8 +53,8 @@ class InvestmentAccountControllerTest {
 
   @Test
   void answersWithTheDeclaredAccount() throws Exception {
-    when(investmentAccountService.declaredIban(eq(authPerson.getRoleCode())))
-        .thenReturn(Optional.of(IBAN));
+    given(investmentAccountService.declaredIban(eq(authPerson.getRoleCode())))
+        .willReturn(Optional.of(IBAN));
 
     mvc.perform(get("/v1/savings-fund/investment-account").with(authentication(authentication)))
         .andExpect(status().isOk())
@@ -63,8 +63,8 @@ class InvestmentAccountControllerTest {
 
   @Test
   void keepsTheAccountThatWasDeclared() throws Exception {
-    when(investmentAccountService.declare(eq(authPerson.getRoleCode()), eq(IBAN)))
-        .thenReturn(
+    given(investmentAccountService.declare(eq(authPerson.getRoleCode()), eq(IBAN)))
+        .willReturn(
             InvestmentAccount.builder().personalCode(authPerson.getRoleCode()).iban(IBAN).build());
 
     mvc.perform(

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/taxreport/InvestmentAccountControllerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/taxreport/InvestmentAccountControllerTest.java
@@ -30,7 +30,7 @@ import org.springframework.test.web.servlet.MockMvc;
 @AutoConfigureMockMvc
 class InvestmentAccountControllerTest {
 
-  private static final String IBAN = "EE471000001020145685";
+  private static final String IBAN = "EE651010220306497226";
 
   @Autowired private MockMvc mvc;
 
@@ -75,6 +75,19 @@ class InvestmentAccountControllerTest {
                 .with(csrf()))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.iban").value(IBAN));
+  }
+
+  @Test
+  void refusesAnAccountNumberThatIsNotOne() throws Exception {
+    mvc.perform(
+            put("/v1/savings-fund/investment-account")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"iban\":\"EE001\"}")
+                .with(authentication(authentication))
+                .with(csrf()))
+        .andExpect(status().isBadRequest());
+
+    verifyNoInteractions(investmentAccountService);
   }
 
   @Test

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/taxreport/InvestmentAccountControllerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/taxreport/InvestmentAccountControllerTest.java
@@ -1,0 +1,92 @@
+package ee.tuleva.onboarding.savings.fund.taxreport;
+
+import static ee.tuleva.onboarding.auth.AuthenticatedPersonFixture.sampleAuthenticatedPersonNonMember;
+import static ee.tuleva.onboarding.auth.authority.Authority.USER;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import ee.tuleva.onboarding.auth.principal.AuthenticatedPerson;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(InvestmentAccountController.class)
+@AutoConfigureMockMvc
+class InvestmentAccountControllerTest {
+
+  private static final String IBAN = "EE471000001020145685";
+
+  @Autowired private MockMvc mvc;
+
+  @MockitoBean private InvestmentAccountService investmentAccountService;
+
+  private final AuthenticatedPerson authPerson = sampleAuthenticatedPersonNonMember().build();
+  private final Authentication authentication =
+      new UsernamePasswordAuthenticationToken(
+          authPerson, null, List.of(new SimpleGrantedAuthority(USER)));
+
+  @Test
+  void answersWithNothingWhenNoAccountWasDeclared() throws Exception {
+    when(investmentAccountService.declaredIban(eq(authPerson.getRoleCode())))
+        .thenReturn(Optional.empty());
+
+    mvc.perform(get("/v1/savings-fund/investment-account").with(authentication(authentication)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.iban").doesNotExist());
+  }
+
+  @Test
+  void answersWithTheDeclaredAccount() throws Exception {
+    when(investmentAccountService.declaredIban(eq(authPerson.getRoleCode())))
+        .thenReturn(Optional.of(IBAN));
+
+    mvc.perform(get("/v1/savings-fund/investment-account").with(authentication(authentication)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.iban").value(IBAN));
+  }
+
+  @Test
+  void keepsTheAccountThatWasDeclared() throws Exception {
+    when(investmentAccountService.declare(eq(authPerson.getRoleCode()), eq(IBAN)))
+        .thenReturn(
+            InvestmentAccount.builder().personalCode(authPerson.getRoleCode()).iban(IBAN).build());
+
+    mvc.perform(
+            put("/v1/savings-fund/investment-account")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"iban\":\"" + IBAN + "\"}")
+                .with(authentication(authentication))
+                .with(csrf()))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.iban").value(IBAN));
+  }
+
+  @Test
+  void refusesAnEmptyAccountNumber() throws Exception {
+    mvc.perform(
+            put("/v1/savings-fund/investment-account")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"iban\":\"\"}")
+                .with(authentication(authentication))
+                .with(csrf()))
+        .andExpect(status().isBadRequest());
+
+    verifyNoInteractions(investmentAccountService);
+  }
+}

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/taxreport/InvestmentAccountRepositoryDeclareIbanTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/taxreport/InvestmentAccountRepositoryDeclareIbanTest.java
@@ -1,0 +1,43 @@
+package ee.tuleva.onboarding.savings.fund.taxreport;
+
+import static org.mockito.Answers.CALLS_REAL_METHODS;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class InvestmentAccountRepositoryDeclareIbanTest {
+
+  private static final String PERSONAL_CODE = "38888888888";
+  private static final String IBAN = "EE123456789012345678";
+
+  @Mock(answer = CALLS_REAL_METHODS)
+  private InvestmentAccountRepository investmentAccountRepository;
+
+  @Test
+  void updatesAgainWhenAnotherDeclarationInsertedTheAccountFirst() {
+    given(investmentAccountRepository.updateIban(PERSONAL_CODE, IBAN)).willReturn(0, 1);
+    given(investmentAccountRepository.insertIfAbsent(PERSONAL_CODE, IBAN)).willReturn(0);
+
+    investmentAccountRepository.declareIban(PERSONAL_CODE, IBAN);
+
+    verify(investmentAccountRepository, times(2)).updateIban(PERSONAL_CODE, IBAN);
+    verify(investmentAccountRepository).insertIfAbsent(PERSONAL_CODE, IBAN);
+  }
+
+  @Test
+  void insertsWhenNobodyDeclaredAnAccountYet() {
+    given(investmentAccountRepository.updateIban(PERSONAL_CODE, IBAN)).willReturn(0);
+    given(investmentAccountRepository.insertIfAbsent(PERSONAL_CODE, IBAN)).willReturn(1);
+
+    investmentAccountRepository.declareIban(PERSONAL_CODE, IBAN);
+
+    verify(investmentAccountRepository).updateIban(PERSONAL_CODE, IBAN);
+    verify(investmentAccountRepository).insertIfAbsent(PERSONAL_CODE, IBAN);
+  }
+}

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/taxreport/InvestmentAccountRepositoryTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/taxreport/InvestmentAccountRepositoryTest.java
@@ -1,0 +1,46 @@
+package ee.tuleva.onboarding.savings.fund.taxreport;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+
+@DataJpaTest
+class InvestmentAccountRepositoryTest {
+
+  private static final String PERSONAL_CODE = "38888888888";
+  private static final String IBAN = "EE123456789012345678";
+  private static final String ANOTHER_IBAN = "EE987654321098765432";
+
+  @Autowired private InvestmentAccountRepository investmentAccountRepository;
+
+  @Test
+  void declaresAnAccountForSomeoneWhoHasNoneYet() {
+    investmentAccountRepository.declareIban(PERSONAL_CODE, IBAN);
+
+    assertThat(investmentAccountRepository.findAll())
+        .containsExactly(new InvestmentAccount(PERSONAL_CODE, IBAN));
+  }
+
+  @Test
+  void replacesThePreviouslyDeclaredAccount() {
+    investmentAccountRepository.declareIban(PERSONAL_CODE, IBAN);
+
+    investmentAccountRepository.declareIban(PERSONAL_CODE, ANOTHER_IBAN);
+
+    assertThat(investmentAccountRepository.findAll())
+        .containsExactly(new InvestmentAccount(PERSONAL_CODE, ANOTHER_IBAN));
+  }
+
+  @Test
+  void insertsNothingWhenAnotherDeclarationWonTheRace() {
+    investmentAccountRepository.declareIban(PERSONAL_CODE, IBAN);
+
+    int inserted = investmentAccountRepository.insertIfAbsent(PERSONAL_CODE, ANOTHER_IBAN);
+
+    assertThat(inserted).isZero();
+    assertThat(investmentAccountRepository.findAll())
+        .containsExactly(new InvestmentAccount(PERSONAL_CODE, IBAN));
+  }
+}

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/taxreport/InvestmentAccountServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/taxreport/InvestmentAccountServiceTest.java
@@ -1,8 +1,8 @@
 package ee.tuleva.onboarding.savings.fund.taxreport;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
 
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -35,23 +35,18 @@ class InvestmentAccountServiceTest {
 
   @Test
   void keepsTheAccountThatWasDeclared() {
-    given(investmentAccountRepository.save(any(InvestmentAccount.class)))
-        .willAnswer(invocation -> invocation.getArgument(0));
-
     InvestmentAccount declared = investmentAccountService.declare(PERSONAL_CODE, IBAN);
 
-    assertThat(declared.getPersonalCode()).isEqualTo(PERSONAL_CODE);
-    assertThat(declared.getIban()).isEqualTo(IBAN);
+    assertThat(declared).isEqualTo(new InvestmentAccount(PERSONAL_CODE, IBAN));
+    then(investmentAccountRepository).should().declareIban(PERSONAL_CODE, IBAN);
   }
 
   @Test
   void writesAnAccountDownWithoutTheSpacesPeopleTypeIntoIt() {
-    given(investmentAccountRepository.save(any(InvestmentAccount.class)))
-        .willAnswer(invocation -> invocation.getArgument(0));
-
     InvestmentAccount declared =
         investmentAccountService.declare(PERSONAL_CODE, "ee12 3456 7890 1234 5678");
 
     assertThat(declared.getIban()).isEqualTo(IBAN);
+    then(investmentAccountRepository).should().declareIban(PERSONAL_CODE, IBAN);
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/taxreport/InvestmentAccountServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/taxreport/InvestmentAccountServiceTest.java
@@ -6,7 +6,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
 import ee.tuleva.onboarding.error.exception.ErrorsResponseException;
-import ee.tuleva.onboarding.time.TestClockHolder;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -26,14 +25,12 @@ class InvestmentAccountServiceTest {
 
   @BeforeEach
   void setUp() {
-    investmentAccountService =
-        new InvestmentAccountService(investmentAccountRepository, TestClockHolder.clock);
+    investmentAccountService = new InvestmentAccountService(investmentAccountRepository);
   }
 
   @Test
   void hasNoAccountUntilOneIsDeclared() {
-    given(investmentAccountRepository.findByPersonalCode(PERSONAL_CODE))
-        .willReturn(Optional.empty());
+    given(investmentAccountRepository.findById(PERSONAL_CODE)).willReturn(Optional.empty());
 
     assertThat(investmentAccountService.declaredIban(PERSONAL_CODE)).isEmpty();
   }
@@ -47,8 +44,6 @@ class InvestmentAccountServiceTest {
 
     assertThat(declared.getPersonalCode()).isEqualTo(PERSONAL_CODE);
     assertThat(declared.getIban()).isEqualTo(IBAN);
-    assertThat(declared.getCreatedAt()).isEqualTo(TestClockHolder.now);
-    assertThat(declared.getUpdatedAt()).isEqualTo(TestClockHolder.now);
   }
 
   @Test
@@ -67,26 +62,5 @@ class InvestmentAccountServiceTest {
     assertThatThrownBy(
             () -> investmentAccountService.declare(PERSONAL_CODE, "EE471000001020145686"))
         .isInstanceOf(ErrorsResponseException.class);
-  }
-
-  @Test
-  void keepsTheDayTheAccountWasFirstDeclaredWhenItChanges() {
-    InvestmentAccount existing =
-        InvestmentAccount.builder()
-            .personalCode(PERSONAL_CODE)
-            .iban("EE342200221020145685")
-            .createdAt(TestClockHolder.now.minusSeconds(86400))
-            .updatedAt(TestClockHolder.now.minusSeconds(86400))
-            .build();
-    given(investmentAccountRepository.findByPersonalCode(PERSONAL_CODE))
-        .willReturn(Optional.of(existing));
-    given(investmentAccountRepository.save(any(InvestmentAccount.class)))
-        .willAnswer(invocation -> invocation.getArgument(0));
-
-    InvestmentAccount declared = investmentAccountService.declare(PERSONAL_CODE, IBAN);
-
-    assertThat(declared.getIban()).isEqualTo(IBAN);
-    assertThat(declared.getCreatedAt()).isEqualTo(TestClockHolder.now.minusSeconds(86400));
-    assertThat(declared.getUpdatedAt()).isEqualTo(TestClockHolder.now);
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/taxreport/InvestmentAccountServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/taxreport/InvestmentAccountServiceTest.java
@@ -1,11 +1,9 @@
 package ee.tuleva.onboarding.savings.fund.taxreport;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
-import ee.tuleva.onboarding.error.exception.ErrorsResponseException;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -17,7 +15,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class InvestmentAccountServiceTest {
 
   private static final String PERSONAL_CODE = "38888888888";
-  private static final String IBAN = "EE471000001020145685";
+  private static final String IBAN = "EE123456789012345678";
 
   @Mock private InvestmentAccountRepository investmentAccountRepository;
 
@@ -52,15 +50,8 @@ class InvestmentAccountServiceTest {
         .willAnswer(invocation -> invocation.getArgument(0));
 
     InvestmentAccount declared =
-        investmentAccountService.declare(PERSONAL_CODE, "ee47 1000 0010 2014 5685");
+        investmentAccountService.declare(PERSONAL_CODE, "ee12 3456 7890 1234 5678");
 
     assertThat(declared.getIban()).isEqualTo(IBAN);
-  }
-
-  @Test
-  void refusesAnAccountNumberThatIsNotOne() {
-    assertThatThrownBy(
-            () -> investmentAccountService.declare(PERSONAL_CODE, "EE471000001020145686"))
-        .isInstanceOf(ErrorsResponseException.class);
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/taxreport/InvestmentAccountServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/taxreport/InvestmentAccountServiceTest.java
@@ -1,6 +1,7 @@
 package ee.tuleva.onboarding.savings.fund.taxreport;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 
@@ -15,7 +16,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class InvestmentAccountServiceTest {
 
   private static final String PERSONAL_CODE = "38888888888";
-  private static final String IBAN = "EE123456789012345678";
+  private static final String IBAN = "EE651010220306497226";
 
   @Mock private InvestmentAccountRepository investmentAccountRepository;
 
@@ -42,9 +43,17 @@ class InvestmentAccountServiceTest {
   }
 
   @Test
+  void refusesToDeclareAnAccountNumberThatIsNotAnIban() {
+    assertThatThrownBy(
+            () -> investmentAccountService.declare(PERSONAL_CODE, "EE123456789012345678"))
+        .isInstanceOf(IllegalArgumentException.class);
+    then(investmentAccountRepository).shouldHaveNoInteractions();
+  }
+
+  @Test
   void writesAnAccountDownWithoutTheSpacesPeopleTypeIntoIt() {
     InvestmentAccount declared =
-        investmentAccountService.declare(PERSONAL_CODE, "ee12 3456 7890 1234 5678");
+        investmentAccountService.declare(PERSONAL_CODE, "ee65 1010 2203 0649 7226");
 
     assertThat(declared.getIban()).isEqualTo(IBAN);
     then(investmentAccountRepository).should().declareIban(PERSONAL_CODE, IBAN);

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/taxreport/InvestmentAccountServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/taxreport/InvestmentAccountServiceTest.java
@@ -2,6 +2,7 @@ package ee.tuleva.onboarding.savings.fund.taxreport;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
 import ee.tuleva.onboarding.error.exception.ErrorsResponseException;
@@ -10,7 +11,6 @@ import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -40,7 +40,7 @@ class InvestmentAccountServiceTest {
 
   @Test
   void keepsTheAccountThatWasDeclared() {
-    given(investmentAccountRepository.save(ArgumentMatchers.any(InvestmentAccount.class)))
+    given(investmentAccountRepository.save(any(InvestmentAccount.class)))
         .willAnswer(invocation -> invocation.getArgument(0));
 
     InvestmentAccount declared = investmentAccountService.declare(PERSONAL_CODE, IBAN);
@@ -53,7 +53,7 @@ class InvestmentAccountServiceTest {
 
   @Test
   void writesAnAccountDownWithoutTheSpacesPeopleTypeIntoIt() {
-    given(investmentAccountRepository.save(ArgumentMatchers.any(InvestmentAccount.class)))
+    given(investmentAccountRepository.save(any(InvestmentAccount.class)))
         .willAnswer(invocation -> invocation.getArgument(0));
 
     InvestmentAccount declared =
@@ -80,7 +80,7 @@ class InvestmentAccountServiceTest {
             .build();
     given(investmentAccountRepository.findByPersonalCode(PERSONAL_CODE))
         .willReturn(Optional.of(existing));
-    given(investmentAccountRepository.save(ArgumentMatchers.any(InvestmentAccount.class)))
+    given(investmentAccountRepository.save(any(InvestmentAccount.class)))
         .willAnswer(invocation -> invocation.getArgument(0));
 
     InvestmentAccount declared = investmentAccountService.declare(PERSONAL_CODE, IBAN);

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/taxreport/InvestmentAccountServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/taxreport/InvestmentAccountServiceTest.java
@@ -1,0 +1,92 @@
+package ee.tuleva.onboarding.savings.fund.taxreport;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import ee.tuleva.onboarding.error.exception.ErrorsResponseException;
+import ee.tuleva.onboarding.time.TestClockHolder;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class InvestmentAccountServiceTest {
+
+  private static final String PERSONAL_CODE = "38888888888";
+  private static final String IBAN = "EE471000001020145685";
+
+  @Mock private InvestmentAccountRepository investmentAccountRepository;
+
+  private InvestmentAccountService investmentAccountService;
+
+  @BeforeEach
+  void setUp() {
+    investmentAccountService =
+        new InvestmentAccountService(investmentAccountRepository, TestClockHolder.clock);
+  }
+
+  @Test
+  void hasNoAccountUntilOneIsDeclared() {
+    given(investmentAccountRepository.findByPersonalCode(PERSONAL_CODE))
+        .willReturn(Optional.empty());
+
+    assertThat(investmentAccountService.declaredIban(PERSONAL_CODE)).isEmpty();
+  }
+
+  @Test
+  void keepsTheAccountThatWasDeclared() {
+    given(investmentAccountRepository.save(ArgumentMatchers.any(InvestmentAccount.class)))
+        .willAnswer(invocation -> invocation.getArgument(0));
+
+    InvestmentAccount declared = investmentAccountService.declare(PERSONAL_CODE, IBAN);
+
+    assertThat(declared.getPersonalCode()).isEqualTo(PERSONAL_CODE);
+    assertThat(declared.getIban()).isEqualTo(IBAN);
+    assertThat(declared.getCreatedAt()).isEqualTo(TestClockHolder.now);
+    assertThat(declared.getUpdatedAt()).isEqualTo(TestClockHolder.now);
+  }
+
+  @Test
+  void writesAnAccountDownWithoutTheSpacesPeopleTypeIntoIt() {
+    given(investmentAccountRepository.save(ArgumentMatchers.any(InvestmentAccount.class)))
+        .willAnswer(invocation -> invocation.getArgument(0));
+
+    InvestmentAccount declared =
+        investmentAccountService.declare(PERSONAL_CODE, "ee47 1000 0010 2014 5685");
+
+    assertThat(declared.getIban()).isEqualTo(IBAN);
+  }
+
+  @Test
+  void refusesAnAccountNumberThatIsNotOne() {
+    assertThatThrownBy(
+            () -> investmentAccountService.declare(PERSONAL_CODE, "EE471000001020145686"))
+        .isInstanceOf(ErrorsResponseException.class);
+  }
+
+  @Test
+  void keepsTheDayTheAccountWasFirstDeclaredWhenItChanges() {
+    InvestmentAccount existing =
+        InvestmentAccount.builder()
+            .personalCode(PERSONAL_CODE)
+            .iban("EE342200221020145685")
+            .createdAt(TestClockHolder.now.minusSeconds(86400))
+            .updatedAt(TestClockHolder.now.minusSeconds(86400))
+            .build();
+    given(investmentAccountRepository.findByPersonalCode(PERSONAL_CODE))
+        .willReturn(Optional.of(existing));
+    given(investmentAccountRepository.save(ArgumentMatchers.any(InvestmentAccount.class)))
+        .willAnswer(invocation -> invocation.getArgument(0));
+
+    InvestmentAccount declared = investmentAccountService.declare(PERSONAL_CODE, IBAN);
+
+    assertThat(declared.getIban()).isEqualTo(IBAN);
+    assertThat(declared.getCreatedAt()).isEqualTo(TestClockHolder.now.minusSeconds(86400));
+    assertThat(declared.getUpdatedAt()).isEqualTo(TestClockHolder.now);
+  }
+}

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/taxreport/SavingsFundTaxReportServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/taxreport/SavingsFundTaxReportServiceTest.java
@@ -111,6 +111,23 @@ class SavingsFundTaxReportServiceTest {
   }
 
   @Test
+  void recognisesTheDeclaredAccountHoweverTheBankSpacedIt() {
+    given(savingsFundTransactionService.getTransactions(person))
+        .willReturn(
+            List.of(
+                bought("2025-02-10T10:00:00Z", "100", "200.00", "ee47 1000 0010 2014 5685"),
+                sold("2025-07-10T10:00:00Z", "100", "260.00", INVESTMENT_IBAN)));
+    given(investmentAccountService.declaredIban(person.getRoleCode()))
+        .willReturn(Optional.of(INVESTMENT_IBAN));
+
+    SavingsFundTaxReport report = savingsFundTaxReportService.getTaxReport(person, 2025, FIFO);
+
+    assertThat(report.investmentAccount().redeemedOutsideTheAccount()).isFalse();
+    assertThat(report.investmentAccount().totalGain()).isEqualByComparingTo("60.00");
+    assertThat(report.totalGain()).isEqualByComparingTo("0.00");
+  }
+
+  @Test
   void doesNotPickAPoolForSomeoneWhoRedeemedToAnotherAccountThanTheyBoughtFrom() {
     given(savingsFundTransactionService.getTransactions(person))
         .willReturn(

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/taxreport/SavingsFundTaxReportServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/taxreport/SavingsFundTaxReportServiceTest.java
@@ -7,6 +7,8 @@ import static ee.tuleva.onboarding.epis.cashflows.CashFlow.Type.SUBTRACTION;
 import static ee.tuleva.onboarding.savings.fund.taxreport.CostBasisMethod.FIFO;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 import ee.tuleva.onboarding.account.transaction.Transaction;
 import ee.tuleva.onboarding.auth.principal.AuthenticatedPerson;
@@ -30,8 +32,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class SavingsFundTaxReportServiceTest {
 
-  private static final String INVESTMENT_IBAN = "EE123456789012345678";
-  private static final String ORDINARY_IBAN = "EE111111111111111111";
+  private static final String INVESTMENT_IBAN = "EE651010220306497226";
+  private static final String ORDINARY_IBAN = "EE241010220306719221";
 
   @Mock private SavingsFundTransactionService savingsFundTransactionService;
   @Mock private InvestmentAccountService investmentAccountService;
@@ -97,19 +99,19 @@ class SavingsFundTaxReportServiceTest {
   }
 
   @Test
-  void reportsOnePoolWhenNoInvestmentAccountWasDeclared() {
-    given(savingsFundTransactionService.getTransactionsWithCounterpartyIbans(person))
+  void reportsOnePoolWithoutLookingUpCounterpartiesWhenNoInvestmentAccountWasDeclared() {
+    given(savingsFundTransactionService.getTransactions(person))
         .willReturn(
-            new Statement()
-                .facing(bought("2025-01-10T10:00:00Z", "100", "100.00"), ORDINARY_IBAN)
-                .facing(sold("2025-06-10T10:00:00Z", "100", "150.00"), ORDINARY_IBAN)
-                .build());
+            List.of(
+                bought("2025-01-10T10:00:00Z", "100", "100.00"),
+                sold("2025-06-10T10:00:00Z", "100", "150.00")));
     given(investmentAccountService.declaredIban(person.getRoleCode())).willReturn(Optional.empty());
 
     SavingsFundTaxReport report = savingsFundTaxReportService.getTaxReport(person, 2025, FIFO);
 
     assertThat(report.totalGain()).isEqualByComparingTo("50.00");
     assertThat(report.investmentAccount()).isNull();
+    verify(savingsFundTransactionService, never()).getTransactionsWithCounterpartyIbans(person);
   }
 
   @Test
@@ -180,7 +182,9 @@ class SavingsFundTaxReportServiceTest {
     given(savingsFundTransactionService.getTransactionsWithCounterpartyIbans(person))
         .willReturn(
             new Statement()
-                .fromAnUnknownAccount(bought("2025-02-10T10:00:00Z", "100", "200.00"))
+                .facing(bought("2025-01-10T10:00:00Z", "100", "100.00"), ORDINARY_IBAN)
+                .facing(bought("2025-02-10T10:00:00Z", "100", "200.00"), INVESTMENT_IBAN)
+                .fromAnUnknownAccount(sold("2025-06-10T10:00:00Z", "100", "150.00"))
                 .facing(sold("2025-07-10T10:00:00Z", "100", "260.00"), INVESTMENT_IBAN)
                 .build());
     given(investmentAccountService.declaredIban(person.getRoleCode()))
@@ -189,6 +193,26 @@ class SavingsFundTaxReportServiceTest {
     SavingsFundTaxReport report = savingsFundTaxReportService.getTaxReport(person, 2025, FIFO);
 
     assertThat(report.investmentAccount().totalGain()).isNull();
+    assertThat(report.totalGain()).isEqualByComparingTo("110.00");
+  }
+
+  @Test
+  void doesNotCallATransactionOrdinaryJustBecauseItsAccountIsGarbled() {
+    given(savingsFundTransactionService.getTransactionsWithCounterpartyIbans(person))
+        .willReturn(
+            new Statement()
+                .facing(bought("2025-01-10T10:00:00Z", "100", "100.00"), ORDINARY_IBAN)
+                .facing(bought("2025-02-10T10:00:00Z", "100", "200.00"), INVESTMENT_IBAN)
+                .facing(sold("2025-06-10T10:00:00Z", "100", "150.00"), "NOT_AN_IBAN")
+                .facing(sold("2025-07-10T10:00:00Z", "100", "260.00"), INVESTMENT_IBAN)
+                .build());
+    given(investmentAccountService.declaredIban(person.getRoleCode()))
+        .willReturn(Optional.of(INVESTMENT_IBAN));
+
+    SavingsFundTaxReport report = savingsFundTaxReportService.getTaxReport(person, 2025, FIFO);
+
+    assertThat(report.investmentAccount().totalGain()).isNull();
+    assertThat(report.totalGain()).isEqualByComparingTo("110.00");
   }
 
   @Test
@@ -196,7 +220,7 @@ class SavingsFundTaxReportServiceTest {
     given(savingsFundTransactionService.getTransactionsWithCounterpartyIbans(person))
         .willReturn(
             new Statement()
-                .facing(bought("2025-02-10T10:00:00Z", "100", "200.00"), "ee12 3456 7890 1234 5678")
+                .facing(bought("2025-02-10T10:00:00Z", "100", "200.00"), "ee65 1010 2203 0649 7226")
                 .facing(sold("2025-07-10T10:00:00Z", "100", "260.00"), INVESTMENT_IBAN)
                 .build());
     given(investmentAccountService.declaredIban(person.getRoleCode()))

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/taxreport/SavingsFundTaxReportServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/taxreport/SavingsFundTaxReportServiceTest.java
@@ -10,10 +10,15 @@ import static org.mockito.BDDMockito.given;
 
 import ee.tuleva.onboarding.account.transaction.Transaction;
 import ee.tuleva.onboarding.auth.principal.AuthenticatedPerson;
+import ee.tuleva.onboarding.epis.cashflows.CashFlow;
 import ee.tuleva.onboarding.savings.fund.SavingsFundTransactionService;
+import ee.tuleva.onboarding.savings.fund.TransactionsWithCounterparties;
 import java.math.BigDecimal;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -44,20 +49,16 @@ class SavingsFundTaxReportServiceTest {
             investmentAccountService);
   }
 
-  private static Transaction bought(String time, String units, String amount, String iban) {
-    return transaction(time, units, amount, iban, CONTRIBUTION_CASH);
+  private static Transaction bought(String time, String units, String amount) {
+    return transaction(time, units, amount, CONTRIBUTION_CASH);
   }
 
-  private static Transaction sold(String time, String units, String amount, String iban) {
-    return transaction(time, units, amount, iban, SUBTRACTION);
+  private static Transaction sold(String time, String units, String amount) {
+    return transaction(time, units, amount, SUBTRACTION);
   }
 
   private static Transaction transaction(
-      String time,
-      String units,
-      String amount,
-      String iban,
-      ee.tuleva.onboarding.epis.cashflows.CashFlow.Type type) {
+      String time, String units, String amount, CashFlow.Type type) {
     Instant at = Instant.parse(time);
     return Transaction.builder()
         .id(UUID.randomUUID())
@@ -70,17 +71,39 @@ class SavingsFundTaxReportServiceTest {
         .type(type)
         .units(new BigDecimal(units))
         .nav(new BigDecimal("1.00"))
-        .counterpartyIban(iban)
         .build();
+  }
+
+  private static final class Statement {
+
+    private final List<Transaction> transactions = new ArrayList<>();
+    private final Map<UUID, String> counterpartyIbans = new HashMap<>();
+
+    Statement facing(Transaction transaction, String iban) {
+      transactions.add(transaction);
+      counterpartyIbans.put(transaction.id(), iban);
+      return this;
+    }
+
+    Statement fromAnUnknownAccount(Transaction transaction) {
+      transactions.add(transaction);
+      return this;
+    }
+
+    TransactionsWithCounterparties build() {
+      return new TransactionsWithCounterparties(
+          List.copyOf(transactions), Map.copyOf(counterpartyIbans));
+    }
   }
 
   @Test
   void reportsOnePoolWhenNoInvestmentAccountWasDeclared() {
-    given(savingsFundTransactionService.getTransactions(person))
+    given(savingsFundTransactionService.getTransactionsWithCounterpartyIbans(person))
         .willReturn(
-            List.of(
-                bought("2025-01-10T10:00:00Z", "100", "100.00", ORDINARY_IBAN),
-                sold("2025-06-10T10:00:00Z", "100", "150.00", ORDINARY_IBAN)));
+            new Statement()
+                .facing(bought("2025-01-10T10:00:00Z", "100", "100.00"), ORDINARY_IBAN)
+                .facing(sold("2025-06-10T10:00:00Z", "100", "150.00"), ORDINARY_IBAN)
+                .build());
     given(investmentAccountService.declaredIban(person.getRoleCode())).willReturn(Optional.empty());
 
     SavingsFundTaxReport report = savingsFundTaxReportService.getTaxReport(person, 2025, FIFO);
@@ -91,13 +114,14 @@ class SavingsFundTaxReportServiceTest {
 
   @Test
   void keepsInvestmentAccountGainsOutOfTheGainsSomeoneDeclares() {
-    given(savingsFundTransactionService.getTransactions(person))
+    given(savingsFundTransactionService.getTransactionsWithCounterpartyIbans(person))
         .willReturn(
-            List.of(
-                bought("2025-01-10T10:00:00Z", "100", "100.00", ORDINARY_IBAN),
-                bought("2025-02-10T10:00:00Z", "100", "200.00", INVESTMENT_IBAN),
-                sold("2025-06-10T10:00:00Z", "100", "150.00", ORDINARY_IBAN),
-                sold("2025-07-10T10:00:00Z", "100", "260.00", INVESTMENT_IBAN)));
+            new Statement()
+                .facing(bought("2025-01-10T10:00:00Z", "100", "100.00"), ORDINARY_IBAN)
+                .facing(bought("2025-02-10T10:00:00Z", "100", "200.00"), INVESTMENT_IBAN)
+                .facing(sold("2025-06-10T10:00:00Z", "100", "150.00"), ORDINARY_IBAN)
+                .facing(sold("2025-07-10T10:00:00Z", "100", "260.00"), INVESTMENT_IBAN)
+                .build());
     given(investmentAccountService.declaredIban(person.getRoleCode()))
         .willReturn(Optional.of(INVESTMENT_IBAN));
 
@@ -111,13 +135,14 @@ class SavingsFundTaxReportServiceTest {
 
   @Test
   void leavesAClosedYearAloneWhenALaterRedemptionGoesElsewhere() {
-    given(savingsFundTransactionService.getTransactions(person))
+    given(savingsFundTransactionService.getTransactionsWithCounterpartyIbans(person))
         .willReturn(
-            List.of(
-                bought("2025-02-10T10:00:00Z", "100", "200.00", INVESTMENT_IBAN),
-                sold("2025-07-10T10:00:00Z", "100", "260.00", INVESTMENT_IBAN),
-                bought("2026-02-10T10:00:00Z", "100", "200.00", INVESTMENT_IBAN),
-                sold("2026-07-10T10:00:00Z", "100", "300.00", ORDINARY_IBAN)));
+            new Statement()
+                .facing(bought("2025-02-10T10:00:00Z", "100", "200.00"), INVESTMENT_IBAN)
+                .facing(sold("2025-07-10T10:00:00Z", "100", "260.00"), INVESTMENT_IBAN)
+                .facing(bought("2026-02-10T10:00:00Z", "100", "200.00"), INVESTMENT_IBAN)
+                .facing(sold("2026-07-10T10:00:00Z", "100", "300.00"), ORDINARY_IBAN)
+                .build());
     given(investmentAccountService.declaredIban(person.getRoleCode()))
         .willReturn(Optional.of(INVESTMENT_IBAN));
 
@@ -130,11 +155,12 @@ class SavingsFundTaxReportServiceTest {
 
   @Test
   void doesNotCallATransactionOrdinaryJustBecauseItsAccountIsUnknown() {
-    given(savingsFundTransactionService.getTransactions(person))
+    given(savingsFundTransactionService.getTransactionsWithCounterpartyIbans(person))
         .willReturn(
-            List.of(
-                bought("2025-02-10T10:00:00Z", "100", "200.00", null),
-                sold("2025-07-10T10:00:00Z", "100", "260.00", INVESTMENT_IBAN)));
+            new Statement()
+                .fromAnUnknownAccount(bought("2025-02-10T10:00:00Z", "100", "200.00"))
+                .facing(sold("2025-07-10T10:00:00Z", "100", "260.00"), INVESTMENT_IBAN)
+                .build());
     given(investmentAccountService.declaredIban(person.getRoleCode()))
         .willReturn(Optional.of(INVESTMENT_IBAN));
 
@@ -145,11 +171,12 @@ class SavingsFundTaxReportServiceTest {
 
   @Test
   void recognisesTheDeclaredAccountHoweverTheBankSpacedIt() {
-    given(savingsFundTransactionService.getTransactions(person))
+    given(savingsFundTransactionService.getTransactionsWithCounterpartyIbans(person))
         .willReturn(
-            List.of(
-                bought("2025-02-10T10:00:00Z", "100", "200.00", "ee12 3456 7890 1234 5678"),
-                sold("2025-07-10T10:00:00Z", "100", "260.00", INVESTMENT_IBAN)));
+            new Statement()
+                .facing(bought("2025-02-10T10:00:00Z", "100", "200.00"), "ee12 3456 7890 1234 5678")
+                .facing(sold("2025-07-10T10:00:00Z", "100", "260.00"), INVESTMENT_IBAN)
+                .build());
     given(investmentAccountService.declaredIban(person.getRoleCode()))
         .willReturn(Optional.of(INVESTMENT_IBAN));
 
@@ -162,11 +189,12 @@ class SavingsFundTaxReportServiceTest {
 
   @Test
   void doesNotPickAPoolForSomeoneWhoRedeemedToAnotherAccountThanTheyBoughtFrom() {
-    given(savingsFundTransactionService.getTransactions(person))
+    given(savingsFundTransactionService.getTransactionsWithCounterpartyIbans(person))
         .willReturn(
-            List.of(
-                bought("2025-02-10T10:00:00Z", "100", "200.00", INVESTMENT_IBAN),
-                sold("2025-07-10T10:00:00Z", "100", "260.00", ORDINARY_IBAN)));
+            new Statement()
+                .facing(bought("2025-02-10T10:00:00Z", "100", "200.00"), INVESTMENT_IBAN)
+                .facing(sold("2025-07-10T10:00:00Z", "100", "260.00"), ORDINARY_IBAN)
+                .build());
     given(investmentAccountService.declaredIban(person.getRoleCode()))
         .willReturn(Optional.of(INVESTMENT_IBAN));
 

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/taxreport/SavingsFundTaxReportServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/taxreport/SavingsFundTaxReportServiceTest.java
@@ -154,6 +154,28 @@ class SavingsFundTaxReportServiceTest {
   }
 
   @Test
+  void leavesAClosedYearAloneWhenALaterTransactionFacesAnUnknownAccount() {
+    given(savingsFundTransactionService.getTransactionsWithCounterpartyIbans(person))
+        .willReturn(
+            new Statement()
+                .facing(bought("2025-01-10T10:00:00Z", "100", "100.00"), ORDINARY_IBAN)
+                .facing(bought("2025-02-10T10:00:00Z", "100", "200.00"), INVESTMENT_IBAN)
+                .facing(sold("2025-06-10T10:00:00Z", "100", "150.00"), ORDINARY_IBAN)
+                .facing(sold("2025-07-10T10:00:00Z", "100", "260.00"), INVESTMENT_IBAN)
+                .fromAnUnknownAccount(bought("2026-03-10T10:00:00Z", "100", "300.00"))
+                .build());
+    given(investmentAccountService.declaredIban(person.getRoleCode()))
+        .willReturn(Optional.of(INVESTMENT_IBAN));
+
+    SavingsFundTaxReport report = savingsFundTaxReportService.getTaxReport(person, 2025, FIFO);
+
+    assertThat(report.investmentAccount().totalGain()).isNotNull();
+    assertThat(report.investmentAccount().totalGain()).isEqualByComparingTo("60.00");
+    assertThat(report.totalGain()).isEqualByComparingTo("50.00");
+    assertThat(report.redemptions()).hasSize(1);
+  }
+
+  @Test
   void doesNotCallATransactionOrdinaryJustBecauseItsAccountIsUnknown() {
     given(savingsFundTransactionService.getTransactionsWithCounterpartyIbans(person))
         .willReturn(

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/taxreport/SavingsFundTaxReportServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/taxreport/SavingsFundTaxReportServiceTest.java
@@ -111,6 +111,41 @@ class SavingsFundTaxReportServiceTest {
   }
 
   @Test
+  void leavesAClosedYearAloneWhenALaterRedemptionGoesElsewhere() {
+    given(savingsFundTransactionService.getTransactions(person))
+        .willReturn(
+            List.of(
+                bought("2025-02-10T10:00:00Z", "100", "200.00", INVESTMENT_IBAN),
+                sold("2025-07-10T10:00:00Z", "100", "260.00", INVESTMENT_IBAN),
+                bought("2026-02-10T10:00:00Z", "100", "200.00", INVESTMENT_IBAN),
+                sold("2026-07-10T10:00:00Z", "100", "300.00", ORDINARY_IBAN)));
+    given(investmentAccountService.declaredIban(person.getRoleCode()))
+        .willReturn(Optional.of(INVESTMENT_IBAN));
+
+    SavingsFundTaxReport report = savingsFundTaxReportService.getTaxReport(person, 2025, FIFO);
+
+    assertThat(report.investmentAccount().redeemedOutsideTheAccount()).isFalse();
+    assertThat(report.investmentAccount().totalGain()).isEqualByComparingTo("60.00");
+    assertThat(report.totalGain()).isEqualByComparingTo("0.00");
+  }
+
+  @Test
+  void doesNotCallATransactionOrdinaryJustBecauseItsAccountIsUnknown() {
+    given(savingsFundTransactionService.getTransactions(person))
+        .willReturn(
+            List.of(
+                bought("2025-02-10T10:00:00Z", "100", "200.00", null),
+                sold("2025-07-10T10:00:00Z", "100", "260.00", INVESTMENT_IBAN)));
+    given(investmentAccountService.declaredIban(person.getRoleCode()))
+        .willReturn(Optional.of(INVESTMENT_IBAN));
+
+    SavingsFundTaxReport report = savingsFundTaxReportService.getTaxReport(person, 2025, FIFO);
+
+    assertThat(report.investmentAccount().redeemedOutsideTheAccount()).isTrue();
+    assertThat(report.investmentAccount().redemptions()).isEmpty();
+  }
+
+  @Test
   void recognisesTheDeclaredAccountHoweverTheBankSpacedIt() {
     given(savingsFundTransactionService.getTransactions(person))
         .willReturn(

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/taxreport/SavingsFundTaxReportServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/taxreport/SavingsFundTaxReportServiceTest.java
@@ -25,8 +25,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class SavingsFundTaxReportServiceTest {
 
-  private static final String INVESTMENT_IBAN = "EE471000001020145685";
-  private static final String ORDINARY_IBAN = "EE342200221020145685";
+  private static final String INVESTMENT_IBAN = "EE123456789012345678";
+  private static final String ORDINARY_IBAN = "EE111111111111111111";
 
   @Mock private SavingsFundTransactionService savingsFundTransactionService;
   @Mock private InvestmentAccountService investmentAccountService;
@@ -148,7 +148,7 @@ class SavingsFundTaxReportServiceTest {
     given(savingsFundTransactionService.getTransactions(person))
         .willReturn(
             List.of(
-                bought("2025-02-10T10:00:00Z", "100", "200.00", "ee47 1000 0010 2014 5685"),
+                bought("2025-02-10T10:00:00Z", "100", "200.00", "ee12 3456 7890 1234 5678"),
                 sold("2025-07-10T10:00:00Z", "100", "260.00", INVESTMENT_IBAN)));
     given(investmentAccountService.declaredIban(person.getRoleCode()))
         .willReturn(Optional.of(INVESTMENT_IBAN));

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/taxreport/SavingsFundTaxReportServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/taxreport/SavingsFundTaxReportServiceTest.java
@@ -105,9 +105,8 @@ class SavingsFundTaxReportServiceTest {
 
     assertThat(report.totalGain()).isEqualByComparingTo("50.00");
     assertThat(report.redemptions()).hasSize(1);
-    assertThat(report.investmentAccount().iban()).isEqualTo(INVESTMENT_IBAN);
     assertThat(report.investmentAccount().totalGain()).isEqualByComparingTo("60.00");
-    assertThat(report.investmentAccount().redeemedOutsideTheAccount()).isFalse();
+    assertThat(report.investmentAccount().totalGain()).isNotNull();
   }
 
   @Test
@@ -124,7 +123,7 @@ class SavingsFundTaxReportServiceTest {
 
     SavingsFundTaxReport report = savingsFundTaxReportService.getTaxReport(person, 2025, FIFO);
 
-    assertThat(report.investmentAccount().redeemedOutsideTheAccount()).isFalse();
+    assertThat(report.investmentAccount().totalGain()).isNotNull();
     assertThat(report.investmentAccount().totalGain()).isEqualByComparingTo("60.00");
     assertThat(report.totalGain()).isEqualByComparingTo("0.00");
   }
@@ -141,8 +140,7 @@ class SavingsFundTaxReportServiceTest {
 
     SavingsFundTaxReport report = savingsFundTaxReportService.getTaxReport(person, 2025, FIFO);
 
-    assertThat(report.investmentAccount().redeemedOutsideTheAccount()).isTrue();
-    assertThat(report.investmentAccount().redemptions()).isEmpty();
+    assertThat(report.investmentAccount().totalGain()).isNull();
   }
 
   @Test
@@ -157,7 +155,7 @@ class SavingsFundTaxReportServiceTest {
 
     SavingsFundTaxReport report = savingsFundTaxReportService.getTaxReport(person, 2025, FIFO);
 
-    assertThat(report.investmentAccount().redeemedOutsideTheAccount()).isFalse();
+    assertThat(report.investmentAccount().totalGain()).isNotNull();
     assertThat(report.investmentAccount().totalGain()).isEqualByComparingTo("60.00");
     assertThat(report.totalGain()).isEqualByComparingTo("0.00");
   }
@@ -175,7 +173,6 @@ class SavingsFundTaxReportServiceTest {
     SavingsFundTaxReport report = savingsFundTaxReportService.getTaxReport(person, 2025, FIFO);
 
     assertThat(report.totalGain()).isEqualByComparingTo("60.00");
-    assertThat(report.investmentAccount().redeemedOutsideTheAccount()).isTrue();
-    assertThat(report.investmentAccount().redemptions()).isEmpty();
+    assertThat(report.investmentAccount().totalGain()).isNull();
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/taxreport/SavingsFundTaxReportServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/taxreport/SavingsFundTaxReportServiceTest.java
@@ -1,0 +1,129 @@
+package ee.tuleva.onboarding.savings.fund.taxreport;
+
+import static ee.tuleva.onboarding.auth.AuthenticatedPersonFixture.sampleAuthenticatedPersonNonMember;
+import static ee.tuleva.onboarding.currency.Currency.EUR;
+import static ee.tuleva.onboarding.epis.cashflows.CashFlow.Type.CONTRIBUTION_CASH;
+import static ee.tuleva.onboarding.epis.cashflows.CashFlow.Type.SUBTRACTION;
+import static ee.tuleva.onboarding.savings.fund.taxreport.CostBasisMethod.FIFO;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import ee.tuleva.onboarding.account.transaction.Transaction;
+import ee.tuleva.onboarding.auth.principal.AuthenticatedPerson;
+import ee.tuleva.onboarding.savings.fund.SavingsFundTransactionService;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SavingsFundTaxReportServiceTest {
+
+  private static final String INVESTMENT_IBAN = "EE471000001020145685";
+  private static final String ORDINARY_IBAN = "EE342200221020145685";
+
+  @Mock private SavingsFundTransactionService savingsFundTransactionService;
+  @Mock private InvestmentAccountService investmentAccountService;
+
+  private final AuthenticatedPerson person = sampleAuthenticatedPersonNonMember().build();
+
+  private SavingsFundTaxReportService savingsFundTaxReportService;
+
+  @BeforeEach
+  void setUp() {
+    savingsFundTaxReportService =
+        new SavingsFundTaxReportService(
+            savingsFundTransactionService,
+            new SavingsFundCostBasisCalculator(),
+            investmentAccountService);
+  }
+
+  private static Transaction bought(String time, String units, String amount, String iban) {
+    return transaction(time, units, amount, iban, CONTRIBUTION_CASH);
+  }
+
+  private static Transaction sold(String time, String units, String amount, String iban) {
+    return transaction(time, units, amount, iban, SUBTRACTION);
+  }
+
+  private static Transaction transaction(
+      String time,
+      String units,
+      String amount,
+      String iban,
+      ee.tuleva.onboarding.epis.cashflows.CashFlow.Type type) {
+    Instant at = Instant.parse(time);
+    return Transaction.builder()
+        .id(UUID.randomUUID())
+        .amount(new BigDecimal(amount))
+        .currency(EUR)
+        .time(at)
+        .priceTime(at)
+        .settledTime(at)
+        .isin("EE0000003283")
+        .type(type)
+        .units(new BigDecimal(units))
+        .nav(new BigDecimal("1.00"))
+        .counterpartyIban(iban)
+        .build();
+  }
+
+  @Test
+  void reportsOnePoolWhenNoInvestmentAccountWasDeclared() {
+    given(savingsFundTransactionService.getTransactions(person))
+        .willReturn(
+            List.of(
+                bought("2025-01-10T10:00:00Z", "100", "100.00", ORDINARY_IBAN),
+                sold("2025-06-10T10:00:00Z", "100", "150.00", ORDINARY_IBAN)));
+    given(investmentAccountService.declaredIban(person.getRoleCode())).willReturn(Optional.empty());
+
+    SavingsFundTaxReport report = savingsFundTaxReportService.getTaxReport(person, 2025, FIFO);
+
+    assertThat(report.totalGain()).isEqualByComparingTo("50.00");
+    assertThat(report.investmentAccount()).isNull();
+  }
+
+  @Test
+  void keepsInvestmentAccountGainsOutOfTheGainsSomeoneDeclares() {
+    given(savingsFundTransactionService.getTransactions(person))
+        .willReturn(
+            List.of(
+                bought("2025-01-10T10:00:00Z", "100", "100.00", ORDINARY_IBAN),
+                bought("2025-02-10T10:00:00Z", "100", "200.00", INVESTMENT_IBAN),
+                sold("2025-06-10T10:00:00Z", "100", "150.00", ORDINARY_IBAN),
+                sold("2025-07-10T10:00:00Z", "100", "260.00", INVESTMENT_IBAN)));
+    given(investmentAccountService.declaredIban(person.getRoleCode()))
+        .willReturn(Optional.of(INVESTMENT_IBAN));
+
+    SavingsFundTaxReport report = savingsFundTaxReportService.getTaxReport(person, 2025, FIFO);
+
+    assertThat(report.totalGain()).isEqualByComparingTo("50.00");
+    assertThat(report.redemptions()).hasSize(1);
+    assertThat(report.investmentAccount().iban()).isEqualTo(INVESTMENT_IBAN);
+    assertThat(report.investmentAccount().totalGain()).isEqualByComparingTo("60.00");
+    assertThat(report.investmentAccount().redeemedOutsideTheAccount()).isFalse();
+  }
+
+  @Test
+  void doesNotPickAPoolForSomeoneWhoRedeemedToAnotherAccountThanTheyBoughtFrom() {
+    given(savingsFundTransactionService.getTransactions(person))
+        .willReturn(
+            List.of(
+                bought("2025-02-10T10:00:00Z", "100", "200.00", INVESTMENT_IBAN),
+                sold("2025-07-10T10:00:00Z", "100", "260.00", ORDINARY_IBAN)));
+    given(investmentAccountService.declaredIban(person.getRoleCode()))
+        .willReturn(Optional.of(INVESTMENT_IBAN));
+
+    SavingsFundTaxReport report = savingsFundTaxReportService.getTaxReport(person, 2025, FIFO);
+
+    assertThat(report.totalGain()).isEqualByComparingTo("60.00");
+    assertThat(report.investmentAccount().redeemedOutsideTheAccount()).isTrue();
+    assertThat(report.investmentAccount().redemptions()).isEmpty();
+  }
+}

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/taxreport/SavingsFundTaxReportServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/taxreport/SavingsFundTaxReportServiceTest.java
@@ -210,6 +210,26 @@ class SavingsFundTaxReportServiceTest {
   }
 
   @Test
+  void splitsThePoolsWhenAPurchaseAndARedemptionShareTheSameInstant() {
+    given(savingsFundTransactionService.getTransactionsWithCounterpartyIbans(person))
+        .willReturn(
+            new Statement()
+                .facing(sold("2025-06-10T10:00:00Z", "100", "150.00"), ORDINARY_IBAN)
+                .facing(sold("2025-02-10T10:00:00Z", "100", "260.00"), INVESTMENT_IBAN)
+                .facing(bought("2025-02-10T10:00:00Z", "100", "200.00"), INVESTMENT_IBAN)
+                .facing(bought("2025-01-10T10:00:00Z", "100", "100.00"), ORDINARY_IBAN)
+                .build());
+    given(investmentAccountService.declaredIban(person.getRoleCode()))
+        .willReturn(Optional.of(INVESTMENT_IBAN));
+
+    SavingsFundTaxReport report = savingsFundTaxReportService.getTaxReport(person, 2025, FIFO);
+
+    assertThat(report.investmentAccount().totalGain()).isEqualByComparingTo("60.00");
+    assertThat(report.totalGain()).isEqualByComparingTo("50.00");
+    assertThat(report.redemptions()).hasSize(1);
+  }
+
+  @Test
   void doesNotPickAPoolForSomeoneWhoRedeemedToAnotherAccountThanTheyBoughtFrom() {
     given(savingsFundTransactionService.getTransactionsWithCounterpartyIbans(person))
         .willReturn(


### PR DESCRIPTION
## What

Under TuMS § 17², units bought with money from a declared investment account are taxed under that regime: the gain on them is not declared as a gain, and tax falls due only once more has left the account than went into it. Units bought with ordinary money are declared the usual way. Someone holding both holds two pools with separate acquisition costs, and a single FIFO or weighted average over all of it answers neither.

Three steps: a person can tell us which account is theirs; every savings fund transaction now carries the account on the other side of it; the report splits by that and runs the existing calculator once per pool.

## Why the calculator is untouched

`SavingsFundCostBasisCalculator` was already a pure function of a transaction list, so the pools are two calls to it rather than a second algorithm.

## Where the account on the other side comes from

No new bank data and no ledger change. `IssuerService` already records the `FUND_SUBSCRIPTION` ledger transaction with the payment's id as its external reference, so a subscription reaches `SavingFundPayment.remitterIban`; redemption entries already carry `REDEMPTION_REQUEST_ID`, so a redemption reaches `RedemptionRequest.customerIban`. One query per direction, both indexed — subscriptions via `findPayments(partyId)` on `idx_saving_fund_payment_party`, the declaration by primary key.

Note `SavingsFundLedger.MetadataKey.PAYER_IBAN` is declared and never written anywhere. It looks like the natural place for this and is not.

## What it refuses to answer

A redemption paid to an account that did not buy the units cannot be assigned to a pool without deciding whether the deferral under § 17² survived — and that decision changes someone's tax return. Same for a transaction whose counterparty we never recorded: that is missing evidence, not evidence of ordinary treatment. In both cases the report returns the unsplit numbers with a null investment-account total, and the page says it could not split them. **The wording of that case needs compliance sign-off before this is announced to anyone.**

## Known and deliberate

- Declaring an account reclassifies all history from it, including payments made before it was an investment account. Simplest thing that works; the copy does not yet say so.
- Nothing checks that the declared account belongs to the person. A parent acting for a child can name their own. `IbanWhitelistService` already knows which accounts have paid in, if we want to close that.
- Taking a declaration back is not exposed. Declaring another account replaces the previous one.

## Merge order

Merge before onboarding-client#1626, which reads `investmentAccount` off the report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)