### PR TITLE
Stop H2 choking on the instrument reference check constraints

### DIFF
--- a/src/test/groovy/ee/tuleva/onboarding/instrument/InstrumentReferenceRulesTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/instrument/InstrumentReferenceRulesTest.java
@@ -1,0 +1,89 @@
+package ee.tuleva.onboarding.instrument;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.simple.JdbcClient;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+class InstrumentReferenceRulesTest {
+
+  private static final List<String> INSTRUMENT_TYPES = List.of("ETF", "FUND");
+  private static final List<String> ASSET_CLASSES = List.of("equity", "bond");
+
+  @Autowired private JdbcClient jdbcClient;
+
+  @Test
+  void everyInstrumentTypeIsOneWeKnow() {
+    var types =
+        jdbcClient
+            .sql("SELECT DISTINCT instrument_type FROM instrument_reference")
+            .query(String.class)
+            .list();
+
+    assertThat(types).allSatisfy(type -> assertThat(type).isIn(INSTRUMENT_TYPES));
+  }
+
+  @Test
+  void everyAssetClassIsOneWeKnow() {
+    var assetClasses =
+        jdbcClient
+            .sql("SELECT DISTINCT asset_class FROM instrument_reference")
+            .query(String.class)
+            .list();
+
+    assertThat(assetClasses).allSatisfy(assetClass -> assertThat(assetClass).isIn(ASSET_CLASSES));
+  }
+
+  @Test
+  void everyBenchmarkProxyNamesExactlyOneIndexTarget() {
+    var contradictions =
+        jdbcClient
+            .sql(
+                """
+                SELECT benchmark_category FROM benchmark_category_proxy
+                WHERE (index_proxy_isin IS NULL AND index_series_key IS NULL)
+                   OR (index_proxy_isin IS NOT NULL AND index_series_key IS NOT NULL)
+                """)
+            .query(String.class)
+            .list();
+
+    assertThat(contradictions).isEmpty();
+  }
+
+  @Test
+  void everyBenchmarkCategoryOnAnInstrumentHasAProxy() {
+    var orphans =
+        jdbcClient
+            .sql(
+                """
+                SELECT ir.isin FROM instrument_reference ir
+                WHERE ir.benchmark_category IS NOT NULL
+                  AND NOT EXISTS (SELECT 1 FROM benchmark_category_proxy p
+                                  WHERE p.benchmark_category = ir.benchmark_category)
+                """)
+            .query(String.class)
+            .list();
+
+    assertThat(orphans).isEmpty();
+  }
+
+  @Test
+  void anExistingInstrumentCanBeUpdated() {
+    assertThatCode(
+            () ->
+                jdbcClient
+                    .sql(
+                        "UPDATE instrument_reference SET seb_position_name = :name WHERE isin = :isin")
+                    .param("name", "Renamed in a console")
+                    .param("isin", "IE00BFG1TM61")
+                    .update())
+        .doesNotThrowAnyException();
+  }
+}

--- a/src/test/resources/db/h2/V1_249_1__drop_alter_added_check_constraints.sql
+++ b/src/test/resources/db/h2/V1_249_1__drop_alter_added_check_constraints.sql
@@ -1,0 +1,16 @@
+-- H2 cannot evaluate a CHECK constraint that was added by ALTER TABLE. Once a second Spring
+-- context opens the shared in-memory database, every INSERT or UPDATE on the constrained table
+-- fails with 23514 ("check constraint invalid" — the expression threw) and an empty constraint
+-- expression in the message, whatever values the statement carries. It reproduces only in the
+-- full suite, never when a test class runs alone, and PostgreSQL is unaffected.
+--
+-- The constraints therefore stay in place everywhere the application actually runs, and are
+-- dropped for H2 only. InstrumentReferenceRulesTest asserts the same rules over the rows, so
+-- the invariants are still checked while the suite runs on H2, and the constraints themselves
+-- are exercised by the pg/ci profiles.
+ALTER TABLE instrument_reference
+    DROP CONSTRAINT IF EXISTS instrument_reference_instrument_type_check;
+ALTER TABLE instrument_reference
+    DROP CONSTRAINT IF EXISTS instrument_reference_asset_class_check;
+ALTER TABLE benchmark_category_proxy
+    DROP CONSTRAINT IF EXISTS benchmark_category_proxy_index_target_check;


### PR DESCRIPTION
## What breaks

`V1_249` added three CHECK constraints with `ALTER TABLE … ADD CONSTRAINT`. H2 cannot evaluate that form. Once a **second** Spring context opens the shared in-memory database, every `INSERT` and `UPDATE` on the constrained table fails:

```
DataIntegrityViolationException: SQL [UPDATE instrument_reference SET seb_position_name = ? WHERE isin = ?];
Check constraint invalid: "instrument_reference_instrument_type_check: " [23514-240]
```

Note the details: error **23514** ("the expression threw"), not 23513 ("the row violated it"); the constraint expression after the colon renders **empty**; and the failing statement sets `seb_position_name`, a column that check does not mention. The values are irrelevant — an `INSERT … VALUES ('ETF', 'equity', …)` fails the same way.

It reproduces **only in the full suite**, never when a test class runs alone, and **PostgreSQL is unaffected** — so the `pg` and `ci` profiles stay green while local `./gradlew test` goes red on tests that have nothing to do with instrument data. This is a documented H2 defect in this repo; a `CHECK` written inline inside `CREATE TABLE` is fine, only the `ALTER`-added form breaks.

## What this does

The constraints are what V1_249 was **for** — after the enum cutover an instrument change is an `UPDATE` typed into a console, and a mistyped instrument type has to fail at the moment of the change. So they stay in every environment the application runs in, and are dropped for **H2 only**, in `db/h2/V1_249_1`.

`InstrumentReferenceRulesTest` then asserts the same four rules over the rows, so nothing is left unchecked while the suite runs on H2:

- every `instrument_type` is `ETF` or `FUND`
- every `asset_class` is `equity` or `bond`
- every `benchmark_category_proxy` row names exactly one index target
- every `benchmark_category` on an instrument has a proxy

plus a regression test that an existing instrument can simply be updated.

`benchmark_category_proxy_index_target_check` is dropped alongside the two on `instrument_reference`: it is the same form and has escaped so far only because no test in the suite writes to that table.

## Test

- Full suite **without** the shim: exactly one failure, `anExistingInstrumentCanBeUpdated`, with the signature above. The four rule assertions pass — the data is fine, the evaluation is not.
- Full suite **with** the shim: green.

> Depends on #1905 — master currently has two migrations numbered V1_249, so no Spring context starts until that lands. This branch is cut from master and carries only the two new files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)