### PR TITLE
Let each check type own its own limit check event row

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/investment/check/limit/LimitCheckEventRepository.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/check/limit/LimitCheckEventRepository.java
@@ -11,5 +11,6 @@ interface LimitCheckEventRepository extends JpaRepository<LimitCheckEvent, Long>
   List<LimitCheckEvent> findByFundAndCheckDate(TulevaFund fund, LocalDate checkDate);
 
   @Transactional
-  void deleteByFundAndCheckDate(TulevaFund fund, LocalDate checkDate);
+  void deleteByFundAndCheckDateAndCheckType(
+      TulevaFund fund, LocalDate checkDate, CheckType checkType);
 }

--- a/src/main/java/ee/tuleva/onboarding/investment/check/limit/LimitCheckService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/check/limit/LimitCheckService.java
@@ -150,7 +150,6 @@ class LimitCheckService {
     var freeCashBreach =
         freeCashLimitChecker.check(fund, cashTotal, liabilityTotal, pendingCashImpact, fundLimit);
 
-    limitCheckEventRepository.deleteByFundAndCheckDate(fund, checkDate);
     saveEvent(fund, checkDate, POSITION, positionBreaches);
     saveEvent(fund, checkDate, PROVIDER, providerBreaches);
     saveEvent(fund, checkDate, RESERVE, reserveBreach);
@@ -235,16 +234,7 @@ class LimitCheckService {
                   return false;
                 });
 
-    var event =
-        LimitCheckEvent.builder()
-            .fund(fund)
-            .checkDate(checkDate)
-            .checkType(checkType)
-            .breachesFound(hasBreaches)
-            .result(Map.of("breaches", breaches))
-            .build();
-
-    limitCheckEventRepository.save(event);
+    replaceEvent(fund, checkDate, checkType, hasBreaches, Map.of("breaches", breaches));
   }
 
   private void saveEvent(
@@ -252,18 +242,12 @@ class LimitCheckService {
       LocalDate checkDate,
       CheckType checkType,
       @org.jspecify.annotations.Nullable ReserveBreach breach) {
-    var hasBreaches = breach != null && breach.severity() != BreachSeverity.OK;
-
-    var event =
-        LimitCheckEvent.builder()
-            .fund(fund)
-            .checkDate(checkDate)
-            .checkType(checkType)
-            .breachesFound(hasBreaches)
-            .result(breach != null ? Map.of("breach", breach) : Map.of())
-            .build();
-
-    limitCheckEventRepository.save(event);
+    replaceEvent(
+        fund,
+        checkDate,
+        checkType,
+        breach != null && breach.severity() != BreachSeverity.OK,
+        breach != null ? Map.of("breach", breach) : Map.of());
   }
 
   private void saveEvent(
@@ -271,17 +255,28 @@ class LimitCheckService {
       LocalDate checkDate,
       CheckType checkType,
       @org.jspecify.annotations.Nullable FreeCashBreach breach) {
-    var hasBreaches = breach != null && breach.severity() != BreachSeverity.OK;
+    replaceEvent(
+        fund,
+        checkDate,
+        checkType,
+        breach != null && breach.severity() != BreachSeverity.OK,
+        breach != null ? Map.of("breach", breach) : Map.of());
+  }
 
-    var event =
+  private void replaceEvent(
+      TulevaFund fund,
+      LocalDate checkDate,
+      CheckType checkType,
+      boolean breachesFound,
+      Map<String, Object> result) {
+    limitCheckEventRepository.deleteByFundAndCheckDateAndCheckType(fund, checkDate, checkType);
+    limitCheckEventRepository.save(
         LimitCheckEvent.builder()
             .fund(fund)
             .checkDate(checkDate)
             .checkType(checkType)
-            .breachesFound(hasBreaches)
-            .result(breach != null ? Map.of("breach", breach) : Map.of())
-            .build();
-
-    limitCheckEventRepository.save(event);
+            .breachesFound(breachesFound)
+            .result(result)
+            .build());
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/investment/check/limit/LimitCheckEventRepositoryTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/check/limit/LimitCheckEventRepositoryTest.java
@@ -2,6 +2,7 @@ package ee.tuleva.onboarding.investment.check.limit;
 
 import static ee.tuleva.onboarding.fund.TulevaFund.TUK75;
 import static ee.tuleva.onboarding.investment.check.limit.CheckType.POSITION;
+import static ee.tuleva.onboarding.investment.check.limit.CheckType.PROVIDER;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.LocalDate;
@@ -31,5 +32,28 @@ class LimitCheckEventRepositoryTest {
 
     var found = repository.findByFundAndCheckDate(TUK75, checkDate);
     assertThat(found).singleElement().satisfies(e -> assertThat(e.isBreachesFound()).isTrue());
+  }
+
+  @Test
+  void deletingOneCheckTypeLeavesTheOtherCheckTypesAlone() {
+    var checkDate = LocalDate.of(2026, 3, 4);
+    repository.save(event(POSITION));
+    var retained = repository.save(event(PROVIDER));
+
+    repository.deleteByFundAndCheckDateAndCheckType(TUK75, checkDate, POSITION);
+
+    assertThat(repository.findByFundAndCheckDate(TUK75, checkDate))
+        .singleElement()
+        .satisfies(e -> assertThat(e.getId()).isEqualTo(retained.getId()));
+  }
+
+  private LimitCheckEvent event(CheckType checkType) {
+    return LimitCheckEvent.builder()
+        .fund(TUK75)
+        .checkDate(LocalDate.of(2026, 3, 4))
+        .checkType(checkType)
+        .breachesFound(false)
+        .result(Map.of())
+        .build();
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/investment/check/limit/LimitCheckServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/check/limit/LimitCheckServiceTest.java
@@ -162,6 +162,26 @@ class LimitCheckServiceTest {
   }
 
   @Test
+  void deletesOnlyTheCheckTypesItRewrites() {
+    service = createService();
+    var today = LocalDate.of(2026, 3, 4);
+    var fund = TUK75;
+
+    when(fundPositionRepository.findLatestNavDateByFundAndAsOfDate(fund, today))
+        .thenReturn(Optional.of(today));
+    when(navReportPositionProvider.getCalculatedAum(fund, today))
+        .thenReturn(Optional.of(new BigDecimal("1000000")));
+
+    service.runChecks();
+
+    verify(limitCheckEventRepository).deleteByFundAndCheckDateAndCheckType(fund, today, POSITION);
+    verify(limitCheckEventRepository).deleteByFundAndCheckDateAndCheckType(fund, today, PROVIDER);
+    verify(limitCheckEventRepository).deleteByFundAndCheckDateAndCheckType(fund, today, RESERVE);
+    verify(limitCheckEventRepository).deleteByFundAndCheckDateAndCheckType(fund, today, FREE_CASH);
+    verify(limitCheckEventRepository, times(4)).save(any(LimitCheckEvent.class));
+  }
+
+  @Test
   void handlesNoPositionData() {
     service = createService();
     var today = LocalDate.of(2026, 3, 4);


### PR DESCRIPTION
## The problem

`LimitCheckService.checkFund` deleted **every** event for a fund and date, then rewrote all four check types:

```java
limitCheckEventRepository.deleteByFundAndCheckDate(fund, checkDate);   // all types
saveEvent(fund, checkDate, POSITION,  positionBreaches);
saveEvent(fund, checkDate, PROVIDER,  providerBreaches);
saveEvent(fund, checkDate, RESERVE,   reserveBreach);
saveEvent(fund, checkDate, FREE_CASH, freeCashBreach);
```

Harmless while all four are written. Destructive the moment one stops: `LimitCheckJob.backfillLimitChecks` re-runs `checkFund` over a **25-day window**, so the first backfill after a check type is retired deletes that type's rows across the window and does not put them back.

That matters now because the provider concentration check is going away, and the `check_type = 'PROVIDER'` rows are the audit record it has to leave behind (A2 in the TKF100 constraints register). This PR is the prerequisite that makes the removal safe. **It does not remove anything** — the provider check still runs, as register entry L10 requires until A2 leaves the prospectus.

## The change

The delete now names the check type it is about to rewrite, so a retired type's rows are never touched.

The three `saveEvent` overloads now only decide `breachesFound` and the result map, handing both to one `replaceEvent` — removing three copies of the same builder. `deleteByFundAndCheckDate` is gone; compilation proves it had exactly one caller.

## Why this is a safe refactor

`LimitCheckIntegrationTest.rerunReplacesExistingEventsInsteadOfCreatingDuplicates` is **unchanged** — still `hasSize(4)`, still all four check types — and still green. That is the proof nothing observable changed.

New coverage:
- `LimitCheckEventRepositoryTest.deletingOneCheckTypeLeavesTheOtherCheckTypesAlone` — two types saved, one deleted by type, the other survives **by id**.
- `LimitCheckServiceTest.deletesOnlyTheCheckTypesItRewrites` — one scoped delete per check type, `times(4)` saves.

## Incidental

`checkFund` is not `@Transactional`, so each delete/save pair runs in its own transaction. Previously a crash between the wide delete and the saves could leave the fund and date with **no** events at all; now the worst case is one check type's row. Not the point of the PR, but strictly better. A real atomicity fix is a separate change.

## Test

`./gradlew build` green on **H2** and on **real PostgreSQL 17** — full suite both times, no failures. The PostgreSQL run used `SPRING_PROFILES_ACTIVE=ci,test` against a native server (no Docker needed; `ci` takes Postgres from localhost, only the `pg` profile uses Testcontainers), with the per-context databases introduced in feb13288.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
