### PR TITLE
Correct the fund settlement date: T+4, dealt on the domicile, counted on TARGET2

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/investment/calendar/Domicile.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/calendar/Domicile.java
@@ -1,7 +1,29 @@
 package ee.tuleva.onboarding.investment.calendar;
 
+import java.util.Arrays;
+import java.util.Optional;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.Nullable;
+
+@Getter
+@RequiredArgsConstructor
 public enum Domicile {
-  IRELAND,
-  LUXEMBOURG,
-  FRANCE
+  IRELAND("IE"),
+  LUXEMBOURG("LU"),
+  FRANCE("FR");
+
+  private final String countryCode;
+
+  /**
+   * Resolves an ISO 3166-1 alpha-2 country code, as stored in {@code instrument_reference.country}.
+   * Empty for a null, blank or unsupported code — the caller decides what to fall back to.
+   */
+  public static Optional<Domicile> forCountryCode(@Nullable String countryCode) {
+    if (countryCode == null || countryCode.isBlank()) {
+      return Optional.empty();
+    }
+    String normalized = countryCode.strip().toUpperCase();
+    return Arrays.stream(values()).filter(it -> it.countryCode.equals(normalized)).findFirst();
+  }
 }

--- a/src/main/java/ee/tuleva/onboarding/investment/calendar/Domicile.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/calendar/Domicile.java
@@ -15,10 +15,6 @@ public enum Domicile {
 
   private final String countryCode;
 
-  /**
-   * Resolves an ISO 3166-1 alpha-2 country code, as stored in {@code instrument_reference.country}.
-   * Empty for a null, blank or unsupported code — the caller decides what to fall back to.
-   */
   public static Optional<Domicile> forCountryCode(@Nullable String countryCode) {
     if (countryCode == null || countryCode.isBlank()) {
       return Optional.empty();

--- a/src/main/java/ee/tuleva/onboarding/investment/calendar/Domicile.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/calendar/Domicile.java
@@ -1,6 +1,7 @@
 package ee.tuleva.onboarding.investment.calendar;
 
 import java.util.Arrays;
+import java.util.Locale;
 import java.util.Optional;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -16,10 +17,10 @@ public enum Domicile {
   private final String countryCode;
 
   public static Optional<Domicile> forCountryCode(@Nullable String countryCode) {
-    if (countryCode == null || countryCode.isBlank()) {
+    if (countryCode == null) {
       return Optional.empty();
     }
-    String normalized = countryCode.strip().toUpperCase();
+    String normalized = countryCode.strip().toUpperCase(Locale.ROOT);
     return Arrays.stream(values()).filter(it -> it.countryCode.equals(normalized)).findFirst();
   }
 }

--- a/src/main/java/ee/tuleva/onboarding/investment/instrument/InstrumentDataValidator.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/instrument/InstrumentDataValidator.java
@@ -7,6 +7,7 @@ import ee.tuleva.onboarding.deadline.PublicHolidays;
 import ee.tuleva.onboarding.instrument.InstrumentReference;
 import ee.tuleva.onboarding.instrument.InstrumentReferenceService;
 import ee.tuleva.onboarding.instrument.InstrumentReferenceService.UnresolvableBenchmarkProxyException;
+import ee.tuleva.onboarding.investment.calendar.Domicile;
 import ee.tuleva.onboarding.investment.portfolio.ModelPortfolioAllocation;
 import ee.tuleva.onboarding.investment.portfolio.ModelPortfolioAllocationRepository;
 import ee.tuleva.onboarding.investment.portfolio.PositionLimit;
@@ -63,6 +64,7 @@ public class InstrumentDataValidator {
     checkProviderLimits(fund, allocations, effectiveDate, findings);
     checkBenchmarkProxies(isins, findings);
     checkActive(isins, findings);
+    checkFundDomicile(isins, findings);
     checkTickerConsistency(allocations, findings);
 
     if (effectiveDate.isAfter(LocalDate.now(clock))) {
@@ -184,6 +186,22 @@ public class InstrumentDataValidator {
                 Severity.FAIL,
                 "ISIN %s is active=false in instrument_reference — prices not being fetched"
                     .formatted(isin)));
+      }
+    }
+  }
+
+  private void checkFundDomicile(Set<String> isins, List<ValidationFinding> findings) {
+    for (var isin : isins) {
+      var instrument = activeInstrument(isin).orElse(null);
+      if (instrument == null || instrument.isExchangeTraded()) {
+        continue;
+      }
+      if (Domicile.forCountryCode(instrument.getCountry()).isEmpty()) {
+        findings.add(
+            new ValidationFinding(
+                Severity.FAIL,
+                "ISIN %s has no supported fund domicile in instrument_reference (country=%s) — settlement dates fall back to the provider's domicile, which is a guess"
+                    .formatted(isin, instrument.getCountry())));
       }
     }
   }

--- a/src/main/java/ee/tuleva/onboarding/investment/instrument/InstrumentDataValidator.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/instrument/InstrumentDataValidator.java
@@ -1,5 +1,6 @@
 package ee.tuleva.onboarding.investment.instrument;
 
+import static ee.tuleva.onboarding.investment.transaction.InstrumentType.FUND;
 import static java.math.BigDecimal.ONE;
 
 import ee.tuleva.onboarding.comparisons.fundvalue.FundValueProvider;
@@ -64,7 +65,7 @@ public class InstrumentDataValidator {
     checkProviderLimits(fund, allocations, effectiveDate, findings);
     checkBenchmarkProxies(isins, findings);
     checkActive(isins, findings);
-    checkFundDomicile(isins, findings);
+    checkFundDomicile(allocations, findings);
     checkTickerConsistency(allocations, findings);
 
     if (effectiveDate.isAfter(LocalDate.now(clock))) {
@@ -190,19 +191,21 @@ public class InstrumentDataValidator {
     }
   }
 
-  private void checkFundDomicile(Set<String> isins, List<ValidationFinding> findings) {
-    for (var isin : isins) {
-      var instrument = activeInstrument(isin).orElse(null);
-      if (instrument == null || instrument.isExchangeTraded()) {
+  private void checkFundDomicile(
+      List<ModelPortfolioAllocation> allocations, List<ValidationFinding> findings) {
+    for (var allocation : allocations) {
+      if (allocation.getInstrumentType() != FUND || allocation.getIsin() == null) {
         continue;
       }
-      if (Domicile.forCountryCode(instrument.getCountry()).isEmpty()) {
-        findings.add(
-            new ValidationFinding(
-                Severity.FAIL,
-                "ISIN %s has no supported fund domicile in instrument_reference (country=%s) — settlement dates fall back to the provider's domicile, which is a guess"
-                    .formatted(isin, instrument.getCountry())));
+      var instrument = activeInstrument(allocation.getIsin()).orElse(null);
+      if (instrument == null || Domicile.forCountryCode(instrument.getCountry()).isPresent()) {
+        continue;
       }
+      findings.add(
+          new ValidationFinding(
+              Severity.FAIL,
+              "ISIN %s has no fund domicile in instrument_reference (country=%s) — its settlement date falls back to the provider's domicile, which is a guess"
+                  .formatted(allocation.getIsin(), instrument.getCountry())));
     }
   }
 

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/SettlementDateCalculator.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/SettlementDateCalculator.java
@@ -92,13 +92,6 @@ public class SettlementDateCalculator {
     };
   }
 
-  /**
-   * A fund deals on its own domicile's calendar, so the domicile has to come from the instrument.
-   * {@code instrument_reference.country} holds it per instrument; the provider is only a fallback
-   * for instruments that have no country recorded. Note that a provider is a fund <em>manager</em>
-   * and a manager can run funds in more than one domicile (BlackRock has both Irish and Luxembourg
-   * entities), so the fallback is a guess, not an answer.
-   */
   private TradingCalendar fundCalendar(String isin, LocalDate tradeDate) {
     return instrumentDomicile(isin)
         .or(() -> providerDomicile(isin, tradeDate))
@@ -126,7 +119,7 @@ public class SettlementDateCalculator {
         .map(
             domicile -> {
               log.warn(
-                  "No country in instrument_reference, using the provider's domicile: isin={}, domicile={}",
+                  "Instrument has no supported country, using the provider's domicile: isin={}, domicile={}",
                   isin,
                   domicile);
               return domicile;

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/SettlementDateCalculator.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/SettlementDateCalculator.java
@@ -52,14 +52,22 @@ public class SettlementDateCalculator {
         .settlementTerms(isin)
         .map(
             terms ->
-                calendarFor(instrumentType, isin, acceptanceDate)
-                    .addBusinessDays(acceptanceDate, terms.daysFromAcceptance()))
+                settleFrom(
+                    dealingDay(acceptanceDate, instrumentType, isin), terms.daysFromAcceptance()))
         .orElseGet(() -> flatSettlementDate(acceptanceDate, instrumentType, isin));
   }
 
   public LocalDate addBusinessDays(
       LocalDate tradeDate, InstrumentType instrumentType, String isin, int businessDays) {
-    return calendarFor(instrumentType, isin, tradeDate).addBusinessDays(tradeDate, businessDays);
+    return settleFrom(dealingDay(tradeDate, instrumentType, isin), businessDays);
+  }
+
+  private LocalDate dealingDay(LocalDate date, InstrumentType instrumentType, String isin) {
+    return dealingCalendar(instrumentType, isin, date).nextOrSameBusinessDay(date);
+  }
+
+  private LocalDate settleFrom(LocalDate acceptanceDate, int businessDays) {
+    return target2Calendar.addBusinessDays(acceptanceDate, businessDays);
   }
 
   private LocalDate flatSettlementDate(
@@ -76,15 +84,15 @@ public class SettlementDateCalculator {
       Instant submittedAt, InstrumentType instrumentType, String isin, SettlementTerms terms) {
     ZonedDateTime submitted = submittedAt.atZone(terms.cutoffZone());
     LocalDate submissionDate = submitted.toLocalDate();
-    TradingCalendar calendar = calendarFor(instrumentType, isin, submissionDate);
+    TradingCalendar dealing = dealingCalendar(instrumentType, isin, submissionDate);
     LocalDate acceptanceDate =
         submitted.toLocalTime().isAfter(terms.cutoffTime())
-            ? calendar.addBusinessDays(submissionDate, 1)
-            : calendar.nextOrSameBusinessDay(submissionDate);
-    return calendar.addBusinessDays(acceptanceDate, terms.daysFromAcceptance());
+            ? dealing.addBusinessDays(submissionDate, 1)
+            : dealing.nextOrSameBusinessDay(submissionDate);
+    return settleFrom(acceptanceDate, terms.daysFromAcceptance());
   }
 
-  private TradingCalendar calendarFor(
+  private TradingCalendar dealingCalendar(
       InstrumentType instrumentType, String isin, LocalDate tradeDate) {
     return switch (instrumentType) {
       case ETF -> target2Calendar;

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/SettlementDateCalculator.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/SettlementDateCalculator.java
@@ -27,7 +27,7 @@ import org.springframework.stereotype.Component;
 public class SettlementDateCalculator {
 
   private static final int ETF_SETTLEMENT_BUSINESS_DAYS = 2;
-  private static final int FUND_SETTLEMENT_BUSINESS_DAYS = 5;
+  private static final int FUND_SETTLEMENT_BUSINESS_DAYS = 4;
   private static final ZoneId DEFAULT_TRADE_ZONE = ZoneId.of(TIMEZONE);
 
   private final Target2Calendar target2Calendar;

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/SettlementDateCalculator.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/SettlementDateCalculator.java
@@ -2,8 +2,10 @@ package ee.tuleva.onboarding.investment.transaction;
 
 import static ee.tuleva.onboarding.investment.JobRunSchedule.TIMEZONE;
 
+import ee.tuleva.onboarding.instrument.InstrumentReference;
 import ee.tuleva.onboarding.instrument.InstrumentReferenceService;
 import ee.tuleva.onboarding.instrument.SettlementTerms;
+import ee.tuleva.onboarding.investment.calendar.Domicile;
 import ee.tuleva.onboarding.investment.calendar.DomicileCalendar;
 import ee.tuleva.onboarding.investment.calendar.Target2Calendar;
 import ee.tuleva.onboarding.investment.calendar.TradingCalendar;
@@ -14,6 +16,7 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -89,17 +92,44 @@ public class SettlementDateCalculator {
     };
   }
 
+  /**
+   * A fund deals on its own domicile's calendar, so the domicile has to come from the instrument.
+   * {@code instrument_reference.country} holds it per instrument; the provider is only a fallback
+   * for instruments that have no country recorded. Note that a provider is a fund <em>manager</em>
+   * and a manager can run funds in more than one domicile (BlackRock has both Irish and Luxembourg
+   * entities), so the fallback is a guess, not an answer.
+   */
   private TradingCalendar fundCalendar(String isin, LocalDate tradeDate) {
+    return instrumentDomicile(isin)
+        .or(() -> providerDomicile(isin, tradeDate))
+        .map(domicileCalendar::forDomicile)
+        .orElseGet(
+            () -> {
+              log.warn("No domicile found for fund, falling back to TARGET2: isin={}", isin);
+              return target2Calendar;
+            });
+  }
+
+  private Optional<Domicile> instrumentDomicile(String isin) {
+    return instrumentReferenceService
+        .findByIsin(isin)
+        .map(InstrumentReference::getCountry)
+        .flatMap(Domicile::forCountryCode);
+  }
+
+  private Optional<Domicile> providerDomicile(String isin, LocalDate tradeDate) {
     return allocationRepository
         .findFirstByIsinAndProviderIsNotNullAndEffectiveDateLessThanEqualOrderByEffectiveDateDesc(
             isin, tradeDate)
         .map(ModelPortfolioAllocation::getProvider)
         .map(Provider::getDomicile)
-        .map(domicileCalendar::forDomicile)
-        .orElseGet(
-            () -> {
-              log.warn("No provider found for fund, falling back to TARGET2: isin={}", isin);
-              return target2Calendar;
+        .map(
+            domicile -> {
+              log.warn(
+                  "No country in instrument_reference, using the provider's domicile: isin={}, domicile={}",
+                  isin,
+                  domicile);
+              return domicile;
             });
   }
 }

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/SettlementDateCalculator.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/SettlementDateCalculator.java
@@ -66,8 +66,8 @@ public class SettlementDateCalculator {
     return dealingCalendar(instrumentType, isin, date).nextOrSameBusinessDay(date);
   }
 
-  private LocalDate settleFrom(LocalDate acceptanceDate, int businessDays) {
-    return target2Calendar.addBusinessDays(acceptanceDate, businessDays);
+  private LocalDate settleFrom(LocalDate dealingDay, int businessDays) {
+    return target2Calendar.addBusinessDays(dealingDay, businessDays);
   }
 
   private LocalDate flatSettlementDate(
@@ -119,18 +119,19 @@ public class SettlementDateCalculator {
   }
 
   private Optional<Domicile> providerDomicile(String isin, LocalDate tradeDate) {
-    return allocationRepository
-        .findFirstByIsinAndProviderIsNotNullAndEffectiveDateLessThanEqualOrderByEffectiveDateDesc(
-            isin, tradeDate)
-        .map(ModelPortfolioAllocation::getProvider)
-        .map(Provider::getDomicile)
-        .map(
-            domicile -> {
-              log.warn(
-                  "Instrument has no supported country, using the provider's domicile: isin={}, domicile={}",
-                  isin,
-                  domicile);
-              return domicile;
-            });
+    Optional<Domicile> domicile =
+        allocationRepository
+            .findFirstByIsinAndProviderIsNotNullAndEffectiveDateLessThanEqualOrderByEffectiveDateDesc(
+                isin, tradeDate)
+            .map(ModelPortfolioAllocation::getProvider)
+            .map(Provider::getDomicile);
+    domicile.ifPresent(
+        it ->
+            log.warn(
+                "Fund has no supported domicile of its own, dealing on its provider's:"
+                    + " isin={}, domicile={}",
+                isin,
+                it));
+    return domicile;
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/investment/instrument/InstrumentDataValidatorSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/instrument/InstrumentDataValidatorSpec.groovy
@@ -379,6 +379,38 @@ class InstrumentDataValidatorSpec extends Specification {
     findings.isEmpty()
   }
 
+  def "FAIL when a mutual fund has no country, before a wrong settlement date is ever calculated"() {
+    given:
+    allocationRepository.findByFundAndEffectiveDate(TUK75, effectiveDate) >> [allocation(isin1, 1.0)]
+    instrumentReferenceService.findByIsin(isin1) >> Optional.of(instrument(isin: isin1, country: country))
+    positionLimitRepository.findLatestByFundAsOf(TUK75, effectiveDate) >> [positionLimit(isin1)]
+    instrumentReferenceService.resolveBenchmarkProxy(_, _) >> Optional.of(new BenchmarkProxy(null, "MSCI_WORLD"))
+
+    when:
+    def findings = validator.validate(TUK75, effectiveDate)
+
+    then:
+    findings.any { it.severity() == FAIL && it.message().contains(isin1) && it.message().contains("domicile") }
+
+    where:
+    country << [null, "", "GB"]
+  }
+
+  def "no domicile finding for an ETF, which settles on TARGET2 wherever it is domiciled"() {
+    given:
+    allocationRepository.findByFundAndEffectiveDate(TUK75, effectiveDate) >> [allocation(isin1, 1.0)]
+    instrumentReferenceService.findByIsin(isin1) >> Optional.of(
+        instrument(isin: isin1, country: null, eodhdTicker: "SGAS.XETRA"))
+    positionLimitRepository.findLatestByFundAsOf(TUK75, effectiveDate) >> [positionLimit(isin1)]
+    instrumentReferenceService.resolveBenchmarkProxy(_, _) >> Optional.of(new BenchmarkProxy(null, "MSCI_WORLD"))
+
+    when:
+    def findings = validator.validate(TUK75, effectiveDate)
+
+    then:
+    findings.every { !it.message().contains("domicile") }
+  }
+
   private ModelPortfolioAllocation allocation(String isin, BigDecimal weight, Provider provider = null) {
     ModelPortfolioAllocation.builder()
         .effectiveDate(effectiveDate).fund(TUK75).isin(isin).weight(weight).provider(provider).build()
@@ -394,6 +426,7 @@ class InstrumentDataValidatorSpec extends Specification {
     def fixture = anInstrument()
         .active(props.containsKey("active") ? props.active : true)
         .eodhdListed(props.containsKey("eodhdListed") ? props.eodhdListed : true)
+        .country(props.containsKey("country") ? props.country : "IE")
     if (props.benchmarkCategory) fixture.benchmarkCategory(props.benchmarkCategory)
     if (props.eodhdTicker) fixture.eodhdTicker(props.eodhdTicker)
     if (props.yahooTicker) fixture.yahooTicker(props.yahooTicker)

--- a/src/test/groovy/ee/tuleva/onboarding/investment/instrument/InstrumentDataValidatorSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/instrument/InstrumentDataValidatorSpec.groovy
@@ -25,6 +25,8 @@ import static ee.tuleva.onboarding.tulevafund.TulevaFund.TKF100
 import static ee.tuleva.onboarding.tulevafund.TulevaFund.TUK75
 import static ee.tuleva.onboarding.instrument.InstrumentReferenceFixture.anInstrument
 import static ee.tuleva.onboarding.investment.instrument.InstrumentDataValidator.Severity.FAIL
+import static ee.tuleva.onboarding.investment.transaction.InstrumentType.ETF
+import static ee.tuleva.onboarding.investment.transaction.InstrumentType.FUND
 import static ee.tuleva.onboarding.investment.instrument.InstrumentDataValidator.Severity.WARNING
 
 class InstrumentDataValidatorSpec extends Specification {
@@ -379,9 +381,9 @@ class InstrumentDataValidatorSpec extends Specification {
     findings.isEmpty()
   }
 
-  def "FAIL when a mutual fund has no country, before a wrong settlement date is ever calculated"() {
+  def "FAIL when a fund allocation has no domicile, before a wrong settlement date is ever calculated"() {
     given:
-    allocationRepository.findByFundAndEffectiveDate(TUK75, effectiveDate) >> [allocation(isin1, 1.0)]
+    allocationRepository.findByFundAndEffectiveDate(TUK75, effectiveDate) >> [fundAllocation(isin1)]
     instrumentReferenceService.findByIsin(isin1) >> Optional.of(instrument(isin: isin1, country: country))
     positionLimitRepository.findLatestByFundAsOf(TUK75, effectiveDate) >> [positionLimit(isin1)]
     instrumentReferenceService.resolveBenchmarkProxy(_, _) >> Optional.of(new BenchmarkProxy(null, "MSCI_WORLD"))
@@ -396,11 +398,24 @@ class InstrumentDataValidatorSpec extends Specification {
     country << [null, "", "GB"]
   }
 
-  def "no domicile finding for an ETF, which settles on TARGET2 wherever it is domiciled"() {
+  def "no domicile finding for a fund allocation whose country is a supported domicile"() {
     given:
-    allocationRepository.findByFundAndEffectiveDate(TUK75, effectiveDate) >> [allocation(isin1, 1.0)]
-    instrumentReferenceService.findByIsin(isin1) >> Optional.of(
-        instrument(isin: isin1, country: null, eodhdTicker: "SGAS.XETRA"))
+    allocationRepository.findByFundAndEffectiveDate(TUK75, effectiveDate) >> [fundAllocation(isin1)]
+    instrumentReferenceService.findByIsin(isin1) >> Optional.of(instrument(isin: isin1, country: "lu"))
+    positionLimitRepository.findLatestByFundAsOf(TUK75, effectiveDate) >> [positionLimit(isin1)]
+    instrumentReferenceService.resolveBenchmarkProxy(_, _) >> Optional.of(new BenchmarkProxy(null, "MSCI_WORLD"))
+
+    when:
+    def findings = validator.validate(TUK75, effectiveDate)
+
+    then:
+    findings.every { !it.message().contains("domicile") }
+  }
+
+  def "no domicile finding for an ETF allocation, which settles on TARGET2 wherever it is domiciled"() {
+    given:
+    allocationRepository.findByFundAndEffectiveDate(TUK75, effectiveDate) >> [etfAllocation(isin1)]
+    instrumentReferenceService.findByIsin(isin1) >> Optional.of(instrument(isin: isin1, country: null))
     positionLimitRepository.findLatestByFundAsOf(TUK75, effectiveDate) >> [positionLimit(isin1)]
     instrumentReferenceService.resolveBenchmarkProxy(_, _) >> Optional.of(new BenchmarkProxy(null, "MSCI_WORLD"))
 
@@ -416,6 +431,14 @@ class InstrumentDataValidatorSpec extends Specification {
         .effectiveDate(effectiveDate).fund(TUK75).isin(isin).weight(weight).provider(provider).build()
   }
 
+  private ModelPortfolioAllocation fundAllocation(String isin) {
+    allocation(isin, 1.0).tap { instrumentType = FUND }
+  }
+
+  private ModelPortfolioAllocation etfAllocation(String isin) {
+    allocation(isin, 1.0).tap { instrumentType = ETF }
+  }
+
   private PositionLimit positionLimit(String isin) {
     PositionLimit.builder()
         .effectiveDate(effectiveDate).fund(TUK75).isin(isin)
@@ -426,7 +449,7 @@ class InstrumentDataValidatorSpec extends Specification {
     def fixture = anInstrument()
         .active(props.containsKey("active") ? props.active : true)
         .eodhdListed(props.containsKey("eodhdListed") ? props.eodhdListed : true)
-        .country(props.containsKey("country") ? props.country : "IE")
+    if (props.containsKey("country")) fixture.country(props.country)
     if (props.benchmarkCategory) fixture.benchmarkCategory(props.benchmarkCategory)
     if (props.eodhdTicker) fixture.eodhdTicker(props.eodhdTicker)
     if (props.yahooTicker) fixture.yahooTicker(props.yahooTicker)

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/SettlementDateCalculatorTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/SettlementDateCalculatorTest.java
@@ -1,5 +1,6 @@
 package ee.tuleva.onboarding.investment.transaction;
 
+import static ee.tuleva.onboarding.instrument.InstrumentReferenceFixture.instrument;
 import static ee.tuleva.onboarding.investment.portfolio.Provider.AMUNDI;
 import static ee.tuleva.onboarding.investment.portfolio.Provider.CCF;
 import static ee.tuleva.onboarding.investment.portfolio.Provider.ISHARES;
@@ -9,7 +10,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verifyNoInteractions;
 
+import ee.tuleva.onboarding.instrument.InstrumentReference;
 import ee.tuleva.onboarding.instrument.InstrumentReferenceService;
 import ee.tuleva.onboarding.instrument.SettlementTerms;
 import ee.tuleva.onboarding.investment.calendar.DomicileCalendar;
@@ -23,6 +26,7 @@ import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Optional;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -36,6 +40,9 @@ class SettlementDateCalculatorTest {
   private static final String LUXEMBOURG_FUND_ISIN = "LU1437018838";
   private static final String UNKNOWN_ISIN = "XX0000000000";
   private static final String CCF_ISIN = "IE0009FT4LX4";
+  // iShares Euro Aggregate Bond Index Fund — run by Blackrock Luxembourg SA, held by TUK00. Its
+  // allocation rows carry provider ISHARES, whose enum domicile is IRELAND.
+  private static final String BLACKROCK_LUXEMBOURG_FUND_ISIN = "LU0826455353";
   private static final ZoneId TALLINN = ZoneId.of("Europe/Tallinn");
   private static final SettlementTerms CCF_TERMS =
       new SettlementTerms(LocalTime.of(9, 30), TALLINN, 3);
@@ -202,6 +209,45 @@ class SettlementDateCalculatorTest {
 
     assertThat(calculator().calculateSettlementDate(tradeDate, FUND, IRISH_FUND_ISIN))
         .isEqualTo(LocalDate.of(2026, 3, 19));
+  }
+
+  @Test
+  void fund_domicileComesFromTheInstrumentsCountryNotItsManagers() {
+    givenCountry(BLACKROCK_LUXEMBOURG_FUND_ISIN, "LU");
+    LocalDate beforeStPatricksDay = LocalDate.of(2026, 3, 12);
+
+    // 17 March is an Irish holiday but not a Luxembourg one. Grouping this fund under its manager
+    // (BlackRock → ISHARES → IRELAND) would skip it and settle a day late, on 20 March.
+    assertThat(
+            calculator()
+                .calculateSettlementDate(beforeStPatricksDay, FUND, BLACKROCK_LUXEMBOURG_FUND_ISIN))
+        .isEqualTo(LocalDate.of(2026, 3, 19));
+    verifyNoInteractions(allocationRepository);
+  }
+
+  @Test
+  void fund_withoutACountryFallsBackToItsProvidersDomicile() {
+    givenCountry(IRISH_FUND_ISIN, null);
+    givenProvider(IRISH_FUND_ISIN, ISHARES);
+    LocalDate beforeStPatricksDay = LocalDate.of(2026, 3, 12);
+
+    assertThat(calculator().calculateSettlementDate(beforeStPatricksDay, FUND, IRISH_FUND_ISIN))
+        .isEqualTo(LocalDate.of(2026, 3, 20));
+  }
+
+  @Test
+  void fund_withAnUnsupportedCountryFallsBackToItsProvidersDomicile() {
+    givenCountry(IRISH_FUND_ISIN, "GB");
+    givenProvider(IRISH_FUND_ISIN, ISHARES);
+    LocalDate beforeStPatricksDay = LocalDate.of(2026, 3, 12);
+
+    assertThat(calculator().calculateSettlementDate(beforeStPatricksDay, FUND, IRISH_FUND_ISIN))
+        .isEqualTo(LocalDate.of(2026, 3, 20));
+  }
+
+  private void givenCountry(String isin, @Nullable String country) {
+    InstrumentReference reference = instrument(isin).country(country).build();
+    given(instrumentReferenceService.findByIsin(isin)).willReturn(Optional.of(reference));
   }
 
   private void givenProvider(String isin, Provider provider) {

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/SettlementDateCalculatorTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/SettlementDateCalculatorTest.java
@@ -131,7 +131,7 @@ class SettlementDateCalculatorTest {
     Instant monday = tallinnInstant(LocalDate.of(2026, 1, 12), LocalTime.of(9, 15));
 
     assertThat(calculator().calculateSettlementDate(monday, FUND, CCF_ISIN))
-        .isEqualTo(LocalDate.of(2026, 1, 19));
+        .isEqualTo(LocalDate.of(2026, 1, 16));
   }
 
   @Test
@@ -172,13 +172,13 @@ class SettlementDateCalculatorTest {
     LocalDate beforeStPatricksDay = LocalDate.of(2026, 3, 12);
 
     assertThat(calculator().calculateSettlementDate(beforeStPatricksDay, FUND, IRISH_FUND_ISIN))
-        .isEqualTo(LocalDate.of(2026, 3, 20));
+        .isEqualTo(LocalDate.of(2026, 3, 19));
   }
 
   @Test
   void fund_luxembourgProviderSkipsAscensionDay() {
     givenProvider(LUXEMBOURG_FUND_ISIN, AMUNDI);
-    LocalDate beforeAscension2026 = LocalDate.of(2026, 5, 7);
+    LocalDate beforeAscension2026 = LocalDate.of(2026, 5, 8);
 
     assertThat(
             calculator().calculateSettlementDate(beforeAscension2026, FUND, LUXEMBOURG_FUND_ISIN))
@@ -195,7 +195,7 @@ class SettlementDateCalculatorTest {
         .willReturn(Optional.empty());
 
     assertThat(calculator().calculateSettlementDate(beforeStPatricksDay, FUND, UNKNOWN_ISIN))
-        .isEqualTo(LocalDate.of(2026, 3, 19));
+        .isEqualTo(LocalDate.of(2026, 3, 18));
   }
 
   @Test
@@ -208,7 +208,7 @@ class SettlementDateCalculatorTest {
         .willReturn(Optional.empty());
 
     assertThat(calculator().calculateSettlementDate(tradeDate, FUND, IRISH_FUND_ISIN))
-        .isEqualTo(LocalDate.of(2026, 3, 19));
+        .isEqualTo(LocalDate.of(2026, 3, 18));
   }
 
   @Test
@@ -221,7 +221,7 @@ class SettlementDateCalculatorTest {
     assertThat(
             calculator()
                 .calculateSettlementDate(beforeStPatricksDay, FUND, BLACKROCK_LUXEMBOURG_FUND_ISIN))
-        .isEqualTo(LocalDate.of(2026, 3, 19));
+        .isEqualTo(LocalDate.of(2026, 3, 18));
     verifyNoInteractions(allocationRepository);
   }
 
@@ -232,7 +232,7 @@ class SettlementDateCalculatorTest {
     LocalDate beforeStPatricksDay = LocalDate.of(2026, 3, 12);
 
     assertThat(calculator().calculateSettlementDate(beforeStPatricksDay, FUND, IRISH_FUND_ISIN))
-        .isEqualTo(LocalDate.of(2026, 3, 20));
+        .isEqualTo(LocalDate.of(2026, 3, 19));
   }
 
   @Test
@@ -242,7 +242,7 @@ class SettlementDateCalculatorTest {
     LocalDate beforeStPatricksDay = LocalDate.of(2026, 3, 12);
 
     assertThat(calculator().calculateSettlementDate(beforeStPatricksDay, FUND, IRISH_FUND_ISIN))
-        .isEqualTo(LocalDate.of(2026, 3, 20));
+        .isEqualTo(LocalDate.of(2026, 3, 19));
   }
 
   private void givenCountry(String isin, @Nullable String country) {

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/SettlementDateCalculatorTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/SettlementDateCalculatorTest.java
@@ -94,14 +94,14 @@ class SettlementDateCalculatorTest {
   }
 
   @Test
-  void ccf_dayCountSkipsIrishHoliday() {
+  void ccf_dayCountRunsThroughAnIrishHolidayBecauseCashSettlesOnTarget2() {
     given(instrumentReferenceService.settlementTerms(CCF_ISIN)).willReturn(Optional.of(CCF_TERMS));
     givenProvider(CCF_ISIN, CCF);
     Instant thursdayBeforeStPatricks =
         tallinnInstant(LocalDate.of(2026, 3, 12), LocalTime.of(9, 15));
 
     assertThat(calculator().calculateSettlementDate(thursdayBeforeStPatricks, FUND, CCF_ISIN))
-        .isEqualTo(LocalDate.of(2026, 3, 18));
+        .isEqualTo(LocalDate.of(2026, 3, 17));
   }
 
   @Test
@@ -166,23 +166,37 @@ class SettlementDateCalculatorTest {
         .isEqualTo(LocalDate.of(2025, 4, 23));
   }
 
+  // The domicile decides when the fund deals, so an order placed on an Irish holiday waits for the
+  // next dealing day. 17 March is a dealing holiday but not a TARGET2 one.
   @Test
-  void fund_irishProviderSkipsStPatricksDay() {
+  void fund_orderPlacedOnAnIrishHolidayIsDealtOnTheNextDealingDay() {
+    givenProvider(IRISH_FUND_ISIN, ISHARES);
+    LocalDate stPatricksDay = LocalDate.of(2026, 3, 17);
+
+    assertThat(calculator().calculateSettlementDate(stPatricksDay, FUND, IRISH_FUND_ISIN))
+        .isEqualTo(LocalDate.of(2026, 3, 24));
+  }
+
+  // Cash settles through TARGET2, not the fund's own calendar: two of these settled on 1 June 2026,
+  // an Irish bank holiday, which counting on the Irish calendar could never produce. Counted the
+  // old
+  // way this would be 19 March, because 17 March would be skipped.
+  @Test
+  void fund_settlementDaysAreCountedOnTarget2NotTheFundsCalendar() {
     givenProvider(IRISH_FUND_ISIN, ISHARES);
     LocalDate beforeStPatricksDay = LocalDate.of(2026, 3, 12);
 
     assertThat(calculator().calculateSettlementDate(beforeStPatricksDay, FUND, IRISH_FUND_ISIN))
-        .isEqualTo(LocalDate.of(2026, 3, 19));
+        .isEqualTo(LocalDate.of(2026, 3, 18));
   }
 
   @Test
-  void fund_luxembourgProviderSkipsAscensionDay() {
+  void fund_orderPlacedOnAscensionDayIsDealtOnTheNextDealingDay() {
     givenProvider(LUXEMBOURG_FUND_ISIN, AMUNDI);
-    LocalDate beforeAscension2026 = LocalDate.of(2026, 5, 8);
+    LocalDate ascensionDay2026 = LocalDate.of(2026, 5, 14);
 
-    assertThat(
-            calculator().calculateSettlementDate(beforeAscension2026, FUND, LUXEMBOURG_FUND_ISIN))
-        .isEqualTo(LocalDate.of(2026, 5, 15));
+    assertThat(calculator().calculateSettlementDate(ascensionDay2026, FUND, LUXEMBOURG_FUND_ISIN))
+        .isEqualTo(LocalDate.of(2026, 5, 21));
   }
 
   @Test
@@ -229,20 +243,20 @@ class SettlementDateCalculatorTest {
   void fund_withoutACountryFallsBackToItsProvidersDomicile() {
     givenCountry(IRISH_FUND_ISIN, null);
     givenProvider(IRISH_FUND_ISIN, ISHARES);
-    LocalDate beforeStPatricksDay = LocalDate.of(2026, 3, 12);
+    LocalDate stPatricksDay = LocalDate.of(2026, 3, 17);
 
-    assertThat(calculator().calculateSettlementDate(beforeStPatricksDay, FUND, IRISH_FUND_ISIN))
-        .isEqualTo(LocalDate.of(2026, 3, 19));
+    assertThat(calculator().calculateSettlementDate(stPatricksDay, FUND, IRISH_FUND_ISIN))
+        .isEqualTo(LocalDate.of(2026, 3, 24));
   }
 
   @Test
   void fund_withAnUnsupportedCountryFallsBackToItsProvidersDomicile() {
     givenCountry(IRISH_FUND_ISIN, "GB");
     givenProvider(IRISH_FUND_ISIN, ISHARES);
-    LocalDate beforeStPatricksDay = LocalDate.of(2026, 3, 12);
+    LocalDate stPatricksDay = LocalDate.of(2026, 3, 17);
 
-    assertThat(calculator().calculateSettlementDate(beforeStPatricksDay, FUND, IRISH_FUND_ISIN))
-        .isEqualTo(LocalDate.of(2026, 3, 19));
+    assertThat(calculator().calculateSettlementDate(stPatricksDay, FUND, IRISH_FUND_ISIN))
+        .isEqualTo(LocalDate.of(2026, 3, 24));
   }
 
   private void givenCountry(String isin, @Nullable String country) {

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/SettlementDateCalculatorTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/SettlementDateCalculatorTest.java
@@ -40,9 +40,7 @@ class SettlementDateCalculatorTest {
   private static final String LUXEMBOURG_FUND_ISIN = "LU1437018838";
   private static final String UNKNOWN_ISIN = "XX0000000000";
   private static final String CCF_ISIN = "IE0009FT4LX4";
-  // iShares Euro Aggregate Bond Index Fund — run by Blackrock Luxembourg SA, held by TUK00. Its
-  // allocation rows carry provider ISHARES, whose enum domicile is IRELAND.
-  private static final String BLACKROCK_LUXEMBOURG_FUND_ISIN = "LU0826455353";
+  private static final String LUXEMBOURG_FUND_WITH_AN_IRISH_PROVIDER_ISIN = "LU0826455353";
   private static final ZoneId TALLINN = ZoneId.of("Europe/Tallinn");
   private static final SettlementTerms CCF_TERMS =
       new SettlementTerms(LocalTime.of(9, 30), TALLINN, 3);
@@ -166,8 +164,6 @@ class SettlementDateCalculatorTest {
         .isEqualTo(LocalDate.of(2025, 4, 23));
   }
 
-  // The domicile decides when the fund deals, so an order placed on an Irish holiday waits for the
-  // next dealing day. 17 March is a dealing holiday but not a TARGET2 one.
   @Test
   void fund_orderPlacedOnAnIrishHolidayIsDealtOnTheNextDealingDay() {
     givenProvider(IRISH_FUND_ISIN, ISHARES);
@@ -177,10 +173,6 @@ class SettlementDateCalculatorTest {
         .isEqualTo(LocalDate.of(2026, 3, 24));
   }
 
-  // Cash settles through TARGET2, not the fund's own calendar: two of these settled on 1 June 2026,
-  // an Irish bank holiday, which counting on the Irish calendar could never produce. Counted the
-  // old
-  // way this would be 19 March, because 17 March would be skipped.
   @Test
   void fund_settlementDaysAreCountedOnTarget2NotTheFundsCalendar() {
     givenProvider(IRISH_FUND_ISIN, ISHARES);
@@ -227,14 +219,13 @@ class SettlementDateCalculatorTest {
 
   @Test
   void fund_domicileComesFromTheInstrumentsCountryNotItsManagers() {
-    givenCountry(BLACKROCK_LUXEMBOURG_FUND_ISIN, "LU");
+    givenCountry(LUXEMBOURG_FUND_WITH_AN_IRISH_PROVIDER_ISIN, "LU");
     LocalDate beforeStPatricksDay = LocalDate.of(2026, 3, 12);
 
-    // 17 March is an Irish holiday but not a Luxembourg one. Grouping this fund under its manager
-    // (BlackRock → ISHARES → IRELAND) would skip it and settle a day late, on 20 March.
     assertThat(
             calculator()
-                .calculateSettlementDate(beforeStPatricksDay, FUND, BLACKROCK_LUXEMBOURG_FUND_ISIN))
+                .calculateSettlementDate(
+                    beforeStPatricksDay, FUND, LUXEMBOURG_FUND_WITH_AN_IRISH_PROVIDER_ISIN))
         .isEqualTo(LocalDate.of(2026, 3, 18));
     verifyNoInteractions(allocationRepository);
   }

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionPipelineIntegrationTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionPipelineIntegrationTest.java
@@ -166,7 +166,7 @@ class TransactionPipelineIntegrationTest {
         .filter(order -> order.getInstrumentType() == FUND)
         .forEach(
             order ->
-                assertThat(order.getExpectedSettlementDate()).isEqualTo(LocalDate.of(2026, 2, 17)));
+                assertThat(order.getExpectedSettlementDate()).isEqualTo(LocalDate.of(2026, 2, 16)));
 
     Map<String, Object> metadata = batch.getMetadata();
     assertThat(metadata).containsKey("xlsxExport");

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/OverdueSettlementDetectorTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/OverdueSettlementDetectorTest.java
@@ -123,39 +123,41 @@ class OverdueSettlementDetectorTest {
   }
 
   @Test
-  void collectOverdue_fundDeadlineUsesDomicileCalendar_irishHolidayDefersOverdue() {
-    // FUND order on Tue 2026-03-10, 5-business-day threshold. On TARGET2 the deadline is
-    // 2026-03-17, but the Irish domicile calendar skips St Patrick's Day (Mar 17), deferring the
-    // deadline to 2026-03-18. As of 2026-03-18 the order is therefore NOT yet overdue.
-    LocalDate stPatricksWeek = LocalDate.of(2026, 3, 18); // Wednesday
+  void collectOverdue_fundOrderedOnANonDealingDay_dealsLaterAndIsNotYetOverdue() {
+    // FUND order placed ON St Patrick's Day, 5-business-day threshold. The Irish domicile calendar
+    // makes it a non-dealing day, so the fund deals on Mar 18 and the deadline is 2026-03-25. As of
+    // 2026-03-25 the order is therefore NOT yet overdue.
+    LocalDate afterTheDeadlineWindow = LocalDate.of(2026, 3, 25); // Wednesday
     givenProvider("IE00BFG1TM61", Provider.ISHARES);
     TransactionOrder sentFund =
-        order(1L, FUND, SENT, dateOnly(2026, 3, 10), TUV100, "IE00BFG1TM61", SENT_UUID);
+        order(1L, FUND, SENT, dateOnly(2026, 3, 17), TUV100, "IE00BFG1TM61", SENT_UUID);
     given(executionRepository.findByOrderIdIn(any())).willReturn(List.of());
 
     List<OverdueLine> overdue =
-        detector().collectOverdue(stPatricksWeek, true, Set.of(), Set.of(), List.of(sentFund));
+        detector()
+            .collectOverdue(afterTheDeadlineWindow, true, Set.of(), Set.of(), List.of(sentFund));
 
     assertThat(overdue).isEmpty();
   }
 
   @Test
-  void collectOverdue_fundDeadlineOnTarget2WithoutProvider_isOverdueOnStPatricksDay() {
-    // Same FUND order as above, but with no resolvable provider the calculator falls back to
-    // TARGET2, whose deadline is 2026-03-17 (St Patrick's Day is a regular TARGET2 business day).
-    // As of 2026-03-18 the order is overdue, confirming the domicile calendar is what defers it.
-    LocalDate stPatricksWeek = LocalDate.of(2026, 3, 18); // Wednesday
+  void collectOverdue_fundWithoutADomicileDealsSameDayAndIsAlreadyOverdue() {
+    // Same FUND order as above, but with no resolvable domicile the calculator falls back to
+    // TARGET2, on which St Patrick's Day is a normal dealing day. The deadline is therefore
+    // 2026-03-24 and the order is overdue, confirming the domicile calendar is what defers it.
+    LocalDate afterTheDeadlineWindow = LocalDate.of(2026, 3, 25); // Wednesday
     TransactionOrder sentFund =
-        order(1L, FUND, SENT, dateOnly(2026, 3, 10), TUV100, "EE3600109443", SENT_UUID);
+        order(1L, FUND, SENT, dateOnly(2026, 3, 17), TUV100, "EE3600109443", SENT_UUID);
     given(executionRepository.findByOrderIdIn(any())).willReturn(List.of());
 
     List<OverdueLine> overdue =
-        detector().collectOverdue(stPatricksWeek, true, Set.of(), Set.of(), List.of(sentFund));
+        detector()
+            .collectOverdue(afterTheDeadlineWindow, true, Set.of(), Set.of(), List.of(sentFund));
 
     assertThat(overdue).hasSize(1);
     assertThat(overdue.get(0).order()).isEqualTo(sentFund);
     assertThat(overdue.get(0).status()).isEqualTo(SENT);
-    assertThat(overdue.get(0).deadline()).isEqualTo(LocalDate.of(2026, 3, 17));
+    assertThat(overdue.get(0).deadline()).isEqualTo(LocalDate.of(2026, 3, 24));
   }
 
   @Test


### PR DESCRIPTION
Three separate things were wrong with the fund settlement date. The first was found by reading the code; the other two by measuring 222 executions in the transaction registry against what actually settled.

**Scope warning for review: every fund settlement date moves by one business day.** This started as the calendar fix in the title and grew; the day-count change is the one with real blast radius.

## 1. The calendar came from the manager, not the fund

`fundCalendar` derived the domicile from the allocation row's `Provider` — but a `Provider` is a fund **manager**, and a manager runs funds in more than one domicile.

| ISIN | Fund | Manager | `country` | Calendar used |
|---|---|---|---|---|
| `LU0826455353` | iShares Euro Aggregate Bond Index Fund | Blackrock Luxembourg SA | `LU` | 🔴 Ireland |
| `LU0839970364` | iShares Global Government Bond Index Fund | Blackrock Luxembourg SA | `LU` | 🔴 Ireland |

Both carry `provider = 'ISHARES'`, declared `IRELAND`. `instrument_reference.country` already records the real domicile per instrument, so resolution is now:

```
instrument_reference.country  →  provider's domicile (warns)  →  TARGET2 (warns)
```

The provider stays as a fallback because `country` is nullable, and dropping straight to TARGET2 would be worse than the old guess. `Domicile` gains its ISO code and a `forCountryCode` lookup.

## 2. Funds settle T+4, not T+5

`FUND_SETTLEMENT_BUSINESS_DAYS` was 5. The registry's **79 executed fund orders** say otherwise:

| rule | rows explained |
|---|---|
| T+4 | **61 / 79 (77%)** |
| T+5 | 6 / 79 (8%) |

T+4 is the mode for **every one of the seven funds** we hold — 25/33 for `IE00BFG1TM61`, 13/21 for `IE0009FT4LX4`, 10/15 for `IE00BKPTWY98` — so this is not one fund dragging an average. ETFs were already right: 128 of 143 settle exactly T+2.

## 3. The domicile calendar was applied to the wrong step

The calendar was used to count the settlement days themselves. It shouldn't be: **two executions settled on 1 June 2026, an Irish bank holiday.** Counting settlement days on the Irish calendar cannot produce that date, so the model was falsified, not merely imprecise. No settlement ever landed on a TARGET2 holiday.

The two calendars do different jobs, and now do them separately:

| step | calendar |
|---|---|
| which day the order is **dealt/accepted** | the fund's domicile |
| counting the **settlement** days after that | TARGET2, as for ETFs |

## Also: a guard against the fallback going unnoticed

Adding an instrument is SQL, not a deploy, so a row can arrive without a `country` and settle silently on the manager's domicile. `InstrumentDataValidator.checkFundDomicile` now raises a **FAIL** for a fund allocation whose country is missing or outside IE/LU/FR, carried by the hourly `InstrumentValidationJob`. ETFs are exempt — they settle on TARGET2 wherever they are domiciled.

## What this does not fix, and cannot

T+4 on TARGET2 explains ~75–80% of executions. **The rest is not a calendar problem and no holiday map will fix it:** on 8 of 28 order dates, funds with the *same* manager and *same* domicile settled on different days.

```
order 2026-03-10:  IE00BFG1TM61 → 16 Mar    IE0009FT4LX4 → 20 Mar
order 2026-08-24:  IE0009FT4LX4 → 27 Aug    IE0005032192 → 28 Aug
                   IE0031080751 → 28 Aug    IE00BFG1TM61 → 1 Sep
```

That spread is per-fund non-dealing days — the sub-fund's own underlying markets, prospectus clauses (a)/(b) — which BlackRock publishes for its Asia/EM funds but not for these. A UK delegate calendar was tested and rejected: only 7 rows can discriminate it, and the 2 it appears to fix are equally explained by the Irish calendar, since 4 May 2026 is both a UK and an Irish bank holiday.

**So the calculated date is an estimate.** The authoritative date is the one SEB reports, and comparing the two per ISIN is the follow-up worth doing — it would catch the residual without needing anyone's schedule.

## Verification

Full suite: **8387 tests, 1124 classes, 0 failures.**

Four existing tests were asserting the behaviour this PR removes, so they were rewritten rather than re-dated. Three of them would otherwise have gone green while covering nothing: with an order on 12 March, the Irish and TARGET2 calendars give the same answer, so the provider-fallback tests stopped discriminating entirely. They now order *on* St Patrick's Day, where the fallback still changes the result.

The GAS side was aligned separately (`SETTLE_CYCLE_DAYS`, `SETTLE_DAYS_FUND`) so the sheet and the service don't disagree by a day.
