### PR TITLE
Call the savings fund by its registered English name

### DIFF
--- a/emails/manifest.json
+++ b/emails/manifest.json
@@ -111,7 +111,7 @@
       "from_name": "Tuleva"
     },
     "savings_fund_payment_cancelled_en": {
-      "subject": "Tuleva Savings Fund payment cancellation succeeded",
+      "subject": "Tuleva Additional Investment Fund payment cancellation succeeded",
       "from_email": "tuleva@tuleva.ee",
       "from_name": "Tuleva"
     },
@@ -121,7 +121,7 @@
       "from_name": "Tuleva"
     },
     "savings_fund_payment_failed_en": {
-      "subject": "Your payment to Tuleva Savings Fund failed",
+      "subject": "Your payment to Tuleva Additional Investment Fund failed",
       "from_email": "tuleva@tuleva.ee",
       "from_name": "Tuleva"
     },
@@ -131,7 +131,7 @@
       "from_name": "Tuleva"
     },
     "savings_fund_payment_success_child_en": {
-      "subject": "Contribution to Tuleva Savings Fund is done",
+      "subject": "Contribution to Tuleva Additional Investment Fund is done",
       "from_email": "tuleva@tuleva.ee",
       "from_name": "Tuleva"
     },
@@ -141,7 +141,7 @@
       "from_name": "Tuleva"
     },
     "savings_fund_payment_success_company_en": {
-      "subject": "Contribution to Tuleva Savings Fund is done",
+      "subject": "Contribution to Tuleva Additional Investment Fund is done",
       "from_email": "tuleva@tuleva.ee",
       "from_name": "Tuleva"
     },
@@ -151,7 +151,7 @@
       "from_name": "Tuleva"
     },
     "savings_fund_payment_success_en": {
-      "subject": "Contribution to Tuleva Savings Fund is done",
+      "subject": "Contribution to Tuleva Additional Investment Fund is done",
       "from_email": "tuleva@tuleva.ee",
       "from_name": "Tuleva"
     },
@@ -161,7 +161,7 @@
       "from_name": "Tuleva"
     },
     "savings_fund_payment_success_person_en": {
-      "subject": "Contribution to Tuleva Savings Fund is done",
+      "subject": "Contribution to Tuleva Additional Investment Fund is done",
       "from_email": "tuleva@tuleva.ee",
       "from_name": "Tuleva"
     },

--- a/emails/src/savings_fund_payment_cancelled_en.mjml
+++ b/emails/src/savings_fund_payment_cancelled_en.mjml
@@ -7,7 +7,7 @@
       <mj-column>
         <mj-text>Hello,&nbsp;*|FNAME|*</mj-text>
         <mj-text>
-          You requested to cancel your payment to Tuleva Savings Fund. We received your request
+          You requested to cancel your payment to Tuleva Additional Investment Fund. We received your request
           on time and will send the money back to your account today. If you want to make a new contribution,
           click here:
         </mj-text>

--- a/emails/src/savings_fund_payment_failed_en.mjml
+++ b/emails/src/savings_fund_payment_failed_en.mjml
@@ -7,7 +7,7 @@
       <mj-column>
         <mj-text>Hello,&nbsp;*|FNAME|*</mj-text>
         <mj-text>
-          Your payment to Tuleva Savings Fund failed and we will send it back to the same
+          Your payment to Tuleva Additional Investment Fund failed and we will send it back to the same
           account it came from by the end of today. Most likely you chose an account whose
           name does not match yours when making the payment. For safety and compliance,
           the payment has to come from your personal account. Please try again here:

--- a/emails/src/savings_fund_payment_success_child_en.mjml
+++ b/emails/src/savings_fund_payment_success_child_en.mjml
@@ -7,10 +7,10 @@
       <mj-column>
         <mj-text>Hello,&nbsp;*|FNAME|*</mj-text>
         <mj-text>
-          *|IF:RECIPIENTNAME|*Your contribution to *|RECIPIENTNAME|*'s Tuleva Savings Fund
-          account has been received.*|ELSE:|*Your contribution to your child's Tuleva Savings
-          Fund account has been received.*|END:IF|* Fund units will appear on the child's
-          account within two business days.
+          *|IF:RECIPIENTNAME|*Your contribution to *|RECIPIENTNAME|*'s Tuleva Additional
+          Investment Fund account has been received.*|ELSE:|*Your contribution to your child's
+          Tuleva Additional Investment Fund account has been received.*|END:IF|* Fund units will
+          appear on the child's account within two business days.
         </mj-text>
       </mj-column>
     </mj-section>

--- a/emails/src/savings_fund_payment_success_company_en.mjml
+++ b/emails/src/savings_fund_payment_success_company_en.mjml
@@ -7,10 +7,10 @@
       <mj-column>
         <mj-text>Hello,&nbsp;*|FNAME|*</mj-text>
         <mj-text>
-          *|IF:RECIPIENTNAME|*Your contribution to *|RECIPIENTNAME|*'s Tuleva Savings Fund
-          account has been received.*|ELSE:|*Your company's contribution to Tuleva Savings
-          Fund has been received.*|END:IF|* Fund units will appear on the company's account
-          within two business days.
+          *|IF:RECIPIENTNAME|*Your contribution to *|RECIPIENTNAME|*'s Tuleva Additional
+          Investment Fund account has been received.*|ELSE:|*Your company's contribution to
+          Tuleva Additional Investment Fund has been received.*|END:IF|* Fund units will appear
+          on the company's account within two business days.
         </mj-text>
       </mj-column>
     </mj-section>

--- a/emails/src/savings_fund_payment_success_en.mjml
+++ b/emails/src/savings_fund_payment_success_en.mjml
@@ -7,8 +7,8 @@
       <mj-column>
         <mj-text>Hello,&nbsp;*|FNAME|*</mj-text>
         <mj-text>
-          Your contribution to Tuleva Savings Fund has been received. Fund units will appear on
-          your Tuleva account in two business days.
+          Your contribution to Tuleva Additional Investment Fund has been received. Fund units
+          will appear on your Tuleva account in two business days.
         </mj-text>
       </mj-column>
     </mj-section>

--- a/emails/src/savings_fund_payment_success_person_en.mjml
+++ b/emails/src/savings_fund_payment_success_person_en.mjml
@@ -7,8 +7,8 @@
       <mj-column>
         <mj-text>Hello,&nbsp;*|FNAME|*</mj-text>
         <mj-text>
-          Your contribution to Tuleva Savings Fund has been received. Fund units will appear on
-          your Tuleva account within two business days.
+          Your contribution to Tuleva Additional Investment Fund has been received. Fund units
+          will appear on your Tuleva account within two business days.
         </mj-text>
       </mj-column>
     </mj-section>


### PR DESCRIPTION
The English emails call the fund "Tuleva Savings Fund". No fund by that name exists: tuleva.ee/en and the regulatory register both say **Tuleva Additional Investment Fund**. Karoliina caught it reviewing the first payment reminder in #1904.

Six templates and their subject lines, all live today:

- `savings_fund_payment_success_person_en`
- `savings_fund_payment_success_child_en`
- `savings_fund_payment_success_company_en`
- `savings_fund_payment_success_en` (legacy)
- `savings_fund_payment_failed_en`
- `savings_fund_payment_cancelled_en`

Both conditional branches of the child and company templates are covered, and `npm test` renders every fixture variant.

Deliberately untouched: template file names, `EmailType` values and column names. Those are identifiers, not text a saver reads, and renaming them would mean recreating the Mandrill templates for no reader-visible gain. The Estonian side is already correct.

Related: TulevaEE/tuleva#420, and #1904 where the new reminder already uses the right name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)