### PR TITLE
Send third pillar payment arrived emails daily

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -556,3 +556,8 @@ sentry:
 population-register:
   url: ${POPULATION_REGISTER_URL:https://xroad-consumer.tuleva.ee/r1/EE/GOV/70008440/rr/domesticDataExchange/v1}
   client-id: ${POPULATION_REGISTER_CLIENT_ID:EE/COM/14118923/tuleva-fund-management}
+
+third-pillar-payment-arrived:
+  cron: "0 0 12 * * *"
+  dry-run: false
+  max-recipients: 200


### PR DESCRIPTION
Flips the payment-arrived job to production mode: daily at 12:00 Tallinn, dry-run off, capped at 200 recipients per run (the guard refuses to run above the cap rather than truncating).

Today's dry run reported an audience of 142, so the first real run clears the backlog within the cap. The nightly 02:00 transaction sync feeds the source table, and the already-emailed guard makes daily runs idempotent. Staging and dev keep the weekly dry-run defaults.