### PR TITLE
Send TKF100 redemption alerts to the investment channel

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/savings/fund/redemption/RedemptionAlertJob.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/redemption/RedemptionAlertJob.java
@@ -1,6 +1,6 @@
 package ee.tuleva.onboarding.savings.fund.redemption;
 
-import static ee.tuleva.onboarding.notification.OperationsNotificationService.Channel.WITHDRAWALS;
+import static ee.tuleva.onboarding.notification.OperationsNotificationService.Channel.INVESTMENT;
 import static ee.tuleva.onboarding.savings.fund.redemption.RedemptionCutoff.TALLINN;
 import static ee.tuleva.onboarding.savings.fund.redemption.RedemptionRequest.Status.VERIFIED;
 import static ee.tuleva.onboarding.tulevafund.TulevaFund.TKF100;
@@ -69,7 +69,7 @@ public class RedemptionAlertJob {
           "PAYOUT WARNING: TKF100 pending redemption payouts: totalAmount=%s EUR, requests=%d. WITHDRAWAL_EUR credit limit increase may be needed."
               .formatted(totalAmount, requestCount);
       log.info("{}", message);
-      notificationService.sendMessage(message, WITHDRAWALS);
+      notificationService.sendMessage(message, INVESTMENT);
     }
   }
 
@@ -94,7 +94,7 @@ public class RedemptionAlertJob {
           "LIQUIDITY WARNING: TKF100 pending withdrawals totalAmount=%s EUR (%s%% of AUM), requests=%d, AUM=%s EUR. Exceeds 1%% threshold."
               .formatted(totalAmount, percentage, requestCount, aumValue);
       log.info("{}", message);
-      notificationService.sendMessage(message, WITHDRAWALS);
+      notificationService.sendMessage(message, INVESTMENT);
     }
   }
 }

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/redemption/RedemptionAlertJob.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/redemption/RedemptionAlertJob.java
@@ -1,6 +1,7 @@
 package ee.tuleva.onboarding.savings.fund.redemption;
 
 import static ee.tuleva.onboarding.notification.OperationsNotificationService.Channel.INVESTMENT;
+import static ee.tuleva.onboarding.notification.OperationsNotificationService.Severity.ERROR;
 import static ee.tuleva.onboarding.savings.fund.redemption.RedemptionCutoff.TALLINN;
 import static ee.tuleva.onboarding.savings.fund.redemption.RedemptionRequest.Status.VERIFIED;
 import static ee.tuleva.onboarding.tulevafund.TulevaFund.TKF100;
@@ -68,8 +69,8 @@ public class RedemptionAlertJob {
       String message =
           "PAYOUT WARNING: TKF100 pending redemption payouts: totalAmount=%s EUR, requests=%d. WITHDRAWAL_EUR credit limit increase may be needed."
               .formatted(totalAmount, requestCount);
-      log.info("{}", message);
-      notificationService.sendMessage(message, INVESTMENT);
+      log.warn(message);
+      notificationService.sendMessage(message, INVESTMENT, ERROR);
     }
   }
 
@@ -93,8 +94,8 @@ public class RedemptionAlertJob {
       String message =
           "LIQUIDITY WARNING: TKF100 pending withdrawals totalAmount=%s EUR (%s%% of AUM), requests=%d, AUM=%s EUR. Exceeds 1%% threshold."
               .formatted(totalAmount, percentage, requestCount, aumValue);
-      log.info("{}", message);
-      notificationService.sendMessage(message, INVESTMENT);
+      log.warn(message);
+      notificationService.sendMessage(message, INVESTMENT, ERROR);
     }
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/redemption/RedemptionAlertJobTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/redemption/RedemptionAlertJobTest.java
@@ -1,6 +1,7 @@
 package ee.tuleva.onboarding.savings.fund.redemption;
 
 import static ee.tuleva.onboarding.notification.OperationsNotificationService.Channel.INVESTMENT;
+import static ee.tuleva.onboarding.notification.OperationsNotificationService.Severity.ERROR;
 import static ee.tuleva.onboarding.savings.fund.redemption.RedemptionRequest.Status.VERIFIED;
 import static ee.tuleva.onboarding.tulevafund.TulevaFund.TKF100;
 import static org.mockito.ArgumentMatchers.contains;
@@ -59,7 +60,7 @@ class RedemptionAlertJobTest {
 
     job.checkRedemptionAlerts();
 
-    verify(notificationService).sendMessage(contains("PAYOUT WARNING"), eq(INVESTMENT));
+    verify(notificationService).sendMessage(contains("PAYOUT WARNING"), eq(INVESTMENT), eq(ERROR));
     verifyNoMoreInteractions(notificationService);
   }
 
@@ -79,7 +80,8 @@ class RedemptionAlertJobTest {
 
     job.checkRedemptionAlerts();
 
-    verify(notificationService).sendMessage(contains("LIQUIDITY WARNING"), eq(INVESTMENT));
+    verify(notificationService)
+        .sendMessage(contains("LIQUIDITY WARNING"), eq(INVESTMENT), eq(ERROR));
     verifyNoMoreInteractions(notificationService);
   }
 
@@ -99,8 +101,9 @@ class RedemptionAlertJobTest {
 
     job.checkRedemptionAlerts();
 
-    verify(notificationService).sendMessage(contains("PAYOUT WARNING"), eq(INVESTMENT));
-    verify(notificationService).sendMessage(contains("LIQUIDITY WARNING"), eq(INVESTMENT));
+    verify(notificationService).sendMessage(contains("PAYOUT WARNING"), eq(INVESTMENT), eq(ERROR));
+    verify(notificationService)
+        .sendMessage(contains("LIQUIDITY WARNING"), eq(INVESTMENT), eq(ERROR));
   }
 
   @Test
@@ -178,7 +181,7 @@ class RedemptionAlertJobTest {
 
     job.checkRedemptionAlerts();
 
-    verify(notificationService).sendMessage(contains("PAYOUT WARNING"), eq(INVESTMENT));
+    verify(notificationService).sendMessage(contains("PAYOUT WARNING"), eq(INVESTMENT), eq(ERROR));
     verifyNoMoreInteractions(notificationService);
   }
 
@@ -198,7 +201,7 @@ class RedemptionAlertJobTest {
 
     job.checkRedemptionAlerts();
 
-    verify(notificationService).sendMessage(contains("PAYOUT WARNING"), eq(INVESTMENT));
+    verify(notificationService).sendMessage(contains("PAYOUT WARNING"), eq(INVESTMENT), eq(ERROR));
     verifyNoMoreInteractions(notificationService);
   }
 

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/redemption/RedemptionAlertJobTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/redemption/RedemptionAlertJobTest.java
@@ -1,6 +1,6 @@
 package ee.tuleva.onboarding.savings.fund.redemption;
 
-import static ee.tuleva.onboarding.notification.OperationsNotificationService.Channel.WITHDRAWALS;
+import static ee.tuleva.onboarding.notification.OperationsNotificationService.Channel.INVESTMENT;
 import static ee.tuleva.onboarding.savings.fund.redemption.RedemptionRequest.Status.VERIFIED;
 import static ee.tuleva.onboarding.tulevafund.TulevaFund.TKF100;
 import static org.mockito.ArgumentMatchers.contains;
@@ -59,7 +59,7 @@ class RedemptionAlertJobTest {
 
     job.checkRedemptionAlerts();
 
-    verify(notificationService).sendMessage(contains("PAYOUT WARNING"), eq(WITHDRAWALS));
+    verify(notificationService).sendMessage(contains("PAYOUT WARNING"), eq(INVESTMENT));
     verifyNoMoreInteractions(notificationService);
   }
 
@@ -79,7 +79,7 @@ class RedemptionAlertJobTest {
 
     job.checkRedemptionAlerts();
 
-    verify(notificationService).sendMessage(contains("LIQUIDITY WARNING"), eq(WITHDRAWALS));
+    verify(notificationService).sendMessage(contains("LIQUIDITY WARNING"), eq(INVESTMENT));
     verifyNoMoreInteractions(notificationService);
   }
 
@@ -99,8 +99,8 @@ class RedemptionAlertJobTest {
 
     job.checkRedemptionAlerts();
 
-    verify(notificationService).sendMessage(contains("PAYOUT WARNING"), eq(WITHDRAWALS));
-    verify(notificationService).sendMessage(contains("LIQUIDITY WARNING"), eq(WITHDRAWALS));
+    verify(notificationService).sendMessage(contains("PAYOUT WARNING"), eq(INVESTMENT));
+    verify(notificationService).sendMessage(contains("LIQUIDITY WARNING"), eq(INVESTMENT));
   }
 
   @Test
@@ -178,7 +178,7 @@ class RedemptionAlertJobTest {
 
     job.checkRedemptionAlerts();
 
-    verify(notificationService).sendMessage(contains("PAYOUT WARNING"), eq(WITHDRAWALS));
+    verify(notificationService).sendMessage(contains("PAYOUT WARNING"), eq(INVESTMENT));
     verifyNoMoreInteractions(notificationService);
   }
 
@@ -198,7 +198,7 @@ class RedemptionAlertJobTest {
 
     job.checkRedemptionAlerts();
 
-    verify(notificationService).sendMessage(contains("PAYOUT WARNING"), eq(WITHDRAWALS));
+    verify(notificationService).sendMessage(contains("PAYOUT WARNING"), eq(INVESTMENT));
     verifyNoMoreInteractions(notificationService);
   }
 


### PR DESCRIPTION
## Probleem

`RedemptionAlertJob` saatis PAYOUT ja LIQUIDITY hoiatused `WITHDRAWALS` kanalisse. Selle kanali ainus teine saatja on `WithdrawalNotifier` — II/III samba väljamaksete mandaadipartiid AML-moodulist, millel ei ole TKF100-ga mingit pistmist.

25.08 tehtud 43555.63 EUR tagasivõtmise kohta tekkis korrektselt hoiatus:

> PAYOUT WARNING: TKF100 pending redemption payouts: totalAmount=43555.63 EUR, requests=1. WITHDRAWAL_EUR credit limit increase may be needed.

…aga kanalisse, mida keegi TKF100 rahavoo pärast ei jälgi, nii et WITHDRAWAL_EUR krediidilimiiti ei tõstetud enne partii väljamakset.

## Miks INVESTMENT, mitte SAVINGS

Sama jaotus on repos juba olemas ühe ja sama paketi sees: `NavNotifier` saadab NAV-i arvutuskäigu `SAVINGS`-i, aga naaber `NavAlertJob` saadab "NAV still missing" `INVESTMENT`-i. Reegel praktikas: **NAV-numbrid → savings, midagi mille peale peab keegi tegutsema → investment.**

Mõlemad tagasivõtmise hoiatused on teist tüüpi — üks palub pangast krediidilimiiti tõsta, teine on fondi likviidsuse hinnang. Lähimad analoogid `LimitCheckNotifier`, `RiskIndicatorNotifier`, `HealthCheckNotifier` ja `SettlementCheckJob` kasutavad kõik juba `INVESTMENT`-i. Kummaski sõnumis ei ole NAV-i numbrit, nii et nav-teated on nõrgem sobivus.

## Ajastus (ei muutu, kirjeldan selguse mõttes)

Hoiatus jõuab kohale ühe tööpäeva enne raha liikumist ja see on õige. `RedemptionBatchJob` cutoff jõuab 25.08 17:52 tehtud soovini alles 27.08 kell 16:00; alertijob käib 16:05 ja valib kõik kuni *tänase* 16:00-ni, seega märgib selle ära 26.08. Tagajärg: väljamaksepäeval enam hoiatust ei tule, sest partii on 16:00 staatuse `REDEEMED`-iks pööranud viis minutit enne alertijobi.

## Ka valjus, mitte ainult kanal

`sendMessage(message, channel)` ilma raskusastmeta läheb Slacki tavalise tekstina;
`Severity.ERROR` läheb punase manusena. `NavAlertJob` — seesama naaber, kust see
suunamine võetud on — saadab oma INVESTMENT-teated ERROR-iga. Krediidilimiiti
paluv hoiatus, mis peab kohale jõudma enne partii väljamakset, ei tohi näha välja
nagu igapäevane sagin, seega lähevad mõlemad nüüd ERROR-iga. Samal ajal:
`log.info("{}", message)` sõnumi kohta, mille pealkiri on WARNING, on nüüd `log.warn`.

## Muudatus

Kaks väljakutsekohta `RedemptionAlertJob`-is + kuus `RedemptionAlertJobTest`-i assertit. `WITHDRAWALS` jääb enumi alles — `WithdrawalNotifier` kasutab seda endiselt õigustatult.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
