### PR TITLE
Use one name formatting rule everywhere

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/auth/principal/Person.java
+++ b/src/main/java/ee/tuleva/onboarding/auth/principal/Person.java
@@ -1,7 +1,5 @@
 package ee.tuleva.onboarding.auth.principal;
 
-import static org.apache.commons.lang3.text.WordUtils.capitalizeFully;
-
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import ee.tuleva.onboarding.user.personalcode.ValidPersonalCode;
 import jakarta.validation.constraints.NotBlank;
@@ -25,9 +23,5 @@ public interface Person {
   @JsonIgnore
   default String getRepresentedPersonalCode() {
     return getPersonalCode();
-  }
-
-  static String capitalize(String name) {
-    return capitalizeFully(name, ' ', '-');
   }
 }

--- a/src/main/java/ee/tuleva/onboarding/auth/principal/PrincipalService.java
+++ b/src/main/java/ee/tuleva/onboarding/auth/principal/PrincipalService.java
@@ -1,7 +1,7 @@
 package ee.tuleva.onboarding.auth.principal;
 
-import static ee.tuleva.onboarding.auth.principal.Person.capitalize;
 import static ee.tuleva.onboarding.auth.role.RoleType.PERSON;
+import static ee.tuleva.onboarding.user.Names.formatted;
 
 import ee.tuleva.onboarding.auth.role.Role;
 import ee.tuleva.onboarding.user.User;
@@ -33,7 +33,7 @@ public class PrincipalService {
     return getFrom(
         person,
         attributes,
-        new Role(PERSON, person.getPersonalCode(), capitalize(person.getFullName())));
+        new Role(PERSON, person.getPersonalCode(), formatted(person.getFullName())));
   }
 
   public AuthenticatedPerson getFrom(
@@ -49,8 +49,8 @@ public class PrincipalService {
     }
 
     return AuthenticatedPerson.builder()
-        .firstName(capitalize(person.getFirstName()))
-        .lastName(capitalize(person.getLastName()))
+        .firstName(formatted(person.getFirstName()))
+        .lastName(formatted(person.getLastName()))
         .personalCode(person.getPersonalCode())
         .userId(user.getId())
         .attributes(attributes)
@@ -72,8 +72,8 @@ public class PrincipalService {
   private User createUser(Person person) {
     return userService.createNewUser(
         User.builder()
-            .firstName(capitalize(person.getFirstName()))
-            .lastName(capitalize(person.getLastName()))
+            .firstName(formatted(person.getFirstName()))
+            .lastName(formatted(person.getLastName()))
             .personalCode(person.getPersonalCode())
             .active(true)
             .build());

--- a/src/main/java/ee/tuleva/onboarding/party/ParentChildLinkRegistrationService.java
+++ b/src/main/java/ee/tuleva/onboarding/party/ParentChildLinkRegistrationService.java
@@ -3,7 +3,7 @@ package ee.tuleva.onboarding.party;
 import static ee.tuleva.onboarding.party.ParentChildLinkStatus.PENDING_KYC;
 import static ee.tuleva.onboarding.party.RepresentationType.GUARDIAN;
 import static ee.tuleva.onboarding.party.RepresentationType.LEGAL_REPRESENTATIVE;
-import static org.apache.commons.lang3.text.WordUtils.capitalizeFully;
+import static ee.tuleva.onboarding.user.Names.formatted;
 import static org.springframework.transaction.annotation.Propagation.REQUIRES_NEW;
 
 import ee.tuleva.onboarding.user.User;
@@ -155,16 +155,16 @@ public class ParentChildLinkRegistrationService {
         .findByPersonalCode(personalCode)
         .ifPresentOrElse(
             existing -> {
-              existing.setFirstName(capitalizeFully(firstName, ' ', '-'));
-              existing.setLastName(capitalizeFully(lastName, ' ', '-'));
+              existing.setFirstName(formatted(firstName));
+              existing.setLastName(formatted(lastName));
               userService.save(existing);
             },
             () ->
                 userService.createNewUser(
                     User.builder()
                         .personalCode(personalCode)
-                        .firstName(capitalizeFully(firstName, ' ', '-'))
-                        .lastName(capitalizeFully(lastName, ' ', '-'))
+                        .firstName(formatted(firstName))
+                        .lastName(formatted(lastName))
                         .active(true)
                         .build()));
   }

--- a/src/main/java/ee/tuleva/onboarding/populationregister/PersonMapper.java
+++ b/src/main/java/ee/tuleva/onboarding/populationregister/PersonMapper.java
@@ -8,7 +8,7 @@ import static ee.tuleva.onboarding.populationregister.CustodyValidity.VALID;
 import static ee.tuleva.onboarding.populationregister.PopulationRegisterPerson.Status.ALIVE;
 import static ee.tuleva.onboarding.populationregister.PopulationRegisterPerson.Status.INACTIVE;
 import static ee.tuleva.onboarding.populationregister.PopulationRegisterPerson.Status.UNKNOWN;
-import static org.apache.commons.lang3.text.WordUtils.capitalizeFully;
+import static ee.tuleva.onboarding.user.Names.formatted;
 
 import ee.tuleva.onboarding.country.CountryCodes;
 import ee.tuleva.onboarding.populationregister.PersonResponse.Citizenship;
@@ -34,8 +34,8 @@ class PersonMapper {
   static PopulationRegisterPerson toPerson(PersonResponse response) {
     return new PopulationRegisterPerson(
         require(response.personalCode(), "isikukood"),
-        capitalizeFully(require(response.firstName(), "eesnimi"), ' ', '-'),
-        capitalizeFully(require(response.lastName(), "perekonnanimi"), ' ', '-'),
+        formatted(require(response.firstName(), "eesnimi")),
+        formatted(require(response.lastName(), "perekonnanimi")),
         parseDate(response.dateOfBirth()),
         toStatus(response.status()),
         toCitizenship(response.citizenship()),
@@ -85,7 +85,7 @@ class PersonMapper {
   // The register returns names in uppercase (JÕEORG); present them the same way the rest of the
   // app stores names (Jõeorg), matching ParentChildLinkRegistrationService.
   private static @Nullable String capitalizeName(@Nullable String name) {
-    return name == null ? null : capitalizeFully(name, ' ', '-');
+    return formatted(name);
   }
 
   private static CustodyRight.Type toCustodyType(@Nullable Code type) {

--- a/src/main/java/ee/tuleva/onboarding/user/Names.java
+++ b/src/main/java/ee/tuleva/onboarding/user/Names.java
@@ -1,7 +1,6 @@
 package ee.tuleva.onboarding.user;
 
 import java.util.Locale;
-import org.apache.commons.lang3.text.WordUtils;
 
 public class Names {
 
@@ -11,9 +10,28 @@ public class Names {
     if (name == null || name.isBlank()) {
       return name;
     }
-    if (!name.equals(name.toUpperCase(ESTONIAN))) {
-      return name;
+    StringBuilder result = new StringBuilder(name.length());
+    StringBuilder token = new StringBuilder();
+    for (char c : name.toCharArray()) {
+      if (c == ' ' || c == '-' || c == '\'') {
+        result.append(formattedToken(token.toString())).append(c);
+        token.setLength(0);
+      } else {
+        token.append(c);
+      }
     }
-    return WordUtils.capitalizeFully(name, ' ', '-', '\'');
+    return result.append(formattedToken(token.toString())).toString();
+  }
+
+  private static String formattedToken(String token) {
+    if (token.isEmpty()) {
+      return token;
+    }
+    boolean allLower = token.equals(token.toLowerCase(ESTONIAN));
+    boolean allUpper = token.equals(token.toUpperCase(ESTONIAN));
+    if (!allLower && !allUpper) {
+      return token;
+    }
+    return token.substring(0, 1).toUpperCase(ESTONIAN) + token.substring(1).toLowerCase(ESTONIAN);
   }
 }

--- a/src/main/java/ee/tuleva/onboarding/user/Names.java
+++ b/src/main/java/ee/tuleva/onboarding/user/Names.java
@@ -1,37 +1,45 @@
 package ee.tuleva.onboarding.user;
 
+import static java.util.stream.Collectors.joining;
+
+import java.util.Arrays;
 import java.util.Locale;
 
 public class Names {
 
   private static final Locale ESTONIAN = Locale.of("et");
+  private static final String NAME_PART_SEPARATORS = " -'";
+  private static final String SPLIT_KEEPING_SEPARATORS = "(?<=[ \\-'])|(?=[ \\-'])";
 
   public static String formatted(String name) {
     if (name == null || name.isBlank()) {
       return name;
     }
-    StringBuilder result = new StringBuilder(name.length());
-    StringBuilder token = new StringBuilder();
-    for (char c : name.toCharArray()) {
-      if (c == ' ' || c == '-' || c == '\'') {
-        result.append(formattedToken(token.toString())).append(c);
-        token.setLength(0);
-      } else {
-        token.append(c);
-      }
-    }
-    return result.append(formattedToken(token.toString())).toString();
+    return Arrays.stream(name.split(SPLIT_KEEPING_SEPARATORS))
+        .map(Names::formattedPart)
+        .collect(joining());
   }
 
-  private static String formattedToken(String token) {
-    if (token.isEmpty()) {
-      return token;
+  private static String formattedPart(String part) {
+    if (part.isEmpty() || isSeparator(part) || hasDeliberateCasing(part)) {
+      return part;
     }
-    boolean allLower = token.equals(token.toLowerCase(ESTONIAN));
-    boolean allUpper = token.equals(token.toUpperCase(ESTONIAN));
-    if (!allLower && !allUpper) {
-      return token;
-    }
-    return token.substring(0, 1).toUpperCase(ESTONIAN) + token.substring(1).toLowerCase(ESTONIAN);
+    return capitalized(part);
+  }
+
+  private static boolean isSeparator(String part) {
+    return part.length() == 1 && NAME_PART_SEPARATORS.contains(part);
+  }
+
+  private static boolean hasDeliberateCasing(String part) {
+    boolean isAllLowerCase = part.equals(part.toLowerCase(ESTONIAN));
+    boolean isAllUpperCase = part.equals(part.toUpperCase(ESTONIAN));
+    return !isAllLowerCase && !isAllUpperCase;
+  }
+
+  private static String capitalized(String part) {
+    String firstLetter = part.substring(0, 1);
+    String rest = part.substring(1);
+    return firstLetter.toUpperCase(ESTONIAN) + rest.toLowerCase(ESTONIAN);
   }
 }

--- a/src/main/java/ee/tuleva/onboarding/user/UserDetailsUpdater.java
+++ b/src/main/java/ee/tuleva/onboarding/user/UserDetailsUpdater.java
@@ -1,6 +1,6 @@
 package ee.tuleva.onboarding.user;
 
-import static ee.tuleva.onboarding.auth.principal.Person.capitalize;
+import static ee.tuleva.onboarding.user.Names.formatted;
 
 import ee.tuleva.onboarding.auth.event.AfterTokenGrantedEvent;
 import ee.tuleva.onboarding.auth.event.BeforeTokenGrantedEvent;
@@ -41,8 +41,8 @@ public class UserDetailsUpdater {
         .findByPersonalCode(person.getPersonalCode())
         .ifPresent(
             user -> {
-              user.setFirstName(capitalize(person.getFirstName()));
-              user.setLastName(capitalize(person.getLastName()));
+              user.setFirstName(formatted(person.getFirstName()));
+              user.setLastName(formatted(person.getLastName()));
               userService.save(user);
             });
   }

--- a/src/main/java/ee/tuleva/onboarding/user/response/UserResponse.java
+++ b/src/main/java/ee/tuleva/onboarding/user/response/UserResponse.java
@@ -1,6 +1,6 @@
 package ee.tuleva.onboarding.user.response;
 
-import static ee.tuleva.onboarding.auth.principal.Person.capitalize;
+import static ee.tuleva.onboarding.user.Names.formatted;
 
 import ee.tuleva.onboarding.auth.principal.Person;
 import ee.tuleva.onboarding.auth.role.Role;
@@ -85,8 +85,8 @@ public class UserResponse implements Person, Emailable {
   private static UserResponseBuilder responseBuilder(@NotNull User user) {
     return builder()
         .id(user.getId())
-        .firstName(capitalize(user.getFirstName()))
-        .lastName(capitalize(user.getLastName()))
+        .firstName(formatted(user.getFirstName()))
+        .lastName(formatted(user.getLastName()))
         .personalCode(user.getPersonalCode())
         .email(user.getEmail())
         .phoneNumber(user.getPhoneNumber())

--- a/src/test/groovy/ee/tuleva/onboarding/user/NamesTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/user/NamesTest.java
@@ -20,11 +20,11 @@ class NamesTest {
     "Mari-Liis, Mari-Liis",
     "mari, Mari",
     "mari-liis, Mari-Liis",
-    "erko risthein, Erko Risthein",
+    "mari maasikas, Mari Maasikas",
     "McGregor, McGregor",
     "van der Berg, Van Der Berg",
   })
-  void formatsOnlyAllCapsNames(String input, String expected) {
+  void capitalizesNamePartsAndKeepsDeliberateCasing(String input, String expected) {
     assertThat(Names.formatted(input)).isEqualTo(expected);
   }
 

--- a/src/test/groovy/ee/tuleva/onboarding/user/NamesTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/user/NamesTest.java
@@ -18,8 +18,11 @@ class NamesTest {
     "O'BRIEN, O'Brien",
     "Mari, Mari",
     "Mari-Liis, Mari-Liis",
+    "mari, Mari",
+    "mari-liis, Mari-Liis",
+    "erko risthein, Erko Risthein",
     "McGregor, McGregor",
-    "van der Berg, van der Berg",
+    "van der Berg, Van Der Berg",
   })
   void formatsOnlyAllCapsNames(String input, String expected) {
     assertThat(Names.formatted(input)).isEqualTo(expected);


### PR DESCRIPTION
Names.formatted becomes the single name capitalization implementation across the backend: the login principal, the user API response, the population register mapper, the parent and child registration, and the emails all use it, and Person.capitalize plus the two inline capitalizeFully copies are gone.

The rule, applied per name part on space, hyphen, and apostrophe boundaries: parts that are entirely upper or lower case are capitalized (MARI-LIIS and mari-liis both become Mari-Liis, per EKI orthography for compound names); parts with deliberate mixed casing are left exactly as written, so a name like McGregor is never mangled. All previous UserResponse capitalization expectations hold unchanged.