### PR TITLE
Finish the English fund rename: partials and the company template

### DIFF
--- a/emails/manifest.json
+++ b/emails/manifest.json
@@ -111,7 +111,7 @@
       "from_name": "Tuleva"
     },
     "savings_fund_company_onboarded_en": {
-      "subject": "The company's Additional Savings Fund account is open",
+      "subject": "The company's Additional Investment Fund account is open",
       "from_email": "tuleva@tuleva.ee",
       "from_name": "Tuleva"
     },

--- a/emails/src/partials/suggest_account_recurring_child_en.mjml
+++ b/emails/src/partials/suggest_account_recurring_child_en.mjml
@@ -1,5 +1,5 @@
 <mj-text>
-  You can also contribute to the Additional Savings Fund with a recurring payment. This way
+  You can also contribute to the Additional Investment Fund with a recurring payment. This way
   a contribution reaches your child's account every month without you having to think
   about it separately.
 </mj-text>

--- a/emails/src/partials/suggest_account_recurring_company_en.mjml
+++ b/emails/src/partials/suggest_account_recurring_company_en.mjml
@@ -1,5 +1,5 @@
 <mj-text>
-  You can also contribute to the Additional Savings Fund with a recurring payment. This way
+  You can also contribute to the Additional Investment Fund with a recurring payment. This way
   a contribution reaches your company's account every month without you having to think
   about it separately.
 </mj-text>

--- a/emails/src/partials/suggest_savings_fund_en.mjml
+++ b/emails/src/partials/suggest_savings_fund_en.mjml
@@ -1,7 +1,7 @@
-<mj-text><strong>Is the Additional Savings Fund your next step?</strong></mj-text>
+<mj-text><strong>Is the Additional Investment Fund your next step?</strong></mj-text>
 <mj-text>
   With your second and third pillar already working hard, you can also save for any goal at
-  Tuleva. The Additional Savings Fund is a low-fee index fund investing in nearly 2,500 of the
+  Tuleva. The Additional Investment Fund is a low-fee index fund investing in nearly 2,500 of the
   world's largest listed companies. The fee is *|savingsFundFee|*% per year and you can start with just
   1&nbsp;euro.
 </mj-text>

--- a/emails/src/savings_fund_company_onboarded_en.mjml
+++ b/emails/src/savings_fund_company_onboarded_en.mjml
@@ -7,7 +7,7 @@
       <mj-column>
         <mj-text>Hello,&nbsp;*|FNAME|*</mj-text>
         <mj-text>
-          The Tuleva Additional Savings Fund account for your company *|RECIPIENTNAME|* is now
+          The Tuleva Additional Investment Fund account for your company *|RECIPIENTNAME|* is now
           open.
         </mj-text>
         <mj-text><strong>You can make the first deposit straight from the company's bank account:</strong></mj-text>


### PR DESCRIPTION
Follow-up to #1910, which renamed the fund in the English emails but searched only for "Tuleva Savings Fund". Five places say **Additional Savings Fund** instead and were missed:

- `partials/suggest_savings_fund_en.mjml` (twice) — included from the pillar emails, so the old name was still reaching readers
- `partials/suggest_account_recurring_child_en.mjml`
- `partials/suggest_account_recurring_company_en.mjml`
- `savings_fund_company_onboarded_en.mjml` and its subject line

After this, no saver-visible English text says "Savings Fund". The `descriptions` block in `manifest.json` still does: it describes templates to us, not to savers.

Related: TulevaEE/tuleva#420

🤖 Generated with [Claude Code](https://claude.com/claude-code)