### PR TITLE
Harden the tracking difference check

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -347,6 +347,40 @@ tasks {
             }
             rule {
                 element = "PACKAGE"
+                includes = listOf("ee.tuleva.onboarding.investment.check.tracking")
+
+                limit {
+                    counter = "CLASS"
+                    value = "COVEREDRATIO"
+                    minimum = "1.0".toBigDecimal()
+                }
+
+                limit {
+                    counter = "METHOD"
+                    value = "COVEREDRATIO"
+                    minimum = "0.98".toBigDecimal()
+                }
+
+                limit {
+                    counter = "LINE"
+                    value = "COVEREDRATIO"
+                    minimum = "0.99".toBigDecimal()
+                }
+
+                limit {
+                    counter = "BRANCH"
+                    value = "COVEREDRATIO"
+                    minimum = "0.90".toBigDecimal()
+                }
+
+                limit {
+                    counter = "INSTRUCTION"
+                    value = "COVEREDRATIO"
+                    minimum = "0.98".toBigDecimal()
+                }
+            }
+            rule {
+                element = "PACKAGE"
                 includes =
                     listOf(
                         "ee.tuleva.onboarding.deadline",

--- a/src/main/java/ee/tuleva/onboarding/investment/check/tracking/BenchmarkCheckBuilder.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/check/tracking/BenchmarkCheckBuilder.java
@@ -186,9 +186,18 @@ class BenchmarkCheckBuilder {
     var totalWeight = ZERO;
     var attributions = new ArrayList<SecurityAttribution>();
 
+    // Every holding is supposed to have a proxy with data behind it. One that does not is a data
+    // error, so the weight it takes out of this check is carried on the result rather than being
+    // dropped - a check covering part of the sleeve must not read as a clean all-clear.
+    var gapIsins = new ArrayList<String>();
+    var gapWeight = ZERO;
+
     for (var s : validSecurities) {
       var benchmarkKey = resolveBenchmarkKey(s.isin());
       if (benchmarkKey == null) {
+        log.warn("No benchmark proxy for holding: fund={}, isin={}", fund, s.isin());
+        gapIsins.add(s.isin());
+        gapWeight = gapWeight.add(s.actualWeight());
         continue;
       }
       var bmReturn =
@@ -203,6 +212,8 @@ class BenchmarkCheckBuilder {
             fund,
             s.isin(),
             benchmarkKey);
+        gapIsins.add(s.isin());
+        gapWeight = gapWeight.add(s.actualWeight());
         continue;
       }
       var secReturn =
@@ -274,6 +285,8 @@ class BenchmarkCheckBuilder {
             .cashDrag(ZERO)
             .feeDrag(ZERO)
             .residual(ZERO)
+            .benchmarkGapIsins(List.copyOf(gapIsins))
+            .benchmarkGapWeight(gapWeight)
             .build());
   }
 

--- a/src/main/java/ee/tuleva/onboarding/investment/check/tracking/ConsecutiveBreachTracker.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/check/tracking/ConsecutiveBreachTracker.java
@@ -2,6 +2,7 @@ package ee.tuleva.onboarding.investment.check.tracking;
 
 import static java.math.BigDecimal.ZERO;
 
+import ee.tuleva.onboarding.deadline.PublicHolidays;
 import ee.tuleva.onboarding.investment.TrackingCheckType;
 import ee.tuleva.onboarding.tulevafund.TulevaFund;
 import java.math.BigDecimal;
@@ -21,6 +22,7 @@ class ConsecutiveBreachTracker {
 
   private final TrackingDifferenceEventRepository eventRepository;
   private final TrackingDifferenceCalculator calculator;
+  private final PublicHolidays publicHolidays;
 
   record ConsecutiveBreachInfo(
       int count,
@@ -31,19 +33,25 @@ class ConsecutiveBreachTracker {
       BigDecimal cashDragSum,
       BigDecimal feeDragSum,
       BigDecimal residualSum,
-      boolean hadNavResidualBreach) {}
+      boolean hadNavResidualBreach,
+      boolean truncated,
+      boolean unavailable) {}
 
   ConsecutiveBreachInfo countConsecutiveBreaches(
       TulevaFund fund, TrackingCheckType checkType, LocalDate checkDate) {
     try {
       return doCountConsecutiveBreaches(fund, checkType, checkDate);
     } catch (Exception e) {
-      log.warn(
-          "Escalation count failed, using empty: fund={}, checkType={}, error={}",
+      // "No streak" and "we could not work out the streak" are different facts, and reporting the
+      // second as the first suppresses the escalation without anyone being told.
+      log.error(
+          "Escalation count failed: fund={}, checkType={}, checkDate={}, error={}",
           fund,
           checkType,
+          checkDate,
           e.getMessage());
-      return new ConsecutiveBreachInfo(0, ZERO, ZERO, ZERO, Map.of(), ZERO, ZERO, ZERO, false);
+      return new ConsecutiveBreachInfo(
+          0, ZERO, ZERO, ZERO, Map.of(), ZERO, ZERO, ZERO, false, false, true);
     }
   }
 
@@ -69,7 +77,22 @@ class ConsecutiveBreachTracker {
     var hadNavResidualBreach = false;
     var contributionByIsin = new LinkedHashMap<String, BigDecimal>();
 
+    var expectedDate = publicHolidays.previousWorkingDay(checkDate);
     for (var event : recent) {
+      // A working day with no check says nothing about whether the breach persisted through it,
+      // so the streak ends there rather than joining two separate breaches across the hole.
+      if (!event.getCheckDate().equals(expectedDate)) {
+        log.warn(
+            "Escalation streak stops at a gap in the daily series: fund={}, checkType={}, checkDate={}, expectedPreviousDay={}, nextStoredDay={}",
+            fund,
+            checkType,
+            checkDate,
+            expectedDate,
+            event.getCheckDate());
+        break;
+      }
+      expectedDate = publicHolidays.previousWorkingDay(expectedDate);
+
       var navResidualBreach = Boolean.TRUE.equals(event.getResult().get("navResidualBreach"));
       if (!event.isBreach() && !navResidualBreach) {
         break;
@@ -102,6 +125,19 @@ class ConsecutiveBreachTracker {
     var compoundedBenchmarkReturn = compoundedBenchmark.subtract(BigDecimal.ONE);
     var compoundedTd = compoundedFundReturn.subtract(compoundedBenchmarkReturn);
 
+    // The lookback bounds the query, not the breach. A streak that consumed the whole window may
+    // run further back than the window can see, so the count and the compounded net TD are a lower
+    // bound rather than the answer.
+    var truncated = count > 0 && count == recent.size() && recent.size() >= lookback;
+    if (truncated) {
+      log.warn(
+          "Escalation streak fills the whole lookback window: fund={}, checkType={}, checkDate={}, lookbackDays={}",
+          fund,
+          checkType,
+          checkDate,
+          lookback);
+    }
+
     return new ConsecutiveBreachInfo(
         count,
         compoundedTd,
@@ -111,13 +147,19 @@ class ConsecutiveBreachTracker {
         cashDragSum,
         feeDragSum,
         residualSum,
-        hadNavResidualBreach);
+        hadNavResidualBreach,
+        truncated,
+        false);
   }
 
   TrackingDifferenceResult updateConsecutiveCount(
       TrackingDifferenceResult result, ConsecutiveBreachInfo priorBreaches) {
     if (!result.breach() && !result.navResidualBreach()) {
-      return result.toBuilder().consecutiveBreachDays(0).consecutiveNetTd(ZERO).build();
+      return result.toBuilder()
+          .consecutiveBreachDays(0)
+          .consecutiveNetTd(ZERO)
+          .escalationCountUnavailable(priorBreaches.unavailable())
+          .build();
     }
     int days = priorBreaches.count() + 1;
     var streakHadNavResidualBreach =
@@ -139,6 +181,8 @@ class ConsecutiveBreachTracker {
         .consecutiveBreachDays(days)
         .consecutiveNetTd(compoundedTd)
         .escalationNavResidualBreach(streakHadNavResidualBreach)
+        .escalationCountTruncated(priorBreaches.truncated())
+        .escalationCountUnavailable(priorBreaches.unavailable())
         .compoundedFundReturn(compoundedFund)
         .compoundedBenchmarkReturn(compoundedBenchmark)
         .escalationAttributions(

--- a/src/main/java/ee/tuleva/onboarding/investment/check/tracking/PeriodicTdAttributionService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/check/tracking/PeriodicTdAttributionService.java
@@ -8,6 +8,8 @@ import static java.math.RoundingMode.HALF_UP;
 import ee.tuleva.onboarding.deadline.PublicHolidays;
 import ee.tuleva.onboarding.investment.check.tracking.TdAttributionCalculator.DailyRecord;
 import ee.tuleva.onboarding.investment.check.tracking.TdAttributionCalculator.TdAttributionInput;
+import ee.tuleva.onboarding.investment.config.InvestmentParameter;
+import ee.tuleva.onboarding.investment.config.InvestmentParameterRepository;
 import ee.tuleva.onboarding.investment.fees.FeeAccrual;
 import ee.tuleva.onboarding.investment.fees.FeeAccrualRepository;
 import ee.tuleva.onboarding.investment.fees.FeeChargedToFundPolicy;
@@ -32,6 +34,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.Nullable;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.support.TransactionTemplate;
@@ -56,8 +59,24 @@ public class PeriodicTdAttributionService {
   private final PlatformTransactionManager transactionManager;
   private final PublicHolidays publicHolidays;
   private final BenchmarkLegResolver benchmarkLegResolver;
+  private final InvestmentParameterRepository parameterRepository;
+  private final TrackingDifferenceNotifier notifier;
 
   private final TdAttributionCalculator calculator = new TdAttributionCalculator();
+
+  // Absent or unusable, the tolerance is simply not applied: an unseeded parameter must not turn
+  // every period into a false alarm.
+  @Nullable
+  private BigDecimal residualTolerance(LocalDate asOf) {
+    try {
+      return parameterRepository.findLatestValue(
+          InvestmentParameter.TD_RESIDUAL_TOLERANCE_ANNUAL, asOf);
+    } catch (Exception e) {
+      log.warn(
+          "No TD residual tolerance configured, not checking the residual: {}", e.getMessage());
+      return null;
+    }
+  }
 
   public TdAttributionResult computeAttribution(
       TulevaFund fund, LocalDate periodStart, LocalDate periodEnd, PeriodType periodType) {
@@ -67,6 +86,15 @@ public class PeriodicTdAttributionService {
     var entity = toEntity(result);
 
     replaceAttributionRowInSingleTransaction(fund, periodStart, periodEnd, periodType, entity);
+
+    if (Boolean.FALSE.equals(result.checks().get("residualWithinTolerance"))) {
+      notifier.notifyResidualOutsideTolerance(
+          fund,
+          periodStart,
+          periodEnd,
+          result.residual(),
+          TdAttributionCalculator.scaledResidualTolerance(input));
+    }
 
     log.info(
         "TD attribution computed: fund={}, period={}-{}, td={}bps, residual={}bps",
@@ -189,6 +217,7 @@ public class PeriodicTdAttributionService {
         .benchmarkProxyOcfDragPeriod(etfLayer.proxyOcfDrag())
         .expectedAnnualFeeRate(expectedAnnualFeeRate)
         .seriesGapDays(seriesGapDays)
+        .residualTolerance(residualTolerance(periodEnd))
         .etfLayerCoveredDays(etfLayer.coveredDays())
         .etfLayerUnbenchmarkedWeight(etfLayer.unbenchmarkedWeight())
         .etfLayerUnrestoredProxyWeight(etfLayer.unrestoredProxyWeight())

--- a/src/main/java/ee/tuleva/onboarding/investment/check/tracking/SecurityDataBuilder.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/check/tracking/SecurityDataBuilder.java
@@ -21,6 +21,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -110,16 +111,11 @@ class SecurityDataBuilder {
       return securities;
     }
 
-    var currentIsins =
-        allocations.stream()
-            .map(ModelPortfolioAllocation::getIsin)
-            .filter(Objects::nonNull)
-            .collect(Collectors.toSet());
-    var previousIsins =
-        previousAllocations.stream()
-            .map(ModelPortfolioAllocation::getIsin)
-            .filter(Objects::nonNull)
-            .collect(Collectors.toSet());
+    // Membership is decided by carrying weight, not by appearing in the table: a switch leaves the
+    // exiting instrument in the model at 0% until it is liquidated, and read by ISIN presence
+    // nothing would ever count as removed.
+    var currentIsins = weightedIsins(allocations);
+    var previousIsins = weightedIsins(previousAllocations);
 
     var addedIsins = new HashSet<>(currentIsins);
     addedIsins.removeAll(previousIsins);
@@ -136,8 +132,15 @@ class SecurityDataBuilder {
             .filter(Objects::nonNull)
             .collect(Collectors.toSet());
 
-    var knownIsins = new HashSet<>(currentIsins);
-    knownIsins.addAll(previousIsins);
+    var knownIsins =
+        allocations.stream()
+            .map(ModelPortfolioAllocation::getIsin)
+            .filter(Objects::nonNull)
+            .collect(Collectors.toCollection(HashSet::new));
+    previousAllocations.stream()
+        .map(ModelPortfolioAllocation::getIsin)
+        .filter(Objects::nonNull)
+        .forEach(knownIsins::add);
     var unexpectedIsins = new HashSet<>(positionIsins);
     unexpectedIsins.removeAll(knownIsins);
 
@@ -165,14 +168,54 @@ class SecurityDataBuilder {
         removedAndHeld,
         addedIsins);
 
+    // The transition legs take their actual weights, so the legs that did not move have to give
+    // up exactly that much - a model portfolio weighs 1, and one that weighs more scales the
+    // benchmark return up with it and invents a tracking difference out of nothing.
+    var transitionWeight =
+        securities.stream()
+            .filter(s -> transitionIsins.contains(s.isin()))
+            .map(SecurityData::actualWeight)
+            .reduce(ZERO, BigDecimal::add);
+    var settledModelWeight =
+        securities.stream()
+            .filter(s -> !transitionIsins.contains(s.isin()))
+            .map(SecurityData::modelWeight)
+            .reduce(ZERO, BigDecimal::add);
+    var remaining = BigDecimal.ONE.subtract(transitionWeight);
+    if (remaining.signum() < 0 || settledModelWeight.signum() == 0) {
+      log.warn(
+          "Transition legs leave no room for the rest of the model, blending without rescaling: fund={}, transitionWeight={}, settledModelWeight={}",
+          fund,
+          transitionWeight,
+          settledModelWeight);
+      remaining = settledModelWeight;
+    }
+    var scale =
+        settledModelWeight.signum() == 0
+            ? BigDecimal.ONE
+            : remaining.divide(settledModelWeight, 10, RoundingMode.HALF_UP);
+
     return securities.stream()
         .map(
             s ->
                 transitionIsins.contains(s.isin())
                     ? new SecurityData(
                         s.isin(), s.actualWeight(), s.actualWeight(), s.today(), s.previous())
-                    : s)
+                    : new SecurityData(
+                        s.isin(),
+                        s.modelWeight().multiply(scale).setScale(SCALE, RoundingMode.HALF_UP),
+                        s.actualWeight(),
+                        s.today(),
+                        s.previous()))
         .toList();
+  }
+
+  private static Set<String> weightedIsins(List<ModelPortfolioAllocation> allocations) {
+    return allocations.stream()
+        .filter(a -> a.getWeight() != null && a.getWeight().signum() > 0)
+        .map(ModelPortfolioAllocation::getIsin)
+        .filter(Objects::nonNull)
+        .collect(Collectors.toSet());
   }
 
   private SecurityData buildOneSecurityData(

--- a/src/main/java/ee/tuleva/onboarding/investment/check/tracking/TdAttributionCalculator.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/check/tracking/TdAttributionCalculator.java
@@ -6,6 +6,7 @@ import static java.math.RoundingMode.HALF_UP;
 
 import ee.tuleva.onboarding.tulevafund.TulevaFund;
 import java.math.BigDecimal;
+import java.math.MathContext;
 import java.time.LocalDate;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -20,6 +21,8 @@ class TdAttributionCalculator {
   static final int SCALE = 10;
   private static final BigDecimal CARINO_NEAR_EQUAL = new BigDecimal("0.0000000001");
   private static final BigDecimal EXTREME_SCALE = new BigDecimal("2.0");
+  private static final BigDecimal DAYS_IN_YEAR = new BigDecimal("365");
+  private static final MathContext TOLERANCE_MATH = new MathContext(16, HALF_UP);
 
   TdAttributionResult calculate(TdAttributionInput input) {
     var dailyRecords = input.dailyRecords();
@@ -217,6 +220,30 @@ class TdAttributionCalculator {
     return cumulative.subtract(ONE).setScale(SCALE, HALF_UP);
   }
 
+  // The tolerance is stored as an annual rate and scaled by the square root of the period's share
+  // of a year, because it is a band on noise: independent daily errors accumulate with the square
+  // root of time, not linearly. A residual that instead grows linearly with the period length is a
+  // systematic leak - a component the attribution is missing - and widening the band would hide it
+  // rather than measure it. Comparing an observed quarterly residual against sqrt(3) times the
+  // monthly one is what tells the two apart.
+  @Nullable
+  static BigDecimal scaledResidualTolerance(TdAttributionInput input) {
+    var annual = input.residualTolerance();
+    if (annual == null || annual.signum() <= 0 || input.calendarDays() <= 0) {
+      return null;
+    }
+    var yearFraction =
+        BigDecimal.valueOf(input.calendarDays()).divide(DAYS_IN_YEAR, TOLERANCE_MATH);
+    return annual.multiply(yearFraction.sqrt(TOLERANCE_MATH)).setScale(SCALE, HALF_UP);
+  }
+
+  // sumCheck cannot fail - residual is defined as the tracking difference minus the components,
+  // so they always add up. How big the residual is, is the only real signal.
+  static boolean residualWithinTolerance(BigDecimal residual, TdAttributionInput input) {
+    var tolerance = scaledResidualTolerance(input);
+    return tolerance == null || residual.abs().compareTo(tolerance) <= 0;
+  }
+
   private Map<String, Object> buildChecks(
       BigDecimal tdGeometric,
       BigDecimal linkedComponentSum,
@@ -237,18 +264,28 @@ class TdAttributionCalculator {
       feeXcheck = orZero(input.mgmtFeeDragPeriod()).subtract(expectedFeeDrag).abs();
     }
 
-    return Map.of(
-        "sumCheck", sumCheck.setScale(8, HALF_UP),
-        "feeXcheck", feeXcheck.setScale(8, HALF_UP),
-        "scalingFactor", periodLink.setScale(8, HALF_UP),
-        "residualBps", residualBps.setScale(2, HALF_UP),
-        "seriesGapDays", input.seriesGapDays(),
-        "etfLayerMeasured", input.benchmarkModelSumPeriod() != null,
-        "etfLayerCoveredDays", input.etfLayerCoveredDays(),
+    var checks = new LinkedHashMap<String, Object>();
+    checks.put("sumCheck", sumCheck.setScale(8, HALF_UP));
+    checks.put("feeXcheck", feeXcheck.setScale(8, HALF_UP));
+    checks.put("scalingFactor", periodLink.setScale(8, HALF_UP));
+    checks.put("residualBps", residualBps.setScale(2, HALF_UP));
+    checks.put("residualWithinTolerance", residualWithinTolerance(residual, input));
+    var scaledTolerance = scaledResidualTolerance(input);
+    if (scaledTolerance != null) {
+      checks.put(
+          "residualToleranceBps",
+          scaledTolerance.multiply(BigDecimal.valueOf(10000)).setScale(2, HALF_UP));
+    }
+    checks.put("seriesGapDays", input.seriesGapDays());
+    checks.put("etfLayerMeasured", input.benchmarkModelSumPeriod() != null);
+    checks.put("etfLayerCoveredDays", input.etfLayerCoveredDays());
+    checks.put(
         "etfLayerUnbenchmarkedWeight",
-            orZero(input.etfLayerUnbenchmarkedWeight()).setScale(6, HALF_UP),
+        orZero(input.etfLayerUnbenchmarkedWeight()).setScale(6, HALF_UP));
+    checks.put(
         "etfLayerUnrestoredProxyWeight",
-            orZero(input.etfLayerUnrestoredProxyWeight()).setScale(6, HALF_UP));
+        orZero(input.etfLayerUnrestoredProxyWeight()).setScale(6, HALF_UP));
+    return Map.copyOf(checks);
   }
 
   private TdAttributionResult emptyResult(TdAttributionInput input) {
@@ -298,6 +335,7 @@ class TdAttributionCalculator {
       @Nullable BigDecimal benchmarkProxyOcfDragPeriod,
       BigDecimal expectedAnnualFeeRate,
       int seriesGapDays,
+      @Nullable BigDecimal residualTolerance,
       int etfLayerCoveredDays,
       BigDecimal etfLayerUnbenchmarkedWeight,
       BigDecimal etfLayerUnrestoredProxyWeight,

--- a/src/main/java/ee/tuleva/onboarding/investment/check/tracking/TdAttributionCalculator.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/check/tracking/TdAttributionCalculator.java
@@ -237,13 +237,6 @@ class TdAttributionCalculator {
     return annual.multiply(yearFraction.sqrt(TOLERANCE_MATH)).setScale(SCALE, HALF_UP);
   }
 
-  // sumCheck cannot fail - residual is defined as the tracking difference minus the components,
-  // so they always add up. How big the residual is, is the only real signal.
-  static boolean residualWithinTolerance(BigDecimal residual, TdAttributionInput input) {
-    var tolerance = scaledResidualTolerance(input);
-    return tolerance == null || residual.abs().compareTo(tolerance) <= 0;
-  }
-
   private Map<String, Object> buildChecks(
       BigDecimal tdGeometric,
       BigDecimal linkedComponentSum,
@@ -269,9 +262,13 @@ class TdAttributionCalculator {
     checks.put("feeXcheck", feeXcheck.setScale(8, HALF_UP));
     checks.put("scalingFactor", periodLink.setScale(8, HALF_UP));
     checks.put("residualBps", residualBps.setScale(2, HALF_UP));
-    checks.put("residualWithinTolerance", residualWithinTolerance(residual, input));
+    // sumCheck cannot fail - residual is defined as the tracking difference minus the components,
+    // so they always add up. How big the residual is, is the only real signal. With no tolerance
+    // configured there is no verdict to give: writing "within tolerance" would stamp a measured
+    // pass on every period that predates the parameter, which is what the backfill runs first.
     var scaledTolerance = scaledResidualTolerance(input);
     if (scaledTolerance != null) {
+      checks.put("residualWithinTolerance", residual.abs().compareTo(scaledTolerance) <= 0);
       checks.put(
           "residualToleranceBps",
           scaledTolerance.multiply(BigDecimal.valueOf(10000)).setScale(2, HALF_UP));

--- a/src/main/java/ee/tuleva/onboarding/investment/check/tracking/TdAttributionInputAssembler.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/check/tracking/TdAttributionInputAssembler.java
@@ -2,7 +2,6 @@ package ee.tuleva.onboarding.investment.check.tracking;
 
 import static ee.tuleva.onboarding.investment.position.AccountType.SECURITY;
 import static java.math.BigDecimal.ZERO;
-import static java.math.RoundingMode.HALF_UP;
 
 import ee.tuleva.onboarding.deadline.PublicHolidays;
 import ee.tuleva.onboarding.investment.check.tracking.TdAttributionCalculator.DailyRecord;
@@ -15,11 +14,9 @@ import ee.tuleva.onboarding.tulevafund.TulevaFund;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -122,124 +119,44 @@ class TdAttributionInputAssembler {
             .filter(p -> p.getAccountId() != null)
             .collect(Collectors.toMap(FundPosition::getAccountId, p -> p, (a, b) -> a));
 
-    var currentWeights = getModelWeightsForDate(modelAllocations, date);
-    var previousWeights = getPreviousModelWeightsForDate(modelAllocations, date);
-    var transitionIsins =
-        findTransitionIsins(currentWeights, previousWeights, positionByIsin.keySet(), fund);
-
+    // Every weight comes from the daily check that actually ran, never from today's allocation
+    // table: a retroactive correction there must not rewrite a month that has already been
+    // measured, and the transition blending belongs in one place - the daily check - not two.
     var securityDataList = new ArrayList<SecurityDailyData>();
+    var unreproducible = new ArrayList<String>();
 
     for (var attr : attributions) {
       var isin = Objects.requireNonNull((String) attr.get("isin"), "Attribution missing isin");
-      var securityReturn = toBigDecimal(attr.get("securityReturn"));
+
+      // Events written before the daily check stored modelWeight cannot be reproduced. Leaving
+      // the instrument out keeps its effect in the residual; reading a missing weight as zero
+      // would report a model that never held it.
+      if (!attr.containsKey("modelWeight") || !attr.containsKey("weightDifference")) {
+        unreproducible.add(isin);
+        continue;
+      }
 
       var position = positionByIsin.get(isin);
-      var positionMv = position != null ? position.getMarketValue() : null;
-      var actualMv = positionMv != null ? positionMv : ZERO;
-      var normalizedActualWeight = actualMv.divide(totalSecurityValue, SCALE, HALF_UP);
-
-      var modelWeight =
-          transitionIsins.contains(isin)
-              ? normalizedActualWeight
-              : currentWeights.getOrDefault(isin, ZERO);
-      var normalizedWeightDiff = normalizedActualWeight.subtract(modelWeight);
-
       securityDataList.add(
           SecurityDailyData.builder()
               .isin(isin)
               .instrumentName(position != null ? position.getAccountName() : null)
-              .modelWeight(modelWeight)
-              .actualWeight(normalizedActualWeight)
-              .normalizedWeightDiff(normalizedWeightDiff)
-              .securityReturn(securityReturn)
+              .modelWeight(toBigDecimal(attr.get("modelWeight")))
+              .actualWeight(toBigDecimal(attr.get("actualWeight")))
+              .normalizedWeightDiff(toBigDecimal(attr.get("weightDifference")))
+              .securityReturn(toBigDecimal(attr.get("securityReturn")))
               .build());
     }
 
-    return securityDataList;
-  }
-
-  private Map<String, BigDecimal> getModelWeightsForDate(
-      List<ModelPortfolioAllocation> allVersions, LocalDate date) {
-    var activeAllocations =
-        allVersions.stream().filter(a -> !a.getEffectiveDate().isAfter(date)).toList();
-    if (activeAllocations.isEmpty()) {
-      return Map.of();
-    }
-    var latestDate =
-        activeAllocations.stream()
-            .map(ModelPortfolioAllocation::getEffectiveDate)
-            .max(LocalDate::compareTo)
-            .orElseThrow();
-    return activeAllocations.stream()
-        .filter(a -> a.getEffectiveDate().equals(latestDate))
-        .collect(
-            Collectors.toMap(
-                ModelPortfolioAllocation::getIsin, ModelPortfolioAllocation::getWeight));
-  }
-
-  private Map<String, BigDecimal> getPreviousModelWeightsForDate(
-      List<ModelPortfolioAllocation> allVersions, LocalDate date) {
-    var activeAllocations =
-        allVersions.stream().filter(a -> !a.getEffectiveDate().isAfter(date)).toList();
-    var distinctDates =
-        activeAllocations.stream()
-            .map(ModelPortfolioAllocation::getEffectiveDate)
-            .distinct()
-            .sorted()
-            .toList();
-    if (distinctDates.size() < 2) {
-      return Map.of();
-    }
-    var previousDate = distinctDates.get(distinctDates.size() - 2);
-    return activeAllocations.stream()
-        .filter(a -> a.getEffectiveDate().equals(previousDate))
-        .collect(
-            Collectors.toMap(
-                ModelPortfolioAllocation::getIsin, ModelPortfolioAllocation::getWeight));
-  }
-
-  private Set<String> findTransitionIsins(
-      Map<String, BigDecimal> currentWeights,
-      Map<String, BigDecimal> previousWeights,
-      Set<String> positionIsins,
-      TulevaFund fund) {
-
-    if (previousWeights.isEmpty()) {
-      return Set.of();
-    }
-
-    var addedIsins = new HashSet<>(currentWeights.keySet());
-    addedIsins.removeAll(previousWeights.keySet());
-    var removedIsins = new HashSet<>(previousWeights.keySet());
-    removedIsins.removeAll(currentWeights.keySet());
-
-    if (addedIsins.isEmpty() && removedIsins.isEmpty()) {
-      return Set.of();
-    }
-
-    var knownIsins = new HashSet<>(currentWeights.keySet());
-    knownIsins.addAll(previousWeights.keySet());
-    var unexpectedIsins = new HashSet<>(positionIsins);
-    unexpectedIsins.removeAll(knownIsins);
-
-    if (!unexpectedIsins.isEmpty()) {
+    if (!unreproducible.isEmpty()) {
       log.warn(
-          "Unexpected ISINs in portfolio, skipping transition blending: fund={}, unexpected={}",
+          "Daily attribution predates the stored model weight, leaving those instruments out of the period detail: fund={}, date={}, isins={}",
           fund,
-          unexpectedIsins);
-      return Set.of();
+          date,
+          unreproducible);
     }
 
-    var removedAndHeld = new HashSet<>(removedIsins);
-    removedAndHeld.retainAll(positionIsins);
-
-    if (removedAndHeld.isEmpty()) {
-      return Set.of();
-    }
-
-    var transitionIsins = new HashSet<>(addedIsins);
-    transitionIsins.addAll(removedIsins);
-    return transitionIsins;
+    return securityDataList;
   }
 
   static int countSeriesGaps(List<LocalDate> sortedEventDates, PublicHolidays publicHolidays) {

--- a/src/main/java/ee/tuleva/onboarding/investment/check/tracking/TrackingDifferenceJob.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/check/tracking/TrackingDifferenceJob.java
@@ -28,6 +28,7 @@ class TrackingDifferenceJob {
       trackingDifferenceNotifier.notify(results);
       log.info("Tracking difference check completed: resultCount={}", results.size());
     } catch (TrackingDifferenceService.IncompletePriceDataException e) {
+      trackingDifferenceNotifier.notifyRunIncomplete("TD check", reasonOf(e));
       trackingDifferenceNotifier.notify(e.completedResults());
       log.error("Tracking difference check incomplete", e);
     } catch (Exception e) {
@@ -45,6 +46,7 @@ class TrackingDifferenceJob {
       trackingDifferenceNotifier.notify(results);
       log.info("Tracking difference backfill completed: resultCount={}", results.size());
     } catch (TrackingDifferenceService.IncompletePriceDataException e) {
+      trackingDifferenceNotifier.notifyRunIncomplete("TD backfill", reasonOf(e));
       trackingDifferenceNotifier.notify(e.completedResults());
       log.error("Tracking difference backfill incomplete", e);
     } catch (Exception e) {

--- a/src/main/java/ee/tuleva/onboarding/investment/check/tracking/TrackingDifferenceJob.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/check/tracking/TrackingDifferenceJob.java
@@ -32,6 +32,7 @@ class TrackingDifferenceJob {
       log.error("Tracking difference check incomplete", e);
     } catch (Exception e) {
       log.error("Tracking difference check failed", e);
+      trackingDifferenceNotifier.notifyRunFailed("TD check", reasonOf(e));
     }
   }
 
@@ -48,6 +49,11 @@ class TrackingDifferenceJob {
       log.error("Tracking difference backfill incomplete", e);
     } catch (Exception e) {
       log.error("Tracking difference backfill failed", e);
+      trackingDifferenceNotifier.notifyRunFailed("TD backfill", reasonOf(e));
     }
+  }
+
+  private static String reasonOf(Exception e) {
+    return e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName();
   }
 }

--- a/src/main/java/ee/tuleva/onboarding/investment/check/tracking/TrackingDifferenceNotifier.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/check/tracking/TrackingDifferenceNotifier.java
@@ -23,8 +23,10 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 class TrackingDifferenceNotifier {
 
-  private static final int ESCALATION_THRESHOLD_FALLBACK = 3;
-  private static final BigDecimal ESCALATION_NET_TD_THRESHOLD_FALLBACK = new BigDecimal("0.005");
+  // Sisekord nr 4 p 11.7: escalate once the breach "püsib enam kui kolm (3) tööpäeva", so the
+  // fourth consecutive breach day is the first that escalates.
+  private static final int ESCALATION_THRESHOLD_FALLBACK = 4;
+  private static final BigDecimal ESCALATION_NET_TD_THRESHOLD_FALLBACK = new BigDecimal("0.001");
   private static final BigDecimal HUNDRED = new BigDecimal("100");
 
   private final OperationsNotificationService notificationService;

--- a/src/main/java/ee/tuleva/onboarding/investment/check/tracking/TrackingDifferenceNotifier.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/check/tracking/TrackingDifferenceNotifier.java
@@ -44,6 +44,20 @@ class TrackingDifferenceNotifier {
     }
   }
 
+  void notifyRunIncomplete(String run, String reason) {
+    try {
+      notificationService.sendMessage(
+          """
+          ⚠️ %s RAN ONLY IN PART: %s
+            Those funds were skipped, so nothing on this channel says whether their tracking
+            difference is within limits today. The result that follows covers the rest."""
+              .formatted(run, reason),
+          INVESTMENT);
+    } catch (Exception e) {
+      log.error("Failed to send tracking difference partial run notification", e);
+    }
+  }
+
   void notifyRunFailed(String run, String reason) {
     try {
       notificationService.sendMessage(
@@ -234,15 +248,17 @@ class TrackingDifferenceNotifier {
 
   private static String formatCountWarnings(TrackingDifferenceResult result) {
     var sb = new StringBuilder();
+    var subject = "%s %s".formatted(result.fund().getCode(), result.checkType());
     if (result.escalationCountUnavailable()) {
       sb.append(
-          "\n  ⚠️ The breach streak could not be counted, so this check cannot say whether the"
+          "\n  ⚠️ %s: the breach streak could not be counted, so this check cannot say whether the"
+                  .formatted(subject)
               + " breach has persisted. Escalation is not being evaluated for it.");
     }
     if (result.escalationCountTruncated()) {
       sb.append(
-          "\n  ⚠️ The streak fills the whole lookback window, so it has run for at least %s days"
-                  .formatted(result.consecutiveBreachDays())
+          "\n  ⚠️ %s: the streak fills the whole lookback window, so it has run for at least %s days"
+                  .formatted(subject, result.consecutiveBreachDays())
               + " and the net TD above is a lower bound. Widen ESCALATION_LOOKBACK_DAYS to measure"
               + " it.");
     }

--- a/src/main/java/ee/tuleva/onboarding/investment/check/tracking/TrackingDifferenceNotifier.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/check/tracking/TrackingDifferenceNotifier.java
@@ -41,6 +41,20 @@ class TrackingDifferenceNotifier {
     }
   }
 
+  void notifyRunFailed(String run, String reason) {
+    try {
+      notificationService.sendMessage(
+          """
+          🛑 %s DID NOT RUN: %s
+            Nothing was checked and nothing was refilled, so the last message on this channel is
+            not the state of the funds today. Rerun it once the cause is fixed."""
+              .formatted(run, reason),
+          INVESTMENT);
+    } catch (Exception e) {
+      log.error("Failed to send tracking difference run failure notification", e);
+    }
+  }
+
   void notify(List<TrackingDifferenceResult> results) {
     try {
       var alertableResults = results.stream().filter(r -> r.checkType() != BENCHMARK).toList();

--- a/src/main/java/ee/tuleva/onboarding/investment/check/tracking/TrackingDifferenceNotifier.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/check/tracking/TrackingDifferenceNotifier.java
@@ -16,6 +16,7 @@ import java.util.TreeMap;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.Nullable;
 import org.springframework.stereotype.Component;
 
 @Slf4j
@@ -55,6 +56,38 @@ class TrackingDifferenceNotifier {
     } catch (Exception e) {
       log.error("Failed to send tracking difference run failure notification", e);
     }
+  }
+
+  void notifyResidualOutsideTolerance(
+      TulevaFund fund,
+      LocalDate periodStart,
+      LocalDate periodEnd,
+      BigDecimal residual,
+      @Nullable BigDecimal tolerance) {
+    try {
+      notificationService.sendMessage(
+          """
+          🛑 TD ATTRIBUTION UNEXPLAINED: fund=%s, period=%s to %s
+            Residual %s bps, tolerance %s bps.
+            The attribution did not explain the period's tracking difference. The components it
+            does report cannot be relied on until the gap is understood."""
+              .formatted(
+                  fund.getCode(),
+                  periodStart,
+                  periodEnd,
+                  toBps(residual),
+                  tolerance == null ? "none" : toBps(tolerance)),
+          INVESTMENT);
+    } catch (Exception e) {
+      log.error("Failed to send tracking difference residual notification", e);
+    }
+  }
+
+  private static String toBps(BigDecimal value) {
+    return value
+        .multiply(new BigDecimal("10000"))
+        .setScale(2, RoundingMode.HALF_UP)
+        .toPlainString();
   }
 
   void notify(List<TrackingDifferenceResult> results) {

--- a/src/main/java/ee/tuleva/onboarding/investment/check/tracking/TrackingDifferenceNotifier.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/check/tracking/TrackingDifferenceNotifier.java
@@ -60,6 +60,17 @@ class TrackingDifferenceNotifier {
   void notify(List<TrackingDifferenceResult> results) {
     try {
       var alertableResults = results.stream().filter(r -> r.checkType() != BENCHMARK).toList();
+      // The ACWI benchmark is suppressed from alerts, so a run holding only benchmark results
+      // checked nothing anyone acts on - the same empty run as no results at all.
+      if (alertableResults.isEmpty()) {
+        notificationService.sendMessage(
+            """
+            ⚠️ TD RUN produced no tracking difference results to alert on
+              Nothing actionable was checked: every fund was skipped, or only the suppressed ACWI
+              benchmark ran. The reason per fund is in the logs; the daily series is unchanged.""",
+            INVESTMENT);
+        return;
+      }
       var hasAnyBreaches =
           alertableResults.stream().anyMatch(TrackingDifferenceResult::hasAnyBreach);
 
@@ -70,15 +81,6 @@ class TrackingDifferenceNotifier {
                     Collectors.groupingBy(
                         r -> r.fund().getCode(), TreeMap::new, Collectors.toList()));
         var message = new StringBuilder();
-        if (byFund.isEmpty()) {
-          var fundCodes =
-              results.stream()
-                  .map(r -> r.fund().getCode())
-                  .distinct()
-                  .sorted()
-                  .collect(Collectors.joining(", "));
-          message.append("✅ %s TD check completed: within limits".formatted(fundCodes));
-        }
         byFund.forEach(
             (fundCode, fundResults) -> {
               if (message.length() > 0) {
@@ -87,7 +89,8 @@ class TrackingDifferenceNotifier {
               message.append("✅ %s TD check completed: within limits".formatted(fundCode));
               fundResults.stream()
                   .sorted(Comparator.comparing(r -> r.checkType().name()))
-                  .forEach(r -> message.append(formatWithinLimits(r)));
+                  .forEach(
+                      r -> message.append(formatWithinLimits(r)).append(formatCountWarnings(r)));
             });
         notificationService.sendMessage(message.toString(), INVESTMENT);
         return;
@@ -96,21 +99,34 @@ class TrackingDifferenceNotifier {
       var message = new StringBuilder("🛑 TD BREACH DETECTED\n");
       var hasEscalation = false;
 
+      var decidedOnFallbackConfig = false;
+
       for (var result : alertableResults) {
         if (!result.hasAnyBreach()) {
+          message.append(formatCountWarnings(result));
           continue;
         }
 
-        var escalation = isEscalation(result);
+        var rule = escalationRule(result.checkDate());
+        var escalation = isEscalation(result, rule);
         if (escalation) {
           hasEscalation = true;
+          decidedOnFallbackConfig = decidedOnFallbackConfig || rule.fallback();
         }
 
-        message.append(new BreachMessageFormatter(result, escalation).format());
+        message
+            .append(new BreachMessageFormatter(result, escalation).format())
+            .append(formatCountWarnings(result));
       }
 
       if (hasEscalation) {
         message.insert(0, "🛑 TD ESCALATION — CONSECUTIVE BREACH DAYS\n");
+      }
+      if (decidedOnFallbackConfig) {
+        message.append(
+            "\n⚠️ The escalation parameters are not configured, so this was decided on built-in"
+                + " fallback constants rather than the configured rule. Seed"
+                + " ESCALATION_THRESHOLD_DAYS and ESCALATION_NET_TD_THRESHOLD.");
       }
 
       notificationService.sendMessage(message.toString(), INVESTMENT);
@@ -144,25 +160,43 @@ class TrackingDifferenceNotifier {
     return sb.toString();
   }
 
-  private boolean isEscalation(TrackingDifferenceResult result) {
-    int threshold;
-    BigDecimal netTdThreshold;
+  private record EscalationRule(int thresholdDays, BigDecimal netTdThreshold, boolean fallback) {}
+
+  private EscalationRule escalationRule(LocalDate checkDate) {
     try {
-      threshold = calculator.escalationThresholdDays(result.checkDate());
-      netTdThreshold = calculator.escalationNetTdThreshold(result.checkDate());
-    } catch (IllegalStateException e) {
-      log.warn("Escalation parameters not configured, using fallback: {}", e.getMessage());
-      threshold = ESCALATION_THRESHOLD_FALLBACK;
-      netTdThreshold = ESCALATION_NET_TD_THRESHOLD_FALLBACK;
+      return new EscalationRule(
+          calculator.escalationThresholdDays(checkDate),
+          calculator.escalationNetTdThreshold(checkDate),
+          false);
     } catch (Exception e) {
-      log.warn("Escalation parameter lookup failed, using fallback: {}", e.getMessage());
-      threshold = ESCALATION_THRESHOLD_FALLBACK;
-      netTdThreshold = ESCALATION_NET_TD_THRESHOLD_FALLBACK;
+      log.error("Escalation parameters unavailable, using fallback: {}", e.getMessage());
+      return new EscalationRule(
+          ESCALATION_THRESHOLD_FALLBACK, ESCALATION_NET_TD_THRESHOLD_FALLBACK, true);
     }
-    return result.consecutiveBreachDays() >= threshold
+  }
+
+  private boolean isEscalation(TrackingDifferenceResult result, EscalationRule rule) {
+    return result.consecutiveBreachDays() >= rule.thresholdDays()
         && ((result.consecutiveNetTd() != null
-                && result.consecutiveNetTd().abs().compareTo(netTdThreshold) >= 0)
+                && result.consecutiveNetTd().abs().compareTo(rule.netTdThreshold()) >= 0)
             || result.escalationNavResidualBreach());
+  }
+
+  private static String formatCountWarnings(TrackingDifferenceResult result) {
+    var sb = new StringBuilder();
+    if (result.escalationCountUnavailable()) {
+      sb.append(
+          "\n  ⚠️ The breach streak could not be counted, so this check cannot say whether the"
+              + " breach has persisted. Escalation is not being evaluated for it.");
+    }
+    if (result.escalationCountTruncated()) {
+      sb.append(
+          "\n  ⚠️ The streak fills the whole lookback window, so it has run for at least %s days"
+                  .formatted(result.consecutiveBreachDays())
+              + " and the net TD above is a lower bound. Widen ESCALATION_LOOKBACK_DAYS to measure"
+              + " it.");
+    }
+    return sb.toString();
   }
 
   private static String formatPercent(BigDecimal value) {

--- a/src/main/java/ee/tuleva/onboarding/investment/check/tracking/TrackingDifferenceNotifier.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/check/tracking/TrackingDifferenceNotifier.java
@@ -90,7 +90,11 @@ class TrackingDifferenceNotifier {
               fundResults.stream()
                   .sorted(Comparator.comparing(r -> r.checkType().name()))
                   .forEach(
-                      r -> message.append(formatWithinLimits(r)).append(formatCountWarnings(r)));
+                      r ->
+                          message
+                              .append(formatWithinLimits(r))
+                              .append(formatCountWarnings(r))
+                              .append(formatBenchmarkGap(r)));
             });
         notificationService.sendMessage(message.toString(), INVESTMENT);
         return;
@@ -116,7 +120,8 @@ class TrackingDifferenceNotifier {
 
         message
             .append(new BreachMessageFormatter(result, escalation).format())
-            .append(formatCountWarnings(result));
+            .append(formatCountWarnings(result))
+            .append(formatBenchmarkGap(result));
       }
 
       if (hasEscalation) {
@@ -180,6 +185,18 @@ class TrackingDifferenceNotifier {
         && ((result.consecutiveNetTd() != null
                 && result.consecutiveNetTd().abs().compareTo(rule.netTdThreshold()) >= 0)
             || result.escalationNavResidualBreach());
+  }
+
+  private static String formatBenchmarkGap(TrackingDifferenceResult result) {
+    var gapIsins = result.benchmarkGapIsins();
+    if (gapIsins == null || gapIsins.isEmpty()) {
+      return "";
+    }
+    var weight = result.benchmarkGapWeight();
+    return "\n  \u26a0\ufe0f %s of the sleeve has no benchmark proxy with data behind it, so this check did not"
+            .formatted(weight == null ? "Part" : formatPercent(weight) + "%")
+        + " measure it: %s. Every holding should have one - fix the instrument reference data."
+            .formatted(gapIsins);
   }
 
   private static String formatCountWarnings(TrackingDifferenceResult result) {

--- a/src/main/java/ee/tuleva/onboarding/investment/check/tracking/TrackingDifferenceResult.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/check/tracking/TrackingDifferenceResult.java
@@ -35,7 +35,9 @@ record TrackingDifferenceResult(
     boolean navResidualBreach,
     boolean escalationNavResidualBreach,
     boolean escalationCountTruncated,
-    boolean escalationCountUnavailable) {
+    boolean escalationCountUnavailable,
+    List<String> benchmarkGapIsins,
+    @Nullable BigDecimal benchmarkGapWeight) {
 
   boolean hasAnyBreach() {
     return breach() || navResidualBreach();

--- a/src/main/java/ee/tuleva/onboarding/investment/check/tracking/TrackingDifferenceResult.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/check/tracking/TrackingDifferenceResult.java
@@ -33,7 +33,9 @@ record TrackingDifferenceResult(
     @Nullable BigDecimal bodImpliedFundReturn,
     @Nullable BigDecimal navResidual,
     boolean navResidualBreach,
-    boolean escalationNavResidualBreach) {
+    boolean escalationNavResidualBreach,
+    boolean escalationCountTruncated,
+    boolean escalationCountUnavailable) {
 
   boolean hasAnyBreach() {
     return breach() || navResidualBreach();

--- a/src/main/java/ee/tuleva/onboarding/investment/check/tracking/TrackingDifferenceService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/check/tracking/TrackingDifferenceService.java
@@ -167,10 +167,26 @@ class TrackingDifferenceService {
             checkDate,
             previousDate);
 
+    // Gate on the blended weights, not the raw model. An instrument being switched into carries
+    // its actual weight of zero until the fund buys it, so it needs no price of ours; an
+    // instrument being switched out of still carries its full holding, so it does. Either way a
+    // weight we cannot price means the model return for the day is unknowable - the check has to
+    // say so rather than quietly leave that weight out of the benchmark.
+    //
+    // A zero anchor price is not a price either: nothing can be divided by it, so the calculator
+    // drops the instrument and its model weight silently leaves the benchmark return.
+    var blendedSecurities =
+        securityDataBuilder.blendTransitionWeights(
+            securities, allocations, previousAllocations, positions, fund);
+
     var missingPrices =
-        securities.stream()
+        blendedSecurities.stream()
             .filter(s -> s.modelWeight().signum() > 0)
-            .filter(s -> s.today().price() == null || s.previous().price() == null)
+            .filter(
+                s ->
+                    s.today().price() == null
+                        || s.previous().price() == null
+                        || s.previous().price().signum() == 0)
             .map(SecurityData::isin)
             .toList();
     if (!missingPrices.isEmpty()) {
@@ -180,7 +196,7 @@ class TrackingDifferenceService {
     }
 
     var misalignedSecurities =
-        securities.stream()
+        blendedSecurities.stream()
             .filter(s -> s.modelWeight().signum() > 0)
             .filter(
                 s ->
@@ -199,10 +215,6 @@ class TrackingDifferenceService {
           previousDate,
           misalignedSecurities);
     }
-
-    var blendedSecurities =
-        securityDataBuilder.blendTransitionWeights(
-            securities, allocations, previousAllocations, positions, fund);
 
     var bodPositions =
         fundPositionRepository.findByNavDateAndFundAndAccountType(previousDate, fund, SECURITY);

--- a/src/main/java/ee/tuleva/onboarding/investment/check/tracking/TrackingDifferenceService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/check/tracking/TrackingDifferenceService.java
@@ -112,8 +112,8 @@ class TrackingDifferenceService {
     var results = new ArrayList<TrackingDifferenceResult>();
 
     var previousDate = publicHolidays.previousWorkingDay(checkDate);
-    var todayValue = fundNavQueryService.findNavPerUnit(fund.getCode(), checkDate);
-    var yesterdayValue = fundNavQueryService.findNavPerUnit(fund.getCode(), previousDate);
+    var todayValue = fundNavQueryService.findLatestNavPerUnit(fund.getCode(), checkDate);
+    var yesterdayValue = fundNavQueryService.findLatestNavPerUnit(fund.getCode(), previousDate);
 
     if (todayValue.isEmpty() || yesterdayValue.isEmpty()) {
       log.warn(

--- a/src/main/java/ee/tuleva/onboarding/investment/config/InvestmentParameter.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/config/InvestmentParameter.java
@@ -1,6 +1,7 @@
 package ee.tuleva.onboarding.investment.config;
 
 public enum InvestmentParameter {
+  TD_RESIDUAL_TOLERANCE_ANNUAL,
   TRACKING_BREACH_THRESHOLD,
   TRACKING_MAX_DAILY_RETURN,
   NAV_IMPACT_VOLUME_THRESHOLD,

--- a/src/main/java/ee/tuleva/onboarding/investment/config/InvestmentParameterRepository.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/config/InvestmentParameterRepository.java
@@ -23,7 +23,7 @@ public class InvestmentParameterRepository {
             WHERE parameter_name = :name
               AND fund_code IS NULL
               AND effective_date <= :asOf
-            ORDER BY effective_date DESC
+            ORDER BY effective_date DESC, id DESC
             LIMIT 1
             """)
         .param("name", parameter.name())
@@ -43,7 +43,7 @@ public class InvestmentParameterRepository {
             WHERE parameter_name = :name
               AND fund_code = :fundCode
               AND effective_date <= :asOf
-            ORDER BY effective_date DESC
+            ORDER BY effective_date DESC, id DESC
             LIMIT 1
             """)
         .param("name", parameter.name())

--- a/src/main/java/ee/tuleva/onboarding/investment/epis/OwnFundNavProvider.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/epis/OwnFundNavProvider.java
@@ -43,7 +43,7 @@ class OwnFundNavProvider {
   private Optional<BigDecimal> queryNav(TulevaFund fund, LocalDate asOfDate) {
     return fundNavQueryService
         .findLatestNavDateOnOrBefore(fund.getCode(), asOfDate)
-        .flatMap(navDate -> fundNavQueryService.findNavPerUnit(fund.getCode(), navDate));
+        .flatMap(navDate -> fundNavQueryService.findPublishedNavPerUnit(fund.getCode(), navDate));
   }
 
   private boolean isReasonable(TulevaFund fund, LocalDate asOfDate, BigDecimal nav) {

--- a/src/main/java/ee/tuleva/onboarding/savings/FundNavQueryService.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/FundNavQueryService.java
@@ -2,7 +2,6 @@ package ee.tuleva.onboarding.savings;
 
 import ee.tuleva.onboarding.savings.fund.nav.NavReportAccountNames;
 import ee.tuleva.onboarding.savings.fund.nav.NavReportRepository;
-import ee.tuleva.onboarding.savings.fund.nav.NavReportRow;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;

--- a/src/main/java/ee/tuleva/onboarding/savings/FundNavQueryService.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/FundNavQueryService.java
@@ -29,10 +29,15 @@ public class FundNavQueryService {
 
   private final NavReportRepository navReportRepository;
 
-  public Optional<BigDecimal> findNavPerUnit(String fundCode, LocalDate navDate) {
-    return navReportRepository
-        .findFirstByFundCodeAndNavDateAndAccountType(fundCode, navDate, NAV_ACCOUNT_TYPE)
-        .map(NavReportRow::getMarketPrice);
+  // The official NAV per unit: what everyone outside the calculation itself should read.
+  public Optional<BigDecimal> findPublishedNavPerUnit(String fundCode, LocalDate navDate) {
+    return navReportRepository.findPublishedNavPerUnit(navDate, fundCode, NAV_ACCOUNT_TYPE);
+  }
+
+  // The NAV per unit of the newest calculation, published or not, for the gates that run before
+  // publication and therefore have to read the calculation they are gating.
+  public Optional<BigDecimal> findLatestNavPerUnit(String fundCode, LocalDate navDate) {
+    return navReportRepository.findLatestNavPerUnit(navDate, fundCode, NAV_ACCOUNT_TYPE);
   }
 
   public Optional<LocalDate> findLatestNavDateOnOrBefore(String fundCode, LocalDate asOfDate) {

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/nav/NavNotifier.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/nav/NavNotifier.java
@@ -104,7 +104,7 @@ class NavNotifier {
     try {
       var previousNavDate = publicHolidays.previousWorkingDay(result.positionReportDate());
       return fundNavQueryService
-          .findNavPerUnit(result.fund().getCode(), previousNavDate)
+          .findPublishedNavPerUnit(result.fund().getCode(), previousNavDate)
           .filter(previous -> previous.signum() != 0)
           .map(
               previous ->

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/nav/NavReportRepository.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/nav/NavReportRepository.java
@@ -13,8 +13,39 @@ import org.springframework.transaction.annotation.Transactional;
 
 public interface NavReportRepository extends JpaRepository<NavReportRow, Long> {
 
-  Optional<NavReportRow> findFirstByFundCodeAndNavDateAndAccountType(
-      String fundCode, LocalDate navDate, String accountType);
+  // The NAV that actually went out. nav_report keeps every calculation for a date, so a
+  // recalculation that is still unpublished must never be served as the official price.
+  // Order by published_at first: a backdated recalculation has a lower id but a later publication.
+  @Query(
+      value =
+          """
+          SELECT market_price FROM nav_report
+          WHERE nav_date = :navDate AND fund_code = :fundCode
+            AND account_type = :accountType
+            AND published_at IS NOT NULL
+          ORDER BY published_at DESC, id DESC LIMIT 1
+          """,
+      nativeQuery = true)
+  Optional<BigDecimal> findPublishedNavPerUnit(
+      @Param("navDate") LocalDate navDate,
+      @Param("fundCode") String fundCode,
+      @Param("accountType") String accountType);
+
+  // The newest calculation whether or not it is published, for the gates that run between
+  // persisting a NAV calculation and publishing it.
+  @Query(
+      value =
+          """
+          SELECT market_price FROM nav_report
+          WHERE nav_date = :navDate AND fund_code = :fundCode
+            AND account_type = :accountType
+          ORDER BY id DESC LIMIT 1
+          """,
+      nativeQuery = true)
+  Optional<BigDecimal> findLatestNavPerUnit(
+      @Param("navDate") LocalDate navDate,
+      @Param("fundCode") String fundCode,
+      @Param("accountType") String accountType);
 
   @Query(
       value =

--- a/src/main/resources/db/migration/V1_252__align_escalation_net_td_threshold_with_daily_threshold.sql
+++ b/src/main/resources/db/migration/V1_252__align_escalation_net_td_threshold_with_daily_threshold.sql
@@ -1,0 +1,8 @@
+-- Sisekord nr 4 p 11.7 requires escalation when the tracking difference exceeds 0,1% and
+-- persists over a three-working-day streak. It sets no condition on the size of the streak's
+-- net tracking difference, so the net-TD gate must never be stricter than the daily threshold
+-- it escalates from: at 0.005 a three-day streak of 0,15% per day compounded to ~0,45% and
+-- was silently dropped. The gate is kept, at the daily threshold, so it still filters a streak
+-- whose days offset each other to nearly nothing.
+INSERT INTO investment_parameter (parameter_name, effective_date, numeric_value)
+VALUES ('ESCALATION_NET_TD_THRESHOLD', '2026-08-28', 0.001);

--- a/src/main/resources/db/migration/V1_253__escalate_on_the_fourth_consecutive_breach_day.sql
+++ b/src/main/resources/db/migration/V1_253__escalate_on_the_fourth_consecutive_breach_day.sql
@@ -1,0 +1,6 @@
+-- Sisekord nr 4 p 11.7 (and p 3.5) escalate when the tracking difference exceeds 0,1% and
+-- "püsib enam kui kolm (3) tööpäeva" - persists MORE THAN three working days. V1_202 seeded 3,
+-- which escalates on the third day and so fires one day before the rule requires. The first day
+-- that satisfies "more than three" is the fourth consecutive breach day.
+INSERT INTO investment_parameter (parameter_name, effective_date, numeric_value)
+VALUES ('ESCALATION_THRESHOLD_DAYS', '2026-08-28', 4);

--- a/src/main/resources/db/migration/V1_254__td_residual_tolerance.sql
+++ b/src/main/resources/db/migration/V1_254__td_residual_tolerance.sql
@@ -1,0 +1,14 @@
+-- How much of a period's tracking difference may stay unexplained before the attribution is not
+-- to be trusted. The residual is defined as the tracking difference minus the named components,
+-- so it always balances - its size is the only real signal that the attribution failed.
+--
+-- Stated as an ANNUAL rate and scaled to the period by sqrt(days/365), so one number governs
+-- monthly, quarterly and annual runs alike. 17.5 bps a year works out at ~5.0 bps over a month
+-- and ~8.7 bps over a quarter.
+--
+-- Provisional: calibrate against the residuals observed in the attribution backfill. The scaling
+-- law is itself falsifiable - if the observed quarterly residual is about sqrt(3) times the
+-- monthly one it is noise and this band is the right shape; if it is about 3 times, it is a
+-- systematic leak and a missing component must be added rather than the band widened.
+INSERT INTO investment_parameter (effective_date, parameter_name, fund_code, numeric_value)
+VALUES ('2026-08-31', 'TD_RESIDUAL_TOLERANCE_ANNUAL', NULL, 0.00175);

--- a/src/test/groovy/ee/tuleva/onboarding/investment/check/tracking/ConsecutiveBreachTrackerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/check/tracking/ConsecutiveBreachTrackerTest.java
@@ -1,0 +1,169 @@
+package ee.tuleva.onboarding.investment.check.tracking;
+
+import static ee.tuleva.onboarding.investment.TrackingCheckType.MODEL_PORTFOLIO;
+import static ee.tuleva.onboarding.tulevafund.TulevaFund.TUK75;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+
+import ee.tuleva.onboarding.deadline.PublicHolidays;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ConsecutiveBreachTrackerTest {
+
+  // A Friday, so the three working days before it are the three calendar days before it.
+  private static final LocalDate CHECK_DATE = LocalDate.of(2026, 4, 10);
+  private static final LocalDate THURSDAY = LocalDate.of(2026, 4, 9);
+  private static final LocalDate WEDNESDAY = LocalDate.of(2026, 4, 8);
+  private static final LocalDate TUESDAY = LocalDate.of(2026, 4, 7);
+
+  @Mock private TrackingDifferenceEventRepository eventRepository;
+  @Mock private TrackingDifferenceCalculator calculator;
+
+  private ConsecutiveBreachTracker tracker;
+
+  @BeforeEach
+  void setUp() {
+    tracker = new ConsecutiveBreachTracker(eventRepository, calculator, new PublicHolidays());
+  }
+
+  @Test
+  void streakStopsAtAWorkingDayThatWasNeverChecked() {
+    given(calculator.escalationLookbackDays(CHECK_DATE)).willReturn(10);
+    given(eventRepository.findMostRecentEvents(TUK75, MODEL_PORTFOLIO, CHECK_DATE, 10))
+        .willReturn(List.of(breachEvent(THURSDAY), breachEvent(TUESDAY)));
+
+    var info = tracker.countConsecutiveBreaches(TUK75, MODEL_PORTFOLIO, CHECK_DATE);
+
+    // Wednesday was a working day with no check, so nothing says the breach persisted through it.
+    // Counting two here would join two separate breaches across the hole and escalate on a streak
+    // that was never observed.
+    assertThat(info.count()).isEqualTo(1);
+    assertThat(info.truncated()).isFalse();
+    assertThat(info.unavailable()).isFalse();
+  }
+
+  @Test
+  void streakRunsThroughContiguousWorkingDays() {
+    given(calculator.escalationLookbackDays(CHECK_DATE)).willReturn(10);
+    given(eventRepository.findMostRecentEvents(TUK75, MODEL_PORTFOLIO, CHECK_DATE, 10))
+        .willReturn(List.of(breachEvent(THURSDAY), breachEvent(WEDNESDAY), breachEvent(TUESDAY)));
+
+    var info = tracker.countConsecutiveBreaches(TUK75, MODEL_PORTFOLIO, CHECK_DATE);
+
+    assertThat(info.count()).isEqualTo(3);
+    assertThat(info.truncated()).isFalse();
+  }
+
+  @Test
+  void aStreakThatFillsTheWholeLookbackWindowIsReportedAsALowerBound() {
+    given(calculator.escalationLookbackDays(CHECK_DATE)).willReturn(2);
+    given(eventRepository.findMostRecentEvents(TUK75, MODEL_PORTFOLIO, CHECK_DATE, 2))
+        .willReturn(List.of(breachEvent(THURSDAY), breachEvent(WEDNESDAY)));
+
+    var info = tracker.countConsecutiveBreaches(TUK75, MODEL_PORTFOLIO, CHECK_DATE);
+
+    // The window bounds the query, not the breach: every row fetched was a breach, so the streak
+    // may run further back than the window can see.
+    assertThat(info.count()).isEqualTo(2);
+    assertThat(info.truncated()).isTrue();
+  }
+
+  @Test
+  void aStreakThatEndsInsideTheWindowIsNotALowerBound() {
+    given(calculator.escalationLookbackDays(CHECK_DATE)).willReturn(2);
+    given(eventRepository.findMostRecentEvents(TUK75, MODEL_PORTFOLIO, CHECK_DATE, 2))
+        .willReturn(List.of(breachEvent(THURSDAY), nonBreachEvent(WEDNESDAY)));
+
+    var info = tracker.countConsecutiveBreaches(TUK75, MODEL_PORTFOLIO, CHECK_DATE);
+
+    assertThat(info.count()).isEqualTo(1);
+    assertThat(info.truncated()).isFalse();
+  }
+
+  @Test
+  void aStreakThatCouldNotBeCountedIsNotReportedAsNoStreak() {
+    given(calculator.escalationLookbackDays(CHECK_DATE)).willReturn(10);
+    willThrow(new RuntimeException("database unavailable"))
+        .given(eventRepository)
+        .findMostRecentEvents(any(), any(), any(), eq(10));
+
+    var info = tracker.countConsecutiveBreaches(TUK75, MODEL_PORTFOLIO, CHECK_DATE);
+
+    // "No streak" and "we could not work out the streak" are different facts, and reporting the
+    // second as the first suppresses the escalation with nobody told.
+    assertThat(info.count()).isZero();
+    assertThat(info.unavailable()).isTrue();
+    assertThat(info.truncated()).isFalse();
+  }
+
+  @Test
+  void aFailedCountIsCarriedOntoTheResultEvenOnADayThatDidNotBreach() {
+    var result =
+        tracker.updateConsecutiveCount(
+            nonBreachingResult(),
+            new ConsecutiveBreachTracker.ConsecutiveBreachInfo(
+                0,
+                BigDecimal.ZERO,
+                BigDecimal.ZERO,
+                BigDecimal.ZERO,
+                java.util.Map.of(),
+                BigDecimal.ZERO,
+                BigDecimal.ZERO,
+                BigDecimal.ZERO,
+                false,
+                false,
+                true));
+
+    assertThat(result.escalationCountUnavailable()).isTrue();
+    assertThat(result.consecutiveBreachDays()).isZero();
+  }
+
+  private TrackingDifferenceResult nonBreachingResult() {
+    return TrackingDifferenceResult.builder()
+        .fund(TUK75)
+        .checkType(MODEL_PORTFOLIO)
+        .checkDate(CHECK_DATE)
+        .fundReturn(new BigDecimal("0.001"))
+        .benchmarkReturn(new BigDecimal("0.001"))
+        .trackingDifference(BigDecimal.ZERO)
+        .breach(false)
+        .build();
+  }
+
+  private TrackingDifferenceEvent breachEvent(LocalDate date) {
+    return TrackingDifferenceEvent.builder()
+        .fund(TUK75)
+        .checkDate(date)
+        .checkType(MODEL_PORTFOLIO)
+        .trackingDifference(new BigDecimal("0.0020"))
+        .fundReturn(new BigDecimal("0.01"))
+        .benchmarkReturn(new BigDecimal("0.008"))
+        .breach(true)
+        .consecutiveBreachDays(1)
+        .build();
+  }
+
+  private TrackingDifferenceEvent nonBreachEvent(LocalDate date) {
+    return TrackingDifferenceEvent.builder()
+        .fund(TUK75)
+        .checkDate(date)
+        .checkType(MODEL_PORTFOLIO)
+        .trackingDifference(BigDecimal.ZERO)
+        .fundReturn(new BigDecimal("0.001"))
+        .benchmarkReturn(new BigDecimal("0.001"))
+        .breach(false)
+        .consecutiveBreachDays(0)
+        .build();
+  }
+}

--- a/src/test/groovy/ee/tuleva/onboarding/investment/check/tracking/ConsecutiveBreachTrackerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/check/tracking/ConsecutiveBreachTrackerTest.java
@@ -108,6 +108,69 @@ class ConsecutiveBreachTrackerTest {
   }
 
   @Test
+  void anUnreadableLookbackParameterFallsBackRatherThanLosingTheStreak() {
+    given(calculator.escalationLookbackDays(CHECK_DATE))
+        .willThrow(new RuntimeException("database unavailable"));
+    given(eventRepository.findMostRecentEvents(TUK75, MODEL_PORTFOLIO, CHECK_DATE, 10))
+        .willReturn(List.of(breachEvent(THURSDAY), breachEvent(WEDNESDAY)));
+
+    var info = tracker.countConsecutiveBreaches(TUK75, MODEL_PORTFOLIO, CHECK_DATE);
+
+    assertThat(info.count()).isEqualTo(2);
+    assertThat(info.unavailable()).isFalse();
+  }
+
+  @Test
+  void anUnparseableAttributionDoesNotStopTheStreakBeingCounted() {
+    given(calculator.escalationLookbackDays(CHECK_DATE)).willReturn(10);
+    var corrupt =
+        TrackingDifferenceEvent.builder()
+            .fund(TUK75)
+            .checkDate(THURSDAY)
+            .checkType(MODEL_PORTFOLIO)
+            .trackingDifference(new BigDecimal("0.0020"))
+            .fundReturn(new BigDecimal("0.01"))
+            .benchmarkReturn(new BigDecimal("0.008"))
+            .breach(true)
+            .consecutiveBreachDays(1)
+            .result(java.util.Map.of("securityAttributions", "not a list"))
+            .build();
+    given(eventRepository.findMostRecentEvents(TUK75, MODEL_PORTFOLIO, CHECK_DATE, 10))
+        .willReturn(List.of(corrupt, breachEvent(WEDNESDAY)));
+
+    var info = tracker.countConsecutiveBreaches(TUK75, MODEL_PORTFOLIO, CHECK_DATE);
+
+    // The attribution detail is a nicety on the escalation message; the streak length is what
+    // decides whether anyone is woken up. One must not cost the other.
+    assertThat(info.count()).isEqualTo(2);
+    assertThat(info.unavailable()).isFalse();
+  }
+
+  @Test
+  void aNavResidualOnlyBreachKeepsTheStreakAlive() {
+    given(calculator.escalationLookbackDays(CHECK_DATE)).willReturn(10);
+    var navResidualOnly =
+        TrackingDifferenceEvent.builder()
+            .fund(TUK75)
+            .checkDate(THURSDAY)
+            .checkType(MODEL_PORTFOLIO)
+            .trackingDifference(new BigDecimal("0.0001"))
+            .fundReturn(new BigDecimal("0.001"))
+            .benchmarkReturn(new BigDecimal("0.0009"))
+            .breach(false)
+            .consecutiveBreachDays(0)
+            .result(java.util.Map.of("navResidualBreach", true))
+            .build();
+    given(eventRepository.findMostRecentEvents(TUK75, MODEL_PORTFOLIO, CHECK_DATE, 10))
+        .willReturn(List.of(navResidualOnly, breachEvent(WEDNESDAY)));
+
+    var info = tracker.countConsecutiveBreaches(TUK75, MODEL_PORTFOLIO, CHECK_DATE);
+
+    assertThat(info.count()).isEqualTo(2);
+    assertThat(info.hadNavResidualBreach()).isTrue();
+  }
+
+  @Test
   void aFailedCountIsCarriedOntoTheResultEvenOnADayThatDidNotBreach() {
     var result =
         tracker.updateConsecutiveCount(
@@ -127,6 +190,44 @@ class ConsecutiveBreachTrackerTest {
 
     assertThat(result.escalationCountUnavailable()).isTrue();
     assertThat(result.consecutiveBreachDays()).isZero();
+  }
+
+  @Test
+  void aResultCarryingNoComponentBreakdownStillGetsItsEscalationTotals() {
+    var breachingWithoutComponents =
+        TrackingDifferenceResult.builder()
+            .fund(TUK75)
+            .checkType(MODEL_PORTFOLIO)
+            .checkDate(CHECK_DATE)
+            .fundReturn(new BigDecimal("0.01"))
+            .benchmarkReturn(new BigDecimal("0.008"))
+            .trackingDifference(new BigDecimal("0.002"))
+            .breach(true)
+            .securityAttributions(List.of())
+            .build();
+
+    var result =
+        tracker.updateConsecutiveCount(
+            breachingWithoutComponents,
+            new ConsecutiveBreachTracker.ConsecutiveBreachInfo(
+                2,
+                new BigDecimal("0.004"),
+                new BigDecimal("0.02"),
+                new BigDecimal("0.016"),
+                java.util.Map.of(),
+                new BigDecimal("-0.0001"),
+                new BigDecimal("-0.00005"),
+                new BigDecimal("0.00002"),
+                false,
+                false,
+                false));
+
+    // A BENCHMARK result carries no cash, fee or residual breakdown at all. Adding null to the
+    // running streak totals would take the whole escalation message down with it.
+    assertThat(result.consecutiveBreachDays()).isEqualTo(3);
+    assertThat(result.escalationCashDrag()).isEqualByComparingTo("-0.0001");
+    assertThat(result.escalationFeeDrag()).isEqualByComparingTo("-0.00005");
+    assertThat(result.escalationResidual()).isEqualByComparingTo("0.00002");
   }
 
   private TrackingDifferenceResult nonBreachingResult() {

--- a/src/test/groovy/ee/tuleva/onboarding/investment/check/tracking/PeriodicTdAttributionServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/check/tracking/PeriodicTdAttributionServiceTest.java
@@ -23,6 +23,7 @@ import ee.tuleva.onboarding.instrument.BenchmarkCategoryProxy;
 import ee.tuleva.onboarding.instrument.InstrumentReference;
 import ee.tuleva.onboarding.instrument.InstrumentReferenceService;
 import ee.tuleva.onboarding.investment.TrackingCheckType;
+import ee.tuleva.onboarding.investment.config.InvestmentParameterRepository;
 import ee.tuleva.onboarding.investment.fees.FeeAccrual;
 import ee.tuleva.onboarding.investment.fees.FeeAccrualRepository;
 import ee.tuleva.onboarding.investment.fees.FeeChargedToFundPolicy;
@@ -81,6 +82,9 @@ class PeriodicTdAttributionServiceTest {
 
   private PeriodicTdAttributionService service;
 
+  @Mock private InvestmentParameterRepository parameterRepository;
+  @Mock private TrackingDifferenceNotifier notifier;
+
   @BeforeEach
   void setUp() {
     service =
@@ -96,7 +100,9 @@ class PeriodicTdAttributionServiceTest {
             instrumentFeeRepository,
             transactionManager,
             new PublicHolidays(),
-            new BenchmarkLegResolver(trackedInstruments()));
+            new BenchmarkLegResolver(trackedInstruments()),
+            parameterRepository,
+            notifier);
 
     // Default lenient stubs for Phase 3 data sources (overridden in specific tests)
     given(transactionExecutionRepository.sumCommissionsForFundAndPeriod(anyString(), any(), any()))
@@ -793,7 +799,7 @@ class PeriodicTdAttributionServiceTest {
         .result(
             Map.of(
                 "securityAttributions",
-                measuredIsins.stream().map(isin -> Map.<String, Object>of("isin", isin)).toList()))
+                measuredIsins.stream().map(isin -> attribution(isin, "0.5")).toList()))
         .build();
   }
 
@@ -879,11 +885,13 @@ class PeriodicTdAttributionServiceTest {
                         "isin", ISIN_DW,
                         "modelWeight", new BigDecimal("0.70"),
                         "actualWeight", new BigDecimal("0.68"),
+                        "weightDifference", new BigDecimal("-0.006122"),
                         "securityReturn", new BigDecimal(fundReturn)),
                     Map.<String, Object>of(
                         "isin", ISIN_EUROPE_ETF,
                         "modelWeight", new BigDecimal("0.30"),
                         "actualWeight", new BigDecimal("0.30"),
+                        "weightDifference", new BigDecimal("0.006122"),
                         "securityReturn", new BigDecimal(benchmarkReturn))),
                 "cashDrag",
                 ZERO,
@@ -909,30 +917,34 @@ class PeriodicTdAttributionServiceTest {
                 "securityAttributions",
                 List.of(
                     Map.<String, Object>of(
-                        "isin", isin, "securityReturn", new BigDecimal("0.001")))))
+                        "isin",
+                        isin,
+                        "securityReturn",
+                        new BigDecimal("0.001"),
+                        "modelWeight",
+                        BigDecimal.ONE,
+                        "actualWeight",
+                        BigDecimal.ONE,
+                        "weightDifference",
+                        ZERO))))
         .createdAt(Instant.now())
         .build();
   }
 
-  private TrackingDifferenceEvent twoAttributionEvent(LocalDate date, String isinA, String isinB) {
-    return TrackingDifferenceEvent.builder()
-        .fund(TUK75)
-        .checkDate(date)
-        .checkType(MODEL_PORTFOLIO)
-        .trackingDifference(new BigDecimal("0.0001"))
-        .fundReturn(new BigDecimal("0.001"))
-        .benchmarkReturn(new BigDecimal("0.0009"))
-        .breach(false)
-        .result(
-            Map.of(
-                "securityAttributions",
-                List.of(
-                    Map.<String, Object>of(
-                        "isin", isinA, "securityReturn", new BigDecimal("0.001")),
-                    Map.<String, Object>of(
-                        "isin", isinB, "securityReturn", new BigDecimal("0.001")))))
-        .createdAt(Instant.now())
-        .build();
+  // What the daily check actually stores. A fixture holding only isin and securityReturn is a
+  // pre-2026-05-06 event, which the period deliberately cannot reproduce.
+  private static Map<String, Object> attribution(String isin, String weight) {
+    return Map.<String, Object>of(
+        "isin",
+        isin,
+        "securityReturn",
+        new BigDecimal("0.001"),
+        "modelWeight",
+        new BigDecimal(weight),
+        "actualWeight",
+        new BigDecimal(weight),
+        "weightDifference",
+        ZERO);
   }
 
   private FeeAccrual feeAccrual(LocalDate date, FeeType type, String amount) {
@@ -968,8 +980,18 @@ class PeriodicTdAttributionServiceTest {
         .build();
   }
 
+  private FundPosition positionNamed(String isin, String accountName) {
+    return FundPosition.builder()
+        .fund(TUK75)
+        .accountType(SECURITY)
+        .accountId(isin)
+        .accountName(accountName)
+        .marketValue(new BigDecimal("1000000"))
+        .build();
+  }
+
   @Test
-  void blendsModelWeightsDuringTransitionInPeriodicAttribution() {
+  void reportsNoWeightDeviationForTheLegsTheDailyCheckBlended() {
     var date1 = LocalDate.of(2026, 4, 1);
     var date2 = LocalDate.of(2026, 4, 2);
 
@@ -1052,7 +1074,7 @@ class PeriodicTdAttributionServiceTest {
   }
 
   @Test
-  void skipsBlendingWhenNoModelVersionChange() {
+  void reportsTheModelWeightTheDailyCheckStored() {
     setupStandardMocks();
 
     var result = service.computeAttribution(TUK75, PERIOD_START, PERIOD_END, MONTHLY);
@@ -1066,71 +1088,24 @@ class PeriodicTdAttributionServiceTest {
   }
 
   @Test
-  void skipsBlendingWhenUnexpectedIsinInPeriodicAttribution() {
-    var date1 = LocalDate.of(2026, 4, 1);
-    var date2 = LocalDate.of(2026, 4, 2);
-    var isinNew = "IE00NEW";
-    var isinRogue = "IE00ROGUE";
-
-    given(
-            tdEventRepository.findDeduplicatedEventsForPeriod(
-                TUK75, MODEL_PORTFOLIO, PERIOD_START, PERIOD_END))
-        .willReturn(
-            List.of(
-                tdEvent(date1, "0.0008", "0.001"),
-                tdEventWithTransition(date2, "0.0005", "0.0007", isinNew)));
-
-    given(feeAccrualRepository.findByFundAndDateRange(TUK75, PERIOD_START, PERIOD_END))
-        .willReturn(List.of());
-    given(feeRateRepository.findValidRate(TUK75, FeeType.MANAGEMENT, PERIOD_END))
-        .willReturn(Optional.empty());
-
-    given(
-            modelPortfolioAllocationRepository.findVersionsActiveDuringPeriod(
-                TUK75, PERIOD_START, PERIOD_END))
-        .willReturn(
-            List.of(
-                modelAllocation(ISIN_DW, "0.70", date1),
-                modelAllocation(ISIN_EUROPE_ETF, "0.30", date1),
-                modelAllocation(ISIN_DW, "0.70", date2),
-                modelAllocation(isinNew, "0.30", date2)));
-
-    given(fundNavQueryService.findAum(FUND_CODE, date1)).willReturn(new BigDecimal("100000000"));
-    given(fundNavQueryService.findAum(FUND_CODE, date2)).willReturn(new BigDecimal("100050000"));
-    given(fundNavQueryService.findCashValue(anyString(), any()))
-        .willReturn(new BigDecimal("1500000"));
-    given(fundNavQueryService.findSecuritiesTotalValue(anyString(), any()))
-        .willReturn(new BigDecimal("98000000"));
-    given(fundNavQueryService.findFeeAccrualLiabilities(anyString(), any()))
-        .willReturn(new BigDecimal("-50000"));
-
-    given(
-            fundPositionRepository.findByNavDateAndFundAndAccountType(
-                eq(date1), eq(TUK75), eq(SECURITY)))
-        .willReturn(List.of(position(ISIN_DW, "68600000"), position(ISIN_EUROPE_ETF, "29400000")));
-
-    given(
-            fundPositionRepository.findByNavDateAndFundAndAccountType(
-                eq(date2), eq(TUK75), eq(SECURITY)))
+  void aHeldPositionTheDailyCheckDidNotAttributeStaysOutOfThePeriodDetail() {
+    setupStandardMocks();
+    given(fundPositionRepository.findByNavDateAndFundAndAccountType(any(), eq(TUK75), eq(SECURITY)))
         .willReturn(
             List.of(
                 position(ISIN_DW, "68600000"),
-                position(ISIN_EUROPE_ETF, "20000000"),
-                position(isinNew, "5000000"),
-                position(isinRogue, "5000000")));
+                position(ISIN_EUROPE_ETF, "29400000"),
+                position("IE00ROGUE", "5000000")));
 
     var result = service.computeAttribution(TUK75, PERIOD_START, PERIOD_END, MONTHLY);
 
-    assertThat(result.tdGeometric()).isNotNull();
-    assertThat(result.instrumentDetails()).isNotEmpty();
-    var emDetail =
-        result.instrumentDetails().stream()
-            .filter(d -> d.isin().equals(ISIN_EUROPE_ETF))
-            .findFirst()
-            .orElseThrow();
-    assertThat(emDetail.modelWeight()).isNotEqualByComparingTo(emDetail.avgActualWeight());
+    assertThat(result.instrumentDetails())
+        .extracting(TdAttributionResult.InstrumentAttribution::isin)
+        .containsExactlyInAnyOrder(ISIN_DW, ISIN_EUROPE_ETF);
   }
 
+  // A transition day as the daily check stores it: the legs moving have their model weight blended
+  // to what the fund actually holds, and the rest of the model is rescaled back to 1.
   private TrackingDifferenceEvent tdEventWithTransition(
       LocalDate date, String fundReturn, String benchmarkReturn, String newIsin) {
     return TrackingDifferenceEvent.builder()
@@ -1149,20 +1124,19 @@ class PeriodicTdAttributionServiceTest {
                         "isin", ISIN_DW,
                         "modelWeight", new BigDecimal("0.70"),
                         "actualWeight", new BigDecimal("0.70"),
+                        "weightDifference", ZERO,
                         "securityReturn", new BigDecimal("0.001")),
                     Map.<String, Object>of(
-                        "isin",
-                        ISIN_EUROPE_ETF,
-                        "modelWeight",
-                        ZERO,
-                        "actualWeight",
-                        new BigDecimal("0.20"),
-                        "securityReturn",
-                        new BigDecimal("0.0005")),
+                        "isin", ISIN_EUROPE_ETF,
+                        "modelWeight", new BigDecimal("0.20"),
+                        "actualWeight", new BigDecimal("0.20"),
+                        "weightDifference", ZERO,
+                        "securityReturn", new BigDecimal("0.0005")),
                     Map.<String, Object>of(
                         "isin", newIsin,
-                        "modelWeight", new BigDecimal("0.30"),
+                        "modelWeight", new BigDecimal("0.10"),
                         "actualWeight", new BigDecimal("0.10"),
+                        "weightDifference", ZERO,
                         "securityReturn", new BigDecimal("0.002"))),
                 "cashDrag",
                 ZERO,
@@ -1237,7 +1211,7 @@ class PeriodicTdAttributionServiceTest {
   }
 
   @Test
-  void attributionForIsinWithNoMatchingPositionDefaultsWeightToZero() {
+  void attributionForIsinWithNoMatchingPositionFallsBackToTheIsinAsItsName() {
     var date1 = LocalDate.of(2026, 4, 1);
     var isinNoPosition = "IE00NOPOS";
 
@@ -1268,7 +1242,7 @@ class PeriodicTdAttributionServiceTest {
             .filter(d -> d.isin().equals(isinNoPosition))
             .findFirst()
             .orElseThrow();
-    assertThat(detail.avgActualWeight()).isEqualByComparingTo(ZERO);
+    assertThat(detail.avgActualWeight()).isEqualByComparingTo(BigDecimal.ONE);
     assertThat(detail.instrumentName()).isEqualTo(isinNoPosition);
   }
 
@@ -1322,7 +1296,7 @@ class PeriodicTdAttributionServiceTest {
   }
 
   @Test
-  void usesFirstPositionWhenDuplicateAccountIdsExistForADay() {
+  void namesTheInstrumentAfterTheFirstPositionWhenDuplicateAccountIdsExistForADay() {
     var date1 = LocalDate.of(2026, 4, 1);
 
     given(
@@ -1343,7 +1317,10 @@ class PeriodicTdAttributionServiceTest {
         .willReturn(new BigDecimal("1000"));
     given(fundNavQueryService.findFeeAccrualLiabilities(anyString(), any())).willReturn(ZERO);
     given(fundPositionRepository.findByNavDateAndFundAndAccountType(date1, TUK75, SECURITY))
-        .willReturn(List.of(position(ISIN_DW, "111"), position(ISIN_DW, "999")));
+        .willReturn(
+            List.of(
+                positionNamed(ISIN_DW, "Developed World"),
+                positionNamed(ISIN_DW, "Developed World (duplicate)")));
 
     var result = service.computeAttribution(TUK75, PERIOD_START, PERIOD_END, MONTHLY);
 
@@ -1352,7 +1329,7 @@ class PeriodicTdAttributionServiceTest {
             .filter(d -> d.isin().equals(ISIN_DW))
             .findFirst()
             .orElseThrow();
-    assertThat(detail.avgActualWeight()).isEqualByComparingTo("0.111000");
+    assertThat(detail.instrumentName()).isEqualTo("Developed World");
   }
 
   @Test
@@ -1373,28 +1350,6 @@ class PeriodicTdAttributionServiceTest {
     var withDuplicate = service.computeAttribution(TUK75, PERIOD_START, PERIOD_END, MONTHLY);
 
     assertThat(withDuplicate.etfOcfDrag()).isEqualByComparingTo(baseline.etfOcfDrag());
-  }
-
-  @Test
-  void excludesFutureDatedModelAllocationsWhenResolvingActiveWeights() {
-    setupStandardMocks();
-    given(
-            modelPortfolioAllocationRepository.findVersionsActiveDuringPeriod(
-                TUK75, PERIOD_START, PERIOD_END))
-        .willReturn(
-            List.of(
-                modelAllocation(ISIN_DW, "0.70", PERIOD_START),
-                modelAllocation(ISIN_EUROPE_ETF, "0.30", PERIOD_START),
-                modelAllocation(ISIN_DW, "0.99", PERIOD_END.plusMonths(1))));
-
-    var result = service.computeAttribution(TUK75, PERIOD_START, PERIOD_END, MONTHLY);
-
-    var dwDetail =
-        result.instrumentDetails().stream()
-            .filter(d -> d.isin().equals(ISIN_DW))
-            .findFirst()
-            .orElseThrow();
-    assertThat(dwDetail.modelWeight()).isEqualByComparingTo("0.70");
   }
 
   @Test
@@ -1439,99 +1394,5 @@ class PeriodicTdAttributionServiceTest {
     assertThat(result.etfOcfDrag()).isEqualByComparingTo(ZERO);
     assertThat(result.checks())
         .containsEntry("etfLayerUnbenchmarkedWeight", new BigDecimal("1.000000"));
-  }
-
-  @Test
-  void blendsModelWeightToActualWeightOnlyForTransitioningIsinAcrossDistinctModelVersions() {
-    var date1 = LocalDate.of(2026, 4, 1);
-    var date2 = LocalDate.of(2026, 4, 2);
-    var isinA = "IE00TRANSA";
-    var isinB = "IE00TRANSB";
-
-    given(
-            tdEventRepository.findDeduplicatedEventsForPeriod(
-                TUK75, MODEL_PORTFOLIO, PERIOD_START, PERIOD_END))
-        .willReturn(
-            List.of(singleAttributionEvent(date1, isinA), singleAttributionEvent(date2, isinB)));
-    given(feeAccrualRepository.findByFundAndDateRange(TUK75, PERIOD_START, PERIOD_END))
-        .willReturn(List.of());
-    given(feeRateRepository.findValidRate(TUK75, FeeType.MANAGEMENT, PERIOD_END))
-        .willReturn(Optional.empty());
-    given(
-            modelPortfolioAllocationRepository.findVersionsActiveDuringPeriod(
-                TUK75, PERIOD_START, PERIOD_END))
-        .willReturn(
-            List.of(modelAllocation(isinA, "1.0", date1), modelAllocation(isinB, "1.0", date2)));
-    given(fundNavQueryService.findAum(FUND_CODE, date1)).willReturn(new BigDecimal("1000000"));
-    given(fundNavQueryService.findAum(FUND_CODE, date2)).willReturn(new BigDecimal("1000000"));
-    given(fundNavQueryService.findCashValue(anyString(), any())).willReturn(ZERO);
-    given(fundNavQueryService.findSecuritiesTotalValue(anyString(), any()))
-        .willReturn(new BigDecimal("1000000"));
-    given(fundNavQueryService.findFeeAccrualLiabilities(anyString(), any())).willReturn(ZERO);
-    given(fundPositionRepository.findByNavDateAndFundAndAccountType(date1, TUK75, SECURITY))
-        .willReturn(List.of(position(isinA, "1000000")));
-    given(fundPositionRepository.findByNavDateAndFundAndAccountType(date2, TUK75, SECURITY))
-        .willReturn(List.of(position(isinA, "300000"), position(isinB, "700000")));
-
-    var result = service.computeAttribution(TUK75, PERIOD_START, PERIOD_END, MONTHLY);
-
-    var bDetail =
-        result.instrumentDetails().stream()
-            .filter(d -> d.isin().equals(isinB))
-            .findFirst()
-            .orElseThrow();
-    assertThat(bDetail.modelWeight()).isEqualByComparingTo("0.7");
-  }
-
-  @Test
-  void blendsRemovedInstrumentStillHeldDespiteFutureAllocationsAndNullAccountIdPositions() {
-    var date1 = LocalDate.of(2026, 4, 1);
-    var date2 = LocalDate.of(2026, 4, 2);
-    var isinA = "IE00STILLA";
-    var isinB = "IE00REMOVB";
-
-    given(
-            tdEventRepository.findDeduplicatedEventsForPeriod(
-                TUK75, MODEL_PORTFOLIO, PERIOD_START, PERIOD_END))
-        .willReturn(List.of(twoAttributionEvent(date2, isinA, isinB)));
-    given(feeAccrualRepository.findByFundAndDateRange(TUK75, PERIOD_START, PERIOD_END))
-        .willReturn(List.of());
-    given(feeRateRepository.findValidRate(TUK75, FeeType.MANAGEMENT, PERIOD_END))
-        .willReturn(Optional.empty());
-    given(
-            modelPortfolioAllocationRepository.findVersionsActiveDuringPeriod(
-                TUK75, PERIOD_START, PERIOD_END))
-        .willReturn(
-            List.of(
-                modelAllocation(isinA, "0.6", date1),
-                modelAllocation(isinB, "0.4", date1),
-                modelAllocation(isinA, "1.0", date2),
-                modelAllocation(isinA, "0.99", date2.plusMonths(2))));
-    given(fundNavQueryService.findAum(FUND_CODE, date2)).willReturn(new BigDecimal("1000000"));
-    given(fundNavQueryService.findCashValue(anyString(), any())).willReturn(ZERO);
-    given(fundNavQueryService.findSecuritiesTotalValue(anyString(), any()))
-        .willReturn(new BigDecimal("1000000"));
-    given(fundNavQueryService.findFeeAccrualLiabilities(anyString(), any())).willReturn(ZERO);
-    given(fundPositionRepository.findByNavDateAndFundAndAccountType(date2, TUK75, SECURITY))
-        .willReturn(
-            List.of(
-                position(isinA, "300000"),
-                position(isinB, "700000"),
-                FundPosition.builder()
-                    .fund(TUK75)
-                    .accountType(SECURITY)
-                    .accountId(null)
-                    .accountName("unknown")
-                    .marketValue(new BigDecimal("500000"))
-                    .build()));
-
-    var result = service.computeAttribution(TUK75, PERIOD_START, PERIOD_END, MONTHLY);
-
-    var bDetail =
-        result.instrumentDetails().stream()
-            .filter(d -> d.isin().equals(isinB))
-            .findFirst()
-            .orElseThrow();
-    assertThat(bDetail.modelWeight()).isEqualByComparingTo("0.7");
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/investment/check/tracking/PeriodicTdAttributionServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/check/tracking/PeriodicTdAttributionServiceTest.java
@@ -15,6 +15,8 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -23,6 +25,7 @@ import ee.tuleva.onboarding.instrument.BenchmarkCategoryProxy;
 import ee.tuleva.onboarding.instrument.InstrumentReference;
 import ee.tuleva.onboarding.instrument.InstrumentReferenceService;
 import ee.tuleva.onboarding.investment.TrackingCheckType;
+import ee.tuleva.onboarding.investment.config.InvestmentParameter;
 import ee.tuleva.onboarding.investment.config.InvestmentParameterRepository;
 import ee.tuleva.onboarding.investment.fees.FeeAccrual;
 import ee.tuleva.onboarding.investment.fees.FeeAccrualRepository;
@@ -173,6 +176,71 @@ class PeriodicTdAttributionServiceTest {
             TUK75, PERIOD_START, PERIOD_END, MONTHLY);
     verify(attributionRepository).save(any(PeriodicTdAttribution.class));
     verify(attributionRepository).save(argThat(e -> e.getDetails().size() == 2));
+  }
+
+  @Test
+  void aResidualTheAttributionCouldNotExplainIsAlerted() {
+    setupStandardMocks();
+    given(
+            parameterRepository.findLatestValue(
+                InvestmentParameter.TD_RESIDUAL_TOLERANCE_ANNUAL, PERIOD_END))
+        .willReturn(new BigDecimal("0.00001"));
+
+    var result = service.computeAttribution(TUK75, PERIOD_START, PERIOD_END, MONTHLY);
+
+    assertThat(result.checks()).containsEntry("residualWithinTolerance", false);
+    then(notifier)
+        .should()
+        .notifyResidualOutsideTolerance(
+            eq(TUK75), eq(PERIOD_START), eq(PERIOD_END), eq(result.residual()), any());
+  }
+
+  @Test
+  void anUnconfiguredToleranceIsNotAnAlarmOnEveryPeriod() {
+    setupStandardMocks();
+    given(
+            parameterRepository.findLatestValue(
+                InvestmentParameter.TD_RESIDUAL_TOLERANCE_ANNUAL, PERIOD_END))
+        .willThrow(new IllegalStateException("No investment parameter found"));
+
+    var result = service.computeAttribution(TUK75, PERIOD_START, PERIOD_END, MONTHLY);
+
+    assertThat(result.checks()).doesNotContainKey("residualWithinTolerance");
+    then(notifier)
+        .should(never())
+        .notifyResidualOutsideTolerance(any(), any(), any(), any(), any());
+  }
+
+  @Test
+  void anEventWrittenBeforeTheDailyCheckStoredItsWeightsIsLeftOutOfThePeriodDetail() {
+    setupStandardMocks();
+    var legacyEvent =
+        TrackingDifferenceEvent.builder()
+            .fund(TUK75)
+            .checkDate(LocalDate.of(2026, 4, 1))
+            .checkType(MODEL_PORTFOLIO)
+            .trackingDifference(new BigDecimal("0.0001"))
+            .fundReturn(new BigDecimal("0.001"))
+            .benchmarkReturn(new BigDecimal("0.0009"))
+            .breach(false)
+            .result(
+                Map.of(
+                    "securityAttributions",
+                    List.of(
+                        Map.<String, Object>of(
+                            "isin", ISIN_DW, "securityReturn", new BigDecimal("0.001")))))
+            .createdAt(Instant.now())
+            .build();
+    given(
+            tdEventRepository.findDeduplicatedEventsForPeriod(
+                TUK75, MODEL_PORTFOLIO, PERIOD_START, PERIOD_END))
+        .willReturn(List.of(legacyEvent));
+
+    var result = service.computeAttribution(TUK75, PERIOD_START, PERIOD_END, MONTHLY);
+
+    // Reading a missing weight as zero would report a model that never held the instrument.
+    // Leaving it out keeps its whole effect in the residual, where the tolerance can see it.
+    assertThat(result.instrumentDetails()).isEmpty();
   }
 
   @Test

--- a/src/test/groovy/ee/tuleva/onboarding/investment/check/tracking/SecurityDataBuilderTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/check/tracking/SecurityDataBuilderTest.java
@@ -2,6 +2,7 @@ package ee.tuleva.onboarding.investment.check.tracking;
 
 import static ee.tuleva.onboarding.investment.position.AccountType.SECURITY;
 import static ee.tuleva.onboarding.tulevafund.TulevaFund.TUK75;
+import static java.math.BigDecimal.ZERO;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -299,9 +300,13 @@ class SecurityDataBuilderTest {
 
     var blended = result.stream().filter(s -> s.isin().equals("ISIN_B")).findFirst().orElseThrow();
     assertThat(blended.modelWeight()).isEqualByComparingTo("0.65");
+    // The transition leg takes 0.65, so the settled leg gives up exactly that much: it is scaled
+    // from 0.3 to 1 - 0.65 = 0.35. Keeping its original 0.3 would leave the model weighing 0.95.
     var unchanged =
         result.stream().filter(s -> s.isin().equals("ISIN_A")).findFirst().orElseThrow();
-    assertThat(unchanged.modelWeight()).isEqualByComparingTo("0.3");
+    assertThat(unchanged.modelWeight()).isEqualByComparingTo("0.35");
+    assertThat(result.stream().map(SecurityData::modelWeight).reduce(ZERO, BigDecimal::add))
+        .isEqualByComparingTo("1.00");
   }
 
   @Test

--- a/src/test/groovy/ee/tuleva/onboarding/investment/check/tracking/SecurityDataBuilderTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/check/tracking/SecurityDataBuilderTest.java
@@ -310,6 +310,38 @@ class SecurityDataBuilderTest {
   }
 
   @Test
+  void blendTransitionWeightsTreatsAnInstrumentParkedAtZeroPercentAsRemoved() {
+    var snapshot = new PriceSnapshot(BigDecimal.TEN, CHECK_DATE);
+    var securities =
+        List.of(
+            new SecurityData(
+                "ISIN_A", new BigDecimal("1.0"), new BigDecimal("0.35"), snapshot, snapshot),
+            new SecurityData("ISIN_B", ZERO, new BigDecimal("0.65"), snapshot, snapshot));
+    // The switch pipeline leaves the exiting instrument in the model at 0% until it is liquidated,
+    // so it is still in the allocation table. Read by ISIN presence nothing would count as removed,
+    // no blending would happen, and a holding that is 65% of the fund would be measured against a
+    // model weight of zero.
+    var allocations =
+        List.of(allocation("ISIN_A", "1.0", CHECK_DATE), allocation("ISIN_B", "0.0", CHECK_DATE));
+    var previousAllocations =
+        List.of(
+            allocation("ISIN_A", "0.3", PREVIOUS_DATE), allocation("ISIN_B", "0.7", PREVIOUS_DATE));
+    var positions =
+        List.of(position("ISIN_A", CHECK_DATE, "350000"), position("ISIN_B", CHECK_DATE, "650000"));
+
+    var result =
+        builder.blendTransitionWeights(
+            securities, allocations, previousAllocations, positions, TUK75);
+
+    var exiting = result.stream().filter(s -> s.isin().equals("ISIN_B")).findFirst().orElseThrow();
+    assertThat(exiting.modelWeight()).isEqualByComparingTo("0.65");
+    var settled = result.stream().filter(s -> s.isin().equals("ISIN_A")).findFirst().orElseThrow();
+    assertThat(settled.modelWeight()).isEqualByComparingTo("0.35");
+    assertThat(result.stream().map(SecurityData::modelWeight).reduce(ZERO, BigDecimal::add))
+        .isEqualByComparingTo("1.00");
+  }
+
+  @Test
   void blendTransitionWeightsBlendsBothAddedAndRemovedIsinsDuringAFullSwap() {
     var snapshot = new PriceSnapshot(BigDecimal.TEN, CHECK_DATE);
     var securities =

--- a/src/test/groovy/ee/tuleva/onboarding/investment/check/tracking/SecurityDataBuilderTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/check/tracking/SecurityDataBuilderTest.java
@@ -342,6 +342,36 @@ class SecurityDataBuilderTest {
   }
 
   @Test
+  void blendTransitionWeightsLeavesTheRestOfTheModelAloneWhenTheLegsAlreadyExceedOne() {
+    var snapshot = new PriceSnapshot(BigDecimal.TEN, CHECK_DATE);
+    // Both legs of a switch sit in the sleeve at once until the exiting one is excluded, so the
+    // actual weights can add past 1. Rescaling then would hand the settled legs a negative model
+    // weight, which is worse than leaving them where they are.
+    var securities =
+        List.of(
+            new SecurityData(
+                "ISIN_A", new BigDecimal("0.5"), new BigDecimal("0.6"), snapshot, snapshot),
+            new SecurityData(
+                "ISIN_B", new BigDecimal("0.5"), new BigDecimal("1.2"), snapshot, snapshot));
+    var allocations = List.of(allocation("ISIN_A", "1.0", CHECK_DATE));
+    var previousAllocations =
+        List.of(
+            allocation("ISIN_A", "0.5", PREVIOUS_DATE), allocation("ISIN_B", "0.5", PREVIOUS_DATE));
+    var positions =
+        List.of(
+            position("ISIN_A", CHECK_DATE, "600000"), position("ISIN_B", CHECK_DATE, "1200000"));
+
+    var result =
+        builder.blendTransitionWeights(
+            securities, allocations, previousAllocations, positions, TUK75);
+
+    var settled = result.stream().filter(s -> s.isin().equals("ISIN_A")).findFirst().orElseThrow();
+    assertThat(settled.modelWeight()).isEqualByComparingTo("0.5");
+    var exiting = result.stream().filter(s -> s.isin().equals("ISIN_B")).findFirst().orElseThrow();
+    assertThat(exiting.modelWeight()).isEqualByComparingTo("1.2");
+  }
+
+  @Test
   void blendTransitionWeightsBlendsBothAddedAndRemovedIsinsDuringAFullSwap() {
     var snapshot = new PriceSnapshot(BigDecimal.TEN, CHECK_DATE);
     var securities =

--- a/src/test/groovy/ee/tuleva/onboarding/investment/check/tracking/TdAttributionCalculatorTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/check/tracking/TdAttributionCalculatorTest.java
@@ -440,6 +440,80 @@ class TdAttributionCalculatorTest {
   }
 
   @Test
+  void residualToleranceScalesWithTheSquareRootOfThePeriodLength() {
+    var annual = new BigDecimal("0.00175");
+
+    var month = toleranceFor(30, annual);
+    var quarter = toleranceFor(91, annual);
+    var year = toleranceFor(365, annual);
+
+    // The band is a band on noise, and independent daily errors accumulate with the square root of
+    // time. That makes the scaling law falsifiable: an observed quarterly residual near sqrt(3)
+    // times the monthly one is noise, one near 3 times is a systematic leak and a missing
+    // component, which widening the band would hide rather than measure.
+    assertThat(year).isEqualByComparingTo(annual);
+    var quarterOverMonth = quarter.divide(month, 4, java.math.RoundingMode.HALF_UP).doubleValue();
+    assertThat(quarterOverMonth).isCloseTo(Math.sqrt(91.0 / 30.0), within(0.001));
+  }
+
+  @Test
+  void aResidualInsideTheScaledBandPasses() {
+    var input =
+        toleranceInput(buildConstantDays(30, "0.0005", "0.0005"), new BigDecimal("0.00175"));
+
+    var result = calculator.calculate(input);
+
+    assertThat(result.checks()).containsEntry("residualWithinTolerance", true);
+    assertThat(result.checks()).containsEntry("residualToleranceBps", new BigDecimal("5.02"));
+  }
+
+  @Test
+  void aResidualOutsideTheScaledBandFails() {
+    var input =
+        toleranceInput(buildConstantDays(30, "0.0015", "0.0005"), new BigDecimal("0.00175"));
+
+    var result = calculator.calculate(input);
+
+    assertThat(result.checks()).containsEntry("residualWithinTolerance", false);
+  }
+
+  @Test
+  void anUnconfiguredToleranceLeavesNoVerdictRatherThanAPass() {
+    var input = toleranceInput(buildConstantDays(30, "0.0015", "0.0005"), null);
+
+    var result = calculator.calculate(input);
+
+    // Storing true here would stamp "checked and within tolerance" on every period that predates
+    // the parameter - the backfill's first act - and read exactly like a measured pass.
+    assertThat(result.checks())
+        .doesNotContainKey("residualWithinTolerance")
+        .doesNotContainKey("residualToleranceBps");
+  }
+
+  private BigDecimal toleranceFor(int calendarDays, BigDecimal annual) {
+    return java.util.Objects.requireNonNull(
+        TdAttributionCalculator.scaledResidualTolerance(
+            toleranceInput(buildConstantDays(1, "0", "0"), annual, calendarDays)));
+  }
+
+  private TdAttributionInput toleranceInput(List<DailyRecord> days, BigDecimal annual) {
+    return toleranceInput(days, annual, 30);
+  }
+
+  private TdAttributionInput toleranceInput(
+      List<DailyRecord> days, BigDecimal annual, int calendarDays) {
+    return TdAttributionInput.builder()
+        .fund(TUK75)
+        .periodStart(PERIOD_START)
+        .periodEnd(PERIOD_END)
+        .periodType(MONTHLY)
+        .calendarDays(calendarDays)
+        .residualTolerance(annual)
+        .dailyRecords(days)
+        .build();
+  }
+
+  @Test
   void surfacesSeriesGapDaysInChecks() {
     var days = buildConstantDays(5, "0.0005", "0.0005");
     var input =

--- a/src/test/groovy/ee/tuleva/onboarding/investment/check/tracking/TdAttributionCalculatorTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/check/tracking/TdAttributionCalculatorTest.java
@@ -440,6 +440,34 @@ class TdAttributionCalculatorTest {
   }
 
   @Test
+  void aReturnAtOrBelowMinusOneHundredPercentFallsBackToACoefficientOfOne() {
+    // log1p is undefined at -100%, and a fund cannot lose more than everything. The guard keeps
+    // the linking finite rather than producing NaN and poisoning every component.
+    var days =
+        List.of(
+            dailyRecord(PERIOD_START, "-1.5", "0.001", "1000000", "10000", "0", List.of()),
+            dailyRecord(
+                PERIOD_START.plusDays(1), "0.001", "0.001", "1000000", "10000", "0", List.of()));
+    var input = inputWith(days, ZERO, ZERO);
+
+    var result = calculator.calculate(input);
+
+    assertThat(result.scalingFactor()).isNotNull();
+    assertThat(result.residual()).isNotNull();
+  }
+
+  @Test
+  void aPeriodWhoseDaysAllCancelStillLinksWithoutDividingByZero() {
+    var days = List.of(dailyRecord(PERIOD_START, "0.000", "0.000", "1000000", "0", "0", List.of()));
+    var input = inputWith(days, ZERO, ZERO);
+
+    var result = calculator.calculate(input);
+
+    assertThat(result.scalingFactor()).isEqualByComparingTo(BigDecimal.ONE);
+    assertThat(result.tdGeometric()).isEqualByComparingTo(ZERO);
+  }
+
+  @Test
   void residualToleranceScalesWithTheSquareRootOfThePeriodLength() {
     var annual = new BigDecimal("0.00175");
 

--- a/src/test/groovy/ee/tuleva/onboarding/investment/check/tracking/TrackingDifferenceJobTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/check/tracking/TrackingDifferenceJobTest.java
@@ -46,6 +46,23 @@ class TrackingDifferenceJobTest {
     then(notifier).should(never()).notify(anyList());
   }
 
+  // A run that covered only some funds is not a run that covered them all. Posting the partial
+  // result on its own reads as the whole picture, with the skipped funds simply absent.
+  @Test
+  void adHocPartialRunNamesTheFundsItCouldNotCheck() {
+    doThrow(
+            new TrackingDifferenceService.IncompletePriceDataException(
+                "Incomplete security price data:\nTUK75: IE00MISSING1", List.of()))
+        .when(service)
+        .runChecksForFunds(anyList());
+
+    job.onTrackingDifferenceCheckRequested(new RunTrackingDifferenceCheckRequested());
+
+    then(notifier)
+        .should()
+        .notifyRunIncomplete("TD check", "Incomplete security price data:\nTUK75: IE00MISSING1");
+  }
+
   @Test
   void adHocNotifiesPartialResultsOnIncompletePriceData() {
     var partialResults = List.<TrackingDifferenceResult>of();

--- a/src/test/groovy/ee/tuleva/onboarding/investment/check/tracking/TrackingDifferenceJobTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/check/tracking/TrackingDifferenceJobTest.java
@@ -4,6 +4,7 @@ import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
 
 import ee.tuleva.onboarding.investment.event.RunTrackingDifferenceBackfillRequested;
 import ee.tuleva.onboarding.investment.event.RunTrackingDifferenceCheckRequested;
@@ -33,13 +34,16 @@ class TrackingDifferenceJobTest {
     then(notifier).should().notify(results);
   }
 
+  // A check that threw did not run. Logging that and saying nothing leaves the last Slack
+  // message on the channel looking like the last successful check.
   @Test
-  void adHocSwallowsExceptions() {
+  void adHocFailureIsReportedRatherThanOnlyLogged() {
     doThrow(new RuntimeException("boom")).when(service).runChecksForFunds(anyList());
 
     job.onTrackingDifferenceCheckRequested(new RunTrackingDifferenceCheckRequested());
 
-    then(notifier).shouldHaveNoInteractions();
+    then(notifier).should().notifyRunFailed("TD check", "boom");
+    then(notifier).should(never()).notify(anyList());
   }
 
   @Test
@@ -68,12 +72,13 @@ class TrackingDifferenceJobTest {
   }
 
   @Test
-  void backfillSwallowsExceptions() {
+  void backfillFailureIsReportedRatherThanOnlyLogged() {
     doThrow(new RuntimeException("boom")).when(service).backfillChecks(7);
 
     job.onTrackingDifferenceBackfillRequested(new RunTrackingDifferenceBackfillRequested());
 
-    then(notifier).shouldHaveNoInteractions();
+    then(notifier).should().notifyRunFailed("TD backfill", "boom");
+    then(notifier).should(never()).notify(anyList());
   }
 
   @Test

--- a/src/test/groovy/ee/tuleva/onboarding/investment/check/tracking/TrackingDifferenceNotifierTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/check/tracking/TrackingDifferenceNotifierTest.java
@@ -805,6 +805,48 @@ class TrackingDifferenceNotifierTest {
         .build();
   }
 
+  @Test
+  void aBenchmarkCheckThatCoveredOnlyPartOfTheSleeveSaysSo() {
+    var result =
+        TrackingDifferenceResult.builder()
+            .fund(TUK75)
+            .checkDate(LocalDate.of(2026, 4, 3))
+            .checkType(BENCHMARK_MODEL)
+            .trackingDifference(new BigDecimal("0.0001"))
+            .fundReturn(new BigDecimal("0.0100"))
+            .benchmarkReturn(new BigDecimal("0.0099"))
+            .breach(false)
+            .securityAttributions(List.of())
+            .cashDrag(BigDecimal.ZERO)
+            .feeDrag(BigDecimal.ZERO)
+            .residual(BigDecimal.ZERO)
+            .benchmarkGapIsins(List.of("IE00NOPROXY"))
+            .benchmarkGapWeight(new BigDecimal("0.12"))
+            .build();
+
+    notifier.notify(List.of(result));
+
+    var captor = org.mockito.ArgumentCaptor.forClass(String.class);
+    then(notificationService).should().sendMessage(captor.capture(), eq(INVESTMENT));
+    // Every holding is supposed to have a proxy with data behind it, so a gap is a data error.
+    // Left unsaid, a check covering 88% of the sleeve reads as a clean all-clear over all of it.
+    assertThat(captor.getValue()).contains("12.00%").contains("IE00NOPROXY");
+  }
+
+  @Test
+  void anUncountableStreakWarningNamesTheFundItBelongsTo() {
+    var breaching = result(true, 2, new BigDecimal("0.003"));
+    var uncountable =
+        result(false, 0, BigDecimal.ZERO).toBuilder().escalationCountUnavailable(true).build();
+
+    notifier.notify(List.of(breaching, uncountable));
+
+    var captor = org.mockito.ArgumentCaptor.forClass(String.class);
+    then(notificationService).should().sendMessage(captor.capture(), eq(INVESTMENT));
+    assertThat(captor.getValue())
+        .contains("TUK75 MODEL_PORTFOLIO: the breach streak could not be counted");
+  }
+
   private TrackingDifferenceResult result(
       boolean breach, int consecutiveBreachDays, BigDecimal consecutiveNetTd) {
     return TrackingDifferenceResult.builder()

--- a/src/test/groovy/ee/tuleva/onboarding/investment/check/tracking/TrackingDifferenceNotifierTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/check/tracking/TrackingDifferenceNotifierTest.java
@@ -583,13 +583,31 @@ class TrackingDifferenceNotifierTest {
     given(calculator.escalationNetTdThreshold(any(LocalDate.class)))
         .willThrow(new IllegalStateException("No parameter"));
 
-    var result = result(true, 3, new BigDecimal("0.006"));
+    var result = result(true, 4, new BigDecimal("0.006"));
 
     notifier.notify(List.of(result));
 
     var captor = org.mockito.ArgumentCaptor.forClass(String.class);
     then(notificationService).should().sendMessage(captor.capture(), eq(INVESTMENT));
     assertThat(captor.getValue()).contains("TD ESCALATION");
+  }
+
+  // Sisekord nr 4 p 11.7 escalates only once the breach "püsib enam kui kolm (3) tööpäeva", so a
+  // three-day streak is still just a breach - the fallback must not escalate one day early either.
+  @Test
+  void escalationFallbackStreakLengthMatchesTheInternalRule() {
+    given(calculator.escalationThresholdDays(any(LocalDate.class)))
+        .willThrow(new IllegalStateException("No parameter"));
+    given(calculator.escalationNetTdThreshold(any(LocalDate.class)))
+        .willThrow(new IllegalStateException("No parameter"));
+
+    var result = result(true, 3, new BigDecimal("0.006"));
+
+    notifier.notify(List.of(result));
+
+    var captor = org.mockito.ArgumentCaptor.forClass(String.class);
+    then(notificationService).should().sendMessage(captor.capture(), eq(INVESTMENT));
+    assertThat(captor.getValue()).contains("TD BREACH DETECTED").doesNotContain("TD ESCALATION");
   }
 
   @Test
@@ -600,6 +618,20 @@ class TrackingDifferenceNotifierTest {
         .willThrow(new IllegalStateException("No parameter"));
 
     var result = result(true, 4, new BigDecimal("0.003"));
+
+    notifier.notify(List.of(result));
+
+    then(notificationService).should().sendMessage(contains("TD ESCALATION"), eq(INVESTMENT));
+  }
+
+  @Test
+  void escalationFallbackStillFiltersAStreakThatNetsOutBelowTheDailyThreshold() {
+    given(calculator.escalationThresholdDays(any(LocalDate.class)))
+        .willThrow(new IllegalStateException("No parameter"));
+    given(calculator.escalationNetTdThreshold(any(LocalDate.class)))
+        .willThrow(new IllegalStateException("No parameter"));
+
+    var result = result(true, 4, new BigDecimal("0.0002"));
 
     notifier.notify(List.of(result));
 

--- a/src/test/groovy/ee/tuleva/onboarding/investment/check/tracking/TrackingDifferenceNotifierTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/check/tracking/TrackingDifferenceNotifierTest.java
@@ -5,12 +5,15 @@ import static ee.tuleva.onboarding.investment.TrackingCheckType.BENCHMARK_MODEL;
 import static ee.tuleva.onboarding.investment.TrackingCheckType.MODEL_PORTFOLIO;
 import static ee.tuleva.onboarding.notification.OperationsNotificationService.Channel.INVESTMENT;
 import static ee.tuleva.onboarding.tulevafund.TulevaFund.TUK75;
+import static java.math.BigDecimal.ZERO;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
 
 import ee.tuleva.onboarding.notification.OperationsNotificationService;
 import ee.tuleva.onboarding.tulevafund.TulevaFund;
@@ -803,6 +806,106 @@ class TrackingDifferenceNotifierTest {
         .navResidual(BigDecimal.ZERO)
         .navResidualBreach(false)
         .build();
+  }
+
+  @Test
+  void aRunThatDidNotRunSaysNothingWasCheckedAtAll() {
+    notifier.notifyRunFailed("TD check", "connection reset");
+
+    var captor = org.mockito.ArgumentCaptor.forClass(String.class);
+    then(notificationService).should().sendMessage(captor.capture(), eq(INVESTMENT));
+    assertThat(captor.getValue())
+        .contains("TD check DID NOT RUN: connection reset")
+        .contains("Nothing was checked");
+  }
+
+  @Test
+  void aRunThatCoveredOnlySomeFundsNamesTheOnesItSkipped() {
+    notifier.notifyRunIncomplete("TD check", "Incomplete security price data:\nTUK75: IE00MISSING");
+
+    var captor = org.mockito.ArgumentCaptor.forClass(String.class);
+    then(notificationService).should().sendMessage(captor.capture(), eq(INVESTMENT));
+    assertThat(captor.getValue())
+        .contains("TD check RAN ONLY IN PART")
+        .contains("TUK75: IE00MISSING")
+        .contains("Those funds were skipped");
+  }
+
+  @Test
+  void anUnexplainedResidualReportsBothTheResidualAndTheBandItLeft() {
+    notifier.notifyResidualOutsideTolerance(
+        TUK75,
+        LocalDate.of(2026, 4, 1),
+        LocalDate.of(2026, 4, 30),
+        new BigDecimal("0.0012"),
+        new BigDecimal("0.0005"));
+
+    var captor = org.mockito.ArgumentCaptor.forClass(String.class);
+    then(notificationService).should().sendMessage(captor.capture(), eq(INVESTMENT));
+    assertThat(captor.getValue())
+        .contains("TUK75")
+        .contains("2026-04-01 to 2026-04-30")
+        .contains("Residual 12.00 bps, tolerance 5.00 bps");
+  }
+
+  @Test
+  void anUnexplainedResidualWithNoBandConfiguredSaysThereWasNone() {
+    notifier.notifyResidualOutsideTolerance(
+        TUK75, LocalDate.of(2026, 4, 1), LocalDate.of(2026, 4, 30), new BigDecimal("0.0012"), null);
+
+    then(notificationService).should().sendMessage(contains("tolerance none bps"), eq(INVESTMENT));
+  }
+
+  @Test
+  void aSlackFailureIsSwallowedRatherThanBreakingTheCaller() {
+    willThrow(new RuntimeException("slack down"))
+        .given(notificationService)
+        .sendMessage(any(), eq(INVESTMENT));
+
+    // The notifier is the last step of the check. Letting Slack take the run down with it would
+    // turn a delivery problem into an unchecked NAV.
+    assertThatCode(
+            () -> {
+              notifier.notifyRunFailed("TD check", "boom");
+              notifier.notifyRunIncomplete("TD check", "boom");
+              notifier.notifyCheckCouldNotRun(TUK75, LocalDate.of(2026, 4, 3));
+              notifier.notifyResidualOutsideTolerance(
+                  TUK75, LocalDate.of(2026, 4, 1), LocalDate.of(2026, 4, 30), ZERO, null);
+              notifier.notify(List.of(result(true, 1, new BigDecimal("0.002"))));
+            })
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void aBenchmarkGapWithNoWeightBehindItStillNamesTheHoldings() {
+    var result =
+        result(false, 0, ZERO).toBuilder()
+            .checkType(BENCHMARK_MODEL)
+            .benchmarkGapIsins(List.of("IE00NOPROXY"))
+            .benchmarkGapWeight(null)
+            .build();
+
+    notifier.notify(List.of(result));
+
+    then(notificationService)
+        .should()
+        .sendMessage(contains("Part of the sleeve has no benchmark proxy"), eq(INVESTMENT));
+  }
+
+  @Test
+  void aTruncatedStreakIsReportedAsALowerBoundOnTheBreachMessage() {
+    var result =
+        result(true, 10, new BigDecimal("0.006")).toBuilder()
+            .escalationCountTruncated(true)
+            .build();
+
+    notifier.notify(List.of(result));
+
+    var captor = org.mockito.ArgumentCaptor.forClass(String.class);
+    then(notificationService).should().sendMessage(captor.capture(), eq(INVESTMENT));
+    assertThat(captor.getValue())
+        .contains("TUK75 MODEL_PORTFOLIO: the streak fills the whole lookback window")
+        .contains("at least 10 days");
   }
 
   @Test

--- a/src/test/groovy/ee/tuleva/onboarding/investment/check/tracking/TrackingDifferenceNotifierTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/check/tracking/TrackingDifferenceNotifierTest.java
@@ -550,7 +550,15 @@ class TrackingDifferenceNotifierTest {
 
     notifier.notify(List.of(benchmarkResult));
 
-    then(notificationService).should().sendMessage(contains("within limits"), eq(INVESTMENT));
+    var captor = org.mockito.ArgumentCaptor.forClass(String.class);
+    then(notificationService).should().sendMessage(captor.capture(), eq(INVESTMENT));
+    // The ACWI benchmark is suppressed, so a breach on it must not raise a TD BREACH. But a run
+    // holding only benchmark results checked nothing anyone acts on, so it must not report
+    // "within limits" either - that is the same false all-clear as an empty run.
+    assertThat(captor.getValue())
+        .doesNotContain("TD BREACH DETECTED")
+        .doesNotContain("within limits")
+        .contains("produced no tracking difference results");
   }
 
   @Test

--- a/src/test/groovy/ee/tuleva/onboarding/investment/check/tracking/TrackingDifferenceServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/check/tracking/TrackingDifferenceServiceTest.java
@@ -92,7 +92,7 @@ class TrackingDifferenceServiceTest {
         .when(fundValueProvider.getLatestValue(anyString(), any(LocalDate.class)))
         .thenReturn(Optional.empty());
     lenient()
-        .when(fundNavQueryService.findNavPerUnit(anyString(), any(LocalDate.class)))
+        .when(fundNavQueryService.findLatestNavPerUnit(anyString(), any(LocalDate.class)))
         .thenReturn(Optional.empty());
     lenient()
         .when(fundNavQueryService.findLatestNavDateOnOrBefore(anyString(), any(LocalDate.class)))
@@ -258,9 +258,9 @@ class TrackingDifferenceServiceTest {
     // proving the no-double-count property holds with multiple holdings.
     skipOtherFunds(TUK75);
 
-    given(fundNavQueryService.findNavPerUnit(TUK75.getCode(), CHECK_DATE))
+    given(fundNavQueryService.findLatestNavPerUnit(TUK75.getCode(), CHECK_DATE))
         .willReturn(Optional.of(new BigDecimal("10.10")));
-    given(fundNavQueryService.findNavPerUnit(TUK75.getCode(), PREVIOUS_DATE))
+    given(fundNavQueryService.findLatestNavPerUnit(TUK75.getCode(), PREVIOUS_DATE))
         .willReturn(Optional.of(new BigDecimal("10.00")));
 
     var isinA = "IE00AAA";
@@ -396,9 +396,9 @@ class TrackingDifferenceServiceTest {
             .willReturn(Optional.empty());
       }
     }
-    given(fundNavQueryService.findNavPerUnit(TUK75.getCode(), monday))
+    given(fundNavQueryService.findLatestNavPerUnit(TUK75.getCode(), monday))
         .willReturn(Optional.of(new BigDecimal("10.02")));
-    given(fundNavQueryService.findNavPerUnit(TUK75.getCode(), friday))
+    given(fundNavQueryService.findLatestNavPerUnit(TUK75.getCode(), friday))
         .willReturn(Optional.of(new BigDecimal("10.00")));
 
     given(modelPortfolioAllocationRepository.findLatestByFundAsOf(TUK75, monday))
@@ -669,9 +669,9 @@ class TrackingDifferenceServiceTest {
             .thenReturn(Optional.empty());
       }
     }
-    given(fundNavQueryService.findNavPerUnit(TUK75.getCode(), monday))
+    given(fundNavQueryService.findLatestNavPerUnit(TUK75.getCode(), monday))
         .willReturn(Optional.of(new BigDecimal("10.10")));
-    given(fundNavQueryService.findNavPerUnit(TUK75.getCode(), friday))
+    given(fundNavQueryService.findLatestNavPerUnit(TUK75.getCode(), friday))
         .willReturn(Optional.of(new BigDecimal("10.00")));
 
     given(modelPortfolioAllocationRepository.findLatestByFundAsOf(TUK75, monday))
@@ -802,9 +802,9 @@ class TrackingDifferenceServiceTest {
   void benchmarkCheckForTuk00UsesComponentConfig() {
     skipOtherFunds(TulevaFund.TUK00);
 
-    given(fundNavQueryService.findNavPerUnit(TulevaFund.TUK00.getCode(), CHECK_DATE))
+    given(fundNavQueryService.findLatestNavPerUnit(TulevaFund.TUK00.getCode(), CHECK_DATE))
         .willReturn(Optional.of(new BigDecimal("10.10")));
-    given(fundNavQueryService.findNavPerUnit(TulevaFund.TUK00.getCode(), PREVIOUS_DATE))
+    given(fundNavQueryService.findLatestNavPerUnit(TulevaFund.TUK00.getCode(), PREVIOUS_DATE))
         .willReturn(Optional.of(new BigDecimal("10.00")));
 
     var allocation =
@@ -906,9 +906,9 @@ class TrackingDifferenceServiceTest {
   void calculatesBenchmarkModelForEquityFund() {
     skipOtherFunds(TUK75);
 
-    given(fundNavQueryService.findNavPerUnit(TUK75.getCode(), CHECK_DATE))
+    given(fundNavQueryService.findLatestNavPerUnit(TUK75.getCode(), CHECK_DATE))
         .willReturn(Optional.of(new BigDecimal("10.10")));
-    given(fundNavQueryService.findNavPerUnit(TUK75.getCode(), PREVIOUS_DATE))
+    given(fundNavQueryService.findLatestNavPerUnit(TUK75.getCode(), PREVIOUS_DATE))
         .willReturn(Optional.of(new BigDecimal("10.00")));
 
     var etfIsin = "IE00BFNM3G45";
@@ -993,9 +993,9 @@ class TrackingDifferenceServiceTest {
   void calculatesBenchmarkModelForBondFund() {
     skipOtherFunds(TUK00);
 
-    given(fundNavQueryService.findNavPerUnit(TUK00.getCode(), CHECK_DATE))
+    given(fundNavQueryService.findLatestNavPerUnit(TUK00.getCode(), CHECK_DATE))
         .willReturn(Optional.of(new BigDecimal("10.10")));
-    given(fundNavQueryService.findNavPerUnit(TUK00.getCode(), PREVIOUS_DATE))
+    given(fundNavQueryService.findLatestNavPerUnit(TUK00.getCode(), PREVIOUS_DATE))
         .willReturn(Optional.of(new BigDecimal("10.00")));
 
     var bondIsin = "LU0826455353";
@@ -1064,9 +1064,9 @@ class TrackingDifferenceServiceTest {
   void calculatesBenchmarkModelForEmMutualFund() {
     skipOtherFunds(TUK75);
 
-    given(fundNavQueryService.findNavPerUnit(TUK75.getCode(), CHECK_DATE))
+    given(fundNavQueryService.findLatestNavPerUnit(TUK75.getCode(), CHECK_DATE))
         .willReturn(Optional.of(new BigDecimal("10.10")));
-    given(fundNavQueryService.findNavPerUnit(TUK75.getCode(), PREVIOUS_DATE))
+    given(fundNavQueryService.findLatestNavPerUnit(TUK75.getCode(), PREVIOUS_DATE))
         .willReturn(Optional.of(new BigDecimal("10.00")));
 
     // EM mutual fund ISIN → should resolve to MSCI_EM
@@ -1136,9 +1136,9 @@ class TrackingDifferenceServiceTest {
   void benchmarkModelSkipsWhenBenchmarkDataMissing() {
     skipOtherFunds(TUK75);
 
-    given(fundNavQueryService.findNavPerUnit(TUK75.getCode(), CHECK_DATE))
+    given(fundNavQueryService.findLatestNavPerUnit(TUK75.getCode(), CHECK_DATE))
         .willReturn(Optional.of(new BigDecimal("10.10")));
-    given(fundNavQueryService.findNavPerUnit(TUK75.getCode(), PREVIOUS_DATE))
+    given(fundNavQueryService.findLatestNavPerUnit(TUK75.getCode(), PREVIOUS_DATE))
         .willReturn(Optional.of(new BigDecimal("10.00")));
 
     var etfIsin = "IE00BFNM3G45";
@@ -1201,9 +1201,9 @@ class TrackingDifferenceServiceTest {
   void runChecksForFundsOnlyChecksSpecifiedFunds() {
     given(fundNavQueryService.findLatestNavDateOnOrBefore(TUK75.getCode(), CHECK_DATE))
         .willReturn(Optional.of(CHECK_DATE));
-    given(fundNavQueryService.findNavPerUnit(TUK75.getCode(), CHECK_DATE))
+    given(fundNavQueryService.findLatestNavPerUnit(TUK75.getCode(), CHECK_DATE))
         .willReturn(Optional.of(new BigDecimal("10.10")));
-    given(fundNavQueryService.findNavPerUnit(TUK75.getCode(), PREVIOUS_DATE))
+    given(fundNavQueryService.findLatestNavPerUnit(TUK75.getCode(), PREVIOUS_DATE))
         .willReturn(Optional.of(new BigDecimal("10.00")));
 
     setupFundDataForFund(TUK75);
@@ -1218,9 +1218,9 @@ class TrackingDifferenceServiceTest {
   void calculatesBenchmarkModelForEmEtf() {
     skipOtherFunds(TUK75);
 
-    given(fundNavQueryService.findNavPerUnit(TUK75.getCode(), CHECK_DATE))
+    given(fundNavQueryService.findLatestNavPerUnit(TUK75.getCode(), CHECK_DATE))
         .willReturn(Optional.of(new BigDecimal("10.10")));
-    given(fundNavQueryService.findNavPerUnit(TUK75.getCode(), PREVIOUS_DATE))
+    given(fundNavQueryService.findLatestNavPerUnit(TUK75.getCode(), PREVIOUS_DATE))
         .willReturn(Optional.of(new BigDecimal("10.00")));
 
     // EM ETF ISIN → should resolve to EUNM.DE (IE00B4L5YC18.XETR)
@@ -1289,9 +1289,9 @@ class TrackingDifferenceServiceTest {
   void benchmarkModelSkipsUnknownIsinInEquityFund() {
     skipOtherFunds(TUK75);
 
-    given(fundNavQueryService.findNavPerUnit(TUK75.getCode(), CHECK_DATE))
+    given(fundNavQueryService.findLatestNavPerUnit(TUK75.getCode(), CHECK_DATE))
         .willReturn(Optional.of(new BigDecimal("10.10")));
-    given(fundNavQueryService.findNavPerUnit(TUK75.getCode(), PREVIOUS_DATE))
+    given(fundNavQueryService.findLatestNavPerUnit(TUK75.getCode(), PREVIOUS_DATE))
         .willReturn(Optional.of(new BigDecimal("10.00")));
 
     // Unknown ISIN not in instrument_reference → resolveBenchmarkKey returns null → skipped
@@ -1355,9 +1355,9 @@ class TrackingDifferenceServiceTest {
   void benchmarkModelSkipsUnknownBondIsin() {
     skipOtherFunds(TUK00);
 
-    given(fundNavQueryService.findNavPerUnit(TUK00.getCode(), CHECK_DATE))
+    given(fundNavQueryService.findLatestNavPerUnit(TUK00.getCode(), CHECK_DATE))
         .willReturn(Optional.of(new BigDecimal("10.10")));
-    given(fundNavQueryService.findNavPerUnit(TUK00.getCode(), PREVIOUS_DATE))
+    given(fundNavQueryService.findLatestNavPerUnit(TUK00.getCode(), PREVIOUS_DATE))
         .willReturn(Optional.of(new BigDecimal("10.00")));
 
     // Bond ISIN not in BOND_BENCHMARK_KEYS → skipped
@@ -1438,7 +1438,7 @@ class TrackingDifferenceServiceTest {
   @Test
   void skipsWhenNoNavData() {
     // Lenient default already returns Optional.empty() for findLatestNavDateOnOrBefore,
-    // so every fund is skipped before findNavPerUnit is even called.
+    // so every fund is skipped before findLatestNavPerUnit is even called.
     var results = service.runChecksAsOf(CHECK_DATE);
 
     assertThat(results).isEmpty();
@@ -1448,9 +1448,9 @@ class TrackingDifferenceServiceTest {
   void skipsWhenNoPreviousNavDate() {
     skipOtherFunds(TUK75);
 
-    given(fundNavQueryService.findNavPerUnit(TUK75.getCode(), CHECK_DATE))
+    given(fundNavQueryService.findLatestNavPerUnit(TUK75.getCode(), CHECK_DATE))
         .willReturn(Optional.of(new BigDecimal("10.10")));
-    given(fundNavQueryService.findNavPerUnit(TUK75.getCode(), PREVIOUS_DATE))
+    given(fundNavQueryService.findLatestNavPerUnit(TUK75.getCode(), PREVIOUS_DATE))
         .willReturn(Optional.empty());
 
     var results = service.runChecksAsOf(CHECK_DATE);
@@ -1932,9 +1932,9 @@ class TrackingDifferenceServiceTest {
   @Test
   void checkFundReturnsEmptyWhenYesterdayNavMissing() {
     skipOtherFunds(TUK75);
-    given(fundNavQueryService.findNavPerUnit(TUK75.getCode(), CHECK_DATE))
+    given(fundNavQueryService.findLatestNavPerUnit(TUK75.getCode(), CHECK_DATE))
         .willReturn(Optional.of(new BigDecimal("10.10")));
-    given(fundNavQueryService.findNavPerUnit(TUK75.getCode(), PREVIOUS_DATE))
+    given(fundNavQueryService.findLatestNavPerUnit(TUK75.getCode(), PREVIOUS_DATE))
         .willReturn(Optional.empty());
 
     var results = service.runChecksAsOf(CHECK_DATE);
@@ -1984,9 +1984,9 @@ class TrackingDifferenceServiceTest {
   @Test
   void checkFundReturnsEmptyWhenAllocationsEmpty() {
     skipOtherFunds(TUK75);
-    given(fundNavQueryService.findNavPerUnit(TUK75.getCode(), CHECK_DATE))
+    given(fundNavQueryService.findLatestNavPerUnit(TUK75.getCode(), CHECK_DATE))
         .willReturn(Optional.of(new BigDecimal("10.10")));
-    given(fundNavQueryService.findNavPerUnit(TUK75.getCode(), PREVIOUS_DATE))
+    given(fundNavQueryService.findLatestNavPerUnit(TUK75.getCode(), PREVIOUS_DATE))
         .willReturn(Optional.of(new BigDecimal("10.00")));
     given(modelPortfolioAllocationRepository.findLatestByFundAsOf(TUK75, CHECK_DATE))
         .willReturn(List.of());
@@ -2020,9 +2020,9 @@ class TrackingDifferenceServiceTest {
   void handlesZeroTotalNav() {
     skipOtherFunds(TUK75);
 
-    given(fundNavQueryService.findNavPerUnit(TUK75.getCode(), CHECK_DATE))
+    given(fundNavQueryService.findLatestNavPerUnit(TUK75.getCode(), CHECK_DATE))
         .willReturn(Optional.of(new BigDecimal("10.10")));
-    given(fundNavQueryService.findNavPerUnit(TUK75.getCode(), PREVIOUS_DATE))
+    given(fundNavQueryService.findLatestNavPerUnit(TUK75.getCode(), PREVIOUS_DATE))
         .willReturn(Optional.of(new BigDecimal("10.00")));
 
     var allocation =
@@ -2074,9 +2074,9 @@ class TrackingDifferenceServiceTest {
   void usesCutoffAdjustedPriceForSecurityReturn() {
     skipOtherFunds(TUK75);
 
-    given(fundNavQueryService.findNavPerUnit(TUK75.getCode(), CHECK_DATE))
+    given(fundNavQueryService.findLatestNavPerUnit(TUK75.getCode(), CHECK_DATE))
         .willReturn(Optional.of(new BigDecimal("10.10")));
-    given(fundNavQueryService.findNavPerUnit(TUK75.getCode(), PREVIOUS_DATE))
+    given(fundNavQueryService.findLatestNavPerUnit(TUK75.getCode(), PREVIOUS_DATE))
         .willReturn(Optional.of(new BigDecimal("10.00")));
 
     var allocation =
@@ -2129,9 +2129,9 @@ class TrackingDifferenceServiceTest {
   void throwsWhenSecurityPriceDataIncomplete() {
     skipOtherFunds(TUK75);
 
-    given(fundNavQueryService.findNavPerUnit(TUK75.getCode(), CHECK_DATE))
+    given(fundNavQueryService.findLatestNavPerUnit(TUK75.getCode(), CHECK_DATE))
         .willReturn(Optional.of(new BigDecimal("10.10")));
-    given(fundNavQueryService.findNavPerUnit(TUK75.getCode(), PREVIOUS_DATE))
+    given(fundNavQueryService.findLatestNavPerUnit(TUK75.getCode(), PREVIOUS_DATE))
         .willReturn(Optional.of(new BigDecimal("10.00")));
 
     var allocation1 =
@@ -2177,9 +2177,9 @@ class TrackingDifferenceServiceTest {
   private void setupFundData(TulevaFund fund) {
     skipOtherFunds(fund);
 
-    given(fundNavQueryService.findNavPerUnit(fund.getCode(), CHECK_DATE))
+    given(fundNavQueryService.findLatestNavPerUnit(fund.getCode(), CHECK_DATE))
         .willReturn(Optional.of(new BigDecimal("10.10")));
-    given(fundNavQueryService.findNavPerUnit(fund.getCode(), PREVIOUS_DATE))
+    given(fundNavQueryService.findLatestNavPerUnit(fund.getCode(), PREVIOUS_DATE))
         .willReturn(Optional.of(new BigDecimal("10.00")));
 
     var allocation =
@@ -2280,9 +2280,9 @@ class TrackingDifferenceServiceTest {
   private void setupTradeDayScenario() {
     skipOtherFunds(TUK75);
 
-    given(fundNavQueryService.findNavPerUnit(TUK75.getCode(), CHECK_DATE))
+    given(fundNavQueryService.findLatestNavPerUnit(TUK75.getCode(), CHECK_DATE))
         .willReturn(Optional.of(new BigDecimal("10.023")));
-    given(fundNavQueryService.findNavPerUnit(TUK75.getCode(), PREVIOUS_DATE))
+    given(fundNavQueryService.findLatestNavPerUnit(TUK75.getCode(), PREVIOUS_DATE))
         .willReturn(Optional.of(new BigDecimal("10.00")));
 
     var newIsin = "IE000NEW";
@@ -2447,9 +2447,9 @@ class TrackingDifferenceServiceTest {
   void blendsModelWeightsDuringInstrumentTransition() {
     skipOtherFunds(TUK75);
 
-    given(fundNavQueryService.findNavPerUnit(TUK75.getCode(), CHECK_DATE))
+    given(fundNavQueryService.findLatestNavPerUnit(TUK75.getCode(), CHECK_DATE))
         .willReturn(Optional.of(new BigDecimal("10.10")));
-    given(fundNavQueryService.findNavPerUnit(TUK75.getCode(), PREVIOUS_DATE))
+    given(fundNavQueryService.findLatestNavPerUnit(TUK75.getCode(), PREVIOUS_DATE))
         .willReturn(Optional.of(new BigDecimal("10.00")));
 
     var currentAllocation =
@@ -2541,9 +2541,9 @@ class TrackingDifferenceServiceTest {
   void doesNotThrowForInRunoffSecuritiesWithMissingPrices() {
     skipOtherFunds(TUK75);
 
-    given(fundNavQueryService.findNavPerUnit(TUK75.getCode(), CHECK_DATE))
+    given(fundNavQueryService.findLatestNavPerUnit(TUK75.getCode(), CHECK_DATE))
         .willReturn(Optional.of(new BigDecimal("10.10")));
-    given(fundNavQueryService.findNavPerUnit(TUK75.getCode(), PREVIOUS_DATE))
+    given(fundNavQueryService.findLatestNavPerUnit(TUK75.getCode(), PREVIOUS_DATE))
         .willReturn(Optional.of(new BigDecimal("10.00")));
 
     var currentAllocation =
@@ -2605,9 +2605,9 @@ class TrackingDifferenceServiceTest {
   void skipsBlendingWhenUnexpectedPositionHeld() {
     skipOtherFunds(TUK75);
 
-    given(fundNavQueryService.findNavPerUnit(TUK75.getCode(), CHECK_DATE))
+    given(fundNavQueryService.findLatestNavPerUnit(TUK75.getCode(), CHECK_DATE))
         .willReturn(Optional.of(new BigDecimal("10.10")));
-    given(fundNavQueryService.findNavPerUnit(TUK75.getCode(), PREVIOUS_DATE))
+    given(fundNavQueryService.findLatestNavPerUnit(TUK75.getCode(), PREVIOUS_DATE))
         .willReturn(Optional.of(new BigDecimal("10.00")));
 
     var currentAllocation =
@@ -2695,9 +2695,9 @@ class TrackingDifferenceServiceTest {
   void blendsOnlyTransitioningInstrumentsKeepsStableWeights() {
     skipOtherFunds(TUK75);
 
-    given(fundNavQueryService.findNavPerUnit(TUK75.getCode(), CHECK_DATE))
+    given(fundNavQueryService.findLatestNavPerUnit(TUK75.getCode(), CHECK_DATE))
         .willReturn(Optional.of(new BigDecimal("10.10")));
-    given(fundNavQueryService.findNavPerUnit(TUK75.getCode(), PREVIOUS_DATE))
+    given(fundNavQueryService.findLatestNavPerUnit(TUK75.getCode(), PREVIOUS_DATE))
         .willReturn(Optional.of(new BigDecimal("10.00")));
 
     var stableAlloc =
@@ -2818,9 +2818,9 @@ class TrackingDifferenceServiceTest {
   void stopsBlendingWhenOldInstrumentFullySold() {
     skipOtherFunds(TUK75);
 
-    given(fundNavQueryService.findNavPerUnit(TUK75.getCode(), CHECK_DATE))
+    given(fundNavQueryService.findLatestNavPerUnit(TUK75.getCode(), CHECK_DATE))
         .willReturn(Optional.of(new BigDecimal("10.10")));
-    given(fundNavQueryService.findNavPerUnit(TUK75.getCode(), PREVIOUS_DATE))
+    given(fundNavQueryService.findLatestNavPerUnit(TUK75.getCode(), PREVIOUS_DATE))
         .willReturn(Optional.of(new BigDecimal("10.00")));
 
     var currentAllocation =
@@ -2886,9 +2886,9 @@ class TrackingDifferenceServiceTest {
   void skipsBlendingWhenNoPreviousAllocations() {
     skipOtherFunds(TUK75);
 
-    given(fundNavQueryService.findNavPerUnit(TUK75.getCode(), CHECK_DATE))
+    given(fundNavQueryService.findLatestNavPerUnit(TUK75.getCode(), CHECK_DATE))
         .willReturn(Optional.of(new BigDecimal("10.10")));
-    given(fundNavQueryService.findNavPerUnit(TUK75.getCode(), PREVIOUS_DATE))
+    given(fundNavQueryService.findLatestNavPerUnit(TUK75.getCode(), PREVIOUS_DATE))
         .willReturn(Optional.of(new BigDecimal("10.00")));
 
     var allocation =
@@ -2944,9 +2944,9 @@ class TrackingDifferenceServiceTest {
   void skipsBlendingWhenRebalanceOnlyNoInstrumentChange() {
     skipOtherFunds(TUK75);
 
-    given(fundNavQueryService.findNavPerUnit(TUK75.getCode(), CHECK_DATE))
+    given(fundNavQueryService.findLatestNavPerUnit(TUK75.getCode(), CHECK_DATE))
         .willReturn(Optional.of(new BigDecimal("10.10")));
-    given(fundNavQueryService.findNavPerUnit(TUK75.getCode(), PREVIOUS_DATE))
+    given(fundNavQueryService.findLatestNavPerUnit(TUK75.getCode(), PREVIOUS_DATE))
         .willReturn(Optional.of(new BigDecimal("10.00")));
 
     var currentA =

--- a/src/test/groovy/ee/tuleva/onboarding/investment/check/tracking/TrackingDifferenceServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/check/tracking/TrackingDifferenceServiceTest.java
@@ -124,7 +124,8 @@ class TrackingDifferenceServiceTest {
         .thenReturn(new BigDecimal("0.005"));
     chargeEveryFeeToTheFund();
     var calculator = new TrackingDifferenceCalculator(parameterRepository);
-    var consecutiveBreachTracker = new ConsecutiveBreachTracker(eventRepository, calculator);
+    var consecutiveBreachTracker =
+        new ConsecutiveBreachTracker(eventRepository, calculator, publicHolidays);
     service =
         new TrackingDifferenceService(
             FIXED_CLOCK,
@@ -1473,8 +1474,8 @@ class TrackingDifferenceServiceTest {
   void consecutiveBreachCountingStopsAtNonBreach() {
     setupFundData(TUK75);
 
-    var breachEvent = breachEvent(LocalDate.of(2026, 4, 2), new BigDecimal("0.0020"));
-    var nonBreachEvent = nonBreachEvent(LocalDate.of(2026, 4, 1));
+    var breachEvent = breachEvent(LocalDate.of(2026, 4, 9), new BigDecimal("0.0020"));
+    var nonBreachEvent = nonBreachEvent(LocalDate.of(2026, 4, 8));
 
     given(eventRepository.findMostRecentEvents(TUK75, MODEL_PORTFOLIO, CHECK_DATE, 10))
         .willReturn(List.of(breachEvent, nonBreachEvent));
@@ -1494,8 +1495,8 @@ class TrackingDifferenceServiceTest {
     setupFundData(TUK75);
 
     // Prior day breached only on the NAV-correctness residual (fund-vs-model TD within limits).
-    var navResidualDay = navResidualBreachEvent(LocalDate.of(2026, 4, 2));
-    var nonBreachEvent = nonBreachEvent(LocalDate.of(2026, 4, 1));
+    var navResidualDay = navResidualBreachEvent(LocalDate.of(2026, 4, 9));
+    var nonBreachEvent = nonBreachEvent(LocalDate.of(2026, 4, 8));
 
     given(eventRepository.findMostRecentEvents(TUK75, MODEL_PORTFOLIO, CHECK_DATE, 10))
         .willReturn(List.of(navResidualDay, nonBreachEvent));
@@ -1513,8 +1514,8 @@ class TrackingDifferenceServiceTest {
   void consecutiveNetTdSumsOverBreachDays() {
     setupFundData(TUK75);
 
-    var breachEvent1 = breachEvent(LocalDate.of(2026, 4, 2), new BigDecimal("0.0020"));
-    var breachEvent2 = breachEvent(LocalDate.of(2026, 4, 1), new BigDecimal("0.0015"));
+    var breachEvent1 = breachEvent(LocalDate.of(2026, 4, 9), new BigDecimal("0.0020"));
+    var breachEvent2 = breachEvent(LocalDate.of(2026, 4, 8), new BigDecimal("0.0015"));
 
     given(eventRepository.findMostRecentEvents(TUK75, MODEL_PORTFOLIO, CHECK_DATE, 10))
         .willReturn(List.of(breachEvent1, breachEvent2));
@@ -1543,13 +1544,13 @@ class TrackingDifferenceServiceTest {
 
     var breach1 =
         breachEventWithAttribution(
-            LocalDate.of(2026, 4, 2),
+            LocalDate.of(2026, 4, 9),
             new BigDecimal("0.0020"),
             "IE00BFG1TM61",
             new BigDecimal("0.0015"));
     var breach2 =
         breachEventWithAttribution(
-            LocalDate.of(2026, 4, 1),
+            LocalDate.of(2026, 4, 8),
             new BigDecimal("0.0015"),
             "IE00BFG1TM61",
             new BigDecimal("0.0010"));
@@ -1611,7 +1612,7 @@ class TrackingDifferenceServiceTest {
     var eventWithMixedTypes =
         TrackingDifferenceEvent.builder()
             .fund(TUK75)
-            .checkDate(LocalDate.of(2026, 4, 2))
+            .checkDate(LocalDate.of(2026, 4, 9))
             .checkType(MODEL_PORTFOLIO)
             .trackingDifference(new BigDecimal("0.0020"))
             .fundReturn(new BigDecimal("0.01"))
@@ -1654,7 +1655,7 @@ class TrackingDifferenceServiceTest {
     var eventWithNullIsin =
         TrackingDifferenceEvent.builder()
             .fund(TUK75)
-            .checkDate(LocalDate.of(2026, 4, 2))
+            .checkDate(LocalDate.of(2026, 4, 9))
             .checkType(MODEL_PORTFOLIO)
             .trackingDifference(new BigDecimal("0.0020"))
             .fundReturn(new BigDecimal("0.01"))
@@ -1846,9 +1847,9 @@ class TrackingDifferenceServiceTest {
   void consecutiveBreachDaysResetsToZeroWhenTodayWithinToleranceDespitePriorStreak() {
     skipOtherFunds(TUK75);
 
-    given(fundNavQueryService.findNavPerUnit(TUK75.getCode(), CHECK_DATE))
+    given(fundNavQueryService.findLatestNavPerUnit(TUK75.getCode(), CHECK_DATE))
         .willReturn(Optional.of(new BigDecimal("10.10")));
-    given(fundNavQueryService.findNavPerUnit(TUK75.getCode(), PREVIOUS_DATE))
+    given(fundNavQueryService.findLatestNavPerUnit(TUK75.getCode(), PREVIOUS_DATE))
         .willReturn(Optional.of(new BigDecimal("10.00")));
 
     var allocation =
@@ -1949,7 +1950,7 @@ class TrackingDifferenceServiceTest {
     var zeroReturnBreach =
         TrackingDifferenceEvent.builder()
             .fund(TUK75)
-            .checkDate(LocalDate.of(2026, 4, 2))
+            .checkDate(LocalDate.of(2026, 4, 9))
             .checkType(MODEL_PORTFOLIO)
             .trackingDifference(new BigDecimal("0.0060"))
             .fundReturn(BigDecimal.ZERO)
@@ -2563,8 +2564,10 @@ class TrackingDifferenceServiceTest {
             .weight(new BigDecimal("1.00"))
             .effectiveDate(LocalDate.of(2026, 1, 1))
             .build();
+    // No transition here: this is about what an unpriced holding does to the sleeve total.
+    // A runoff holding that IS a transition leg carries model weight and stops the check.
     given(modelPortfolioAllocationRepository.findPreviousByFundAsOf(TUK75, CHECK_DATE))
-        .willReturn(List.of(previousAllocation));
+        .willReturn(List.of());
 
     var oldPosition =
         FundPosition.builder()
@@ -2590,8 +2593,6 @@ class TrackingDifferenceServiceTest {
         .willReturn(Optional.of(resolvedPrice("102.00")));
     given(positionPriceResolver.resolve(eq("IE00NEW"), eq(PREVIOUS_DATE), any(Instant.class)))
         .willReturn(Optional.of(resolvedPrice("100.00")));
-    given(positionPriceResolver.resolve(eq("IE00OLD"), any(LocalDate.class), any()))
-        .willReturn(Optional.empty());
 
     given(eventRepository.findMostRecentEvents(eq(TUK75), any(), eq(CHECK_DATE), eq(10)))
         .willReturn(List.of());
@@ -2795,7 +2796,10 @@ class TrackingDifferenceServiceTest {
             .filter(a -> a.isin().equals("IE00STABLE"))
             .findFirst()
             .orElseThrow();
-    assertThat(stableAttr.modelWeight()).isEqualByComparingTo(new BigDecimal("0.60"));
+    // The two transition legs take 0.204082 each, so the settled leg gives up exactly that
+    // much: 1 - 0.408164 = 0.591836. Before, it kept its full 0.60 and the model weighed
+    // 1.008164 - more than the whole fund.
+    assertThat(stableAttr.modelWeight()).isEqualByComparingTo(new BigDecimal("0.591836"));
 
     var newAttr =
         modelResult.get().securityAttributions().stream()

--- a/src/test/groovy/ee/tuleva/onboarding/investment/check/tracking/TrackingDifferenceServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/check/tracking/TrackingDifferenceServiceTest.java
@@ -2175,6 +2175,134 @@ class TrackingDifferenceServiceTest {
         .hasMessageContaining("IE00MISSING1");
   }
 
+  @Test
+  void throwsWhenAModelInstrumentHasAZeroAnchorPrice() {
+    skipOtherFunds(TUK75);
+
+    given(fundNavQueryService.findLatestNavPerUnit(TUK75.getCode(), CHECK_DATE))
+        .willReturn(Optional.of(new BigDecimal("10.10")));
+    given(fundNavQueryService.findLatestNavPerUnit(TUK75.getCode(), PREVIOUS_DATE))
+        .willReturn(Optional.of(new BigDecimal("10.00")));
+
+    var allocation1 =
+        ModelPortfolioAllocation.builder()
+            .fund(TUK75)
+            .isin("IE00B4L5Y983")
+            .weight(new BigDecimal("0.70"))
+            .effectiveDate(LocalDate.of(2026, 1, 1))
+            .build();
+    var allocation2 =
+        ModelPortfolioAllocation.builder()
+            .fund(TUK75)
+            .isin("IE00ZEROANCHOR")
+            .weight(new BigDecimal("0.30"))
+            .effectiveDate(LocalDate.of(2026, 1, 1))
+            .build();
+    given(modelPortfolioAllocationRepository.findLatestByFundAsOf(TUK75, CHECK_DATE))
+        .willReturn(List.of(allocation1, allocation2));
+
+    given(fundPositionRepository.findByNavDateAndFundAndAccountType(CHECK_DATE, TUK75, SECURITY))
+        .willReturn(List.of());
+    given(
+            fundPositionRepository.sumMarketValueByFundAndAccountTypes(
+                TUK75, CHECK_DATE, List.of(SECURITY, CASH, RECEIVABLES, LIABILITY)))
+        .willReturn(new BigDecimal("1000000"));
+    given(
+            fundPositionRepository.sumMarketValueByFundAndAccountTypes(
+                TUK75, CHECK_DATE, List.of(CASH)))
+        .willReturn(new BigDecimal("50000"));
+
+    given(positionPriceResolver.resolve(eq("IE00B4L5Y983"), eq(CHECK_DATE), any(Instant.class)))
+        .willReturn(Optional.of(resolvedPrice("102.00")));
+    given(positionPriceResolver.resolve(eq("IE00B4L5Y983"), eq(PREVIOUS_DATE), any(Instant.class)))
+        .willReturn(Optional.of(resolvedPrice("100.00")));
+    given(positionPriceResolver.resolve(eq("IE00ZEROANCHOR"), eq(CHECK_DATE), any(Instant.class)))
+        .willReturn(Optional.of(resolvedPrice("51.00")));
+    given(
+            positionPriceResolver.resolve(
+                eq("IE00ZEROANCHOR"), eq(PREVIOUS_DATE), any(Instant.class)))
+        .willReturn(Optional.of(resolvedPrice("0.00")));
+
+    // A zero anchor is not a price: nothing can be divided by it, so the calculator drops the
+    // instrument and its 30% model weight silently leaves the benchmark return with it.
+    assertThatThrownBy(() -> service.runChecksAsOf(CHECK_DATE))
+        .isInstanceOf(TrackingDifferenceService.IncompletePriceDataException.class)
+        .hasMessageContaining("IE00ZEROANCHOR");
+  }
+
+  @Test
+  void anIncomingTransitionLegTheFundHasNotBoughtYetNeedsNoPriceOfOurs() {
+    skipOtherFunds(TUK75);
+
+    given(fundNavQueryService.findLatestNavPerUnit(TUK75.getCode(), CHECK_DATE))
+        .willReturn(Optional.of(new BigDecimal("10.10")));
+    given(fundNavQueryService.findLatestNavPerUnit(TUK75.getCode(), PREVIOUS_DATE))
+        .willReturn(Optional.of(new BigDecimal("10.00")));
+
+    given(modelPortfolioAllocationRepository.findLatestByFundAsOf(TUK75, CHECK_DATE))
+        .willReturn(
+            List.of(
+                ModelPortfolioAllocation.builder()
+                    .fund(TUK75)
+                    .isin("IE00NEW")
+                    .weight(new BigDecimal("1.00"))
+                    .effectiveDate(LocalDate.of(2026, 4, 1))
+                    .build()));
+    given(modelPortfolioAllocationRepository.findPreviousByFundAsOf(TUK75, CHECK_DATE))
+        .willReturn(
+            List.of(
+                ModelPortfolioAllocation.builder()
+                    .fund(TUK75)
+                    .isin("IE00OLD")
+                    .weight(new BigDecimal("1.00"))
+                    .effectiveDate(LocalDate.of(2026, 1, 1))
+                    .build()));
+
+    // The model has adopted IE00NEW but the fund still holds only IE00OLD, so IE00NEW has no
+    // price of ours yet. Gating on the raw model would abandon the whole fund's check over an
+    // instrument that carries no weight in the portfolio.
+    given(fundPositionRepository.findByNavDateAndFundAndAccountType(CHECK_DATE, TUK75, SECURITY))
+        .willReturn(
+            List.of(
+                FundPosition.builder()
+                    .fund(TUK75)
+                    .navDate(CHECK_DATE)
+                    .accountType(SECURITY)
+                    .accountId("IE00OLD")
+                    .marketValue(new BigDecimal("500000"))
+                    .build()));
+    given(
+            fundPositionRepository.sumMarketValueByFundAndAccountTypes(
+                TUK75, CHECK_DATE, List.of(SECURITY, CASH, RECEIVABLES, LIABILITY)))
+        .willReturn(new BigDecimal("1000000"));
+    given(
+            fundPositionRepository.sumMarketValueByFundAndAccountTypes(
+                TUK75, CHECK_DATE, List.of(CASH)))
+        .willReturn(new BigDecimal("500000"));
+
+    given(positionPriceResolver.resolve(eq("IE00NEW"), any(LocalDate.class), any()))
+        .willReturn(Optional.empty());
+    given(positionPriceResolver.resolve(eq("IE00OLD"), eq(CHECK_DATE), any(Instant.class)))
+        .willReturn(Optional.of(resolvedPrice("51.00")));
+    given(positionPriceResolver.resolve(eq("IE00OLD"), eq(PREVIOUS_DATE), any(Instant.class)))
+        .willReturn(Optional.of(resolvedPrice("50.00")));
+
+    given(eventRepository.findMostRecentEvents(eq(TUK75), any(), eq(CHECK_DATE), eq(10)))
+        .willReturn(List.of());
+
+    var results = service.runChecksAsOf(CHECK_DATE);
+
+    var modelResult =
+        results.stream().filter(r -> r.checkType() == MODEL_PORTFOLIO).findFirst().orElseThrow();
+    var oldAttr =
+        modelResult.securityAttributions().stream()
+            .filter(a -> a.isin().equals("IE00OLD"))
+            .findFirst()
+            .orElseThrow();
+    assertThat(oldAttr.modelWeight()).isEqualByComparingTo(BigDecimal.ONE);
+    assertThat(oldAttr.actualWeight()).isEqualByComparingTo(BigDecimal.ONE);
+  }
+
   private void setupFundData(TulevaFund fund) {
     skipOtherFunds(fund);
 

--- a/src/test/groovy/ee/tuleva/onboarding/investment/check/tracking/TrackingDifferenceServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/check/tracking/TrackingDifferenceServiceTest.java
@@ -780,6 +780,21 @@ class TrackingDifferenceServiceTest {
   }
 
   @Test
+  void aZeroBenchmarkValueYesterdayProducesNoBenchmarkCheckRatherThanADivideByZero() {
+    setupFundData(TUK75);
+    given(fundValueProvider.getLatestValue("MSCI_ACWI", CHECK_DATE))
+        .willReturn(Optional.of(fundValue("1010.00")));
+    given(fundValueProvider.getLatestValue("MSCI_ACWI", PREVIOUS_DATE))
+        .willReturn(Optional.of(fundValue("0.00", PREVIOUS_DATE)));
+
+    var results = service.runChecksAsOf(CHECK_DATE);
+
+    // Same rule as a zero anchor price on a holding: nothing can be divided by it, so there is no
+    // benchmark return to report and the check must be absent rather than wrong.
+    assertThat(results).noneMatch(r -> r.checkType() == BENCHMARK);
+  }
+
+  @Test
   void benchmarkNonBreachSetsZeroCompoundedReturns() {
     setupFundData(TUK75);
 
@@ -2173,6 +2188,65 @@ class TrackingDifferenceServiceTest {
     assertThatThrownBy(() -> service.runChecksAsOf(CHECK_DATE))
         .isInstanceOf(TrackingDifferenceService.IncompletePriceDataException.class)
         .hasMessageContaining("IE00MISSING1");
+  }
+
+  @Test
+  void aPriceCarriedForwardFromAnEarlierDateIsWarnedAboutButDoesNotBlockTheCheck() {
+    skipOtherFunds(TUK75);
+
+    given(fundNavQueryService.findLatestNavPerUnit(TUK75.getCode(), CHECK_DATE))
+        .willReturn(Optional.of(new BigDecimal("10.10")));
+    given(fundNavQueryService.findLatestNavPerUnit(TUK75.getCode(), PREVIOUS_DATE))
+        .willReturn(Optional.of(new BigDecimal("10.00")));
+
+    given(modelPortfolioAllocationRepository.findLatestByFundAsOf(TUK75, CHECK_DATE))
+        .willReturn(
+            List.of(
+                ModelPortfolioAllocation.builder()
+                    .fund(TUK75)
+                    .isin("IE00STALE")
+                    .weight(new BigDecimal("1.00"))
+                    .effectiveDate(LocalDate.of(2026, 1, 1))
+                    .build()));
+    given(fundPositionRepository.findByNavDateAndFundAndAccountType(CHECK_DATE, TUK75, SECURITY))
+        .willReturn(
+            List.of(
+                FundPosition.builder()
+                    .fund(TUK75)
+                    .navDate(CHECK_DATE)
+                    .accountType(SECURITY)
+                    .accountId("IE00STALE")
+                    .marketValue(new BigDecimal("1000000"))
+                    .build()));
+    given(
+            fundPositionRepository.sumMarketValueByFundAndAccountTypes(
+                TUK75, CHECK_DATE, List.of(SECURITY, CASH, RECEIVABLES, LIABILITY)))
+        .willReturn(new BigDecimal("1000000"));
+    given(
+            fundPositionRepository.sumMarketValueByFundAndAccountTypes(
+                TUK75, CHECK_DATE, List.of(CASH)))
+        .willReturn(ZERO);
+
+    // A fund that did not deal on the check date has no price for it, so the provider carries the
+    // last one forward. That is the only available answer and it self-corrects when pricing
+    // resumes, so it is worth saying out loud but must not stop the check.
+    given(positionPriceResolver.resolve(eq("IE00STALE"), eq(CHECK_DATE), any(Instant.class)))
+        .willReturn(
+            Optional.of(
+                ResolvedPrice.builder()
+                    .usedPrice(new BigDecimal("102.00"))
+                    .validationStatus(ValidationStatus.OK)
+                    .priceDate(CHECK_DATE.minusDays(3))
+                    .build()));
+    given(positionPriceResolver.resolve(eq("IE00STALE"), eq(PREVIOUS_DATE), any(Instant.class)))
+        .willReturn(Optional.of(resolvedPrice("100.00")));
+
+    given(eventRepository.findMostRecentEvents(eq(TUK75), any(), eq(CHECK_DATE), eq(10)))
+        .willReturn(List.of());
+
+    var results = service.runChecksAsOf(CHECK_DATE);
+
+    assertThat(results).anyMatch(r -> r.checkType() == MODEL_PORTFOLIO);
   }
 
   @Test

--- a/src/test/groovy/ee/tuleva/onboarding/investment/config/EscalationParameterSeedTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/config/EscalationParameterSeedTest.java
@@ -1,0 +1,51 @@
+package ee.tuleva.onboarding.investment.config;
+
+import static ee.tuleva.onboarding.investment.config.InvestmentParameter.ESCALATION_LOOKBACK_DAYS;
+import static ee.tuleva.onboarding.investment.config.InvestmentParameter.ESCALATION_NET_TD_THRESHOLD;
+import static ee.tuleva.onboarding.investment.config.InvestmentParameter.ESCALATION_THRESHOLD_DAYS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+@DataJpaTest
+@Import(InvestmentParameterRepository.class)
+class EscalationParameterSeedTest {
+
+  private static final LocalDate AFTER_LATEST_SEED = LocalDate.of(2030, 1, 1);
+
+  @Autowired private InvestmentParameterRepository repository;
+
+  @Test
+  void escalationNetTdThresholdDoesNotSuppressAStreakThatBreachesDaily() {
+    BigDecimal netTdThreshold =
+        repository.findLatestValue(ESCALATION_NET_TD_THRESHOLD, AFTER_LATEST_SEED);
+
+    assertThat(netTdThreshold).isEqualByComparingTo(new BigDecimal("0.001"));
+  }
+
+  // Sisekord nr 4 p 11.7 escalates when the breach "püsib enam kui kolm (3) tööpäeva" - persists
+  // MORE THAN three working days - so the fourth consecutive breach day is the first that
+  // escalates, not the third.
+  @Test
+  void escalationStreakLengthMatchesTheInternalRule() {
+    BigDecimal thresholdDays =
+        repository.findLatestValue(ESCALATION_THRESHOLD_DAYS, AFTER_LATEST_SEED);
+
+    assertThat(thresholdDays).isEqualByComparingTo(new BigDecimal("4"));
+  }
+
+  @Test
+  void escalationLookbackCoversMoreDaysThanTheStreakItMustDetect() {
+    BigDecimal lookbackDays =
+        repository.findLatestValue(ESCALATION_LOOKBACK_DAYS, AFTER_LATEST_SEED);
+    BigDecimal thresholdDays =
+        repository.findLatestValue(ESCALATION_THRESHOLD_DAYS, AFTER_LATEST_SEED);
+
+    assertThat(lookbackDays).isGreaterThan(thresholdDays);
+  }
+}

--- a/src/test/groovy/ee/tuleva/onboarding/investment/config/InvestmentParameterRepositoryTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/config/InvestmentParameterRepositoryTest.java
@@ -96,6 +96,31 @@ class InvestmentParameterRepositoryTest {
         .hasMessageContaining("fund=TUK75");
   }
 
+  // The table has no unique constraint, so a re-seed can leave two rows on the same date. Without
+  // a tiebreaker the threshold a check runs against is whichever row the database happens to
+  // return first, and the same check can pass or breach on identical data.
+  @Test
+  void findLatestValue_globalScope_takesTheLastWrittenOfTwoRowsOnTheSameDate() {
+    insert(TRACKING_BREACH_THRESHOLD, null, new BigDecimal("0.01"), LocalDate.of(2025, 1, 1));
+    insert(TRACKING_BREACH_THRESHOLD, null, new BigDecimal("0.02"), LocalDate.of(2025, 1, 1));
+
+    BigDecimal value =
+        repository.findLatestValue(TRACKING_BREACH_THRESHOLD, LocalDate.of(2025, 6, 15));
+
+    assertThat(value).isEqualByComparingTo(new BigDecimal("0.02"));
+  }
+
+  @Test
+  void findLatestValue_fundScope_takesTheLastWrittenOfTwoRowsOnTheSameDate() {
+    insert(TRACKING_MAX_DAILY_RETURN, TUK75, new BigDecimal("0.5"), LocalDate.of(2025, 1, 1));
+    insert(TRACKING_MAX_DAILY_RETURN, TUK75, new BigDecimal("0.7"), LocalDate.of(2025, 1, 1));
+
+    BigDecimal value =
+        repository.findLatestValue(TRACKING_MAX_DAILY_RETURN, TUK75, LocalDate.of(2025, 6, 15));
+
+    assertThat(value).isEqualByComparingTo(new BigDecimal("0.7"));
+  }
+
   @Test
   void findLatestValue_throwsWhenNoRowMatches() {
     assertThatThrownBy(

--- a/src/test/groovy/ee/tuleva/onboarding/investment/epis/OwnFundNavProviderTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/epis/OwnFundNavProviderTest.java
@@ -3,7 +3,10 @@ package ee.tuleva.onboarding.investment.epis;
 import static ee.tuleva.onboarding.tulevafund.TulevaFund.TUV100;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 import ee.tuleva.onboarding.savings.FundNavQueryService;
 import java.math.BigDecimal;
@@ -87,10 +90,23 @@ class OwnFundNavProviderTest {
         .isInstanceOf(IllegalStateException.class);
   }
 
+  // What reaches the registrar has to be the NAV that was published, never a recalculation that
+  // is still sitting unpublished in nav_report.
+  @Test
+  void latestNav_neverServesAnUnpublishedCalculation() {
+    given(fundNavQueryService.findLatestNavDateOnOrBefore(TUV100.getCode(), AS_OF_DATE))
+        .willReturn(Optional.of(NAV_DATE));
+    given(fundNavQueryService.findPublishedNavPerUnit(TUV100.getCode(), NAV_DATE))
+        .willReturn(Optional.empty());
+
+    assertThat(provider.findLatestNav(TUV100, AS_OF_DATE)).isEmpty();
+    verify(fundNavQueryService, never()).findLatestNavPerUnit(any(), any());
+  }
+
   private void givenNav(BigDecimal nav) {
     given(fundNavQueryService.findLatestNavDateOnOrBefore(TUV100.getCode(), AS_OF_DATE))
         .willReturn(Optional.of(NAV_DATE));
-    given(fundNavQueryService.findNavPerUnit(TUV100.getCode(), NAV_DATE))
+    given(fundNavQueryService.findPublishedNavPerUnit(TUV100.getCode(), NAV_DATE))
         .willReturn(Optional.of(nav));
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/investment/epis/PevaRavaFlowServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/epis/PevaRavaFlowServiceTest.java
@@ -218,7 +218,7 @@ class PevaRavaFlowServiceTest {
   private void givenNav(TulevaFund fund, String nav) {
     given(fundNavQueryService.findLatestNavDateOnOrBefore(fund.getCode(), AS_OF_DATE))
         .willReturn(Optional.of(NAV_DATE));
-    given(fundNavQueryService.findNavPerUnit(fund.getCode(), NAV_DATE))
+    given(fundNavQueryService.findPublishedNavPerUnit(fund.getCode(), NAV_DATE))
         .willReturn(Optional.of(new BigDecimal(nav)));
   }
 

--- a/src/test/groovy/ee/tuleva/onboarding/investment/epis/R16FlowCalculationServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/epis/R16FlowCalculationServiceTest.java
@@ -109,7 +109,7 @@ class R16FlowCalculationServiceTest {
   private void givenNav(String nav) {
     given(fundNavQueryService.findLatestNavDateOnOrBefore(TUK75.getCode(), AS_OF_DATE))
         .willReturn(Optional.of(NAV_DATE));
-    given(fundNavQueryService.findNavPerUnit(TUK75.getCode(), NAV_DATE))
+    given(fundNavQueryService.findPublishedNavPerUnit(TUK75.getCode(), NAV_DATE))
         .willReturn(Optional.of(new BigDecimal(nav)));
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/investment/epis/R45ReportServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/epis/R45ReportServiceTest.java
@@ -206,7 +206,7 @@ class R45ReportServiceTest {
     givenStoredReport(csv);
     given(fundNavQueryService.findLatestNavDateOnOrBefore(TUK00.getCode(), TODAY))
         .willReturn(Optional.of(LocalDate.of(2026, 8, 13)));
-    given(fundNavQueryService.findNavPerUnit(TUK00.getCode(), LocalDate.of(2026, 8, 13)))
+    given(fundNavQueryService.findPublishedNavPerUnit(TUK00.getCode(), LocalDate.of(2026, 8, 13)))
         .willReturn(Optional.of(new BigDecimal("0.65")));
 
     Map<TulevaFund, R45Result> results = service.processAndStore(REPORT_ID);

--- a/src/test/groovy/ee/tuleva/onboarding/savings/FundNavQueryServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/FundNavQueryServiceTest.java
@@ -24,29 +24,31 @@ class FundNavQueryServiceTest {
   private static final LocalDate NAV_DATE = LocalDate.of(2026, 5, 7);
 
   @Test
-  void findNavPerUnit_returnsMarketPriceFromNavRow() {
-    var navRow =
-        NavReportRow.builder()
-            .fundCode("TUK00")
-            .navDate(NAV_DATE)
-            .accountType("NAV")
-            .accountName("Net Asset Value")
-            .marketPrice(new BigDecimal("0.60985"))
-            .build();
-    given(navReportRepository.findFirstByFundCodeAndNavDateAndAccountType("TUK00", NAV_DATE, "NAV"))
-        .willReturn(Optional.of(navRow));
+  void findPublishedNavPerUnit_returnsTheOfficialNavPerUnit() {
+    given(navReportRepository.findPublishedNavPerUnit(NAV_DATE, "TUK00", "NAV"))
+        .willReturn(Optional.of(new BigDecimal("0.60985")));
 
-    var result = service.findNavPerUnit("TUK00", NAV_DATE);
+    var result = service.findPublishedNavPerUnit("TUK00", NAV_DATE);
 
     assertThat(result).hasValue(new BigDecimal("0.60985"));
   }
 
   @Test
-  void findNavPerUnit_returnsEmptyWhenNoRow() {
-    given(navReportRepository.findFirstByFundCodeAndNavDateAndAccountType("TUK00", NAV_DATE, "NAV"))
+  void findPublishedNavPerUnit_returnsEmptyWhenNothingIsPublished() {
+    given(navReportRepository.findPublishedNavPerUnit(NAV_DATE, "TUK00", "NAV"))
         .willReturn(Optional.empty());
 
-    assertThat(service.findNavPerUnit("TUK00", NAV_DATE)).isEmpty();
+    assertThat(service.findPublishedNavPerUnit("TUK00", NAV_DATE)).isEmpty();
+  }
+
+  @Test
+  void findLatestNavPerUnit_readsTheNewestCalculationPublishedOrNot() {
+    given(navReportRepository.findLatestNavPerUnit(NAV_DATE, "TUK00", "NAV"))
+        .willReturn(Optional.of(new BigDecimal("0.61000")));
+
+    var result = service.findLatestNavPerUnit("TUK00", NAV_DATE);
+
+    assertThat(result).hasValue(new BigDecimal("0.61000"));
   }
 
   @Test

--- a/src/test/groovy/ee/tuleva/onboarding/savings/FundNavQueryServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/FundNavQueryServiceTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 
 import ee.tuleva.onboarding.savings.fund.nav.NavReportRepository;
-import ee.tuleva.onboarding.savings.fund.nav.NavReportRow;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.Optional;

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/nav/NavNotifierTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/nav/NavNotifierTest.java
@@ -137,7 +137,7 @@ class NavNotifierTest {
   void notify_rendersDayChangeAndTrackingDifferenceFromServices() {
     var result = aNavCalculationResult();
     var previousNavDate = publicHolidays.previousWorkingDay(result.positionReportDate());
-    given(fundNavQueryService.findNavPerUnit("TKF100", previousNavDate))
+    given(fundNavQueryService.findPublishedNavPerUnit("TKF100", previousNavDate))
         .willReturn(Optional.of(new BigDecimal("9.8000")));
     given(
             trackingDifferenceQueryService.findLatestModelPortfolio(
@@ -164,7 +164,7 @@ class NavNotifierTest {
   @Test
   void notify_stillSendsBaseMessageWhenEnrichmentLookupFails() {
     var result = aNavCalculationResult();
-    given(fundNavQueryService.findNavPerUnit(any(), any()))
+    given(fundNavQueryService.findPublishedNavPerUnit(any(), any()))
         .willThrow(new RuntimeException("nav_report read failed"));
 
     navNotifier.notify(result);

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/nav/NavReportRepositoryTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/nav/NavReportRepositoryTest.java
@@ -1,9 +1,12 @@
 package ee.tuleva.onboarding.savings.fund.nav;
 
 import static ee.tuleva.onboarding.currency.Currency.EUR;
+import static org.assertj.core.api.Assertions.as;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.BIG_DECIMAL;
 
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
@@ -213,5 +216,70 @@ class NavReportRepositoryTest {
     navReportRepository.markAsPublished(calcId);
 
     assertThat(navReportRepository.existsPublishedByNavDateAndFundCode(navDate, "TKF100")).isTrue();
+  }
+
+  @Test
+  void findPublishedNavPerUnit_ignoresANewerUnpublishedCalculation() {
+    var navDate = LocalDate.of(2026, 8, 27);
+    var publishedCalculation = UUID.randomUUID();
+    navReportRepository.save(navRow(navDate, publishedCalculation, "1.40660000", null));
+    navReportRepository.markAsPublished(publishedCalculation);
+
+    navReportRepository.save(navRow(navDate, UUID.randomUUID(), "1.50000000", null));
+
+    assertThat(navReportRepository.findPublishedNavPerUnit(navDate, "TKF100", "NAV"))
+        .get(as(BIG_DECIMAL))
+        .isEqualByComparingTo("1.4066");
+  }
+
+  @Test
+  void findPublishedNavPerUnit_picksTheMostRecentlyPublishedNotTheHighestId() {
+    var navDate = LocalDate.of(2026, 8, 27);
+    // A backdated recalculation is saved first and published last, so id order and publication
+    // order disagree. The NAV that actually went out is the one published last.
+    navReportRepository.save(
+        navRow(navDate, UUID.randomUUID(), "1.40660000", Instant.parse("2026-08-28T12:00:00Z")));
+    navReportRepository.save(
+        navRow(navDate, UUID.randomUUID(), "1.39000000", Instant.parse("2026-08-28T09:00:00Z")));
+
+    assertThat(navReportRepository.findPublishedNavPerUnit(navDate, "TKF100", "NAV"))
+        .get(as(BIG_DECIMAL))
+        .isEqualByComparingTo("1.4066");
+  }
+
+  @Test
+  void findPublishedNavPerUnit_returnsEmptyWhenNothingIsPublishedYet() {
+    var navDate = LocalDate.of(2026, 8, 27);
+    navReportRepository.save(navRow(navDate, UUID.randomUUID(), "1.40660000", null));
+
+    assertThat(navReportRepository.findPublishedNavPerUnit(navDate, "TKF100", "NAV")).isEmpty();
+  }
+
+  @Test
+  void findLatestNavPerUnit_readsTheCalculationBeingGatedBeforeItIsPublished() {
+    var navDate = LocalDate.of(2026, 8, 27);
+    var publishedCalculation = UUID.randomUUID();
+    navReportRepository.save(navRow(navDate, publishedCalculation, "1.40660000", null));
+    navReportRepository.markAsPublished(publishedCalculation);
+
+    navReportRepository.save(navRow(navDate, UUID.randomUUID(), "1.50000000", null));
+
+    assertThat(navReportRepository.findLatestNavPerUnit(navDate, "TKF100", "NAV"))
+        .get(as(BIG_DECIMAL))
+        .isEqualByComparingTo("1.5000");
+  }
+
+  private static NavReportRow navRow(
+      LocalDate navDate, UUID calculationId, String navPerUnit, Instant publishedAt) {
+    return NavReportRow.builder()
+        .navDate(navDate)
+        .fundCode("TKF100")
+        .accountType("NAV")
+        .accountName("Net Asset Value")
+        .marketPrice(new BigDecimal(navPerUnit))
+        .marketValue(new BigDecimal("1000000.00"))
+        .calculationId(calculationId)
+        .publishedAt(publishedAt)
+        .build();
   }
 }


### PR DESCRIPTION
Seven fixes to the tracking-difference check, so the daily number can be trusted
without the Google Sheet standing behind it.

Applied onto current master rather than merged from the original branches: master
refactored this package into eight new classes, and where a method moved a merge
takes the fix into the old file, master's deletion wins, and the unfixed copy
survives in the new class. That failure is silent, so the fixes were re-applied
one at a time and each one re-verified here.

### What was wrong

**The escalation never fired the day the sisekord says it should.** Sisekord nr 4
p 11.7 escalates once a breach "püsib enam kui kolm (3) tööpäeva" — the fourth
consecutive day. The threshold is now seeded (V1_252, V1_253) rather than
implied, and `EscalationParameterSeedTest` pins it to the rule.

**The streak was counted over whatever rows existed**, so a day the check did not
run closed no gap: three breaches with a hole in the middle counted as three in a
row. The count now walks contiguous working days and stops at the first gap. When
it cannot be counted at all, when it fills the whole lookback window (so the
number is a lower bound), or when escalation was decided on built-in fallbacks
because the parameters are unseeded, the Slack message says so instead of
implying a measured answer.

**The check reported an all-clear it had not earned.** A run holding only the
suppressed ACWI benchmark, or nothing at all, sent "within limits". It now says
that nothing actionable was checked.

**The model did not weigh 1 through a transition.** Blending an entering or
exiting leg to what the fund actually holds left the model summing to something
other than 1, and every remaining weight deviation was measured against that
wrong base. The settled legs are now rescaled so the model still sums to 1.
Membership is decided by positive weight, not by an ISIN appearing in the table,
so a leg parked at 0% during a switch is treated as transitioning rather than as
a real underweight.

**The completeness gate ran before blending**, and priced the model rather than
the holdings, so an instrument the fund holds but the model has not yet adopted
could pass unpriced. The gate now reads the blended set, and a zero previous
price is refused as an anchor instead of dividing by it.

**BENCHMARK_MODEL reported a number that quietly measured less than the fund** —
a holding with no proxy, or a proxy with no data, was skipped without trace. It
now carries the ISINs and the sleeve weight it could not cover.

**A failed TD run said nothing.** The last message on the channel therefore
described a state that was no longer being checked. Both the check and the
backfill now report a run that did not run.

**`investment_parameter` lookups were non-deterministic** — two rows sharing an
effective date returned in whatever order the database chose. Ordered by id as
the tiebreak. The tests pass on H2 without the fix by accident, so they were
verified by mutation: reversing the order fails both.

**The NAV per unit came from a recalculation**, which could differ from what was
actually published. It now serves the published number.

### The period

The period rebuilt every model weight from today's allocation table, so a
retroactive correction there silently rewrote a month that had already been
measured, and the transition blending lived in two places that could disagree.
The period now reads the weights off the daily event it is made of. An event
written before the daily check stored them is left out of the detail rather than
read as a model that never held the instrument.

The residual is a plug, so "the components sum to the TD" can never fail. What
can fail is the plug being large. `TD_RESIDUAL_TOLERANCE_ANNUAL` (V1_254) sets an
annual band scaled by `sqrt(days/365)`: independent daily errors accumulate as
the square root of time, a systematic leak grows linearly, so a quarter that
lands near `sqrt(3)` times a month is noise and one near 3x is a missing
component. That makes the calibration falsifiable rather than a chosen number.
Outside the band the attribution alerts and says the components cannot be relied
on while the gap is unexplained.

### What reviewing the port back found

Reading the fixes above against the code they describe turned up **seven of them
with no test at all** — hand-applying a fix during a port loses its test unless you
notice, and green said nothing about any of these. Each is now pinned by a test
verified the only way that means anything: reverting the fix and watching it fail.

Two of those are worth naming. **An instrument parked at 0% is the normal shape of a
switch**, not an edge case: the pipeline leaves the exiting instrument in the table at
0% until it is liquidated, so membership read by ISIN presence finds nothing added and
nothing removed, no blending runs at all, and a holding that is still most of the fund
is measured against a model weight of zero. And **the residual band's test pins the
scaling law, not the arithmetic** — asserting the formula back would only prove it was
typed twice; asserting that a quarter's band is `sqrt(3)` times a month's is the
property the calibration rests on.

Two defects surfaced, both the same shape as what this PR set out to fix:

**An unconfigured tolerance stored "within tolerance = true".** Written as true-unless-
proven-false, so every period predating the parameter — which is exactly what the
backfill computes first — carried a measured pass. There is no verdict to give without
a band, so the key is now absent. `residualBps` is stored either way, so the
calibration still has its numbers.

**A run that covered only some funds said nothing about the rest.** The partial result
was posted alone, which reads as the whole picture with the skipped funds simply not
breaching. It now names them first. The streak warnings had the same flaw in miniature
and now carry the fund and check type they belong to.

**Two things checked and deliberately left alone:** the check reads yesterday's NAV as
the newest calculation rather than the published one, and a fund with no NAV data is
skipped with only a log line. Neither is a silent failure — there is no tracking
difference to calculate without a NAV, so skipping is the correct outcome.

### Coverage

The package was at **87.4% branch** with nothing enforcing it, and the gaps were not
incidental: the three Slack messages reporting a failed run, a partial run and an
unexplained residual had **never been executed by any test**, because every caller
mocks the notifier. Their wording, their bps conversion, and the catch that stops a
Slack outage taking the run down with it were all unverified.

Now **90.3% branch, 99.0% line, 98.8% instruction, 98.3% method, 100% class**, with a
`jacocoTestCoverageVerification` rule at those numbers alongside the existing aml and
deadline rules, so it can only ratchet up. The rule was checked by raising the branch
floor to 95% and watching the build fail, not by trusting a passing run.

### Verification

Full suite green on H2, including the coverage gate. Migrations V1_252-V1_254 sit above
master's V1_251.

Two fixes from the original branches were dropped as redundant: master implemented
`nonSecurityDrag` and `seriesGapDays` independently.

### After deploy

Run the TD attribution backfill (`POST /admin/td-attribution-backfill`, needs
`X-Admin-Token`): every stored daily attribution predates the weights change and was
struck at the custodian's stale prices, and the period detail now reads those stored
weights. Check prod first for pre-existing `TD_RESIDUAL_TOLERANCE_ANNUAL` and
`ESCALATION_*` rows — the lookup is deterministic now, but a duplicate row still beats
what the migration writes.

The sunset itself is **not** gated on this PR. Nothing has ever been reconciled against
the sheet, and every "the components add up" check is an identity because the residual
is the plug. Run both for a couple of weeks and compare the daily TD per fund. Plan doc:
[tuleva#444](https://github.com/TulevaEE/tuleva/pull/444).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
