### PR TITLE
Never let an unexecuted buy become sellable inventory

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/PendingOrderImpactService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/PendingOrderImpactService.java
@@ -107,19 +107,14 @@ class PendingOrderImpactService {
       return;
     }
     unreportedValues.merge(isin, signed(order, unfilledValue), BigDecimal::add);
+    addUnfilledSellQuantity(order, executed, isin, unreportedQuantities);
+  }
 
-    // Quantity is asymmetric, because the two directions carry different knowledge and different
-    // risk.
-    //
-    // An unfilled SELL is units we have already instructed away. Synthesizing them REDUCES the
-    // holding, which is the safe direction — it stops the same units being sold twice — and the
-    // quantity is one we chose, so it is known.
-    //
-    // An unfilled BUY is not a holding at all. Its quantity is what we asked for, not what we got:
-    // it may fill short, at a different size, or not at all. Synthesizing it INFLATES the position
-    // by units that do not exist, and a later sell sized off that position would dispose of
-    // something we do not own. A position may be sold before it lands — but only once it is
-    // EXECUTED and the real quantity is a fact, which is the fills loop above.
+  private static void addUnfilledSellQuantity(
+      TransactionOrder order,
+      ExecutedTotals executed,
+      String isin,
+      Map<String, BigDecimal> unreportedQuantities) {
     if (order.getTransactionType() == BUY) {
       return;
     }
@@ -129,7 +124,6 @@ class PendingOrderImpactService {
     }
   }
 
-  /** Order quantity not yet executed. Used to VALUE the reserved cash, never to add a holding. */
   private static BigDecimal unfilledQuantity(TransactionOrder order, ExecutedTotals executed) {
     BigDecimal orderQuantity = order.getOrderQuantity();
     return orderQuantity == null

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/PendingOrderImpactService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/PendingOrderImpactService.java
@@ -107,10 +107,34 @@ class PendingOrderImpactService {
       return;
     }
     unreportedValues.merge(isin, signed(order, unfilledValue), BigDecimal::add);
+
+    // Quantity is asymmetric, because the two directions carry different knowledge and different
+    // risk.
+    //
+    // An unfilled SELL is units we have already instructed away. Synthesizing them REDUCES the
+    // holding, which is the safe direction — it stops the same units being sold twice — and the
+    // quantity is one we chose, so it is known.
+    //
+    // An unfilled BUY is not a holding at all. Its quantity is what we asked for, not what we got:
+    // it may fill short, at a different size, or not at all. Synthesizing it INFLATES the position
+    // by units that do not exist, and a later sell sized off that position would dispose of
+    // something we do not own. A position may be sold before it lands — but only once it is
+    // EXECUTED and the real quantity is a fact, which is the fills loop above.
+    if (order.getTransactionType() == BUY) {
+      return;
+    }
     BigDecimal unfilledQuantity = unfilledQuantity(order, executed);
     if (order.getInstrumentType() == ETF && unfilledQuantity.signum() != 0) {
       unreportedQuantities.merge(isin, signed(order, unfilledQuantity), BigDecimal::add);
     }
+  }
+
+  /** Order quantity not yet executed. Used to VALUE the reserved cash, never to add a holding. */
+  private static BigDecimal unfilledQuantity(TransactionOrder order, ExecutedTotals executed) {
+    BigDecimal orderQuantity = order.getOrderQuantity();
+    return orderQuantity == null
+        ? ZERO
+        : orderQuantity.abs().subtract(executed.quantity()).max(ZERO);
   }
 
   private static boolean isMissingFromPositionReport(
@@ -129,13 +153,6 @@ class PendingOrderImpactService {
       return false;
     }
     return reportedDate.isAfter(positionDate);
-  }
-
-  private static BigDecimal unfilledQuantity(TransactionOrder order, ExecutedTotals executed) {
-    BigDecimal orderQuantity = order.getOrderQuantity();
-    return orderQuantity == null
-        ? ZERO
-        : orderQuantity.abs().subtract(executed.quantity()).max(ZERO);
   }
 
   private record ExecutedTotals(BigDecimal consideration, BigDecimal quantity) {

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/PendingOrderImpactService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/PendingOrderImpactService.java
@@ -2,6 +2,7 @@ package ee.tuleva.onboarding.investment.transaction;
 
 import static ee.tuleva.onboarding.investment.transaction.InstrumentType.ETF;
 import static ee.tuleva.onboarding.investment.transaction.TransactionType.BUY;
+import static ee.tuleva.onboarding.investment.transaction.TransactionType.SELL;
 import static java.math.BigDecimal.ZERO;
 
 import ee.tuleva.onboarding.comparisons.fundvalue.PositionPriceResolver;
@@ -107,17 +108,16 @@ class PendingOrderImpactService {
       return;
     }
     unreportedValues.merge(isin, signed(order, unfilledValue), BigDecimal::add);
-    addUnfilledSellQuantity(order, executed, isin, unreportedQuantities);
+    if (order.getTransactionType() == SELL) {
+      addUnfilledQuantity(order, executed, isin, unreportedQuantities);
+    }
   }
 
-  private static void addUnfilledSellQuantity(
+  private static void addUnfilledQuantity(
       TransactionOrder order,
       ExecutedTotals executed,
       String isin,
       Map<String, BigDecimal> unreportedQuantities) {
-    if (order.getTransactionType() == BUY) {
-      return;
-    }
     BigDecimal unfilledQuantity = unfilledQuantity(order, executed);
     if (order.getInstrumentType() == ETF && unfilledQuantity.signum() != 0) {
       unreportedQuantities.merge(isin, signed(order, unfilledQuantity), BigDecimal::add);

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/PendingOrderImpactServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/PendingOrderImpactServiceTest.java
@@ -579,6 +579,52 @@ class PendingOrderImpactServiceTest {
   }
 
   @Test
+  void aSellPlacedInEurosReducesTheValueButNotTheUnitsBecauseNoUnitCountWasGiven() {
+    given(orderRepository.findUnsettledOrders(TUV100, AS_OF_DATE))
+        .willReturn(
+            List.of(
+                order(
+                    1L,
+                    "IE00A",
+                    TransactionType.SELL,
+                    InstrumentType.ETF,
+                    OrderStatus.SENT,
+                    null,
+                    new BigDecimal("4000"))));
+    given(executionRepository.findByOrderIdIn(List.of(1L))).willReturn(List.of());
+
+    var impact = service.calculate(TUV100, AS_OF_DATE, POSITION_DATE);
+
+    assertThat(impact.unreportedPositionValues())
+        .containsExactly(Map.entry("IE00A", new BigDecimal("-4000")));
+    assertThat(impact.unreportedPositionQuantities()).isEmpty();
+    assertThat(impact.pendingSells()).isEqualByComparingTo(new BigDecimal("4000"));
+  }
+
+  @Test
+  void anUnfilledFundSellReducesTheValueButContributesNoUnits() {
+    given(orderRepository.findUnsettledOrders(TUV100, AS_OF_DATE))
+        .willReturn(
+            List.of(
+                order(
+                    1L,
+                    "IE00B",
+                    TransactionType.SELL,
+                    InstrumentType.FUND,
+                    OrderStatus.SENT,
+                    new BigDecimal("20"),
+                    new BigDecimal("1000"))));
+    given(executionRepository.findByOrderIdIn(List.of(1L))).willReturn(List.of());
+
+    var impact = service.calculate(TUV100, AS_OF_DATE, POSITION_DATE);
+
+    assertThat(impact.unreportedPositionValues())
+        .containsExactly(Map.entry("IE00B", new BigDecimal("-1000")));
+    assertThat(impact.unreportedPositionQuantities()).isEmpty();
+    assertThat(impact.pendingSells()).isEqualByComparingTo(new BigDecimal("1000"));
+  }
+
+  @Test
   void anUnexecutedEtfBuyNeverInflatesTheQuantityAvailableToSell() {
     // A sell may be sized against a position that has not landed yet, but only once the buy is
     // EXECUTED and the real quantity is known. A SENT order with no fill is an intention, not a

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/PendingOrderImpactServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/PendingOrderImpactServiceTest.java
@@ -64,8 +64,9 @@ class PendingOrderImpactServiceTest {
 
     assertThat(impact.unreportedPositionValues())
         .containsExactly(Map.entry("IE00A", new BigDecimal("5000")));
-    assertThat(impact.unreportedPositionQuantities())
-        .containsExactly(Map.entry("IE00A", new BigDecimal("100")));
+    // A SENT buy with no fills reserves its cash but adds NO units: the quantity we asked
+    // for is not the quantity we will get, so it must not become sellable inventory.
+    assertThat(impact.unreportedPositionQuantities()).isEmpty();
     assertThat(impact.pendingBuys()).isEqualByComparingTo(new BigDecimal("5000"));
     assertThat(impact.pendingSells()).isEqualByComparingTo(ZERO);
   }
@@ -140,8 +141,9 @@ class PendingOrderImpactServiceTest {
 
     assertThat(impact.unreportedPositionValues())
         .containsExactly(Map.entry("IE00A", new BigDecimal("5000")));
-    assertThat(impact.unreportedPositionQuantities())
-        .containsExactly(Map.entry("IE00A", new BigDecimal("100")));
+    // A SENT buy with no fills reserves its cash but adds NO units: the quantity we asked
+    // for is not the quantity we will get, so it must not become sellable inventory.
+    assertThat(impact.unreportedPositionQuantities()).isEmpty();
     assertThat(impact.pendingBuys()).isEqualByComparingTo(new BigDecimal("5000"));
   }
 
@@ -514,6 +516,8 @@ class PendingOrderImpactServiceTest {
 
     var impact = service.calculate(TUV100, AS_OF_DATE, POSITION_DATE);
 
+    // Both fills are EXECUTED, so both are real quantities; only the one the custodian has not
+    // reported yet is synthesized.
     assertThat(impact.unreportedPositionValues())
         .containsExactly(Map.entry("IE00A", new BigDecimal("2000")));
     assertThat(impact.unreportedPositionQuantities())
@@ -545,7 +549,7 @@ class PendingOrderImpactServiceTest {
   }
 
   @Test
-  void theUnfilledRemainderIsSynthesizedBecauseItsCashIsAlreadyReserved() {
+  void theUnfilledRemainderReservesCashButAddsNoUnitsToTheHolding() {
     given(orderRepository.findUnsettledOrders(TUV100, AS_OF_DATE))
         .willReturn(
             List.of(
@@ -564,10 +568,42 @@ class PendingOrderImpactServiceTest {
 
     var impact = service.calculate(TUV100, AS_OF_DATE, POSITION_DATE);
 
+    // The 60 executed units are already in the custodian report (reportedDate == POSITION_DATE),
+    // so they are not synthesized. The 40 unfilled units reserve their cash — hence the 2000 of
+    // value — but nobody has executed them, so they add NO quantity: their real size is not known
+    // and may never be 40.
     assertThat(impact.unreportedPositionValues())
         .containsExactly(Map.entry("IE00A", new BigDecimal("2000")));
-    assertThat(impact.unreportedPositionQuantities())
-        .containsExactly(Map.entry("IE00A", new BigDecimal("40")));
+    assertThat(impact.unreportedPositionQuantities()).isEmpty();
+    assertThat(impact.pendingBuys()).isEqualByComparingTo(new BigDecimal("5000"));
+  }
+
+  @Test
+  void anUnexecutedEtfBuyNeverInflatesTheQuantityAvailableToSell() {
+    // A sell may be sized against a position that has not landed yet, but only once the buy is
+    // EXECUTED and the real quantity is known. A SENT order with no fill is an intention, not a
+    // holding: synthesizing its order quantity would let a later sell dispose of units we do not
+    // own. Its cash stays reserved either way.
+    given(orderRepository.findUnsettledOrders(TUV100, AS_OF_DATE))
+        .willReturn(
+            List.of(
+                order(
+                    1L,
+                    "IE00A",
+                    TransactionType.BUY,
+                    InstrumentType.ETF,
+                    OrderStatus.SENT,
+                    new BigDecimal("100"),
+                    new BigDecimal("5000"))));
+    given(executionRepository.findByOrderIdIn(List.of(1L))).willReturn(List.of());
+    given(positionPriceResolver.resolve("IE00A", AS_OF_DATE))
+        .willReturn(Optional.of(ResolvedPrice.builder().usedPrice(new BigDecimal("50")).build()));
+
+    var impact = service.calculate(TUV100, AS_OF_DATE, POSITION_DATE);
+
+    assertThat(impact.unreportedPositionQuantities()).isEmpty();
+    assertThat(impact.unreportedPositionValues())
+        .containsExactly(Map.entry("IE00A", new BigDecimal("5000")));
     assertThat(impact.pendingBuys()).isEqualByComparingTo(new BigDecimal("5000"));
   }
 

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/PendingOrderImpactServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/PendingOrderImpactServiceTest.java
@@ -64,8 +64,6 @@ class PendingOrderImpactServiceTest {
 
     assertThat(impact.unreportedPositionValues())
         .containsExactly(Map.entry("IE00A", new BigDecimal("5000")));
-    // A SENT buy with no fills reserves its cash but adds NO units: the quantity we asked
-    // for is not the quantity we will get, so it must not become sellable inventory.
     assertThat(impact.unreportedPositionQuantities()).isEmpty();
     assertThat(impact.pendingBuys()).isEqualByComparingTo(new BigDecimal("5000"));
     assertThat(impact.pendingSells()).isEqualByComparingTo(ZERO);
@@ -141,8 +139,6 @@ class PendingOrderImpactServiceTest {
 
     assertThat(impact.unreportedPositionValues())
         .containsExactly(Map.entry("IE00A", new BigDecimal("5000")));
-    // A SENT buy with no fills reserves its cash but adds NO units: the quantity we asked
-    // for is not the quantity we will get, so it must not become sellable inventory.
     assertThat(impact.unreportedPositionQuantities()).isEmpty();
     assertThat(impact.pendingBuys()).isEqualByComparingTo(new BigDecimal("5000"));
   }
@@ -516,8 +512,6 @@ class PendingOrderImpactServiceTest {
 
     var impact = service.calculate(TUV100, AS_OF_DATE, POSITION_DATE);
 
-    // Both fills are EXECUTED, so both are real quantities; only the one the custodian has not
-    // reported yet is synthesized.
     assertThat(impact.unreportedPositionValues())
         .containsExactly(Map.entry("IE00A", new BigDecimal("2000")));
     assertThat(impact.unreportedPositionQuantities())
@@ -568,10 +562,6 @@ class PendingOrderImpactServiceTest {
 
     var impact = service.calculate(TUV100, AS_OF_DATE, POSITION_DATE);
 
-    // The 60 executed units are already in the custodian report (reportedDate == POSITION_DATE),
-    // so they are not synthesized. The 40 unfilled units reserve their cash — hence the 2000 of
-    // value — but nobody has executed them, so they add NO quantity: their real size is not known
-    // and may never be 40.
     assertThat(impact.unreportedPositionValues())
         .containsExactly(Map.entry("IE00A", new BigDecimal("2000")));
     assertThat(impact.unreportedPositionQuantities()).isEmpty();
@@ -626,10 +616,6 @@ class PendingOrderImpactServiceTest {
 
   @Test
   void anUnexecutedEtfBuyNeverInflatesTheQuantityAvailableToSell() {
-    // A sell may be sized against a position that has not landed yet, but only once the buy is
-    // EXECUTED and the real quantity is known. A SENT order with no fill is an intention, not a
-    // holding: synthesizing its order quantity would let a later sell dispose of units we do not
-    // own. Its cash stays reserved either way.
     given(orderRepository.findUnsettledOrders(TUV100, AS_OF_DATE))
         .willReturn(
             List.of(


### PR DESCRIPTION
Closes the sell-cap half of #1850 item 2, with the rule stated by the fund
manager: **a position may be sold before it lands, but only once it is EXECUTED
and the real quantity is known.**

`PendingOrderImpactService` synthesized the unfilled remainder of an order into
BOTH the position value and, for ETFs, the position quantity. Value is right —
that cash is already committed. Quantity is not, and the two directions are not
symmetric:

| Unfilled leg | Synthesized quantity | Effect on the holding | Safe? |
|---|---|---|---|
| SELL | negative | reduces it | yes — stops the same units being sold twice, and we chose the quantity |
| BUY | positive | **inflates it** | **no** — those units do not exist yet |

An unfilled BUY is what we asked for, not what we got: it can fill short, at a
different size, or not at all. Adding its order quantity to the position lets a
later sell be sized against units we do not own — and `TransactionInputService`
feeds exactly this adjusted `PositionSnapshot.quantity` into rebalance sizing,
so nothing downstream re-checks it.

Fix: the unfilled remainder keeps contributing VALUE in both directions, and
contributes QUANTITY only for sells. Executed fills are unaffected — they are
real quantities and are still synthesized whenever the custodian has not
reported them yet, which is what makes selling-before-settlement work.

**Tests.** Two existing tests pinned the old behaviour and now assert the new
one (`valuesASentEtfBuyAtTheLatestPriceAndReservesItsCash`,
`aSentOrderWithNoFillsIsSynthesizedEvenIfItWasPlacedBeforeThePositionReport`) —
both keep their value and cash assertions unchanged, so the cash reservation is
provably untouched. `theUnfilledRemainderIsSynthesizedBecauseItsCashIsAlready
Reserved` is renamed to `...ReservesCashButAddsNoUnitsToTheHolding` for the same
reason. New: `anUnexecutedEtfBuyNeverInflatesTheQuantityAvailableToSell`. The
sell-side tests (`recordsASentSellAsANegativePositionValueAndAnIncomingReceipt`,
`aPartiallyFilledEtfSellSynthesizesANegativePosition`) are untouched and still
pass, which is the asymmetry being pinned from the other side.

Latent today: `investment_transaction_execution` has had zero rows in 90 days
and `scheduled_settlement_date` is universally NULL, so no live number moves.
This lands before the first real trading day rather than after it.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

Part of #1850 (item 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)