### PR TITLE
Apply the fee policy per accrual date, not once per month

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/investment/fees/FeeAccrualRepository.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/fees/FeeAccrualRepository.java
@@ -1,9 +1,12 @@
 package ee.tuleva.onboarding.investment.fees;
 
+import static java.util.stream.Collectors.toMap;
+
 import ee.tuleva.onboarding.fund.TulevaFund;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.jdbc.core.simple.JdbcClient;
@@ -33,6 +36,58 @@ public class FeeAccrualRepository {
         .param("beforeDate", beforeDate)
         .query(BigDecimal.class)
         .single();
+  }
+
+  /**
+   * Month-to-date accruals split BY ACCRUAL DATE, so a caller can apply the charged-to-fund policy
+   * per day instead of gating the whole sum on one day's answer. Same rows as {@link
+   * #getAccruedFeesForMonth}, ungrouped.
+   */
+  public Map<LocalDate, BigDecimal> getAccruedFeesByDateForMonth(
+      TulevaFund fund, LocalDate feeMonth, List<FeeType> feeTypes, LocalDate beforeDate) {
+    return jdbcClient
+        .sql(
+            """
+            SELECT accrual_date, COALESCE(SUM(daily_amount_gross), 0) AS amount
+            FROM investment_fee_accrual
+            WHERE fund_code = :fundCode
+              AND fee_month = :feeMonth
+              AND fee_type IN (:feeTypes)
+              AND accrual_date < :beforeDate
+            GROUP BY accrual_date
+            """)
+        .param("fundCode", fund.name())
+        .param("feeMonth", feeMonth)
+        .param("feeTypes", feeTypes.stream().map(FeeType::name).toList())
+        .param("beforeDate", beforeDate)
+        .query((rs, rowNum) -> Map.entry(rs.getDate(1).toLocalDate(), rs.getBigDecimal(2)))
+        .list()
+        .stream()
+        .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
+  }
+
+  /** As {@link #getUnsettledAccrual}, split by accrual date and left unrounded. */
+  public Map<LocalDate, BigDecimal> getUnsettledAccrualByDate(
+      TulevaFund fund, FeeType feeType, LocalDate asOfDate) {
+    return jdbcClient
+        .sql(
+            """
+            SELECT accrual_date, COALESCE(SUM(daily_amount_gross), 0) AS amount
+            FROM investment_fee_accrual
+            WHERE fund_code = :fundCode
+              AND fee_type = :feeType
+              AND fee_month = :feeMonth
+              AND accrual_date <= :asOfDate
+            GROUP BY accrual_date
+            """)
+        .param("fundCode", fund.name())
+        .param("feeType", feeType.name())
+        .param("feeMonth", asOfDate.withDayOfMonth(1))
+        .param("asOfDate", asOfDate)
+        .query((rs, rowNum) -> Map.entry(rs.getDate(1).toLocalDate(), rs.getBigDecimal(2)))
+        .list()
+        .stream()
+        .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
   }
 
   public boolean existsByFundAndFeeMonth(TulevaFund fund, LocalDate feeMonth) {

--- a/src/main/java/ee/tuleva/onboarding/investment/fees/FeeCalculationService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/fees/FeeCalculationService.java
@@ -12,6 +12,7 @@ import ee.tuleva.onboarding.ledger.NavFeeAccrualLedger;
 import ee.tuleva.onboarding.ledger.NavLedgerRepository;
 import ee.tuleva.onboarding.ledger.SystemAccount;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
@@ -120,11 +121,26 @@ public class FeeCalculationService {
       previousFeeMonth = feeMonth;
     }
 
+    // Charged-to-fund is applied PER ACCRUAL DATE. Gating the whole month-to-date sum on the
+    // policy's answer for one day would misstate every month in which the policy flips: the days
+    // before the flip would take the answer belonging to the days after it.
     BigDecimal mgmtFee =
-        feeAccrualRepository.getUnsettledAccrual(fund, FeeType.MANAGEMENT, positionReportDate);
-    BigDecimal depotFee =
-        feeAccrualRepository.getUnsettledAccrual(fund, FeeType.DEPOT, positionReportDate);
+        chargedAccrual(chargedPolicies, fund, FeeType.MANAGEMENT, positionReportDate);
+    BigDecimal depotFee = chargedAccrual(chargedPolicies, fund, FeeType.DEPOT, positionReportDate);
     return new FeeResult(mgmtFee, depotFee);
+  }
+
+  private BigDecimal chargedAccrual(
+      Map<FeeType, FeeChargedToFundPolicy.Resolver> policies,
+      TulevaFund fund,
+      FeeType feeType,
+      LocalDate positionReportDate) {
+    Map<LocalDate, BigDecimal> byDate =
+        feeAccrualRepository.getUnsettledAccrualByDate(fund, feeType, positionReportDate);
+    // Rounded once at the end, exactly where getUnsettledAccrual's ROUND(SUM(...), 2) sat.
+    BigDecimal charged = policies.get(feeType).sumChargedDays(byDate);
+    // Scale mirrors the ROUND(SUM(...), 2) this replaced, including its plain 0 for no rows.
+    return charged.signum() == 0 ? BigDecimal.ZERO : charged.setScale(2, RoundingMode.HALF_UP);
   }
 
   private void recordDailyFees(

--- a/src/main/java/ee/tuleva/onboarding/investment/fees/FeeChargedToFundPolicy.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/fees/FeeChargedToFundPolicy.java
@@ -1,8 +1,10 @@
 package ee.tuleva.onboarding.investment.fees;
 
 import ee.tuleva.onboarding.fund.TulevaFund;
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.jdbc.core.simple.JdbcClient;
 import org.springframework.stereotype.Component;
@@ -73,6 +75,22 @@ public class FeeChargedToFundPolicy {
               + feeType
               + ", date="
               + date);
+    }
+
+    /**
+     * Sum only the days this policy actually charges to the fund.
+     *
+     * <p>The reason this exists: a month-to-date accrual is a sum over many days, and asking
+     * "charged?" once — for the last of them — silently applies that answer to every earlier day. A
+     * policy that flips mid-month then puts NAV and the ledger out of step for the whole month.
+     * Per-day evaluation also keeps the gap and overlap validation in {@link #chargedOn}, which a
+     * single lookup would only apply to one date.
+     */
+    public BigDecimal sumChargedDays(Map<LocalDate, BigDecimal> amountsByDate) {
+      return amountsByDate.entrySet().stream()
+          .filter(entry -> chargedOn(entry.getKey()))
+          .map(Map.Entry::getValue)
+          .reduce(BigDecimal.ZERO, BigDecimal::add);
     }
 
     private boolean predatesTheFoundingPolicy(LocalDate date) {

--- a/src/main/java/ee/tuleva/onboarding/investment/position/FeeAccrualPositionSyncJob.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/position/FeeAccrualPositionSyncJob.java
@@ -16,6 +16,7 @@ import ee.tuleva.onboarding.investment.fees.FeeAccrualRepository;
 import ee.tuleva.onboarding.investment.fees.FeeChargedToFundPolicy;
 import ee.tuleva.onboarding.investment.fees.FeeType;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.Clock;
 import java.time.LocalDate;
 import java.util.List;
@@ -105,9 +106,13 @@ public class FeeAccrualPositionSyncJob {
 
   private BigDecimal chargedAccrual(
       FeeChargedToFundPolicy.Resolver policy, TulevaFund fund, FeeType feeType, LocalDate navDate) {
-    return policy.chargedOn(navDate)
-        ? feeAccrualRepository.getUnsettledAccrual(fund, feeType, navDate)
-        : BigDecimal.ZERO;
+    // Per accrual date. Asking once for navDate would apply that day's policy to the whole
+    // month-to-date sum, so a mid-month flip would put this position out of step with the ledger.
+    BigDecimal charged =
+        policy.sumChargedDays(
+            feeAccrualRepository.getUnsettledAccrualByDate(fund, feeType, navDate));
+    // Scale mirrors the ROUND(SUM(...), 2) this replaced, including its plain 0 for no rows.
+    return charged.signum() == 0 ? BigDecimal.ZERO : charged.setScale(2, RoundingMode.HALF_UP);
   }
 
   private FundPosition feeAccrualPosition(

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionInputService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionInputService.java
@@ -312,11 +312,14 @@ public class TransactionInputService {
   }
 
   private BigDecimal getAccruedFees(TulevaFund fund, LocalDate asOfDate, FeeType feeType) {
-    if (!feeChargedToFundPolicy.chargedToFund(fund, feeType, asOfDate)) {
-      return ZERO;
-    }
     LocalDate feeMonth = asOfDate.withDayOfMonth(1);
-    return feeAccrualRepository.getAccruedFeesForMonth(fund, feeMonth, List.of(feeType), asOfDate);
+    // Per accrual date, not once for asOfDate: a policy that flips mid-month must not hand its
+    // post-flip answer to the days before it.
+    return feeChargedToFundPolicy
+        .resolverFor(fund, feeType)
+        .sumChargedDays(
+            feeAccrualRepository.getAccruedFeesByDateForMonth(
+                fund, feeMonth, List.of(feeType), asOfDate));
   }
 
   private List<ModelPortfolioAllocation> getModelAllocations(TulevaFund fund, LocalDate asOfDate) {

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/nav/NavCalculationService.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/nav/NavCalculationService.java
@@ -12,7 +12,6 @@ import ee.tuleva.onboarding.investment.fees.FeeBases;
 import ee.tuleva.onboarding.investment.fees.FeeCalculationService;
 import ee.tuleva.onboarding.investment.fees.FeeChargedToFundPolicy;
 import ee.tuleva.onboarding.investment.fees.FeeResult;
-import ee.tuleva.onboarding.investment.fees.FeeType;
 import ee.tuleva.onboarding.investment.position.FundPositionRepository;
 import ee.tuleva.onboarding.ledger.LedgerService;
 import ee.tuleva.onboarding.ledger.NavLedgerRepository;
@@ -113,10 +112,11 @@ public class NavCalculationService {
     FeeResult fees =
         feeCalculationService.calculateFeesForNav(
             fund, positionReportDate, feeBases, feeCutoff, context.getSecurityPrices());
-    BigDecimal managementFeeAccrual =
-        navFacingAccrual(fund, FeeType.MANAGEMENT, positionReportDate, fees.managementFeeAccrual());
-    BigDecimal depotFeeAccrual =
-        navFacingAccrual(fund, FeeType.DEPOT, positionReportDate, fees.depotFeeAccrual());
+    // FeeCalculationService already applies charged-to-fund per accrual date, so these are
+    // NAV-facing as they stand. Re-gating the summed figure on one day's answer here would undo
+    // that: a month with a mid-month flip would be zeroed or admitted whole.
+    BigDecimal managementFeeAccrual = fees.managementFeeAccrual();
+    BigDecimal depotFeeAccrual = fees.depotFeeAccrual();
 
     BigDecimal aum =
         calculateAum(
@@ -226,11 +226,6 @@ public class NavCalculationService {
             .add(blackrockAdjustment.min(ZERO).negate());
 
     return assets.subtract(liabilities);
-  }
-
-  private BigDecimal navFacingAccrual(
-      TulevaFund fund, FeeType feeType, LocalDate navDate, BigDecimal accrual) {
-    return feeChargedToFundPolicy.chargedToFund(fund, feeType, navDate) ? accrual : ZERO;
   }
 
   private BigDecimal calculateNavPerUnit(

--- a/src/test/groovy/ee/tuleva/onboarding/investment/fees/FeeCalculationIntegrationTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/fees/FeeCalculationIntegrationTest.java
@@ -86,15 +86,20 @@ class FeeCalculationIntegrationTest {
   }
 
   @Test
-  void calculateFeesForNav_returnsFeeResult() {
+  void calculateFeesForNav_returnsTheNavFacingAccrualNotTheRawOne() {
     Instant feeCutoff = TEST_DATE.plusDays(1).atStartOfDay().atZone(ESTONIAN_ZONE).toInstant();
 
     FeeResult result =
         feeCalculationService.calculateFeesForNav(
             TKF100, TEST_DATE, new FeeBases(BASE_VALUE, BASE_VALUE), feeCutoff, null);
 
+    // FeeResult is NAV-facing: the charged-to-fund policy is applied per accrual date here, so a
+    // fee Tuleva bears comes back as zero even though it was accrued and recorded. TKF100's depot
+    // fee is exactly that case ("tracked but not charged to the fund"); the accrual row still
+    // exists, which the other tests in this class assert.
     assertThat(result.managementFeeAccrual()).isPositive();
-    assertThat(result.depotFeeAccrual()).isPositive();
+    assertThat(result.depotFeeAccrual()).isEqualByComparingTo(java.math.BigDecimal.ZERO);
+    assertThat(findAccrual(TKF100, FeeType.DEPOT, TEST_DATE).dailyAmountGross()).isPositive();
   }
 
   private FeeAccrual findAccrual(TulevaFund fund, FeeType feeType, LocalDate accrualDate) {

--- a/src/test/groovy/ee/tuleva/onboarding/investment/fees/FeeCalculationServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/fees/FeeCalculationServiceTest.java
@@ -28,6 +28,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class FeeCalculationServiceTest {
 
+  private static final LocalDate ACCRUAL_DAY = LocalDate.of(2000, 1, 2);
+
   private static final ZoneId ESTONIAN_ZONE = ZoneId.of("Europe/Tallinn");
 
   @Mock private FeeCalculator calculator1;
@@ -121,10 +123,11 @@ class FeeCalculationServiceTest {
     when(calculator2.calculate(eq(TKF100), any(LocalDate.class), any(FeeBases.class)))
         .thenReturn(depotAccrual);
     stubZeroLedgerBalance();
-    when(feeAccrualRepository.getUnsettledAccrual(TKF100, FeeType.MANAGEMENT, positionReportDate))
-        .thenReturn(new BigDecimal("400.00"));
-    when(feeAccrualRepository.getUnsettledAccrual(TKF100, FeeType.DEPOT, positionReportDate))
-        .thenReturn(new BigDecimal("50.00"));
+    when(feeAccrualRepository.getUnsettledAccrualByDate(
+            TKF100, FeeType.MANAGEMENT, positionReportDate))
+        .thenReturn(Map.of(ACCRUAL_DAY, new BigDecimal("400.00")));
+    when(feeAccrualRepository.getUnsettledAccrualByDate(TKF100, FeeType.DEPOT, positionReportDate))
+        .thenReturn(Map.of(ACCRUAL_DAY, new BigDecimal("50.00")));
 
     FeeResult result =
         service.calculateFeesForNav(
@@ -243,9 +246,10 @@ class FeeCalculationServiceTest {
     when(navLedgerRepository.getSystemAccountBalanceBefore(
             DEPOT_FEE_ACCRUAL.getAccountName(TKF100), settlementCutoff))
         .thenReturn(new BigDecimal("-200.00"));
-    when(feeAccrualRepository.getUnsettledAccrual(TKF100, FeeType.MANAGEMENT, mar1))
-        .thenReturn(ZERO);
-    when(feeAccrualRepository.getUnsettledAccrual(TKF100, FeeType.DEPOT, mar1)).thenReturn(ZERO);
+    when(feeAccrualRepository.getUnsettledAccrualByDate(TKF100, FeeType.MANAGEMENT, mar1))
+        .thenReturn(Map.of());
+    when(feeAccrualRepository.getUnsettledAccrualByDate(TKF100, FeeType.DEPOT, mar1))
+        .thenReturn(Map.of());
 
     service.calculateFeesForNav(TKF100, mar1, new FeeBases(baseValue, baseValue), feeCutoff, null);
 
@@ -281,8 +285,8 @@ class FeeCalculationServiceTest {
   private void stubZeroLedgerBalance() {
     when(navLedgerRepository.getSystemAccountBalanceBefore(any(), any(Instant.class)))
         .thenReturn(ZERO);
-    when(feeAccrualRepository.getUnsettledAccrual(any(), any(), any(LocalDate.class)))
-        .thenReturn(ZERO);
+    when(feeAccrualRepository.getUnsettledAccrualByDate(any(), any(), any(LocalDate.class)))
+        .thenReturn(Map.of());
   }
 
   @Test
@@ -303,10 +307,11 @@ class FeeCalculationServiceTest {
             eq(TKF100), eq(positionReportDate), eq(new FeeBases(baseValue, baseValue))))
         .thenReturn(depotAccrual);
     stubZeroLedgerBalance();
-    when(feeAccrualRepository.getUnsettledAccrual(TKF100, FeeType.MANAGEMENT, positionReportDate))
-        .thenReturn(new BigDecimal("400.12"));
-    when(feeAccrualRepository.getUnsettledAccrual(TKF100, FeeType.DEPOT, positionReportDate))
-        .thenReturn(new BigDecimal("50.34"));
+    when(feeAccrualRepository.getUnsettledAccrualByDate(
+            TKF100, FeeType.MANAGEMENT, positionReportDate))
+        .thenReturn(Map.of(ACCRUAL_DAY, new BigDecimal("400.12")));
+    when(feeAccrualRepository.getUnsettledAccrualByDate(TKF100, FeeType.DEPOT, positionReportDate))
+        .thenReturn(Map.of(ACCRUAL_DAY, new BigDecimal("50.34")));
 
     FeeResult result =
         service.calculateFeesForNav(

--- a/src/test/groovy/ee/tuleva/onboarding/investment/fees/FeeChargedToFundPolicyTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/fees/FeeChargedToFundPolicyTest.java
@@ -8,7 +8,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import ee.tuleva.onboarding.fund.TulevaFund;
+import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
@@ -23,6 +25,41 @@ class FeeChargedToFundPolicyTest {
 
   @Autowired private JdbcClient jdbcClient;
   @Autowired private FeeChargedToFundPolicy policy;
+
+  @Test
+  void sumChargedDays_splitsAMonthThePolicyFlipsInsteadOfTakingOneDaysAnswer() {
+    // The whole point of the per-date sum. Tuleva bears the fee to 14.09, the fund from 15.09.
+    // Asking "charged?" once for the 30th would admit the ENTIRE month into NAV; asking once for
+    // the 1st would admit none of it. Only the post-flip days belong.
+    jdbcClient.sql("DELETE FROM investment_fee_policy").update();
+    insertPolicy(TUK75, DEPOT, false, LocalDate.of(2017, 3, 28), LocalDate.of(2026, 9, 14));
+    insertPolicy(TUK75, DEPOT, true, LocalDate.of(2026, 9, 15), null);
+
+    var resolver = policy.resolverFor(TUK75, DEPOT);
+    var byDate =
+        Map.of(
+            LocalDate.of(2026, 9, 13), new BigDecimal("1.00"),
+            LocalDate.of(2026, 9, 14), new BigDecimal("2.00"),
+            LocalDate.of(2026, 9, 15), new BigDecimal("4.00"),
+            LocalDate.of(2026, 9, 16), new BigDecimal("8.00"));
+
+    assertThat(resolver.sumChargedDays(byDate)).isEqualByComparingTo("12.00");
+  }
+
+  @Test
+  void sumChargedDays_stillRefusesAGapRatherThanSkippingTheDay() {
+    // A day no row covers is not "not charged" — it is unknown, and a sum that quietly dropped it
+    // would understate the fee with no signal.
+    jdbcClient.sql("DELETE FROM investment_fee_policy").update();
+    insertPolicy(TUK75, DEPOT, false, LocalDate.of(2017, 3, 28), LocalDate.of(2026, 6, 30));
+    insertPolicy(TUK75, DEPOT, true, LocalDate.of(2026, 9, 1), null);
+
+    var resolver = policy.resolverFor(TUK75, DEPOT);
+    var byDate = Map.of(LocalDate.of(2026, 7, 15), new BigDecimal("1.00"));
+
+    assertThatThrownBy(() -> resolver.sumChargedDays(byDate))
+        .isInstanceOf(IllegalStateException.class);
+  }
 
   @Test
   void chargedToFund_throwsWhenTheFundAndFeeTypeAreNotConfiguredAtAll() {

--- a/src/test/groovy/ee/tuleva/onboarding/investment/position/FeeAccrualPositionSyncJobTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/position/FeeAccrualPositionSyncJobTest.java
@@ -25,6 +25,7 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -36,6 +37,8 @@ import org.springframework.context.ApplicationEventPublisher;
 
 @ExtendWith(MockitoExtension.class)
 class FeeAccrualPositionSyncJobTest {
+
+  private static final LocalDate ACCRUAL_DAY = LocalDate.of(2000, 1, 2);
 
   private static final Instant NOW = Instant.parse("2025-03-12T10:00:00Z");
   private static final ZoneId ZONE = ZoneId.of("Europe/Tallinn");
@@ -94,10 +97,10 @@ class FeeAccrualPositionSyncJobTest {
     given(fundPositionRepository.findDistinctNavDatesByFund(any())).willReturn(List.of());
     given(fundPositionRepository.findDistinctNavDatesByFund(TKF100)).willReturn(List.of(navDate));
 
-    given(feeAccrualRepository.getUnsettledAccrual(TKF100, MANAGEMENT, navDate))
-        .willReturn(new BigDecimal("52.08"));
-    given(feeAccrualRepository.getUnsettledAccrual(TKF100, DEPOT, navDate))
-        .willReturn(new BigDecimal("6.85"));
+    given(feeAccrualRepository.getUnsettledAccrualByDate(TKF100, MANAGEMENT, navDate))
+        .willReturn(Map.of(ACCRUAL_DAY, new BigDecimal("52.08")));
+    given(feeAccrualRepository.getUnsettledAccrualByDate(TKF100, DEPOT, navDate))
+        .willReturn(Map.of(ACCRUAL_DAY, new BigDecimal("6.85")));
 
     syncJob.sync(7);
 
@@ -131,17 +134,17 @@ class FeeAccrualPositionSyncJobTest {
     given(fundPositionRepository.findDistinctNavDatesByFund(any()))
         .willReturn(List.of(oldDate, recentDate));
 
-    given(feeAccrualRepository.getUnsettledAccrual(any(), any(), eq(recentDate)))
-        .willReturn(BigDecimal.ZERO);
+    given(feeAccrualRepository.getUnsettledAccrualByDate(any(), any(), eq(recentDate)))
+        .willReturn(Map.of());
 
     syncJob.sync(7);
 
-    verify(feeAccrualRepository).getUnsettledAccrual(TKF100, MANAGEMENT, recentDate);
-    verify(feeAccrualRepository, never()).getUnsettledAccrual(any(), any(), eq(oldDate));
+    verify(feeAccrualRepository).getUnsettledAccrualByDate(TKF100, MANAGEMENT, recentDate);
+    verify(feeAccrualRepository, never()).getUnsettledAccrualByDate(any(), any(), eq(oldDate));
   }
 
   @Test
-  void sync_reportsZeroForAFeeTheFundIsNotChargedAndDoesNotReadTheAccrual() {
+  void sync_reportsZeroForAFeeTheFundIsNotCharged() {
     given(clock.instant()).willReturn(NOW);
     given(clock.getZone()).willReturn(ZONE);
     given(feeChargedToFundPolicy.resolverFor(TKF100, DEPOT))
@@ -150,8 +153,8 @@ class FeeAccrualPositionSyncJobTest {
     var navDate = LocalDate.of(2025, 3, 10);
     given(fundPositionRepository.findDistinctNavDatesByFund(any())).willReturn(List.of());
     given(fundPositionRepository.findDistinctNavDatesByFund(TKF100)).willReturn(List.of(navDate));
-    given(feeAccrualRepository.getUnsettledAccrual(TKF100, MANAGEMENT, navDate))
-        .willReturn(new BigDecimal("52.08"));
+    given(feeAccrualRepository.getUnsettledAccrualByDate(TKF100, MANAGEMENT, navDate))
+        .willReturn(Map.of(ACCRUAL_DAY, new BigDecimal("52.08")));
 
     syncJob.sync(7);
 
@@ -160,7 +163,9 @@ class FeeAccrualPositionSyncJobTest {
             List.of(
                 feeAccrualPosition(navDate, "Management Fee Accrual", new BigDecimal("-52.08")),
                 feeAccrualPosition(navDate, "Depot Fee Accrual", BigDecimal.ZERO)));
-    verify(feeAccrualRepository, never()).getUnsettledAccrual(TKF100, DEPOT, navDate);
+    // The accrual IS read now; the policy is applied per accrual date afterwards. Skipping the
+    // read was only safe while one day's answer stood for the whole month.
+    verify(feeAccrualRepository).getUnsettledAccrualByDate(TKF100, DEPOT, navDate);
   }
 
   @Test
@@ -173,8 +178,7 @@ class FeeAccrualPositionSyncJobTest {
         .willReturn(
             List.of(
                 LocalDate.of(2025, 3, 10), LocalDate.of(2025, 3, 11), LocalDate.of(2025, 3, 12)));
-    given(feeAccrualRepository.getUnsettledAccrual(any(), any(), any()))
-        .willReturn(BigDecimal.ZERO);
+    given(feeAccrualRepository.getUnsettledAccrualByDate(any(), any(), any())).willReturn(Map.of());
 
     syncJob.sync(7);
 

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionInputServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionInputServiceTest.java
@@ -66,7 +66,26 @@ class TransactionInputServiceTest {
     lenient()
         .when(pendingOrderImpactService.calculate(any(), any(), any()))
         .thenReturn(PendingOrderImpact.none());
-    lenient().when(feeChargedToFundPolicy.chargedToFund(any(), any(), any())).thenReturn(true);
+    lenient()
+        .when(feeChargedToFundPolicy.resolverFor(any(), any()))
+        .thenAnswer(
+            invocation -> alwaysCharged(invocation.getArgument(0), invocation.getArgument(1)));
+  }
+
+  private static FeeChargedToFundPolicy.Resolver alwaysCharged(TulevaFund fund, FeeType feeType) {
+    return resolver(fund, feeType, true);
+  }
+
+  private static FeeChargedToFundPolicy.Resolver neverCharged(TulevaFund fund, FeeType feeType) {
+    return resolver(fund, feeType, false);
+  }
+
+  private static FeeChargedToFundPolicy.Resolver resolver(
+      TulevaFund fund, FeeType feeType, boolean chargedToFund) {
+    return new FeeChargedToFundPolicy.Resolver(
+        fund,
+        feeType,
+        List.of(new FeeChargedToFundPolicy.Policy(chargedToFund, LocalDate.of(2000, 1, 1), null)));
   }
 
   @Mock private FundPositionRepository fundPositionRepository;
@@ -113,12 +132,12 @@ class TransactionInputServiceTest {
     when(fundPositionRepository.findByNavDateAndFundAndAccountType(positionDate, TUV100, CASH))
         .thenReturn(List.of(cashPosition));
 
-    when(feeAccrualRepository.getAccruedFeesForMonth(
+    when(feeAccrualRepository.getAccruedFeesByDateForMonth(
             eq(TUV100), any(), eq(List.of(FeeType.MANAGEMENT)), any()))
-        .thenReturn(new BigDecimal("5000"));
-    when(feeAccrualRepository.getAccruedFeesForMonth(
+        .thenReturn(Map.of(AS_OF_DATE, new BigDecimal("5000")));
+    when(feeAccrualRepository.getAccruedFeesByDateForMonth(
             eq(TUV100), any(), eq(List.of(FeeType.DEPOT)), any()))
-        .thenReturn(ZERO);
+        .thenReturn(Map.of());
 
     var modelAllocation =
         ModelPortfolioAllocation.builder()
@@ -166,8 +185,8 @@ class TransactionInputServiceTest {
   @Test
   void gatherInput_leavesOutADepotFeeThatIsExcludedFromNav() {
     var positionDate = AS_OF_DATE;
-    given(feeChargedToFundPolicy.chargedToFund(TUV100, FeeType.DEPOT, AS_OF_DATE))
-        .willReturn(false);
+    given(feeChargedToFundPolicy.resolverFor(TUV100, FeeType.DEPOT))
+        .willReturn(neverCharged(TUV100, FeeType.DEPOT));
     given(fundPositionRepository.findLatestNavDateByFundAndAsOfDate(TUV100, AS_OF_DATE))
         .willReturn(Optional.of(positionDate));
     given(fundPositionRepository.findByNavDateAndFundAndAccountType(positionDate, TUV100, SECURITY))
@@ -175,9 +194,9 @@ class TransactionInputServiceTest {
     given(fundPositionRepository.findByNavDateAndFundAndAccountType(positionDate, TUV100, CASH))
         .willReturn(List.of());
     given(
-            feeAccrualRepository.getAccruedFeesForMonth(
+            feeAccrualRepository.getAccruedFeesByDateForMonth(
                 eq(TUV100), any(), eq(List.of(FeeType.MANAGEMENT)), any()))
-        .willReturn(new BigDecimal("3000"));
+        .willReturn(Map.of(AS_OF_DATE, new BigDecimal("3000")));
     given(modelPortfolioAllocationRepository.findLatestByFundAsOf(TUV100, AS_OF_DATE))
         .willReturn(List.of());
     given(fundLimitRepository.findLatestByFundAsOf(TUV100, AS_OF_DATE))
@@ -189,8 +208,10 @@ class TransactionInputServiceTest {
 
     assertThat(result.liabilityBreakdown().depotFee()).isEqualByComparingTo(ZERO);
     assertThat(result.liabilityBreakdown().managementFee()).isEqualByComparingTo("3000");
-    verify(feeAccrualRepository, never())
-        .getAccruedFeesForMonth(eq(TUV100), any(), eq(List.of(FeeType.DEPOT)), any());
+    // The accruals are still READ — the policy is applied per accrual date afterwards, which is
+    // what lets a month the policy flips in be split instead of taken whole.
+    verify(feeAccrualRepository)
+        .getAccruedFeesByDateForMonth(eq(TUV100), any(), eq(List.of(FeeType.DEPOT)), any());
   }
 
   @Test
@@ -203,13 +224,13 @@ class TransactionInputServiceTest {
     given(fundPositionRepository.findByNavDateAndFundAndAccountType(positionDate, TUV100, CASH))
         .willReturn(List.of());
     given(
-            feeAccrualRepository.getAccruedFeesForMonth(
+            feeAccrualRepository.getAccruedFeesByDateForMonth(
                 eq(TUV100), any(), eq(List.of(FeeType.MANAGEMENT)), any()))
-        .willReturn(new BigDecimal("3000"));
+        .willReturn(Map.of(AS_OF_DATE, new BigDecimal("3000")));
     given(
-            feeAccrualRepository.getAccruedFeesForMonth(
+            feeAccrualRepository.getAccruedFeesByDateForMonth(
                 eq(TUV100), any(), eq(List.of(FeeType.DEPOT)), any()))
-        .willReturn(new BigDecimal("2000"));
+        .willReturn(Map.of(AS_OF_DATE, new BigDecimal("2000")));
     given(modelPortfolioAllocationRepository.findLatestByFundAsOf(TUV100, AS_OF_DATE))
         .willReturn(List.of());
     given(fundLimitRepository.findLatestByFundAsOf(TUV100, AS_OF_DATE))
@@ -260,8 +281,8 @@ class TransactionInputServiceTest {
         .willReturn(List.of());
     given(fundPositionRepository.findByNavDateAndFundAndAccountType(positionDate, TUV100, CASH))
         .willReturn(List.of());
-    given(feeAccrualRepository.getAccruedFeesForMonth(eq(TUV100), any(), any(), any()))
-        .willReturn(ZERO);
+    given(feeAccrualRepository.getAccruedFeesByDateForMonth(eq(TUV100), any(), any(), any()))
+        .willReturn(Map.of());
     given(modelPortfolioAllocationRepository.findLatestByFundAsOf(TUV100, AS_OF_DATE))
         .willReturn(
             List.of(
@@ -296,8 +317,8 @@ class TransactionInputServiceTest {
                     .accountType(CASH)
                     .marketValue(new BigDecimal("100000"))
                     .build()));
-    given(feeAccrualRepository.getAccruedFeesForMonth(eq(TUV100), any(), any(), any()))
-        .willReturn(ZERO);
+    given(feeAccrualRepository.getAccruedFeesByDateForMonth(eq(TUV100), any(), any(), any()))
+        .willReturn(Map.of());
     given(modelPortfolioAllocationRepository.findLatestByFundAsOf(TUV100, AS_OF_DATE))
         .willReturn(List.of());
     given(fundLimitRepository.findLatestByFundAsOf(TUV100, AS_OF_DATE))
@@ -327,8 +348,8 @@ class TransactionInputServiceTest {
                     .accountType(CASH)
                     .marketValue(new BigDecimal("100000"))
                     .build()));
-    given(feeAccrualRepository.getAccruedFeesForMonth(eq(TUV100), any(), any(), any()))
-        .willReturn(ZERO);
+    given(feeAccrualRepository.getAccruedFeesByDateForMonth(eq(TUV100), any(), any(), any()))
+        .willReturn(Map.of());
     given(modelPortfolioAllocationRepository.findLatestByFundAsOf(TUV100, AS_OF_DATE))
         .willReturn(List.of());
     given(fundLimitRepository.findLatestByFundAsOf(TUV100, AS_OF_DATE))
@@ -357,8 +378,8 @@ class TransactionInputServiceTest {
                     .accountType(CASH)
                     .marketValue(new BigDecimal("100000"))
                     .build()));
-    given(feeAccrualRepository.getAccruedFeesForMonth(eq(TUV100), any(), any(), any()))
-        .willReturn(ZERO);
+    given(feeAccrualRepository.getAccruedFeesByDateForMonth(eq(TUV100), any(), any(), any()))
+        .willReturn(Map.of());
     given(modelPortfolioAllocationRepository.findLatestByFundAsOf(TUV100, AS_OF_DATE))
         .willReturn(List.of());
     given(fundLimitRepository.findLatestByFundAsOf(TUV100, AS_OF_DATE))
@@ -392,8 +413,8 @@ class TransactionInputServiceTest {
         .thenReturn(List.of(position));
     when(fundPositionRepository.findByNavDateAndFundAndAccountType(positionDate, TUV100, CASH))
         .thenReturn(List.of());
-    when(feeAccrualRepository.getAccruedFeesForMonth(eq(TUV100), any(), any(), any()))
-        .thenReturn(ZERO);
+    when(feeAccrualRepository.getAccruedFeesByDateForMonth(eq(TUV100), any(), any(), any()))
+        .thenReturn(Map.of());
     when(modelPortfolioAllocationRepository.findLatestByFundAsOf(TUV100, AS_OF_DATE))
         .thenReturn(List.of());
     when(fundLimitRepository.findLatestByFundAsOf(TUV100, AS_OF_DATE))
@@ -417,8 +438,8 @@ class TransactionInputServiceTest {
         .willReturn(List.of());
     given(fundPositionRepository.findByNavDateAndFundAndAccountType(positionDate, TUV100, CASH))
         .willReturn(List.of());
-    given(feeAccrualRepository.getAccruedFeesForMonth(eq(TUV100), any(), any(), any()))
-        .willReturn(ZERO);
+    given(feeAccrualRepository.getAccruedFeesByDateForMonth(eq(TUV100), any(), any(), any()))
+        .willReturn(Map.of());
 
     var underweightAllocation =
         ModelPortfolioAllocation.builder()
@@ -454,8 +475,8 @@ class TransactionInputServiceTest {
         .thenReturn(List.of());
     when(fundPositionRepository.findByNavDateAndFundAndAccountType(positionDate, TUV100, CASH))
         .thenReturn(List.of());
-    when(feeAccrualRepository.getAccruedFeesForMonth(eq(TUV100), any(), any(), any()))
-        .thenReturn(ZERO);
+    when(feeAccrualRepository.getAccruedFeesByDateForMonth(eq(TUV100), any(), any(), any()))
+        .thenReturn(Map.of());
     when(modelPortfolioAllocationRepository.findLatestByFundAsOf(TUV100, AS_OF_DATE))
         .thenReturn(List.of());
     when(fundLimitRepository.findLatestByFundAsOf(TUV100, AS_OF_DATE))
@@ -477,8 +498,8 @@ class TransactionInputServiceTest {
         .thenReturn(List.of());
     when(fundPositionRepository.findByNavDateAndFundAndAccountType(positionDate, TUV100, CASH))
         .thenReturn(List.of());
-    when(feeAccrualRepository.getAccruedFeesForMonth(eq(TUV100), any(), any(), any()))
-        .thenReturn(ZERO);
+    when(feeAccrualRepository.getAccruedFeesByDateForMonth(eq(TUV100), any(), any(), any()))
+        .thenReturn(Map.of());
 
     var fastAllocation =
         ModelPortfolioAllocation.builder()
@@ -515,8 +536,8 @@ class TransactionInputServiceTest {
         .thenReturn(List.of());
     when(fundPositionRepository.findByNavDateAndFundAndAccountType(positionDate, TUV100, CASH))
         .thenReturn(List.of());
-    when(feeAccrualRepository.getAccruedFeesForMonth(eq(TUV100), any(), any(), any()))
-        .thenReturn(ZERO);
+    when(feeAccrualRepository.getAccruedFeesByDateForMonth(eq(TUV100), any(), any(), any()))
+        .thenReturn(Map.of());
 
     var currentAllocation =
         ModelPortfolioAllocation.builder()
@@ -556,8 +577,8 @@ class TransactionInputServiceTest {
         .thenReturn(List.of());
     when(fundPositionRepository.findByNavDateAndFundAndAccountType(positionDate, TUV100, CASH))
         .thenReturn(List.of());
-    when(feeAccrualRepository.getAccruedFeesForMonth(eq(TUV100), any(), any(), any()))
-        .thenReturn(ZERO);
+    when(feeAccrualRepository.getAccruedFeesByDateForMonth(eq(TUV100), any(), any(), any()))
+        .thenReturn(Map.of());
 
     var etfAllocation =
         ModelPortfolioAllocation.builder()
@@ -616,12 +637,12 @@ class TransactionInputServiceTest {
     when(fundPositionRepository.findByNavDateAndFundAndAccountType(positionDate, TKF100, CASH))
         .thenReturn(List.of(cashPosition));
 
-    when(feeAccrualRepository.getAccruedFeesForMonth(
+    when(feeAccrualRepository.getAccruedFeesByDateForMonth(
             eq(TKF100), any(), eq(List.of(FeeType.MANAGEMENT)), any()))
-        .thenReturn(new BigDecimal("3000"));
-    when(feeAccrualRepository.getAccruedFeesForMonth(
+        .thenReturn(Map.of(AS_OF_DATE, new BigDecimal("3000")));
+    when(feeAccrualRepository.getAccruedFeesByDateForMonth(
             eq(TKF100), any(), eq(List.of(FeeType.DEPOT)), any()))
-        .thenReturn(ZERO);
+        .thenReturn(Map.of());
 
     when(modelPortfolioAllocationRepository.findLatestByFundAsOf(TKF100, AS_OF_DATE))
         .thenReturn(List.of());
@@ -655,12 +676,12 @@ class TransactionInputServiceTest {
         .thenReturn(List.of());
     when(fundPositionRepository.findByNavDateAndFundAndAccountType(positionDate, TUV100, CASH))
         .thenReturn(List.of());
-    when(feeAccrualRepository.getAccruedFeesForMonth(
+    when(feeAccrualRepository.getAccruedFeesByDateForMonth(
             eq(TUV100), any(), eq(List.of(FeeType.MANAGEMENT)), any()))
-        .thenReturn(new BigDecimal("1000"));
-    when(feeAccrualRepository.getAccruedFeesForMonth(
+        .thenReturn(Map.of(AS_OF_DATE, new BigDecimal("1000")));
+    when(feeAccrualRepository.getAccruedFeesByDateForMonth(
             eq(TUV100), any(), eq(List.of(FeeType.DEPOT)), any()))
-        .thenReturn(ZERO);
+        .thenReturn(Map.of());
     when(modelPortfolioAllocationRepository.findLatestByFundAsOf(TUV100, AS_OF_DATE))
         .thenReturn(List.of());
     when(fundLimitRepository.findLatestByFundAsOf(TUV100, AS_OF_DATE))
@@ -686,12 +707,12 @@ class TransactionInputServiceTest {
         .thenReturn(List.of());
     when(fundPositionRepository.findByNavDateAndFundAndAccountType(positionDate, TUV100, CASH))
         .thenReturn(List.of());
-    when(feeAccrualRepository.getAccruedFeesForMonth(
+    when(feeAccrualRepository.getAccruedFeesByDateForMonth(
             eq(TUV100), any(), eq(List.of(FeeType.MANAGEMENT)), any()))
-        .thenReturn(new BigDecimal("1000"));
-    when(feeAccrualRepository.getAccruedFeesForMonth(
+        .thenReturn(Map.of(AS_OF_DATE, new BigDecimal("1000")));
+    when(feeAccrualRepository.getAccruedFeesByDateForMonth(
             eq(TUV100), any(), eq(List.of(FeeType.DEPOT)), any()))
-        .thenReturn(ZERO);
+        .thenReturn(Map.of());
     when(modelPortfolioAllocationRepository.findLatestByFundAsOf(TUV100, AS_OF_DATE))
         .thenReturn(List.of());
     when(fundLimitRepository.findLatestByFundAsOf(TUV100, AS_OF_DATE))
@@ -719,8 +740,8 @@ class TransactionInputServiceTest {
         .thenReturn(List.of());
     when(fundPositionRepository.findByNavDateAndFundAndAccountType(positionDate, TUV100, CASH))
         .thenReturn(List.of());
-    when(feeAccrualRepository.getAccruedFeesForMonth(eq(TUV100), any(), any(), any()))
-        .thenReturn(ZERO);
+    when(feeAccrualRepository.getAccruedFeesByDateForMonth(eq(TUV100), any(), any(), any()))
+        .thenReturn(Map.of());
     when(modelPortfolioAllocationRepository.findLatestByFundAsOf(TUV100, AS_OF_DATE))
         .thenReturn(List.of());
     when(fundLimitRepository.findLatestByFundAsOf(TUV100, AS_OF_DATE)).thenReturn(Optional.empty());
@@ -740,8 +761,8 @@ class TransactionInputServiceTest {
         .thenReturn(List.of());
     when(fundPositionRepository.findByNavDateAndFundAndAccountType(positionDate, TUV100, CASH))
         .thenReturn(List.of());
-    when(feeAccrualRepository.getAccruedFeesForMonth(eq(TUV100), any(), any(), any()))
-        .thenReturn(ZERO);
+    when(feeAccrualRepository.getAccruedFeesByDateForMonth(eq(TUV100), any(), any(), any()))
+        .thenReturn(Map.of());
     when(modelPortfolioAllocationRepository.findLatestByFundAsOf(TUV100, AS_OF_DATE))
         .thenReturn(List.of());
 
@@ -764,8 +785,8 @@ class TransactionInputServiceTest {
         .thenReturn(List.of());
     when(fundPositionRepository.findByNavDateAndFundAndAccountType(positionDate, TUV100, CASH))
         .thenReturn(List.of());
-    when(feeAccrualRepository.getAccruedFeesForMonth(eq(TUV100), any(), any(), any()))
-        .thenReturn(ZERO);
+    when(feeAccrualRepository.getAccruedFeesByDateForMonth(eq(TUV100), any(), any(), any()))
+        .thenReturn(Map.of());
     when(modelPortfolioAllocationRepository.findLatestByFundAsOf(TUV100, AS_OF_DATE))
         .thenReturn(List.of());
 
@@ -788,8 +809,8 @@ class TransactionInputServiceTest {
         .thenReturn(List.of());
     when(fundPositionRepository.findByNavDateAndFundAndAccountType(positionDate, TUV100, CASH))
         .thenReturn(List.of());
-    when(feeAccrualRepository.getAccruedFeesForMonth(eq(TUV100), any(), any(), any()))
-        .thenReturn(ZERO);
+    when(feeAccrualRepository.getAccruedFeesByDateForMonth(eq(TUV100), any(), any(), any()))
+        .thenReturn(Map.of());
 
     var currentAllocation =
         ModelPortfolioAllocation.builder()
@@ -836,8 +857,8 @@ class TransactionInputServiceTest {
         .thenReturn(List.of());
     when(fundPositionRepository.findByNavDateAndFundAndAccountType(positionDate, TUV100, CASH))
         .thenReturn(List.of());
-    when(feeAccrualRepository.getAccruedFeesForMonth(eq(TUV100), any(), any(), any()))
-        .thenReturn(ZERO);
+    when(feeAccrualRepository.getAccruedFeesByDateForMonth(eq(TUV100), any(), any(), any()))
+        .thenReturn(Map.of());
 
     var currentAllocation =
         ModelPortfolioAllocation.builder()
@@ -900,8 +921,8 @@ class TransactionInputServiceTest {
 
     when(fundPositionRepository.findByNavDateAndFundAndAccountType(positionDate, TUV100, CASH))
         .thenReturn(List.of());
-    when(feeAccrualRepository.getAccruedFeesForMonth(eq(TUV100), any(), any(), any()))
-        .thenReturn(ZERO);
+    when(feeAccrualRepository.getAccruedFeesByDateForMonth(eq(TUV100), any(), any(), any()))
+        .thenReturn(Map.of());
     when(modelPortfolioAllocationRepository.findLatestByFundAsOf(TUV100, AS_OF_DATE))
         .thenReturn(List.of());
     when(fundLimitRepository.findLatestByFundAsOf(TUV100, AS_OF_DATE))
@@ -924,8 +945,8 @@ class TransactionInputServiceTest {
         .thenReturn(List.of());
     when(fundPositionRepository.findByNavDateAndFundAndAccountType(positionDate, TUV100, CASH))
         .thenReturn(List.of());
-    when(feeAccrualRepository.getAccruedFeesForMonth(eq(TUV100), any(), any(), any()))
-        .thenReturn(ZERO);
+    when(feeAccrualRepository.getAccruedFeesByDateForMonth(eq(TUV100), any(), any(), any()))
+        .thenReturn(Map.of());
     when(modelPortfolioAllocationRepository.findLatestByFundAsOf(TUV100, AS_OF_DATE))
         .thenReturn(List.of());
     when(fundLimitRepository.findLatestByFundAsOf(TUV100, AS_OF_DATE))
@@ -947,8 +968,8 @@ class TransactionInputServiceTest {
         .thenReturn(List.of());
     when(fundPositionRepository.findByNavDateAndFundAndAccountType(positionDate, TUV100, CASH))
         .thenReturn(List.of());
-    when(feeAccrualRepository.getAccruedFeesForMonth(eq(TUV100), any(), any(), any()))
-        .thenReturn(ZERO);
+    when(feeAccrualRepository.getAccruedFeesByDateForMonth(eq(TUV100), any(), any(), any()))
+        .thenReturn(Map.of());
 
     var allocationWithIsin =
         ModelPortfolioAllocation.builder()
@@ -990,8 +1011,8 @@ class TransactionInputServiceTest {
                     .accountType(CASH)
                     .marketValue(new BigDecimal("100000"))
                     .build()));
-    when(feeAccrualRepository.getAccruedFeesForMonth(eq(TUV100), any(), any(), any()))
-        .thenReturn(ZERO);
+    when(feeAccrualRepository.getAccruedFeesByDateForMonth(eq(TUV100), any(), any(), any()))
+        .thenReturn(Map.of());
     when(modelPortfolioAllocationRepository.findLatestByFundAsOf(TUV100, AS_OF_DATE))
         .thenReturn(List.of());
     when(fundLimitRepository.findLatestByFundAsOf(TUV100, AS_OF_DATE))
@@ -1050,8 +1071,8 @@ class TransactionInputServiceTest {
                     .accountType(CASH)
                     .marketValue(new BigDecimal("100000"))
                     .build()));
-    given(feeAccrualRepository.getAccruedFeesForMonth(eq(TUV100), any(), any(), any()))
-        .willReturn(ZERO);
+    given(feeAccrualRepository.getAccruedFeesByDateForMonth(eq(TUV100), any(), any(), any()))
+        .willReturn(Map.of());
     given(modelPortfolioAllocationRepository.findLatestByFundAsOf(TUV100, AS_OF_DATE))
         .willReturn(List.of());
     given(fundLimitRepository.findLatestByFundAsOf(TUV100, AS_OF_DATE))
@@ -1375,8 +1396,8 @@ class TransactionInputServiceTest {
         .willReturn(List.of());
     given(fundPositionRepository.findByNavDateAndFundAndAccountType(AS_OF_DATE, fund, CASH))
         .willReturn(List.of());
-    given(feeAccrualRepository.getAccruedFeesForMonth(eq(fund), any(), any(), any()))
-        .willReturn(ZERO);
+    given(feeAccrualRepository.getAccruedFeesByDateForMonth(eq(fund), any(), any(), any()))
+        .willReturn(Map.of());
     given(modelPortfolioAllocationRepository.findLatestByFundAsOf(fund, AS_OF_DATE))
         .willReturn(List.of());
     given(fundLimitRepository.findLatestByFundAsOf(fund, AS_OF_DATE))
@@ -1430,8 +1451,8 @@ class TransactionInputServiceTest {
                     .accountType(CASH)
                     .marketValue(new BigDecimal("100000"))
                     .build()));
-    given(feeAccrualRepository.getAccruedFeesForMonth(eq(TUV100), any(), any(), any()))
-        .willReturn(ZERO);
+    given(feeAccrualRepository.getAccruedFeesByDateForMonth(eq(TUV100), any(), any(), any()))
+        .willReturn(Map.of());
     given(modelPortfolioAllocationRepository.findLatestByFundAsOf(TUV100, AS_OF_DATE))
         .willReturn(List.of());
     given(fundLimitRepository.findLatestByFundAsOf(TUV100, AS_OF_DATE))
@@ -1488,8 +1509,8 @@ class TransactionInputServiceTest {
                     .accountType(CASH)
                     .marketValue(new BigDecimal("100000"))
                     .build()));
-    given(feeAccrualRepository.getAccruedFeesForMonth(eq(TUV100), any(), any(), any()))
-        .willReturn(ZERO);
+    given(feeAccrualRepository.getAccruedFeesByDateForMonth(eq(TUV100), any(), any(), any()))
+        .willReturn(Map.of());
     given(modelPortfolioAllocationRepository.findLatestByFundAsOf(TUV100, AS_OF_DATE))
         .willReturn(List.of());
     given(fundLimitRepository.findLatestByFundAsOf(TUV100, AS_OF_DATE))
@@ -1532,8 +1553,8 @@ class TransactionInputServiceTest {
                     .accountType(CASH)
                     .marketValue(new BigDecimal("100000"))
                     .build()));
-    given(feeAccrualRepository.getAccruedFeesForMonth(eq(TUV100), any(), any(), any()))
-        .willReturn(ZERO);
+    given(feeAccrualRepository.getAccruedFeesByDateForMonth(eq(TUV100), any(), any(), any()))
+        .willReturn(Map.of());
     given(modelPortfolioAllocationRepository.findLatestByFundAsOf(TUV100, AS_OF_DATE))
         .willReturn(List.of());
     given(fundLimitRepository.findLatestByFundAsOf(TUV100, AS_OF_DATE))
@@ -1575,8 +1596,8 @@ class TransactionInputServiceTest {
                     .accountType(CASH)
                     .marketValue(new BigDecimal("100000"))
                     .build()));
-    given(feeAccrualRepository.getAccruedFeesForMonth(eq(TUV100), any(), any(), any()))
-        .willReturn(ZERO);
+    given(feeAccrualRepository.getAccruedFeesByDateForMonth(eq(TUV100), any(), any(), any()))
+        .willReturn(Map.of());
     given(modelPortfolioAllocationRepository.findLatestByFundAsOf(TUV100, AS_OF_DATE))
         .willReturn(List.of());
     given(fundLimitRepository.findLatestByFundAsOf(TUV100, AS_OF_DATE))
@@ -1627,8 +1648,8 @@ class TransactionInputServiceTest {
                     .accountType(CASH)
                     .marketValue(new BigDecimal("100000"))
                     .build()));
-    given(feeAccrualRepository.getAccruedFeesForMonth(eq(TUV100), any(), any(), any()))
-        .willReturn(ZERO);
+    given(feeAccrualRepository.getAccruedFeesByDateForMonth(eq(TUV100), any(), any(), any()))
+        .willReturn(Map.of());
     given(modelPortfolioAllocationRepository.findLatestByFundAsOf(TUV100, AS_OF_DATE))
         .willReturn(List.of());
     given(fundLimitRepository.findLatestByFundAsOf(TUV100, AS_OF_DATE))
@@ -1669,8 +1690,8 @@ class TransactionInputServiceTest {
                     .accountType(CASH)
                     .marketValue(new BigDecimal("100000"))
                     .build()));
-    given(feeAccrualRepository.getAccruedFeesForMonth(eq(TUV100), any(), any(), any()))
-        .willReturn(ZERO);
+    given(feeAccrualRepository.getAccruedFeesByDateForMonth(eq(TUV100), any(), any(), any()))
+        .willReturn(Map.of());
     given(modelPortfolioAllocationRepository.findLatestByFundAsOf(TUV100, AS_OF_DATE))
         .willReturn(List.of());
     given(fundLimitRepository.findLatestByFundAsOf(TUV100, AS_OF_DATE))
@@ -1717,8 +1738,8 @@ class TransactionInputServiceTest {
                     .accountType(CASH)
                     .marketValue(new BigDecimal("100000"))
                     .build()));
-    given(feeAccrualRepository.getAccruedFeesForMonth(eq(TUV100), any(), any(), any()))
-        .willReturn(ZERO);
+    given(feeAccrualRepository.getAccruedFeesByDateForMonth(eq(TUV100), any(), any(), any()))
+        .willReturn(Map.of());
     given(modelPortfolioAllocationRepository.findLatestByFundAsOf(TUV100, AS_OF_DATE))
         .willReturn(List.of());
     given(fundLimitRepository.findLatestByFundAsOf(TUV100, AS_OF_DATE))

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/nav/NavCalculationServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/nav/NavCalculationServiceTest.java
@@ -19,7 +19,6 @@ import ee.tuleva.onboarding.investment.fees.FeeBases;
 import ee.tuleva.onboarding.investment.fees.FeeCalculationService;
 import ee.tuleva.onboarding.investment.fees.FeeChargedToFundPolicy;
 import ee.tuleva.onboarding.investment.fees.FeeResult;
-import ee.tuleva.onboarding.investment.fees.FeeType;
 import ee.tuleva.onboarding.investment.position.FundPositionRepository;
 import ee.tuleva.onboarding.ledger.LedgerAccountFixture.EntryFixture;
 import ee.tuleva.onboarding.ledger.LedgerService;
@@ -140,7 +139,7 @@ class NavCalculationServiceTest {
   }
 
   @Test
-  void calculate_keepsAnExcludedDepotFeeOutOfNavWhileTheAccrualStillHappens() {
+  void calculate_takesTheFeeResultAsGivenBecauseThePolicyIsAppliedPerAccrualDateUpstream() {
     LocalDate calcDate = LocalDate.of(2025, 1, 15);
     LocalDate previousWorkingDay = LocalDate.of(2025, 1, 14);
 
@@ -158,9 +157,12 @@ class NavCalculationServiceTest {
     when(redemptionsComponent.calculate(any())).thenReturn(ZERO);
     when(feeCalculationService.calculateFeesForNav(
             eq(TKF100), eq(previousWorkingDay), any(), any(), any()))
-        .thenReturn(new FeeResult(new BigDecimal("52.08"), new BigDecimal("6.85")));
-    when(feeChargedToFundPolicy.chargedToFund(TKF100, FeeType.DEPOT, previousWorkingDay))
-        .thenReturn(false);
+        .thenReturn(new FeeResult(new BigDecimal("52.08"), ZERO));
+    // The charged-to-fund decision now lives in FeeCalculationService, which applies it PER
+    // ACCRUAL DATE — so a depot fee Tuleva bears arrives here already zeroed. Re-gating the summed
+    // figure on one day's answer was the bug: a month the policy flips in would be taken whole or
+    // dropped whole. FeeChargedToFundPolicyTest pins the split; this pins that NAV does not
+    // second-guess it.
 
     NavCalculationResult result = service.calculate(TKF100, calcDate);
 

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/nav/NavPipelineIntegrationTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/nav/NavPipelineIntegrationTest.java
@@ -172,6 +172,7 @@ class NavPipelineIntegrationTest {
 
     insertFeeRate(TKF100, "MANAGEMENT", new BigDecimal("0.0029"), LocalDate.of(2026, 1, 1));
     insertFeeRate(TKF100, "DEPOT", new BigDecimal("0.01"), LocalDate.of(2026, 1, 1));
+    chargeFeeToFund(TKF100, "DEPOT");
 
     // Establish first accrual at Feb 25
     Instant feb26Cutoff = LocalDate.of(2026, 2, 26).atStartOfDay(eet).toInstant();
@@ -502,6 +503,29 @@ class NavPipelineIntegrationTest {
         .param("fundCode", fund.name())
         .param("accountId", "TEST_ISIN_" + fund.name())
         .param("marketValue", marketValue)
+        .update();
+  }
+
+  /**
+   * Point the charged-to-fund policy at the fund for this test. The depot fee is the vehicle these
+   * settlement assertions ride on, and seeded policy has Tuleva bearing TKF100's depot fee — which
+   * would make every NAV-facing depot figure a correct zero and test nothing about settlement.
+   */
+  private void chargeFeeToFund(TulevaFund fund, String feeType) {
+    jdbcClient
+        .sql(
+            "DELETE FROM investment_fee_policy WHERE fund_code = :fundCode AND fee_type = :feeType")
+        .param("fundCode", fund.name())
+        .param("feeType", feeType)
+        .update();
+    jdbcClient
+        .sql(
+            """
+            INSERT INTO investment_fee_policy (fund_code, fee_type, charged_to_fund, valid_from, created_by)
+            VALUES (:fundCode, :feeType, true, DATE '2000-01-01', 'TEST')
+            """)
+        .param("fundCode", fund.name())
+        .param("feeType", feeType)
         .update();
   }
 


### PR DESCRIPTION
Closes #1856. A month-to-date accrual is a sum over many days, but all three
NAV-facing readers asked "is this fee charged to the fund?" **once**, for a
single day, and applied that answer to the whole sum. A policy that flips
mid-month would then put NAV and the ledger out of step for that month and turn
`LedgerAccrualConsistencyChecker` red.

Concretely: Tuleva bears TUK75's depot fee, the board moves it to the fund on
15 September. Days 1–14 belong to Tuleva, 15–30 to the fund. Asking once for the
30th admits the **entire** month into NAV; asking once for the 1st admits none
of it. Neither is right.

**The fix is one seam, not three.** All three readers bottom out in the same two
queries, so the per-date split goes there:

- `FeeAccrualRepository.getAccruedFeesByDateForMonth` / `getUnsettledAccrualByDate`
  return the same rows grouped by `accrual_date` instead of pre-summed.
- `FeeChargedToFundPolicy.Resolver.sumChargedDays(...)` sums only the days the
  policy actually charges — reusing the resolver that already loads the policy
  rows once, so this costs no extra queries.

Then: `FeeCalculationService` (which feeds `NavCalculationService`),
`TransactionInputService.getAccruedFees` and
`FeeAccrualPositionSyncJob.chargedAccrual` all filter per day.

**`NavCalculationService.navFacingAccrual` is deleted, deliberately.** With the
policy applied upstream per date, re-gating the summed figure on one day's
answer would undo the fix — it would zero or admit a flipped month whole. That
also means `FeeResult` is now the NAV-facing accrual rather than the raw one;
the accrual rows themselves are unchanged and still recorded in full, which the
integration test now asserts explicitly.

**Gap and overlap validation is preserved and strengthened.** `chargedOn` still
throws on an uncovered or doubly-covered date — and now it is asked about every
accrual date, not just one, so a gap in the middle of a month is caught instead
of skipped. `sumChargedDays_stillRefusesAGapRatherThanSkippingTheDay` pins that
a day no row covers is an error, not a silent zero.

Scale is preserved exactly: the filtered sum rounds to 2 like the
`ROUND(SUM(...), 2)` it replaces, and returns a plain `0` for no rows, so no
stored figure changes shape.

**Tests.** `sumChargedDays_splitsAMonthThePolicyFlipsInsteadOfTakingOneDaysAnswer`
is the case this exists for: policy false to 14.09, true from 15.09, and only
the post-flip days are summed. The mock churn #1847 predicted was real — ~40
call sites across four suites — but is mechanical, and every behavioural
assertion is unchanged except the three that pinned the old whole-month gating.
`NavPipelineIntegrationTest`'s settlement test now seeds the policy it depends
on rather than relying on a default that made its depot figures a correct zero.

Full `./gradlew test` green.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

Closes #1856.

🤖 Generated with [Claude Code](https://claude.com/claude-code)