### PR TITLE
Capitalize all caps registry names in emails

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/mandate/email/EmailVariablesAttachments.java
+++ b/src/main/java/ee/tuleva/onboarding/mandate/email/EmailVariablesAttachments.java
@@ -6,6 +6,7 @@ import com.microtripit.mandrillapp.lutung.view.MandrillMessage;
 import ee.tuleva.onboarding.capital.transfer.CapitalTransferContract;
 import ee.tuleva.onboarding.mandate.Mandate;
 import ee.tuleva.onboarding.mandate.batch.MandateBatch;
+import ee.tuleva.onboarding.user.Names;
 import ee.tuleva.onboarding.user.User;
 import java.util.Base64;
 import java.util.List;
@@ -34,7 +35,11 @@ public class EmailVariablesAttachments {
   }
 
   public static Map<String, Object> getNameMergeVars(User user) {
-    return Map.of("fname", user.getFirstName(), "lname", user.getLastName());
+    return Map.of(
+        "fname",
+        Names.formatted(user.getFirstName()),
+        "lname",
+        Names.formatted(user.getLastName()));
   }
 
   public static List<MandrillMessage.MessageContent> getAttachments(User user, Mandate mandate) {

--- a/src/main/java/ee/tuleva/onboarding/notification/email/firstpayment/ThirdPillarPaymentArrivedEmailService.java
+++ b/src/main/java/ee/tuleva/onboarding/notification/email/firstpayment/ThirdPillarPaymentArrivedEmailService.java
@@ -6,6 +6,7 @@ import ee.tuleva.onboarding.analytics.transaction.thirdpillar.FirstThirdPillarPa
 import ee.tuleva.onboarding.mandate.email.persistence.EmailPersistenceService;
 import ee.tuleva.onboarding.notification.email.EmailService;
 import ee.tuleva.onboarding.savings.fund.SavingsFundFees;
+import ee.tuleva.onboarding.user.Names;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
@@ -57,8 +58,8 @@ public class ThirdPillarPaymentArrivedEmailService {
 
   private Map<String, Object> mergeVars(FirstThirdPillarPayment payment) {
     return Map.ofEntries(
-        Map.entry("fname", payment.getFirstName()),
-        Map.entry("lname", payment.getLastName()),
+        Map.entry("fname", Names.formatted(payment.getFirstName())),
+        Map.entry("lname", Names.formatted(payment.getLastName())),
         Map.entry("paymentDate", payment.firstPaymentDate().format(PAYMENT_DATE_FORMAT)),
         Map.entry("hasTulevaUser", payment.hasTulevaUser()),
         Map.entry("leftSecondPillar", payment.leftSecondPillar()),

--- a/src/main/java/ee/tuleva/onboarding/payment/email/SavingsFundPaymentEmail.java
+++ b/src/main/java/ee/tuleva/onboarding/payment/email/SavingsFundPaymentEmail.java
@@ -7,6 +7,7 @@ import static ee.tuleva.onboarding.mandate.email.persistence.EmailType.SAVINGS_F
 import static ee.tuleva.onboarding.mandate.email.persistence.EmailType.SAVINGS_FUND_PAYMENT_SUCCESS_PERSON;
 
 import ee.tuleva.onboarding.mandate.email.persistence.EmailType;
+import ee.tuleva.onboarding.user.Names;
 import java.util.Map;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
@@ -42,6 +43,7 @@ record SavingsFundPaymentEmail(EmailType emailType, Map<String, Object> mergeVar
       EmailType emailType, @Nullable String recipientName) {
     return recipientName == null
         ? withoutRecipient(emailType)
-        : new SavingsFundPaymentEmail(emailType, Map.of("recipientName", recipientName));
+        : new SavingsFundPaymentEmail(
+            emailType, Map.of("recipientName", Names.formatted(recipientName)));
   }
 }

--- a/src/main/java/ee/tuleva/onboarding/user/Names.java
+++ b/src/main/java/ee/tuleva/onboarding/user/Names.java
@@ -1,0 +1,19 @@
+package ee.tuleva.onboarding.user;
+
+import java.util.Locale;
+import org.apache.commons.lang3.text.WordUtils;
+
+public class Names {
+
+  private static final Locale ESTONIAN = Locale.of("et");
+
+  public static String formatted(String name) {
+    if (name == null || name.isBlank()) {
+      return name;
+    }
+    if (!name.equals(name.toUpperCase(ESTONIAN))) {
+      return name;
+    }
+    return WordUtils.capitalizeFully(name, ' ', '-', '\'');
+  }
+}

--- a/src/test/groovy/ee/tuleva/onboarding/user/NamesTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/user/NamesTest.java
@@ -1,0 +1,33 @@
+package ee.tuleva.onboarding.user;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class NamesTest {
+
+  @ParameterizedTest
+  @CsvSource({
+    "MARI, Mari",
+    "MARI-LIIS, Mari-Liis",
+    "ANNA MARIA, Anna Maria",
+    "VÄLI-TAMM, Väli-Tamm",
+    "ÕNNELA, Õnnela",
+    "O'BRIEN, O'Brien",
+    "Mari, Mari",
+    "Mari-Liis, Mari-Liis",
+    "McGregor, McGregor",
+    "van der Berg, van der Berg",
+  })
+  void formatsOnlyAllCapsNames(String input, String expected) {
+    assertThat(Names.formatted(input)).isEqualTo(expected);
+  }
+
+  @Test
+  void keepsNullAndBlankAsTheyAre() {
+    assertThat(Names.formatted(null)).isNull();
+    assertThat(Names.formatted("")).isEmpty();
+  }
+}


### PR DESCRIPTION
Names from the pension registry arrive fully upper case, so emails greeted people with MARI-LIIS. Names that are entirely upper case are now title cased on space, hyphen, and apostrophe boundaries (per EKI orthography: each component of a compound name takes a capital), and anything with existing lowercase is left exactly as the person wrote it, so a logged-in McGregor is never touched. Applies to greeting names, the payment arrived email, and the savings fund recipient names.

Follows the same approach PersonMapper already uses for population register names.