### PR TITLE
Red Slack alerts for missing NAV and faster pillar 2 self-heal

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/notification/OperationsNotificationService.java
+++ b/src/main/java/ee/tuleva/onboarding/notification/OperationsNotificationService.java
@@ -1,8 +1,13 @@
 package ee.tuleva.onboarding.notification;
 
+import org.jspecify.annotations.NullMarked;
+
+@NullMarked
 public interface OperationsNotificationService {
 
   void sendMessage(String message, Channel channel);
+
+  void sendMessage(String message, Channel channel, Severity severity);
 
   enum Channel {
     AML,
@@ -10,5 +15,10 @@ public interface OperationsNotificationService {
     CAPITAL_TRANSFER,
     INVESTMENT,
     SAVINGS
+  }
+
+  enum Severity {
+    INFO,
+    ERROR
   }
 }

--- a/src/main/java/ee/tuleva/onboarding/notification/slack/SlackService.java
+++ b/src/main/java/ee/tuleva/onboarding/notification/slack/SlackService.java
@@ -1,15 +1,18 @@
 package ee.tuleva.onboarding.notification.slack;
 
 import ee.tuleva.onboarding.notification.OperationsNotificationService;
+import java.util.List;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NullMarked;
 import org.springframework.boot.restclient.RestTemplateBuilder;
 import org.springframework.core.env.Environment;
 import org.springframework.http.HttpEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
+@NullMarked
 @Service
 @Slf4j
 public class SlackService implements OperationsNotificationService {
@@ -41,6 +44,11 @@ public class SlackService implements OperationsNotificationService {
 
   @Override
   public void sendMessage(String message, Channel channel) {
+    sendMessage(message, channel, Severity.INFO);
+  }
+
+  @Override
+  public void sendMessage(String message, Channel channel, Severity severity) {
     SlackChannel slackChannel = SlackChannel.valueOf(channel.name());
     String webhookUrl = configuration.getWebhookUrl(slackChannel);
 
@@ -52,10 +60,20 @@ public class SlackService implements OperationsNotificationService {
       return;
     }
 
-    SlackMessage slackMessage = new SlackMessage(message);
+    restTemplate.postForEntity(
+        webhookUrl, new HttpEntity<>(payload(message, severity)), String.class);
+  }
 
-    restTemplate.postForEntity(webhookUrl, new HttpEntity<>(slackMessage), String.class);
+  private static Object payload(String message, Severity severity) {
+    return switch (severity) {
+      case INFO -> new SlackMessage(message);
+      case ERROR -> new SlackAlert(List.of(new Attachment("danger", message, message)));
+    };
   }
 
   private record SlackMessage(String text) {}
+
+  private record SlackAlert(List<Attachment> attachments) {}
+
+  private record Attachment(String color, String text, String fallback) {}
 }

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/nav/NavAlertJob.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/nav/NavAlertJob.java
@@ -5,6 +5,7 @@ import static ee.tuleva.onboarding.fund.TulevaFund.TUK00;
 import static ee.tuleva.onboarding.fund.TulevaFund.TUK75;
 import static ee.tuleva.onboarding.fund.TulevaFund.TUV100;
 import static ee.tuleva.onboarding.notification.OperationsNotificationService.Channel.INVESTMENT;
+import static ee.tuleva.onboarding.notification.OperationsNotificationService.Severity.ERROR;
 
 import ee.tuleva.onboarding.deadline.PublicHolidays;
 import ee.tuleva.onboarding.fund.TulevaFund;
@@ -84,7 +85,7 @@ public class NavAlertJob {
             + missingCodes
             + ", autoRetriesContinueUntil=17:45 Tallinn";
     log.error("{}", message);
-    notificationService.sendMessage(message, INVESTMENT);
+    notificationService.sendMessage(message, INVESTMENT, ERROR);
   }
 
   private void alertIfMissing(
@@ -117,7 +118,7 @@ public class NavAlertJob {
             + autoRetriesContinueUntil
             + " Tallinn";
     log.warn("{}", message);
-    notificationService.sendMessage(message, INVESTMENT);
+    notificationService.sendMessage(message, INVESTMENT, ERROR);
   }
 
   private boolean isNavMissingForToday(TulevaFund fund, LocalDate today) {

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/nav/NavCalculationJob.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/nav/NavCalculationJob.java
@@ -40,7 +40,7 @@ public class NavCalculationJob {
   @Scheduled(
       cron = "#{T(ee.tuleva.onboarding.fund.TulevaFund).TKF100.navCronExpression()}",
       zone = "Europe/Tallinn")
-  @SchedulerLock(name = "NavCalculationJob_TKF100", lockAtMostFor = "10m", lockAtLeastFor = "1m")
+  @SchedulerLock(name = "NavCalculationJob_TKF100", lockAtMostFor = "5m", lockAtLeastFor = "1m")
   public void calculateDailyNav() {
     runPipeline(TKF100, List.of(TKF100), PipelineRun.TriggerSource.SCHEDULED);
   }
@@ -48,7 +48,7 @@ public class NavCalculationJob {
   @Scheduled(
       cron = "#{T(ee.tuleva.onboarding.fund.TulevaFund).TUK75.navCronExpression()}",
       zone = "Europe/Tallinn")
-  @SchedulerLock(name = "NavCalculationJob_Pillar2", lockAtMostFor = "10m", lockAtLeastFor = "1m")
+  @SchedulerLock(name = "NavCalculationJob_Pillar2", lockAtMostFor = "5m", lockAtLeastFor = "1m")
   public void calculatePillar2Nav() {
     TulevaFund.getPillar2Funds()
         .forEach(fund -> runPipeline(fund, List.of(fund), PipelineRun.TriggerSource.SCHEDULED));
@@ -57,7 +57,7 @@ public class NavCalculationJob {
   @Scheduled(
       cron = "#{T(ee.tuleva.onboarding.fund.TulevaFund).TUV100.navCronExpression()}",
       zone = "Europe/Tallinn")
-  @SchedulerLock(name = "NavCalculationJob_Pillar3", lockAtMostFor = "10m", lockAtLeastFor = "1m")
+  @SchedulerLock(name = "NavCalculationJob_Pillar3", lockAtMostFor = "5m", lockAtLeastFor = "1m")
   public void calculatePillar3Nav() {
     TulevaFund.getPillar3Funds()
         .forEach(fund -> runPipeline(fund, List.of(fund), PipelineRun.TriggerSource.SCHEDULED));

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/nav/NavSelfHealJob.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/nav/NavSelfHealJob.java
@@ -49,7 +49,7 @@ public class NavSelfHealJob {
         new NavPipeline(TUV100, List.of(TUV100)));
   }
 
-  @Scheduled(cron = "0 15/5 11 * * MON-FRI", zone = "Europe/Tallinn")
+  @Scheduled(cron = "0 6/5 11 * * MON-FRI", zone = "Europe/Tallinn")
   @SchedulerLock(name = "NavSelfHealRetry_pillar2", lockAtMostFor = "4m", lockAtLeastFor = "1m")
   public void scheduledPillar2Retry() {
     healIfNeeded();

--- a/src/test/groovy/ee/tuleva/onboarding/investment/risk/RiskIndicatorNotifierTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/risk/RiskIndicatorNotifierTest.java
@@ -1083,6 +1083,11 @@ class RiskIndicatorNotifierTest {
       messages.add(message);
     }
 
+    @Override
+    public void sendMessage(String message, Channel channel, Severity severity) {
+      sendMessage(message, channel);
+    }
+
     String lastMessage() {
       return messages.getLast();
     }

--- a/src/test/groovy/ee/tuleva/onboarding/notification/slack/SlackServiceSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/notification/slack/SlackServiceSpec.groovy
@@ -10,6 +10,8 @@ import spock.lang.Specification
 
 import static org.mockito.Mockito.when
 import static ee.tuleva.onboarding.notification.OperationsNotificationService.Channel.AML
+import static ee.tuleva.onboarding.notification.OperationsNotificationService.Channel.INVESTMENT
+import static ee.tuleva.onboarding.notification.OperationsNotificationService.Severity.ERROR
 import static ee.tuleva.onboarding.notification.slack.SlackService.SlackChannel
 import static org.springframework.http.HttpMethod.POST
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.*
@@ -53,6 +55,27 @@ class SlackServiceSpec extends Specification {
 
     when:
     slackService.sendMessage(testMessage, AML)
+
+    then:
+    server.verify()
+  }
+
+  def "should send error message as a red attachment"() {
+    given:
+    def testMessage = "NAV publish still missing"
+
+    when(webhookConfiguration.getWebhookUrl(SlackChannel.INVESTMENT)).thenReturn(dummyWebhookUrl)
+
+    server.expect(requestTo(dummyWebhookUrl))
+        .andExpect(method(POST))
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath('$.attachments[0].color').value("danger"))
+        .andExpect(jsonPath('$.attachments[0].text').value(testMessage))
+        .andExpect(jsonPath('$.attachments[0].fallback').value(testMessage))
+        .andRespond(withSuccess("ok", MediaType.TEXT_PLAIN))
+
+    when:
+    slackService.sendMessage(testMessage, INVESTMENT, ERROR)
 
     then:
     server.verify()

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/nav/NavAlertJobTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/nav/NavAlertJobTest.java
@@ -5,6 +5,7 @@ import static ee.tuleva.onboarding.fund.TulevaFund.TUK00;
 import static ee.tuleva.onboarding.fund.TulevaFund.TUK75;
 import static ee.tuleva.onboarding.fund.TulevaFund.TUV100;
 import static ee.tuleva.onboarding.notification.OperationsNotificationService.Channel.INVESTMENT;
+import static ee.tuleva.onboarding.notification.OperationsNotificationService.Severity.ERROR;
 import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
@@ -56,7 +57,7 @@ class NavAlertJobTest {
 
     job.alertPillar2IfMissing();
 
-    verify(notificationService).sendMessage(contains("TUK75"), eq(INVESTMENT));
+    verify(notificationService).sendMessage(contains("TUK75"), eq(INVESTMENT), eq(ERROR));
   }
 
   @Test
@@ -72,7 +73,8 @@ class NavAlertJobTest {
         .sendMessage(
             org.mockito.ArgumentMatchers.argThat(
                 (String msg) -> msg.contains("TUK75") && msg.contains("TUK00")),
-            eq(INVESTMENT));
+            eq(INVESTMENT),
+            eq(ERROR));
   }
 
   @Test
@@ -128,8 +130,8 @@ class NavAlertJobTest {
 
     job.alertSavingsPillar3IfMissing();
 
-    verify(notificationService).sendMessage(contains("TKF100"), eq(INVESTMENT));
-    verify(notificationService, never()).sendMessage(contains("TUV100"), eq(INVESTMENT));
+    verify(notificationService).sendMessage(contains("TKF100"), eq(INVESTMENT), eq(ERROR));
+    verify(notificationService, never()).sendMessage(contains("TUV100"), eq(INVESTMENT), eq(ERROR));
   }
 
   @Test
@@ -145,7 +147,8 @@ class NavAlertJobTest {
         .sendMessage(
             org.mockito.ArgumentMatchers.argThat(
                 (String msg) -> msg.contains("TKF100") && msg.contains("TUV100")),
-            eq(INVESTMENT));
+            eq(INVESTMENT),
+            eq(ERROR));
   }
 
   @Test
@@ -194,7 +197,8 @@ class NavAlertJobTest {
             org.mockito.ArgumentMatchers.argThat(
                 (String msg) ->
                     msg.contains("URGENT") && msg.contains("TUK75") && msg.contains("TUK00")),
-            eq(INVESTMENT));
+            eq(INVESTMENT),
+            eq(ERROR));
   }
 
   @Test
@@ -243,7 +247,8 @@ class NavAlertJobTest {
             org.mockito.ArgumentMatchers.argThat(
                 (String msg) ->
                     msg.contains("URGENT") && msg.contains("TKF100") && msg.contains("TUV100")),
-            eq(INVESTMENT));
+            eq(INVESTMENT),
+            eq(ERROR));
   }
 
   @Test


### PR DESCRIPTION
## What

- Missing-NAV Slack alerts (both the initial alert and the URGENT escalation) are now sent as red attachments (color: danger, with plain-text fallback for notification clients) instead of plain text.
- NAV calculation ShedLock lockAtMostFor shortened from 10m to 5m (a run takes about 2 minutes), and pillar 2 self-heal retries now start at 11:06 instead of 11:15 (cron 0 6/5 11, so 11:06, 11:11, ... 11:56).

## Why

A deploy that overlaps the 11:00 NAV window can stop the task mid-calculation: the first fund publishes, the second one dies with the context shutdown. The self-heal recovers it, but the first retry slot used to be 11:15. With a 5m lock the first retry can safely run at 11:06, cutting the recovery delay from 15 minutes to about 6. The red alert makes the interim gap visible in Slack instead of blending in as plain text.