### PR TITLE
Deduplicate the cross-sell email nudges and clarify the hasTulevaUser flag

### DIFF
--- a/emails/fixtures/third_pillar_payment_arrived_en.json
+++ b/emails/fixtures/third_pillar_payment_arrived_en.json
@@ -4,34 +4,34 @@
       "FNAME": "Mari",
       "amount": "300.00",
       "paymentDate": "12.08.2026",
-      "hasAccount": true,
+      "hasTulevaUser": true,
       "suggestSecondPillar": true
     },
     "has account, raise the rate": {
       "FNAME": "Mari",
       "amount": "300.00",
       "paymentDate": "12.08.2026",
-      "hasAccount": true,
+      "hasTulevaUser": true,
       "suggestPaymentRate": true
     },
     "has account, membership": {
       "FNAME": "Mari",
       "amount": "300.00",
       "paymentDate": "12.08.2026",
-      "hasAccount": true,
+      "hasTulevaUser": true,
       "suggestMembership": true
     },
     "has account, recurring": {
       "FNAME": "Mari",
       "amount": "300.00",
       "paymentDate": "12.08.2026",
-      "hasAccount": true
+      "hasTulevaUser": true
     },
     "no account": {
       "FNAME": "Mari",
       "amount": "300.00",
       "paymentDate": "12.08.2026",
-      "hasAccount": false,
+      "hasTulevaUser": false,
       "suggestSecondPillar": true
     }
   }

--- a/emails/fixtures/third_pillar_payment_arrived_et.json
+++ b/emails/fixtures/third_pillar_payment_arrived_et.json
@@ -4,34 +4,34 @@
       "FNAME": "Mari",
       "amount": "300.00",
       "paymentDate": "12.08.2026",
-      "hasAccount": true,
+      "hasTulevaUser": true,
       "suggestSecondPillar": true
     },
     "konto olemas, tõsta määra": {
       "FNAME": "Mari",
       "amount": "300.00",
       "paymentDate": "12.08.2026",
-      "hasAccount": true,
+      "hasTulevaUser": true,
       "suggestPaymentRate": true
     },
     "konto olemas, astu liikmeks": {
       "FNAME": "Mari",
       "amount": "300.00",
       "paymentDate": "12.08.2026",
-      "hasAccount": true,
+      "hasTulevaUser": true,
       "suggestMembership": true
     },
     "konto olemas, püsimakse": {
       "FNAME": "Mari",
       "amount": "300.00",
       "paymentDate": "12.08.2026",
-      "hasAccount": true
+      "hasTulevaUser": true
     },
     "kontota": {
       "FNAME": "Mari",
       "amount": "300.00",
       "paymentDate": "12.08.2026",
-      "hasAccount": false,
+      "hasTulevaUser": false,
       "suggestSecondPillar": true
     }
   }

--- a/emails/scripts/merge-language.test.mjs
+++ b/emails/scripts/merge-language.test.mjs
@@ -22,15 +22,15 @@ test('first satisfied branch wins even when several are true', () => {
   assert.equal(renderMergeLanguage(html, { x: true, y: true }), 'X');
 });
 
-test('handles nested conditionals like the hasAccount wrapper', () => {
+test('handles nested conditionals like the hasTulevaUser wrapper', () => {
   const html =
-    '*|IF:hasAccount|*konto:*|IF:suggestSecondPillar|*II*|ELSE:|*muu*|END:IF|**|ELSE:|*logi sisse*|END:IF|*';
+    '*|IF:hasTulevaUser|*konto:*|IF:suggestSecondPillar|*II*|ELSE:|*muu*|END:IF|**|ELSE:|*logi sisse*|END:IF|*';
   assert.equal(
-    renderMergeLanguage(html, { hasAccount: true, suggestSecondPillar: true }),
+    renderMergeLanguage(html, { hasTulevaUser: true, suggestSecondPillar: true }),
     'konto:II',
   );
-  assert.equal(renderMergeLanguage(html, { hasAccount: true }), 'konto:muu');
-  assert.equal(renderMergeLanguage(html, { hasAccount: false }), 'logi sisse');
+  assert.equal(renderMergeLanguage(html, { hasTulevaUser: true }), 'konto:muu');
+  assert.equal(renderMergeLanguage(html, { hasTulevaUser: false }), 'logi sisse');
 });
 
 test('a false outer branch suppresses true inner branches', () => {

--- a/emails/src/membership_en.mjml
+++ b/emails/src/membership_en.mjml
@@ -22,26 +22,10 @@
         </mj-text>
 
         <mj-raw>*|IF:suggestSecondPillar|*</mj-raw>
-        <mj-text>
-          Next, make sure that the fees on your current second pillar do not excessively reduce
-          your asset returns and stay below <strong>0.5%</strong> per year. You can see your
-          second pillar fees on the Tuleva website:
-        </mj-text>
-        <mj-button href="https://pension.tuleva.ee/login?language=en">
-          Log in to your pension account
-        </mj-button>
+        <mj-include path="./partials/suggest_second_pillar_en.mjml" />
 
         <mj-raw>*|ELSEIF:suggestPaymentRate|*</mj-raw>
-        <mj-text><strong>Don't miss out on the second pillar tax benefit.</strong></mj-text>
-        <mj-text>
-          Since second pillar contributions are exempt from income tax,
-          <strong>the higher the percentage, the greater the tax benefit</strong>. For example, if
-          your gross salary is 2000 euros, you could gain a tax benefit of 316 euros. You can
-          change the size of your second pillar contribution once a year up to 6%.
-        </mj-text>
-        <mj-button href="https://tuleva.ee/en/increase-ii-pillar-payments/">
-          Calculate&nbsp;your&nbsp;gain
-        </mj-button>
+        <mj-include path="./partials/suggest_payment_rate_en.mjml" />
         <mj-raw>*|END:IF|*</mj-raw>
       </mj-column>
     </mj-section>

--- a/emails/src/membership_et.mjml
+++ b/emails/src/membership_et.mjml
@@ -21,24 +21,10 @@
         </mj-text>
 
         <mj-raw>*|IF:suggestSecondPillar|*</mj-raw>
-        <mj-text>
-          Järgmisena veendu, et sinu tänase II&nbsp;samba tasud ei vähendaks liigselt sinu vara
-          tootlust ja jääksid <strong>alla 0,5% aastas</strong>. Oma II&nbsp;samba tasusid näed
-          Tuleva veebis:
-        </mj-text>
-        <mj-button href="https://pension.tuleva.ee/login">Logi sisse oma pensionikontole</mj-button>
+        <mj-include path="./partials/suggest_second_pillar_et.mjml" />
 
         <mj-raw>*|ELSEIF:suggestPaymentRate|*</mj-raw>
-        <mj-text><strong>Ära jää ilma ka II&nbsp;samba maksuvõidust</strong></mj-text>
-        <mj-text>
-          Kuna II&nbsp;samba sissemaksed on tulumaksuvabad, siis
-          <strong>mida suurem protsent, seda suurem maksuvõit</strong>. Näiteks kui su brutopalk
-          on 2000&nbsp;eurot, saad maksuvõitu 316&nbsp;eurot. II&nbsp;samba sissemakse suurust
-          saad muuta kord aastas kuni 6% peale.
-        </mj-text>
-        <mj-button href="https://tuleva.ee/ii-samba-sissemakse-suurendamine-2-4-6/">
-          Arvuta oma võit
-        </mj-button>
+        <mj-include path="./partials/suggest_payment_rate_et.mjml" />
         <mj-raw>*|END:IF|*</mj-raw>
       </mj-column>
     </mj-section>

--- a/emails/src/partials/suggest_membership_en.mjml
+++ b/emails/src/partials/suggest_membership_en.mjml
@@ -1,0 +1,12 @@
+<mj-text>
+  <strong>How can you maximize the benefits of saving with Tuleva?</strong>
+</mj-text>
+<mj-text>
+  Tuleva belongs to Estonian people who also save in these funds. As a Tuleva saver, you
+  are not obligated to join the Tuleva association, anyone in Estonia can save with us.
+  However, I invite you to consider becoming a member, as you can benefit the most from
+  Tuleva by being a co-owner yourself.
+</mj-text>
+<mj-button href="https://tuleva.ee/liikmetele/31-marts-korduma-kippuvad-kusimused/">
+  Learn more
+</mj-button>

--- a/emails/src/partials/suggest_membership_et.mjml
+++ b/emails/src/partials/suggest_membership_et.mjml
@@ -1,0 +1,10 @@
+<mj-text><strong>Kuidas saaksid Tulevas kogumisest maksimaalselt kasu?</strong></mj-text>
+<mj-text>
+  Tuleva kuulub Eesti inimestele, kes ka ise neis fondides koguvad. Tulevas kogujana ei ole
+  sul mingit kohustust Tuleva ühistu liikmeks astuda, meiega koos võivad koguda kõik Eesti
+  inimesed. Aga kutsun sind liikmeks astumist kaaluma, sest kõige rohkem saad Tulevast
+  kasu, olles ise kaasomanik.
+</mj-text>
+<mj-button href="https://tuleva.ee/liikmetele/31-marts-korduma-kippuvad-kusimused/">
+  Uuri lähemalt
+</mj-button>

--- a/emails/src/partials/suggest_payment_rate_en.mjml
+++ b/emails/src/partials/suggest_payment_rate_en.mjml
@@ -1,0 +1,14 @@
+<mj-text><strong>Don't miss out on the second pillar tax benefit</strong></mj-text>
+<mj-text>
+  Since second pillar contributions are exempt from income tax,
+  <strong>the higher the percentage, the greater the tax benefit</strong>. For example, if your gross salary is 2,000 euros, you could
+  gain a tax benefit of 316 euros. You can change the size of your second pillar
+  contribution once a year up to 6%.
+</mj-text>
+<mj-text>
+  <strong>
+    Check how much your personal income tax savings could be by increasing your second
+    pillar contribution:
+  </strong>
+</mj-text>
+<mj-button href="https://pension.tuleva.ee/2nd-pillar-tax-win">Check it out</mj-button>

--- a/emails/src/partials/suggest_payment_rate_et.mjml
+++ b/emails/src/partials/suggest_payment_rate_et.mjml
@@ -1,0 +1,14 @@
+<mj-text><strong>Ära jää ilma ka II&nbsp;samba maksuvõidust</strong></mj-text>
+<mj-text>
+  Kuna II&nbsp;samba sissemaksed on tulumaksuvabad, siis
+  <strong>mida suurem protsent, seda suurem maksuvõit</strong>. Näiteks kui su brutopalk on
+  2000 eurot, saad maksuvõitu 316 eurot. II&nbsp;samba sissemakse suurust saad muuta kord
+  aastas kuni 6% peale.
+</mj-text>
+<mj-text>
+  <strong>
+    Vaata järele, kui suureks kujuneks sinu isiklik tulumaksuvõit oma II&nbsp;samba panust
+    suurendades:
+  </strong>
+</mj-text>
+<mj-button href="https://pension.tuleva.ee/2nd-pillar-tax-win">Vaata järele</mj-button>

--- a/emails/src/partials/suggest_second_pillar_en.mjml
+++ b/emails/src/partials/suggest_second_pillar_en.mjml
@@ -1,0 +1,10 @@
+<mj-text>
+  If you're not saving your second pillar with us at Tuleva, make sure your second pillar
+  fund fees are below 0.5% per year, as low fees provide the best foundation for optimal
+  long-term returns.
+</mj-text>
+<mj-text>
+  <strong>Check how much you're currently paying annually in fees for your second
+  pillar:</strong>
+</mj-text>
+<mj-button href="https://pension.tuleva.ee/login">Check out your fees</mj-button>

--- a/emails/src/partials/suggest_second_pillar_et.mjml
+++ b/emails/src/partials/suggest_second_pillar_et.mjml
@@ -1,0 +1,9 @@
+<mj-text>
+  Kui sa ei kogu oma II&nbsp;sammast veel koos meiega Tulevas, siis veendu, et sinu
+  II&nbsp;samba fonditasud jääksid alla 0,5% aastas, sest madalad tasud annavad parimad
+  eeldused parimaks pikaajaliseks tootluseks.
+</mj-text>
+<mj-text>
+  <strong>Vaata järele, kui palju maksad täna aastas oma II&nbsp;samba tasudeks:</strong>
+</mj-text>
+<mj-button href="https://pension.tuleva.ee/login">Vaata oma tasud üle</mj-button>

--- a/emails/src/savings_fund_payment_success_child_et.mjml
+++ b/emails/src/savings_fund_payment_success_child_et.mjml
@@ -26,31 +26,10 @@
         </mj-button>
 
         <mj-raw>*|ELSEIF:suggestSecondPillar|*</mj-raw>
-        <mj-text>
-          Kui sa ei kogu oma II&nbsp;sammast veel koos meiega Tulevas, siis
-          <strong>veendu, et sinu II&nbsp;samba fonditasud jääksid&nbsp;alla&nbsp;0,3% aastas, </strong>
-          sest madalad tasud annavad parimad eeldused parimaks&nbsp;pikaajaliseks&nbsp;tootluseks.
-        </mj-text>
-        <mj-text>
-          <strong>Vaata järele, kui palju maksad täna aastas oma II&nbsp;samba tasudeks:</strong>
-        </mj-text>
-        <mj-button href="https://pension.tuleva.ee/login">Vaata oma tasud üle</mj-button>
+        <mj-include path="./partials/suggest_second_pillar_et.mjml" />
 
         <mj-raw>*|ELSEIF:suggestPaymentRate|*</mj-raw>
-        <mj-text><strong>Ära jää ilma ka II&nbsp;samba maksuvõidust</strong></mj-text>
-        <mj-text>
-          Kuna II&nbsp;samba sissemaksed on tulumaksuvabad, siis
-          <strong>mida suurem protsent, seda suurem maksuvõit</strong>. Näiteks kui su brutopalk
-          on 2000&nbsp;eurot, saad maksuvõitu 316&nbsp;eurot. II&nbsp;samba sissemakse suurust
-          saad muuta kord aastas kuni 6% peale.
-        </mj-text>
-        <mj-text>
-          <strong>
-            Vaata järele, kui suureks kujuneks sinu isiklik tulumaksuvõit oma II&nbsp;samba panust
-            suurendades:
-          </strong>
-        </mj-text>
-        <mj-button href="https://pension.tuleva.ee/2nd-pillar-tax-win">Vaata järele</mj-button>
+        <mj-include path="./partials/suggest_payment_rate_et.mjml" />
 
         <mj-raw>*|ELSE:|*</mj-raw>
         <mj-text>

--- a/emails/src/savings_fund_payment_success_et.mjml
+++ b/emails/src/savings_fund_payment_success_et.mjml
@@ -12,31 +12,10 @@
         </mj-text>
 
         <mj-raw>*|IF:suggestSecondPillar|*</mj-raw>
-        <mj-text>
-          Kui sa ei kogu oma II&nbsp;sammast veel koos meiega Tulevas, siis
-          <strong>veendu, et sinu II&nbsp;samba fonditasud jääksid&nbsp;alla&nbsp;0,5% aastas, </strong>sest
-          madalad tasud annavad parimad eeldused parimaks&nbsp;pikaajaliseks&nbsp;tootluseks.
-        </mj-text>
-        <mj-text>
-          <strong>Vaata järele, kui palju maksad täna aastas oma II&nbsp;samba tasudeks:</strong>
-        </mj-text>
-        <mj-button href="https://pension.tuleva.ee/login">Vaata oma tasud üle</mj-button>
+        <mj-include path="./partials/suggest_second_pillar_et.mjml" />
 
         <mj-raw>*|ELSEIF:suggestPaymentRate|*</mj-raw>
-        <mj-text><strong>Ära jää ilma ka II&nbsp;samba maksuvõidust</strong></mj-text>
-        <mj-text>
-          Kuna II&nbsp;samba sissemaksed on tulumaksuvabad, siis
-          <strong>mida suurem protsent, seda suurem maksuvõit</strong>. Näiteks kui su brutopalk
-          on 2000&nbsp;eurot, saad maksuvõitu 316&nbsp;eurot. II&nbsp;samba sissemakse suurust
-          saad muuta kord aastas kuni 6% peale.
-        </mj-text>
-        <mj-text>
-          <strong>
-            Vaata järele, kui suureks kujuneks sinu isiklik tulumaksuvõit oma II&nbsp;samba
-            panust suurendades:
-          </strong>
-        </mj-text>
-        <mj-button href="https://pension.tuleva.ee/2nd-pillar-tax-win">Vaata järele</mj-button>
+        <mj-include path="./partials/suggest_payment_rate_et.mjml" />
 
         <mj-raw>*|ELSEIF:suggestThirdPillar|*</mj-raw>
         <mj-text>
@@ -47,16 +26,7 @@
         <mj-button href="https://tuleva.ee/iii-sammas/">Arvuta&nbsp;oma&nbsp;maksuvõit</mj-button>
 
         <mj-raw>*|ELSEIF:suggestMembership|*</mj-raw>
-        <mj-text><strong>Kuidas saaksid Tulevas kogumisest maksimaalselt kasu?</strong></mj-text>
-        <mj-text>
-          Tuleva kuulub Eesti inimestele, kes ka ise neis fondides koguvad. Tulevas kogujana ei
-          ole sul mingit kohustust Tuleva ühistu liikmeks astuda – meiega koos võivad koguda kõik
-          Eesti inimesed. Aga kutsun sind liikmeks astumist kaaluma, sest kõige rohkem saad
-          Tulevast kasu, olles ise kaasomanik.
-        </mj-text>
-        <mj-button href="https://tuleva.ee/liikmetele/31-marts-korduma-kippuvad-kusimused/">
-          Uuri lähemalt
-        </mj-button>
+        <mj-include path="./partials/suggest_membership_et.mjml" />
 
         <mj-raw>*|ELSE:|*</mj-raw>
         <mj-text>

--- a/emails/src/savings_fund_payment_success_person_et.mjml
+++ b/emails/src/savings_fund_payment_success_person_et.mjml
@@ -12,31 +12,10 @@
         </mj-text>
 
         <mj-raw>*|IF:suggestSecondPillar|*</mj-raw>
-        <mj-text>
-          Kui sa ei kogu oma II&nbsp;sammast veel koos meiega Tulevas, siis
-          <strong>veendu, et sinu II&nbsp;samba fonditasud jääksid&nbsp;alla&nbsp;0,3% aastas, </strong>sest
-          madalad tasud annavad parimad eeldused parimaks&nbsp;pikaajaliseks&nbsp;tootluseks.
-        </mj-text>
-        <mj-text>
-          <strong>Vaata järele, kui palju maksad täna aastas oma II&nbsp;samba tasudeks:</strong>
-        </mj-text>
-        <mj-button href="https://pension.tuleva.ee/login">Vaata oma tasud üle</mj-button>
+        <mj-include path="./partials/suggest_second_pillar_et.mjml" />
 
         <mj-raw>*|ELSEIF:suggestPaymentRate|*</mj-raw>
-        <mj-text><strong>Ära jää ilma ka II&nbsp;samba maksuvõidust</strong></mj-text>
-        <mj-text>
-          Kuna II&nbsp;samba sissemaksed on tulumaksuvabad, siis
-          <strong>mida suurem protsent, seda suurem maksuvõit</strong>. Näiteks kui su brutopalk
-          on 2000&nbsp;eurot, saad maksuvõitu 316&nbsp;eurot. II&nbsp;samba sissemakse suurust
-          saad muuta kord aastas kuni 6% peale.
-        </mj-text>
-        <mj-text>
-          <strong>
-            Vaata järele, kui suureks kujuneks sinu isiklik tulumaksuvõit oma II&nbsp;samba
-            panust suurendades:
-          </strong>
-        </mj-text>
-        <mj-button href="https://pension.tuleva.ee/2nd-pillar-tax-win">Vaata järele</mj-button>
+        <mj-include path="./partials/suggest_payment_rate_et.mjml" />
 
         <mj-raw>*|ELSEIF:suggestThirdPillar|*</mj-raw>
         <mj-text>
@@ -47,16 +26,7 @@
         <mj-button href="https://tuleva.ee/iii-sammas/">Arvuta&nbsp;oma&nbsp;maksuvõit</mj-button>
 
         <mj-raw>*|ELSEIF:suggestMembership|*</mj-raw>
-        <mj-text><strong>Kuidas saaksid Tulevas kogumisest maksimaalselt kasu?</strong></mj-text>
-        <mj-text>
-          Tuleva kuulub Eesti inimestele, kes ka ise neis fondides koguvad. Tulevas kogujana ei
-          ole sul mingit kohustust Tuleva ühistu liikmeks astuda – meiega koos võivad koguda kõik
-          Eesti inimesed. Aga kutsun sind liikmeks astumist kaaluma, sest kõige rohkem saad
-          Tulevast kasu, olles ise kaasomanik.
-        </mj-text>
-        <mj-button href="https://tuleva.ee/liikmetele/31-marts-korduma-kippuvad-kusimused/">
-          Uuri lähemalt
-        </mj-button>
+        <mj-include path="./partials/suggest_membership_et.mjml" />
 
         <mj-raw>*|ELSE:|*</mj-raw>
         <mj-text>

--- a/emails/src/second_pillar_mandate_en.mjml
+++ b/emails/src/second_pillar_mandate_en.mjml
@@ -25,34 +25,10 @@
         </mj-button>
 
         <mj-raw>*|ELSEIF:suggestPaymentRate|*</mj-raw>
-        <mj-text><strong>Don't miss out on the second pillar tax benefit.</strong></mj-text>
-        <mj-text>
-          Since second pillar contributions are exempt from income tax,
-          <strong>the higher the percentage, the greater the tax benefit</strong>. For
-          example, if your gross salary is 2000 euros, you could gain a tax benefit of 316
-          euros. You can change the size of your second pillar contribution once a year up to
-          6%.
-        </mj-text>
-        <mj-text>
-          <strong>
-            Check how much your personal income tax savings could be by increasing your
-            second pillar contribution:
-          </strong>
-        </mj-text>
-        <mj-button href="https://pension.tuleva.ee/2nd-pillar-tax-win">Check out</mj-button>
+        <mj-include path="./partials/suggest_payment_rate_en.mjml" />
 
         <mj-raw>*|ELSEIF:suggestMembership|*</mj-raw>
-        <mj-text>
-          <strong>How can you maximize the benefits of saving with Tuleva?</strong>
-        </mj-text>
-        <mj-text>
-          Tuleva's owners are the pension savers themselves. As a Tuleva pension fund client,
-          you have no obligation to become a member of Tuleva. All Estonian citizens are able
-          to save together with us in our modern, low-cost pension funds. Having said that, I
-          would still welcome you to think about becoming a member, since you benefit the
-          most from Tuleva whilst being a co-owner yourself.
-        </mj-text>
-        <mj-button href="http://https://tuleva.ee/en/faq/">Read&nbsp;more</mj-button>
+        <mj-include path="./partials/suggest_membership_en.mjml" />
         <mj-raw>*|END:IF|*</mj-raw>
 
         <mj-text>

--- a/emails/src/second_pillar_mandate_et.mjml
+++ b/emails/src/second_pillar_mandate_et.mjml
@@ -21,32 +21,10 @@
         <mj-button href="https://tuleva.ee/iii-sammas/">Arvuta oma võit</mj-button>
 
         <mj-raw>*|ELSEIF:suggestPaymentRate|*</mj-raw>
-        <mj-text><strong>Ära jää ilma ka&nbsp;II&nbsp;samba maksuvõidust</strong></mj-text>
-        <mj-text>
-          Kuna II&nbsp;samba sissemaksed on tulumaksuvabad, siis
-          <strong>mida suurem protsent, seda suurem maksuvõit</strong>. Näiteks kui su
-          brutopalk on 2000&nbsp;eurot, saad maksuvõitu 316 eurot.&nbsp;II&nbsp;samba
-          sissemakse suurust saad muuta kord aastas kuni 6% peale.
-        </mj-text>
-        <mj-text>
-          <strong>
-            Vaata järele, kui suureks kujuneks sinu isiklik tulumaksuvõit oma II&nbsp;samba
-            panust suurendades:
-          </strong>
-        </mj-text>
-        <mj-button href="https://pension.tuleva.ee/2nd-pillar-tax-win">Vaata järele</mj-button>
+        <mj-include path="./partials/suggest_payment_rate_et.mjml" />
 
         <mj-raw>*|ELSEIF:suggestMembership|*</mj-raw>
-        <mj-text><strong>Kuidas saaksid Tulevas kogumisest maksimaalselt kasu?</strong></mj-text>
-        <mj-text>
-          Tuleva kuulub Eesti inimestele, kes ka ise neis fondides koguvad. Tulevas kogujana
-          ei ole sul mingit kohustust Tuleva ühistu liikmeks astuda – meiega koos võivad
-          koguda kõik Eesti inimesed. Aga kutsun sind liikmeks astumist kaaluma, sest kõige
-          rohkem saad Tulevast kasu, olles ise kaasomanik.
-        </mj-text>
-        <mj-button href="https://tuleva.ee/liikmetele/31-marts-korduma-kippuvad-kusimused/">
-          Uuri lähemalt
-        </mj-button>
+        <mj-include path="./partials/suggest_membership_et.mjml" />
         <mj-raw>*|END:IF|*</mj-raw>
 
         <mj-text>

--- a/emails/src/second_pillar_payment_rate_en.mjml
+++ b/emails/src/second_pillar_payment_rate_en.mjml
@@ -37,30 +37,10 @@
         </mj-button>
 
         <mj-raw>*|ELSEIF:suggestSecondPillar|*</mj-raw>
-        <mj-text>
-          If you're not yet saving in the II&nbsp;pillar with us at Tuleva,
-          <strong>make sure that your II&nbsp;pillar fund fees are below 0.5% per year</strong>,
-          as low fees provide the best conditions for optimal long-term returns.
-        </mj-text>
-        <mj-text>
-          <strong>Check how much you are currently paying annually in fees for your
-          II&nbsp;pillar:</strong>
-        </mj-text>
-        <mj-button href="https://pension.tuleva.ee/login?language=en">
-          Check&nbsp;out&nbsp;your&nbsp;savings
-        </mj-button>
+        <mj-include path="./partials/suggest_second_pillar_en.mjml" />
 
         <mj-raw>*|ELSEIF:suggestMembership|*</mj-raw>
-        <mj-text>
-          <strong>How can you maximize the benefits of saving with Tuleva?</strong>
-        </mj-text>
-        <mj-text>
-          Tuleva belongs to Estonian people who also save in these funds. As a Tuleva saver, you
-          are not obligated to join the Tuleva association – anyone in Estonia can save with us.
-          However, I invite you to consider becoming a member, as you can benefit the most from
-          Tuleva by being a co-owner yourself.
-        </mj-text>
-        <mj-button href="https://tuleva.ee/en/faq/">Read&nbsp;more</mj-button>
+        <mj-include path="./partials/suggest_membership_en.mjml" />
 
         <mj-raw>*|ELSE:|*</mj-raw>
         <mj-text>

--- a/emails/src/second_pillar_payment_rate_et.mjml
+++ b/emails/src/second_pillar_payment_rate_et.mjml
@@ -33,29 +33,10 @@
         <mj-button href="https://tuleva.ee/iii-sammas/">Arvuta oma võit</mj-button>
 
         <mj-raw>*|ELSEIF:suggestSecondPillar|*</mj-raw>
-        <mj-text>
-          Kui sa ei kogu oma II&nbsp;sammast veel koos meiega Tulevas, siis
-          <strong>veendu, et sinu II&nbsp;samba fonditasud jääksid&nbsp;alla&nbsp;0,5% aastas,
-          </strong>sest madalad tasud annavad parimad eeldused parimaks&nbsp;pikaajaliseks&nbsp;tootluseks.
-        </mj-text>
-        <mj-text>
-          <strong>Vaata järele, kui palju maksad täna aastas oma II&nbsp;samba tasudeks:</strong>
-        </mj-text>
-        <mj-button href="https://pension.tuleva.ee/login">Vaata oma tasud üle</mj-button>
+        <mj-include path="./partials/suggest_second_pillar_et.mjml" />
 
         <mj-raw>*|ELSEIF:suggestMembership|*</mj-raw>
-        <mj-text>
-          <strong>Kuidas saaksid Tulevas kogumisest maksimaalselt kasu?</strong>
-        </mj-text>
-        <mj-text>
-          Tuleva kuulub Eesti inimestele, kes ka ise neis fondides koguvad. Tulevas kogujana ei
-          ole sul mingit kohustust Tuleva ühistu liikmeks astuda – meiega koos võivad koguda kõik
-          Eesti inimesed. Aga kutsun sind liikmeks astumist kaaluma, sest kõige rohkem saad
-          Tulevast kasu, olles ise kaasomanik.
-        </mj-text>
-        <mj-button href="https://tuleva.ee/liikmetele/31-marts-korduma-kippuvad-kusimused/">
-          Uuri lähemalt
-        </mj-button>
+        <mj-include path="./partials/suggest_membership_et.mjml" />
 
         <mj-raw>*|ELSE:|*</mj-raw>
         <mj-text>

--- a/emails/src/third_pillar_payment_arrived_en.mjml
+++ b/emails/src/third_pillar_payment_arrived_en.mjml
@@ -12,49 +12,16 @@
           in your pension account.
         </mj-text>
 
-        <mj-raw>*|IF:hasAccount|*</mj-raw>
+        <mj-raw>*|IF:hasTulevaUser|*</mj-raw>
 
         <mj-raw>*|IF:suggestSecondPillar|*</mj-raw>
-        <mj-text>
-          If you're not saving your second pillar with us at Tuleva, make sure your second pillar
-          fund fees are below 0.5% per year, as low fees provide the best foundation for optimal
-          long-term returns.
-        </mj-text>
-        <mj-text>
-          <strong>Check how much you're currently paying annually in fees for your second
-          pillar:</strong>
-        </mj-text>
-        <mj-button href="https://pension.tuleva.ee/login">Check out your fees</mj-button>
+        <mj-include path="./partials/suggest_second_pillar_en.mjml" />
 
         <mj-raw>*|ELSEIF:suggestPaymentRate|*</mj-raw>
-        <mj-text><strong>Don't miss out on the second pillar tax benefit</strong></mj-text>
-        <mj-text>
-          Since second pillar contributions are exempt from income tax, the higher the percentage,
-          the greater the tax benefit. For example, if your gross salary is 2,000 euros, you could
-          gain a tax benefit of 316 euros. You can change the size of your second pillar
-          contribution once a year up to 6%.
-        </mj-text>
-        <mj-text>
-          <strong>
-            Check how much your personal income tax savings could be by increasing your second
-            pillar contribution:
-          </strong>
-        </mj-text>
-        <mj-button href="https://pension.tuleva.ee/2nd-pillar-tax-win">Check it out</mj-button>
+        <mj-include path="./partials/suggest_payment_rate_en.mjml" />
 
         <mj-raw>*|ELSEIF:suggestMembership|*</mj-raw>
-        <mj-text>
-          <strong>How can you maximize the benefits of saving with Tuleva?</strong>
-        </mj-text>
-        <mj-text>
-          Tuleva belongs to Estonian people who also save in these funds. As a Tuleva saver, you
-          are not obligated to join the Tuleva association, anyone in Estonia can save with us.
-          However, I invite you to consider becoming a member, as you can benefit the most from
-          Tuleva by being a co-owner yourself.
-        </mj-text>
-        <mj-button href="https://tuleva.ee/liikmetele/31-marts-korduma-kippuvad-kusimused/">
-          Learn more
-        </mj-button>
+        <mj-include path="./partials/suggest_membership_en.mjml" />
 
         <mj-raw>*|ELSE:|*</mj-raw>
         <mj-text>

--- a/emails/src/third_pillar_payment_arrived_et.mjml
+++ b/emails/src/third_pillar_payment_arrived_et.mjml
@@ -12,45 +12,16 @@
           pensionikontol olemas.
         </mj-text>
 
-        <mj-raw>*|IF:hasAccount|*</mj-raw>
+        <mj-raw>*|IF:hasTulevaUser|*</mj-raw>
 
         <mj-raw>*|IF:suggestSecondPillar|*</mj-raw>
-        <mj-text>
-          Kui sa ei kogu oma II&nbsp;sammast veel koos meiega Tulevas, siis veendu, et sinu
-          II&nbsp;samba fonditasud jääksid alla 0,5% aastas, sest madalad tasud annavad parimad
-          eeldused parimaks pikaajaliseks tootluseks.
-        </mj-text>
-        <mj-text>
-          <strong>Vaata järele, kui palju maksad täna aastas oma II&nbsp;samba tasudeks:</strong>
-        </mj-text>
-        <mj-button href="https://pension.tuleva.ee/login">Vaata oma tasud üle</mj-button>
+        <mj-include path="./partials/suggest_second_pillar_et.mjml" />
 
         <mj-raw>*|ELSEIF:suggestPaymentRate|*</mj-raw>
-        <mj-text><strong>Ära jää ilma ka II&nbsp;samba maksuvõidust</strong></mj-text>
-        <mj-text>
-          Kuna II&nbsp;samba sissemaksed on tulumaksuvabad, siis mida suurem protsent, seda suurem
-          maksuvõit. Näiteks kui su brutopalk on 2000 eurot, saad maksuvõitu 316 eurot.
-          II&nbsp;samba sissemakse suurust saad muuta kord aastas kuni 6% peale.
-        </mj-text>
-        <mj-text>
-          <strong>
-            Vaata järele, kui suureks kujuneks sinu isiklik tulumaksuvõit oma II&nbsp;samba panust
-            suurendades:
-          </strong>
-        </mj-text>
-        <mj-button href="https://pension.tuleva.ee/2nd-pillar-tax-win">Vaata järele</mj-button>
+        <mj-include path="./partials/suggest_payment_rate_et.mjml" />
 
         <mj-raw>*|ELSEIF:suggestMembership|*</mj-raw>
-        <mj-text><strong>Kuidas saaksid Tulevas kogumisest maksimaalselt kasu?</strong></mj-text>
-        <mj-text>
-          Tuleva kuulub Eesti inimestele, kes ka ise neis fondides koguvad. Tulevas kogujana ei ole
-          sul mingit kohustust Tuleva ühistu liikmeks astuda, meiega koos võivad koguda kõik Eesti
-          inimesed. Aga kutsun sind liikmeks astumist kaaluma, sest kõige rohkem saad Tulevast
-          kasu, olles ise kaasomanik.
-        </mj-text>
-        <mj-button href="https://tuleva.ee/liikmetele/31-marts-korduma-kippuvad-kusimused/">
-          Uuri lähemalt
-        </mj-button>
+        <mj-include path="./partials/suggest_membership_et.mjml" />
 
         <mj-raw>*|ELSE:|*</mj-raw>
         <mj-text>

--- a/emails/src/third_pillar_payment_success_mandate_en.mjml
+++ b/emails/src/third_pillar_payment_success_mandate_en.mjml
@@ -14,46 +14,13 @@
         </mj-text>
 
         <mj-raw>*|IF:suggestSecondPillar|*</mj-raw>
-        <mj-text>
-          If you're not saving your second pillar with us at Tuleva,
-          <strong>make sure your second pillar fund fees are below 0.5% per year</strong>, as low
-          fees provide the best foundation for optimal long-term returns.
-        </mj-text>
-        <mj-text>
-          <strong>Check how much you're currently paying annually in fees for your second
-          pillar:</strong>
-        </mj-text>
-        <mj-button href="https://pension.tuleva.ee/login?language=en">
-          Check out your fees
-        </mj-button>
+        <mj-include path="./partials/suggest_second_pillar_en.mjml" />
 
         <mj-raw>*|ELSEIF:suggestPaymentRate|*</mj-raw>
-        <mj-text><strong>Don't miss out on the second pillar tax benefit</strong></mj-text>
-        <mj-text>
-          Since second pillar contributions are exempt from income tax,
-          <strong>the higher the percentage, the greater the tax benefit</strong>. For example,
-          if your gross salary is 2,000 euros, you could gain a tax benefit of 316 euros. You can
-          change the size of your second pillar contribution once a year up to 6%.
-        </mj-text>
-        <mj-text>
-          <strong>
-            Check how much your personal income tax savings could be by increasing your second
-            pillar contribution:
-          </strong>
-        </mj-text>
-        <mj-button href="https://pension.tuleva.ee/2nd-pillar-tax-win">Check out</mj-button>
+        <mj-include path="./partials/suggest_payment_rate_en.mjml" />
 
         <mj-raw>*|ELSEIF:suggestMembership|*</mj-raw>
-        <mj-text>
-          <strong>How can you maximize the benefits of saving with Tuleva?</strong>
-        </mj-text>
-        <mj-text>
-          Tuleva belongs to Estonian people who also save in these funds. As a Tuleva saver, you
-          are not obligated to join the Tuleva association, anyone in Estonia can save with us.
-          However, I invite you to consider becoming a member, as you can benefit the most from
-          Tuleva by being a co-owner yourself.
-        </mj-text>
-        <mj-button href="https://tuleva.ee/en/faq/">Learn more</mj-button>
+        <mj-include path="./partials/suggest_membership_en.mjml" />
 
         <mj-raw>*|ELSE:|*</mj-raw>
         <mj-text>

--- a/emails/src/third_pillar_payment_success_mandate_et.mjml
+++ b/emails/src/third_pillar_payment_success_mandate_et.mjml
@@ -14,43 +14,13 @@
         </mj-text>
 
         <mj-raw>*|IF:suggestSecondPillar|*</mj-raw>
-        <mj-text>
-          Kui sa ei kogu oma II&nbsp;sammast veel koos meiega Tulevas, siis
-          <strong>veendu, et sinu II&nbsp;samba fonditasud jääksid alla 0,5% aastas,</strong>
-          sest madalad tasud annavad parimad eeldused parimaks pikaajaliseks tootluseks.
-        </mj-text>
-        <mj-text>
-          <strong>Vaata järele, kui palju maksad täna aastas oma II&nbsp;samba tasudeks:</strong>
-        </mj-text>
-        <mj-button href="https://pension.tuleva.ee/login">Vaata oma tasud üle</mj-button>
+        <mj-include path="./partials/suggest_second_pillar_et.mjml" />
 
         <mj-raw>*|ELSEIF:suggestPaymentRate|*</mj-raw>
-        <mj-text><strong>Ära jää ilma ka II&nbsp;samba maksuvõidust</strong></mj-text>
-        <mj-text>
-          Kuna II&nbsp;samba sissemaksed on tulumaksuvabad, siis
-          <strong>mida suurem protsent, seda suurem maksuvõit</strong>. Näiteks kui su brutopalk
-          on 2000 eurot, saad maksuvõitu 316 eurot. II&nbsp;samba sissemakse suurust saad muuta
-          kord aastas kuni 6% peale.
-        </mj-text>
-        <mj-text>
-          <strong>
-            Vaata järele, kui suureks kujuneks sinu isiklik tulumaksuvõit oma II&nbsp;samba
-            panust suurendades:
-          </strong>
-        </mj-text>
-        <mj-button href="https://pension.tuleva.ee/2nd-pillar-tax-win">Vaata järele</mj-button>
+        <mj-include path="./partials/suggest_payment_rate_et.mjml" />
 
         <mj-raw>*|ELSEIF:suggestMembership|*</mj-raw>
-        <mj-text><strong>Kuidas saaksid Tulevas kogumisest maksimaalselt kasu?</strong></mj-text>
-        <mj-text>
-          Tuleva kuulub Eesti inimestele, kes ka ise neis fondides koguvad. Tulevas kogujana ei
-          ole sul mingit kohustust Tuleva ühistu liikmeks astuda, meiega koos võivad koguda kõik
-          Eesti inimesed. Aga kutsun sind liikmeks astumist kaaluma, sest kõige rohkem saad
-          Tulevast kasu, olles ise kaasomanik.
-        </mj-text>
-        <mj-button href="https://tuleva.ee/liikmetele/31-marts-korduma-kippuvad-kusimused/">
-          Uuri lähemalt
-        </mj-button>
+        <mj-include path="./partials/suggest_membership_et.mjml" />
 
         <mj-raw>*|ELSE:|*</mj-raw>
         <mj-text>

--- a/src/main/java/ee/tuleva/onboarding/analytics/transaction/thirdpillar/FirstThirdPillarPayment.java
+++ b/src/main/java/ee/tuleva/onboarding/analytics/transaction/thirdpillar/FirstThirdPillarPayment.java
@@ -13,7 +13,7 @@ public record FirstThirdPillarPayment(
     String languagePreference,
     BigDecimal amount,
     LocalDate firstPaymentDate,
-    boolean hasAccount,
+    boolean hasTulevaUser,
     boolean suggestSecondPillar,
     boolean suggestPaymentRate,
     boolean suggestMembership)

--- a/src/main/java/ee/tuleva/onboarding/analytics/transaction/thirdpillar/FirstThirdPillarPaymentRepository.java
+++ b/src/main/java/ee/tuleva/onboarding/analytics/transaction/thirdpillar/FirstThirdPillarPaymentRepository.java
@@ -59,7 +59,7 @@ public class FirstThirdPillarPaymentRepository {
                COALESCE(uo.language_preference, 'EST') AS language_preference,
                fa.amount,
                fa.first_payment_date,
-               (u.id IS NOT NULL) AS has_account,
+               (u.id IS NOT NULL) AS has_tuleva_user,
                (uo.personal_id IS NULL
                  OR uo.p2_choice IS NULL
                  OR uo.p2_choice NOT IN ('TUK75', 'TUK00')) AS suggest_second_pillar,
@@ -98,7 +98,7 @@ public class FirstThirdPillarPaymentRepository {
                     rs.getString("language_preference"),
                     rs.getBigDecimal("amount"),
                     rs.getObject("first_payment_date", LocalDate.class),
-                    rs.getBoolean("has_account"),
+                    rs.getBoolean("has_tuleva_user"),
                     rs.getBoolean("suggest_second_pillar"),
                     rs.getBoolean("suggest_payment_rate"),
                     rs.getBoolean("suggest_membership")))

--- a/src/main/java/ee/tuleva/onboarding/notification/email/firstpayment/ThirdPillarPaymentArrivedEmailService.java
+++ b/src/main/java/ee/tuleva/onboarding/notification/email/firstpayment/ThirdPillarPaymentArrivedEmailService.java
@@ -58,7 +58,7 @@ public class ThirdPillarPaymentArrivedEmailService {
         "lname", payment.getLastName(),
         "amount", payment.amount(),
         "paymentDate", payment.firstPaymentDate().format(PAYMENT_DATE_FORMAT),
-        "hasAccount", payment.hasAccount(),
+        "hasTulevaUser", payment.hasTulevaUser(),
         "suggestSecondPillar", payment.suggestSecondPillar(),
         "suggestPaymentRate", payment.suggestPaymentRate(),
         "suggestMembership", payment.suggestMembership());

--- a/src/test/groovy/ee/tuleva/onboarding/notification/email/firstpayment/ThirdPillarPaymentArrivedEmailIntegrationTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/notification/email/firstpayment/ThirdPillarPaymentArrivedEmailIntegrationTest.java
@@ -102,7 +102,7 @@ class ThirdPillarPaymentArrivedEmailIntegrationTest {
             argThat(
                 mergeVars ->
                     Boolean.TRUE.equals(mergeVars.get("suggestSecondPillar"))
-                        && Boolean.TRUE.equals(mergeVars.get("hasAccount"))
+                        && Boolean.TRUE.equals(mergeVars.get("hasTulevaUser"))
                         && LocalDate.now()
                             .minusDays(1)
                             .format(java.time.format.DateTimeFormatter.ofPattern("dd.MM.yyyy"))
@@ -184,7 +184,7 @@ class ThirdPillarPaymentArrivedEmailIntegrationTest {
             argThat(
                 mergeVars ->
                     Boolean.TRUE.equals(mergeVars.get("suggestSecondPillar"))
-                        && Boolean.FALSE.equals(mergeVars.get("hasAccount"))),
+                        && Boolean.FALSE.equals(mergeVars.get("hasTulevaUser"))),
             any(),
             any());
     verify(emailService, times(1))


### PR DESCRIPTION
Extracts the second-pillar, payment-rate, and membership suggestion blocks (copied into 13 templates, drifted: 0,3% vs 0,5% fee threshold, differing emphasis, a stale campaign button, one broken double-scheme link) into one partial per family and language — 353 duplicated lines become 32 includes with canonical wording. Only the 13 affected templates change bytes; the other 39 stay identical and will not republish.

Also renames the ambiguous hasAccount merge variable to hasTulevaUser (it checks for a users row, i.e. a Tuleva web login).

Merge timing: the template publish is instant on merge while the ECS deploy lags ~20 minutes, and the payment-arrived job sends at 12:00 — merge outside the noon window so the renamed merge tag and claim switch together.