### PR TITLE
Revise a published NAV when the custodian re-issues a position report

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/investment/position/FundPositionImportJob.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/position/FundPositionImportJob.java
@@ -21,6 +21,7 @@ import ee.tuleva.onboarding.investment.report.InvestmentReport;
 import ee.tuleva.onboarding.investment.report.InvestmentReportService;
 import ee.tuleva.onboarding.investment.report.ReportProvider;
 import ee.tuleva.onboarding.pipeline.PipelineTracker;
+import ee.tuleva.onboarding.savings.fund.nav.NavPositionsUpdated;
 import ee.tuleva.onboarding.tulevafund.TulevaFund;
 import java.time.Clock;
 import java.time.LocalDate;
@@ -149,13 +150,13 @@ public class FundPositionImportJob {
     Optional<InvestmentReport> report = reportService.getReport(provider, POSITIONS, date);
     if (report.isEmpty()) {
       log.info("No positions report in database: provider={}, date={}", provider, date);
-      return new ImportResult(0, 0);
+      return ImportResult.none();
     }
 
     FundPositionParser parser = parsers.get(provider);
     if (parser == null) {
       log.warn("No parser configured for provider: provider={}", provider);
-      return new ImportResult(0, 0);
+      return ImportResult.none();
     }
 
     InvestmentReport investmentReport = report.get();
@@ -173,7 +174,7 @@ public class FundPositionImportJob {
       healthCheckFailureDetail = "Import blocked: provider=%s, date=%s".formatted(provider, date);
       notifyHealth(provider, date, healthResults);
       log.error("Health check failed, import blocked: provider={}, date={}", provider, date);
-      return new ImportResult(0, 0);
+      return ImportResult.none();
     }
 
     ImportResult result = importService.upsertPositions(positions);
@@ -199,9 +200,14 @@ public class FundPositionImportJob {
 
     navFunds.forEach(fund -> fundPositionLedgerService.recordPositionsToLedger(fund, date));
 
-    if (result.updated() > 0) {
-      navFunds.forEach(fund -> fundPositionLedgerService.rerecordPositionsFromDate(fund, date));
-    }
+    result.changedRowsByFund().entrySet().stream()
+        .filter(entry -> entry.getKey().hasNavCalculation())
+        .forEach(
+            entry -> {
+              fundPositionLedgerService.rerecordPositionsFromDate(entry.getKey(), date);
+              eventPublisher.publishEvent(
+                  new NavPositionsUpdated(entry.getKey(), date, entry.getValue()));
+            });
 
     return result;
   }

--- a/src/main/java/ee/tuleva/onboarding/investment/position/FundPositionImportService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/position/FundPositionImportService.java
@@ -1,9 +1,17 @@
 package ee.tuleva.onboarding.investment.position;
 
+import static java.util.stream.Collectors.collectingAndThen;
+import static java.util.stream.Collectors.counting;
+import static java.util.stream.Collectors.groupingBy;
+
+import ee.tuleva.onboarding.tulevafund.TulevaFund;
 import java.math.BigDecimal;
 import java.time.Clock;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.Nullable;
@@ -47,8 +55,8 @@ public class FundPositionImportService {
 
   @Transactional
   public ImportResult upsertPositions(List<FundPosition> positions) {
-    int imported = 0;
-    int updated = 0;
+    List<FundPosition> importedPositions = new ArrayList<>();
+    List<FundPosition> updatedPositions = new ArrayList<>();
 
     for (FundPosition position : positions) {
       Optional<FundPosition> existing =
@@ -60,22 +68,24 @@ public class FundPositionImportService {
 
       if (existing.isPresent()) {
         if (updateIfChanged(existing.get(), position)) {
-          updated++;
+          updatedPositions.add(existing.get());
         }
       } else {
         repository.save(position);
-        imported++;
+        importedPositions.add(position);
       }
     }
 
+    ImportResult result =
+        new ImportResult(List.copyOf(importedPositions), List.copyOf(updatedPositions));
     log.info(
         "Upsert completed: total={}, imported={}, updated={}, unchanged={}",
         positions.size(),
-        imported,
-        updated,
-        positions.size() - imported - updated);
+        result.imported(),
+        result.updated(),
+        positions.size() - result.changed());
 
-    return new ImportResult(imported, updated);
+    return result;
   }
 
   private boolean updateIfChanged(FundPosition existing, FundPosition incoming) {
@@ -99,5 +109,29 @@ public class FundPositionImportService {
     return a.compareTo(b) == 0;
   }
 
-  public record ImportResult(int imported, int updated) {}
+  public record ImportResult(
+      List<FundPosition> importedPositions, List<FundPosition> updatedPositions) {
+
+    public static ImportResult none() {
+      return new ImportResult(List.of(), List.of());
+    }
+
+    public int imported() {
+      return importedPositions.size();
+    }
+
+    public int updated() {
+      return updatedPositions.size();
+    }
+
+    public int changed() {
+      return imported() + updated();
+    }
+
+    public Map<TulevaFund, Integer> changedRowsByFund() {
+      return Stream.concat(importedPositions.stream(), updatedPositions.stream())
+          .collect(
+              groupingBy(FundPosition::getFund, collectingAndThen(counting(), Long::intValue)));
+    }
+  }
 }

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/nav/NavPositionsUpdated.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/nav/NavPositionsUpdated.java
@@ -1,0 +1,6 @@
+package ee.tuleva.onboarding.savings.fund.nav;
+
+import ee.tuleva.onboarding.tulevafund.TulevaFund;
+import java.time.LocalDate;
+
+public record NavPositionsUpdated(TulevaFund fund, LocalDate navDate, int changedRows) {}

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/nav/NavPublisher.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/nav/NavPublisher.java
@@ -53,6 +53,28 @@ public class NavPublisher {
         result.aum());
   }
 
+  void publishRevision(NavCalculationResult result, NavRevision revision) {
+    UUID calculationId = UUID.randomUUID();
+    List<NavReportRow> reportRows = persistReportRows(result, calculationId);
+
+    if (reportRows.isEmpty()) {
+      throw new IllegalStateException(
+          "NAV revision rows not persisted: fund=%s, date=%s"
+              .formatted(result.fund().getCode(), result.positionReportDate()));
+    }
+
+    String reason = revision.describe(result);
+    routeToInternalReview(
+        result, reportRows, calculationId, reason, revisionActionMessage(result, reason));
+
+    log.info(
+        "Published NAV revision: fund={}, date={}, navPerUnit={}, aum={}",
+        result.fund(),
+        result.positionReportDate(),
+        result.navPerUnit(),
+        result.aum());
+  }
+
   private void publishToFundValueApi(NavCalculationResult result) {
     if (result.fund().isSavingsFund()) {
       publishNav(result);
@@ -98,7 +120,12 @@ public class NavPublisher {
       NavCalculationResult result, List<NavReportRow> reportRows, UUID calculationId) {
     Optional<String> gateFailure = checkGates(result);
     if (gateFailure.isPresent()) {
-      routeToInternalReview(result, reportRows, calculationId, gateFailure.get());
+      routeToInternalReview(
+          result,
+          reportRows,
+          calculationId,
+          gateFailure.get(),
+          reviewActionMessage(result, gateFailure.get()));
       return;
     }
 
@@ -125,9 +152,10 @@ public class NavPublisher {
       NavCalculationResult result,
       List<NavReportRow> reportRows,
       UUID calculationId,
-      String reason) {
+      String reason,
+      String actionMessage) {
     log.error(
-        "NAV report held by TD gate, routing to internal review (NOT sent to SEB): fund={}, date={}, reason={}",
+        "NAV report held for internal review (NOT sent to SEB): fund={}, date={}, reason={}",
         result.fund(),
         result.positionReportDate(),
         reason);
@@ -135,7 +163,7 @@ public class NavPublisher {
     if (navReportEmailSender.sendForReview(reportRows, result)) {
       navReportRepository.markAsPublished(calculationId);
       pipelineTracker.stepCompleted(REPORT_EMAIL);
-      notificationService.sendMessage(reviewActionMessage(result, reason), SAVINGS);
+      notificationService.sendMessage(actionMessage, SAVINGS);
     } else {
       pipelineTracker.stepFailed(REPORT_EMAIL, "internal review email failed");
       log.error(
@@ -161,6 +189,25 @@ public class NavPublisher {
         3. Optional (needs compliance sign-off) — widen the TD gate going forward:
            INSERT INTO investment_parameter (parameter_name, fund_code, effective_date, numeric_value) VALUES ('TRACKING_BREACH_THRESHOLD', NULL, CURRENT_DATE, 0.005);"""
         .formatted(reason, result.fund().getCode());
+  }
+
+  private String revisionActionMessage(NavCalculationResult result, String reason) {
+    String fundCode = result.fund().getCode();
+    String savingsFundStep =
+        result.fund().isSavingsFund()
+            ? "\n4. %s only: the public NAV in index_values is append-only and still holds the earlier value; correct it manually."
+                .formatted(fundCode)
+            : "";
+    return """
+        🔴 NAV REVISED after the custodian position report changed — held for review, NOT sent to SEB.
+        fund=%s, navDate=%s: %s
+        The revised CSV report was emailed to funds@tuleva.ee.
+
+        What to do now:
+        1. Check the changed rows against the new SEB position report.
+        2. If SEB has not received the revised NAV yet, forward the "%s NAV arvutamine ..." email to trustee@seb.ee.
+        3. This revision now supersedes the earlier calculation in nav_report; no DB change is needed.%s"""
+        .formatted(fundCode, result.positionReportDate(), reason, fundCode, savingsFundStep);
   }
 
   private boolean sendEmail(List<NavReportRow> reportRows, NavCalculationResult result) {

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/nav/NavRevision.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/nav/NavRevision.java
@@ -1,0 +1,24 @@
+package ee.tuleva.onboarding.savings.fund.nav;
+
+import static java.math.RoundingMode.HALF_UP;
+
+import java.math.BigDecimal;
+
+record NavRevision(BigDecimal publishedNavPerUnit, int changedPositionRows) {
+
+  String describe(NavCalculationResult revised) {
+    return "Position report re-imported with %d changed rows: publishedNav=%s, revisedNav=%s (%s%%)"
+        .formatted(
+            changedPositionRows,
+            publishedNavPerUnit.toPlainString(),
+            revised.navPerUnit().toPlainString(),
+            changePercent(revised.navPerUnit()).toPlainString());
+  }
+
+  private BigDecimal changePercent(BigDecimal revisedNavPerUnit) {
+    return revisedNavPerUnit
+        .subtract(publishedNavPerUnit)
+        .multiply(BigDecimal.valueOf(100))
+        .divide(publishedNavPerUnit, 2, HALF_UP);
+  }
+}

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/nav/NavRevisionService.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/nav/NavRevisionService.java
@@ -1,0 +1,74 @@
+package ee.tuleva.onboarding.savings.fund.nav;
+
+import static ee.tuleva.onboarding.notification.OperationsNotificationService.Channel.SAVINGS;
+
+import ee.tuleva.onboarding.deadline.PublicHolidays;
+import ee.tuleva.onboarding.notification.OperationsNotificationService;
+import ee.tuleva.onboarding.savings.FundNavQueryService;
+import java.math.BigDecimal;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+class NavRevisionService {
+
+  private final NavReportRepository navReportRepository;
+  private final FundNavQueryService fundNavQueryService;
+  private final NavCalculationService navCalculationService;
+  private final NavPublisher navPublisher;
+  private final OperationsNotificationService notificationService;
+  private final PublicHolidays publicHolidays;
+
+  @EventListener
+  void onNavPositionsUpdated(NavPositionsUpdated event) {
+    String fundCode = event.fund().getCode();
+    if (!navReportRepository.existsPublishedByNavDateAndFundCode(event.navDate(), fundCode)) {
+      log.info(
+          "Positions changed before NAV publication, no revision needed: fund={}, navDate={}, changedRows={}",
+          fundCode,
+          event.navDate(),
+          event.changedRows());
+      return;
+    }
+    try {
+      revise(event);
+    } catch (Exception e) {
+      log.error(
+          "NAV revision failed after position change: fund={}, navDate={}, changedRows={}",
+          fundCode,
+          event.navDate(),
+          event.changedRows(),
+          e);
+      notificationService.sendMessage(revisionFailedMessage(event), SAVINGS);
+    }
+  }
+
+  private void revise(NavPositionsUpdated event) {
+    String fundCode = event.fund().getCode();
+    BigDecimal publishedNav =
+        fundNavQueryService
+            .findPublishedNavPerUnit(fundCode, event.navDate())
+            .orElseThrow(
+                () ->
+                    new IllegalStateException(
+                        "Published NAV row missing: fund=%s, navDate=%s"
+                            .formatted(fundCode, event.navDate())));
+    NavCalculationResult revised =
+        navCalculationService.calculate(
+            event.fund(), publicHolidays.nextWorkingDay(event.navDate()));
+    navPublisher.publishRevision(revised, new NavRevision(publishedNav, event.changedRows()));
+  }
+
+  private String revisionFailedMessage(NavPositionsUpdated event) {
+    return """
+        🔴 NAV revision FAILED after the custodian position report changed: fund=%s, navDate=%s, changedRows=%d
+        The published NAV for that date may be stale. Recalculate manually:
+        POST /admin/calculate-nav?fundCode=%s&date=<next working day>&publish=false"""
+        .formatted(
+            event.fund().getCode(), event.navDate(), event.changedRows(), event.fund().getCode());
+  }
+}

--- a/src/main/java/ee/tuleva/onboarding/savings/fund/nav/NavRevisionService.java
+++ b/src/main/java/ee/tuleva/onboarding/savings/fund/nav/NavRevisionService.java
@@ -6,6 +6,7 @@ import ee.tuleva.onboarding.deadline.PublicHolidays;
 import ee.tuleva.onboarding.notification.OperationsNotificationService;
 import ee.tuleva.onboarding.savings.FundNavQueryService;
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
@@ -58,17 +59,21 @@ class NavRevisionService {
                         "Published NAV row missing: fund=%s, navDate=%s"
                             .formatted(fundCode, event.navDate())));
     NavCalculationResult revised =
-        navCalculationService.calculate(
-            event.fund(), publicHolidays.nextWorkingDay(event.navDate()));
+        navCalculationService.calculate(event.fund(), calculationDate(event));
     navPublisher.publishRevision(revised, new NavRevision(publishedNav, event.changedRows()));
   }
 
+  private LocalDate calculationDate(NavPositionsUpdated event) {
+    return publicHolidays.nextWorkingDay(event.navDate());
+  }
+
   private String revisionFailedMessage(NavPositionsUpdated event) {
+    String fundCode = event.fund().getCode();
     return """
         🔴 NAV revision FAILED after the custodian position report changed: fund=%s, navDate=%s, changedRows=%d
         The published NAV for that date may be stale. Recalculate manually:
-        POST /admin/calculate-nav?fundCode=%s&date=<next working day>&publish=false"""
+        POST /admin/calculate-nav?fundCode=%s&date=%s&publish=false"""
         .formatted(
-            event.fund().getCode(), event.navDate(), event.changedRows(), event.fund().getCode());
+            fundCode, event.navDate(), event.changedRows(), fundCode, calculationDate(event));
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/investment/position/FundPositionImportJobTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/position/FundPositionImportJobTest.java
@@ -10,6 +10,7 @@ import static ee.tuleva.onboarding.tulevafund.TulevaFund.TUV100;
 import static java.util.Map.entry;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
 import ee.tuleva.onboarding.investment.check.health.HealthCheckNotifier;
@@ -20,6 +21,7 @@ import ee.tuleva.onboarding.investment.position.parser.SwedbankFundPositionParse
 import ee.tuleva.onboarding.investment.report.InvestmentReport;
 import ee.tuleva.onboarding.investment.report.InvestmentReportService;
 import ee.tuleva.onboarding.pipeline.PipelineTracker;
+import ee.tuleva.onboarding.savings.fund.nav.NavPositionsUpdated;
 import ee.tuleva.onboarding.tulevafund.TulevaFund;
 import java.time.Clock;
 import java.time.Instant;
@@ -158,6 +160,84 @@ class FundPositionImportJobTest {
     job.importForProviderAndDate(SWEDBANK, date);
 
     verify(repository, times(2)).save(any(FundPosition.class));
+  }
+
+  @Test
+  void importForProviderAndDate_publishesNavPositionsUpdated_forFundsWithChangedRows() {
+    LocalDate date = LocalDate.of(2026, 1, 5);
+    given(reportService.getReport(SWEDBANK, POSITIONS, date))
+        .willReturn(Optional.of(createSwedbankReport(date)));
+    given(repository.findByNavDateAndFundAndAccountTypeAndAccountName(any(), any(), any(), any()))
+        .willReturn(Optional.empty());
+    given(
+            repository.findByNavDateAndFundAndAccountTypeAndAccountName(
+                eq(date), eq(TUK75), eq(SECURITY), eq("ISHARES DEV WLD ESG")))
+        .willReturn(
+            Optional.of(
+                FundPosition.builder()
+                    .navDate(date)
+                    .fund(TUK75)
+                    .accountType(SECURITY)
+                    .accountName("ISHARES DEV WLD ESG")
+                    .quantity(new java.math.BigDecimal("999999"))
+                    .marketValue(new java.math.BigDecimal("33500000"))
+                    .build()));
+
+    job.importForProviderAndDate(SWEDBANK, date);
+
+    var inOrder = inOrder(fundPositionLedgerService, eventPublisher);
+    inOrder.verify(fundPositionLedgerService).rerecordPositionsFromDate(TUK75, date);
+    inOrder.verify(eventPublisher).publishEvent(new NavPositionsUpdated(TUK75, date, 2));
+    verify(eventPublisher).publishEvent(new NavPositionsUpdated(TUV100, date, 1));
+  }
+
+  @Test
+  void importForProviderAndDate_doesNotPublishNavPositionsUpdated_whenNothingChanged() {
+    LocalDate date = LocalDate.of(2026, 1, 5);
+    given(reportService.getReport(SWEDBANK, POSITIONS, date))
+        .willReturn(Optional.of(createSwedbankReport(date)));
+    given(
+            repository.findByNavDateAndFundAndAccountTypeAndAccountName(
+                eq(date), eq(TUK75), eq(SECURITY), eq("ISHARES DEV WLD ESG")))
+        .willReturn(
+            Optional.of(
+                existingPosition(
+                    date, TUK75, SECURITY, "ISHARES DEV WLD ESG", "1000000", "33500000")));
+    given(
+            repository.findByNavDateAndFundAndAccountTypeAndAccountName(
+                eq(date), eq(TUK75), eq(CASH), eq("Overnight Deposit")))
+        .willReturn(
+            Optional.of(
+                existingPosition(date, TUK75, CASH, "Overnight Deposit", "5000000", "5000000")));
+    given(
+            repository.findByNavDateAndFundAndAccountTypeAndAccountName(
+                eq(date), eq(TUV100), eq(SECURITY), eq("ISHARES USA ESG")))
+        .willReturn(
+            Optional.of(
+                existingPosition(date, TUV100, SECURITY, "ISHARES USA ESG", "500000", "6000000")));
+
+    job.importForProviderAndDate(SWEDBANK, date);
+
+    verify(eventPublisher, never()).publishEvent(any(NavPositionsUpdated.class));
+    verify(fundPositionLedgerService, never()).rerecordPositionsFromDate(any(), any());
+  }
+
+  private static FundPosition existingPosition(
+      LocalDate date,
+      TulevaFund fund,
+      ee.tuleva.onboarding.investment.position.AccountType accountType,
+      String accountName,
+      String quantity,
+      String marketValue) {
+    return FundPosition.builder()
+        .navDate(date)
+        .fund(fund)
+        .accountType(accountType)
+        .accountName(accountName)
+        .quantity(new java.math.BigDecimal(quantity))
+        .marketPrice(accountType == CASH ? java.math.BigDecimal.ONE : null)
+        .marketValue(new java.math.BigDecimal(marketValue))
+        .build();
   }
 
   @Test

--- a/src/test/groovy/ee/tuleva/onboarding/investment/position/FundPositionImportServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/position/FundPositionImportServiceTest.java
@@ -5,6 +5,7 @@ import static ee.tuleva.onboarding.tulevafund.TulevaFund.TUK00;
 import static ee.tuleva.onboarding.tulevafund.TulevaFund.TUK75;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
 import ee.tuleva.onboarding.tulevafund.TulevaFund;
@@ -14,6 +15,7 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -125,6 +127,52 @@ class FundPositionImportServiceTest {
     assertThat(existing.getMarketValue()).isEqualByComparingTo("10000");
     assertThat(existing.getUpdatedAt()).isNotNull();
     verify(repository).save(existing);
+  }
+
+  @Test
+  void upsertPositions_reportsChangedRowsPerFund_countingUpdatedAndNewRows() {
+    FundPosition changedTuk75 = createPosition(TUK75, "Asset 1");
+    FundPosition unchangedTuk00 = createPosition(TUK00, "Asset 2");
+    FundPosition newTuk75 = createPosition(TUK75, "Asset 3");
+    FundPosition changedTuk75Again = createPosition(TUK75, "Asset 4");
+
+    given(repository.findByNavDateAndFundAndAccountTypeAndAccountName(any(), any(), any(), any()))
+        .willReturn(Optional.empty());
+    given(
+            repository.findByNavDateAndFundAndAccountTypeAndAccountName(
+                changedTuk75.getNavDate(), TUK75, SECURITY, "Asset 1"))
+        .willReturn(Optional.of(withQuantity(changedTuk75, "500")));
+    given(
+            repository.findByNavDateAndFundAndAccountTypeAndAccountName(
+                changedTuk75Again.getNavDate(), TUK75, SECURITY, "Asset 4"))
+        .willReturn(Optional.of(withQuantity(changedTuk75Again, "700")));
+    given(
+            repository.findByNavDateAndFundAndAccountTypeAndAccountName(
+                unchangedTuk00.getNavDate(), TUK00, SECURITY, "Asset 2"))
+        .willReturn(Optional.of(withQuantity(unchangedTuk00, "1000")));
+
+    var result =
+        service.upsertPositions(List.of(changedTuk75, unchangedTuk00, newTuk75, changedTuk75Again));
+
+    assertThat(result.imported()).isEqualTo(1);
+    assertThat(result.updated()).isEqualTo(2);
+    assertThat(result.changedRowsByFund()).isEqualTo(Map.of(TUK75, 3));
+  }
+
+  private static FundPosition withQuantity(FundPosition incoming, String quantity) {
+    return FundPosition.builder()
+        .id(42L)
+        .navDate(incoming.getNavDate())
+        .fund(incoming.getFund())
+        .accountType(incoming.getAccountType())
+        .accountName(incoming.getAccountName())
+        .accountId(incoming.getAccountId())
+        .quantity(new BigDecimal(quantity))
+        .marketPrice(incoming.getMarketPrice())
+        .currency("EUR")
+        .marketValue(incoming.getMarketValue())
+        .createdAt(Instant.parse("2026-01-05T10:00:00Z"))
+        .build();
   }
 
   @Test

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/nav/NavPipelineIntegrationTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/nav/NavPipelineIntegrationTest.java
@@ -22,18 +22,21 @@ import ee.tuleva.onboarding.investment.fees.FeeCalculationService;
 import ee.tuleva.onboarding.investment.fees.FeeResult;
 import ee.tuleva.onboarding.investment.position.AccountType;
 import ee.tuleva.onboarding.investment.position.FundPosition;
+import ee.tuleva.onboarding.investment.position.FundPositionImportJob;
 import ee.tuleva.onboarding.investment.position.FundPositionImportService;
 import ee.tuleva.onboarding.investment.position.FundPositionLedgerService;
 import ee.tuleva.onboarding.investment.position.FundPositionRepository;
 import ee.tuleva.onboarding.investment.position.parser.SebFundPositionParser;
 import ee.tuleva.onboarding.investment.report.InvestmentReportService;
 import ee.tuleva.onboarding.ledger.*;
+import ee.tuleva.onboarding.savings.FundNavQueryService;
 import ee.tuleva.onboarding.time.ClockHolder;
 import ee.tuleva.onboarding.tulevafund.TulevaFund;
 import ee.tuleva.onboarding.user.User;
 import jakarta.persistence.EntityManager;
 import java.io.ByteArrayInputStream;
 import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.sql.Timestamp;
@@ -74,6 +77,9 @@ class NavPipelineIntegrationTest {
   @Autowired FeeCalculationService feeCalculationService;
   @Autowired JdbcClient jdbcClient;
   @Autowired EntityManager entityManager;
+  @Autowired FundPositionImportJob fundPositionImportJob;
+  @Autowired FundNavQueryService fundNavQueryService;
+  @Autowired NavReportRepository navReportRepository;
 
   User testUser = sampleUser().personalCode("38001010001").build();
 
@@ -112,6 +118,111 @@ class NavPipelineIntegrationTest {
     } finally {
       ClockHolder.setDefaultClock();
     }
+  }
+
+  @Test
+  @SneakyThrows
+  void reissuedPositionReportAfterPublish_revisesNavFromCorrectedPositions() {
+    NavTestPair pair = testPairs().findFirst().orElseThrow();
+    var navData = parseNavCsv(pair.navCsvFile);
+    BigDecimal cashCorrection = new BigDecimal("10000.00");
+
+    Instant ledgerTime = navData.navDate.atStartOfDay(ZoneId.of("Europe/Tallinn")).toInstant();
+    ClockHolder.setClock(Clock.fixed(ledgerTime, ZoneId.of("UTC")));
+    try {
+      importPositionReport(pair.positionReportFile, navData.navDate);
+      recordPositionsToLedger(navData);
+      insertFeeRate(TKF100, "MANAGEMENT", new BigDecimal("0.0029"), navData.navDate);
+      insertFeeRate(TKF100, "DEPOT", new BigDecimal("0.01"), navData.navDate.withDayOfMonth(1));
+      insertPrices(pair.calculationDate);
+      issueFundUnits(navData.unitsOutstanding, navData.navDate);
+      entityManager.flush();
+      entityManager.clear();
+
+      var published = navCalculationService.calculate(TKF100, pair.calculationDate);
+      navPublisher.publish(published);
+      jdbcClient
+          .sql("UPDATE nav_report SET published_at = CURRENT_TIMESTAMP WHERE nav_date = :navDate")
+          .param("navDate", navData.navDate)
+          .update();
+      entityManager.flush();
+      entityManager.clear();
+      var originalCalculationId =
+          navReportRepository
+              .findLatestByNavDateAndFundCode(navData.navDate, "TKF100")
+              .getFirst()
+              .getCalculationId();
+
+      saveReissuedReportWithCashReducedBy(pair, cashCorrection);
+      seedModelPortfolioFromImportedSecurities(navData.navDate);
+      fundPositionImportJob.importForProviderAndDate(SEB, navData.navDate);
+      entityManager.flush();
+      entityManager.clear();
+
+      var expectedRevisedNav =
+          published
+              .aum()
+              .subtract(cashCorrection)
+              .divide(published.unitsOutstanding(), published.navPerUnit().scale(), HALF_UP);
+      var revisionRows =
+          navReportRepository.findAll().stream()
+              .filter(row -> row.getNavDate().equals(navData.navDate))
+              .filter(row -> !row.getCalculationId().equals(originalCalculationId))
+              .toList();
+      var revisionNavRow =
+          revisionRows.stream().filter(row -> row.getAccountType().equals("NAV")).findFirst();
+
+      assertThat(revisionRows).isNotEmpty();
+      assertThat(revisionNavRow.orElseThrow().getMarketPrice())
+          .isEqualByComparingTo(expectedRevisedNav);
+
+      navReportRepository.markAsPublished(revisionRows.getFirst().getCalculationId());
+
+      assertThat(fundNavQueryService.findPublishedNavPerUnit("TKF100", navData.navDate))
+          .contains(expectedRevisedNav.setScale(8, HALF_UP));
+    } finally {
+      ClockHolder.setDefaultClock();
+    }
+  }
+
+  @SneakyThrows
+  private void saveReissuedReportWithCashReducedBy(NavTestPair pair, BigDecimal reduction) {
+    String original = Files.readString(pair.positionReportFile);
+    String cashRow =
+        original
+            .lines()
+            .filter(line -> line.contains("Cash account in SEB Pank"))
+            .findFirst()
+            .orElseThrow();
+    String[] cells = cashRow.split(";");
+    BigDecimal cash = new BigDecimal(cells[4].replace(",", "."));
+    BigDecimal reduced = cash.subtract(reduction);
+    String reissuedRow =
+        cashRow
+            .replace(cells[4], reduced.toPlainString().replace(".", ","))
+            .replace(cells[7], reduced.setScale(2, HALF_UP).toPlainString().replace(".", ","));
+    byte[] csvBytes = original.replace(cashRow, reissuedRow).getBytes(StandardCharsets.UTF_8);
+    investmentReportService.saveReport(
+        SEB, POSITIONS, pair.navDate, new ByteArrayInputStream(csvBytes), ';', 5, Map.of());
+  }
+
+  private void seedModelPortfolioFromImportedSecurities(LocalDate effectiveDate) {
+    var securities =
+        fundPositionRepository.findByNavDateAndFundAndAccountType(effectiveDate, TKF100, SECURITY);
+    BigDecimal weight = BigDecimal.ONE.divide(BigDecimal.valueOf(securities.size()), 8, HALF_UP);
+    securities.forEach(
+        position ->
+            jdbcClient
+                .sql(
+                    """
+                    INSERT INTO investment_model_portfolio_allocation
+                      (effective_date, fund_code, isin, weight, provider)
+                    VALUES (:effectiveDate, 'TKF100', :isin, :weight, 'ISHARES')
+                    """)
+                .param("effectiveDate", effectiveDate)
+                .param("isin", position.getAccountId())
+                .param("weight", weight)
+                .update());
   }
 
   @Test

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/nav/NavPublisherTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/nav/NavPublisherTest.java
@@ -4,10 +4,12 @@ import static ee.tuleva.onboarding.notification.OperationsNotificationService.Ch
 import static ee.tuleva.onboarding.tulevafund.TulevaFund.TKF100;
 import static ee.tuleva.onboarding.tulevafund.TulevaFund.TUK75;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentCaptor.forClass;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
 import ee.tuleva.onboarding.comparisons.fundvalue.FundValue;
@@ -263,6 +265,62 @@ class NavPublisherTest {
 
     verify(navReportEmailSender).send(any(), eq(result));
     verify(navReportRepository).markAsPublished(reportRow.getCalculationId());
+  }
+
+  @Test
+  void publishRevision_persistsRowsAndRoutesToInternalReview_withoutTrusteeEmailOrFundValues() {
+    LocalDate today = LocalDate.of(2025, 1, 15);
+    LocalDate yesterday = LocalDate.of(2025, 1, 14);
+    var result = buildResult(TUK75, today, yesterday, Instant.parse("2025-01-15T14:00:00Z"));
+    var reportRow = NavReportRow.builder().navDate(yesterday).fundCode("TUK75").build();
+    given(navReportMapper.map(result)).willReturn(List.of(reportRow));
+    given(navReportEmailSender.sendForReview(any(), eq(result))).willReturn(true);
+
+    navPublisher.publishRevision(result, new NavRevision(new BigDecimal("9.75000"), 4));
+
+    verify(navReportRepository).replaceByNavDateAndFundCode(eq(yesterday), eq("TUK75"), any());
+    assertThat(reportRow.getCalculationId()).isNotNull();
+    verify(navReportEmailSender).sendForReview(any(), eq(result));
+    verify(navReportRepository).markAsPublished(reportRow.getCalculationId());
+    verify(notificationService)
+        .sendMessage(
+            contains(
+                "Position report re-imported with 4 changed rows: publishedNav=9.75000, revisedNav=9.69941 (-0.52%)"),
+            eq(SAVINGS));
+    verify(navReportEmailSender, never()).send(any(), any());
+    verify(fundValueWriter, never()).save(any());
+    verify(trackingDifferenceGate, never()).check(any(), any());
+    verify(navNotifier, never()).notify(any());
+  }
+
+  @Test
+  void publishRevision_throws_whenNoReportRowsPersisted() {
+    LocalDate today = LocalDate.of(2025, 1, 15);
+    LocalDate yesterday = LocalDate.of(2025, 1, 14);
+    var result = buildResult(TUK75, today, yesterday, Instant.parse("2025-01-15T14:00:00Z"));
+    given(navReportMapper.map(result)).willReturn(List.of());
+
+    assertThatThrownBy(
+            () -> navPublisher.publishRevision(result, new NavRevision(new BigDecimal("9.75"), 1)))
+        .isInstanceOf(IllegalStateException.class);
+
+    verify(navReportEmailSender, never()).sendForReview(any(), any());
+    verify(navReportRepository, never()).markAsPublished(any(UUID.class));
+  }
+
+  @Test
+  void publishRevision_pointsAtFundValueApiCorrection_forSavingsFund() {
+    LocalDate today = LocalDate.of(2025, 1, 15);
+    LocalDate yesterday = LocalDate.of(2025, 1, 14);
+    var result = buildResult(TKF100, today, yesterday, Instant.parse("2025-01-15T14:00:00Z"));
+    given(navReportMapper.map(result))
+        .willReturn(List.of(NavReportRow.builder().navDate(yesterday).fundCode("TKF100").build()));
+    given(navReportEmailSender.sendForReview(any(), eq(result))).willReturn(true);
+
+    navPublisher.publishRevision(result, new NavRevision(new BigDecimal("9.75000"), 1));
+
+    verify(notificationService).sendMessage(contains("index_values"), eq(SAVINGS));
+    verify(fundValueWriter, never()).save(any());
   }
 
   private NavCalculationResult buildResult(

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/nav/NavRevisionServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/nav/NavRevisionServiceTest.java
@@ -1,0 +1,107 @@
+package ee.tuleva.onboarding.savings.fund.nav;
+
+import static ee.tuleva.onboarding.notification.OperationsNotificationService.Channel.SAVINGS;
+import static ee.tuleva.onboarding.tulevafund.TulevaFund.TUK75;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import ee.tuleva.onboarding.deadline.PublicHolidays;
+import ee.tuleva.onboarding.notification.OperationsNotificationService;
+import ee.tuleva.onboarding.savings.FundNavQueryService;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class NavRevisionServiceTest {
+
+  private static final LocalDate NAV_DATE = LocalDate.of(2026, 9, 1);
+  private static final LocalDate NEXT_WORKING_DAY = LocalDate.of(2026, 9, 2);
+  private static final BigDecimal PUBLISHED_NAV = new BigDecimal("1.60377");
+
+  @Mock private NavReportRepository navReportRepository;
+  @Mock private FundNavQueryService fundNavQueryService;
+  @Mock private NavCalculationService navCalculationService;
+  @Mock private NavPublisher navPublisher;
+  @Mock private OperationsNotificationService notificationService;
+  @Spy private PublicHolidays publicHolidays = new PublicHolidays();
+
+  @InjectMocks private NavRevisionService service;
+
+  @Test
+  void onNavPositionsUpdated_publishesRevision_whenNavAlreadyPublished() {
+    given(navReportRepository.existsPublishedByNavDateAndFundCode(NAV_DATE, "TUK75"))
+        .willReturn(true);
+    given(fundNavQueryService.findPublishedNavPerUnit("TUK75", NAV_DATE))
+        .willReturn(Optional.of(PUBLISHED_NAV));
+    var revised = revisedResult();
+    given(navCalculationService.calculate(TUK75, NEXT_WORKING_DAY)).willReturn(revised);
+
+    service.onNavPositionsUpdated(new NavPositionsUpdated(TUK75, NAV_DATE, 4));
+
+    verify(navPublisher).publishRevision(revised, new NavRevision(PUBLISHED_NAV, 4));
+    verifyNoInteractions(notificationService);
+  }
+
+  @Test
+  void onNavPositionsUpdated_doesNothing_whenNavNotPublishedYet() {
+    given(navReportRepository.existsPublishedByNavDateAndFundCode(NAV_DATE, "TUK75"))
+        .willReturn(false);
+
+    service.onNavPositionsUpdated(new NavPositionsUpdated(TUK75, NAV_DATE, 4));
+
+    verifyNoInteractions(navCalculationService, navPublisher, notificationService);
+  }
+
+  @Test
+  void onNavPositionsUpdated_alertsInsteadOfThrowing_whenRevisionFails() {
+    given(navReportRepository.existsPublishedByNavDateAndFundCode(NAV_DATE, "TUK75"))
+        .willReturn(true);
+    given(fundNavQueryService.findPublishedNavPerUnit("TUK75", NAV_DATE))
+        .willReturn(Optional.of(PUBLISHED_NAV));
+    given(navCalculationService.calculate(TUK75, NEXT_WORKING_DAY))
+        .willThrow(new IllegalStateException("No position report found"));
+
+    service.onNavPositionsUpdated(new NavPositionsUpdated(TUK75, NAV_DATE, 4));
+
+    verify(navPublisher, never()).publishRevision(any(), any());
+    verify(notificationService)
+        .sendMessage(contains("fund=TUK75, navDate=2026-09-01"), eq(SAVINGS));
+  }
+
+  private static NavCalculationResult revisedResult() {
+    return NavCalculationResult.builder()
+        .fund(TUK75)
+        .calculationDate(NEXT_WORKING_DAY)
+        .securitiesValue(new BigDecimal("1124014464.12"))
+        .cashPosition(new BigDecimal("12900827.85"))
+        .receivables(BigDecimal.ZERO)
+        .pendingSubscriptions(BigDecimal.ZERO)
+        .pendingRedemptions(BigDecimal.ZERO)
+        .managementFeeAccrual(new BigDecimal("6418.71"))
+        .depotFeeAccrual(BigDecimal.ZERO)
+        .payables(BigDecimal.ZERO)
+        .blackrockAdjustment(BigDecimal.ZERO)
+        .aum(new BigDecimal("1136908873.26"))
+        .unitsOutstanding(new BigDecimal("712594777.749"))
+        .navPerUnit(new BigDecimal("1.59545"))
+        .positionReportDate(NAV_DATE)
+        .priceDate(NAV_DATE)
+        .calculatedAt(Instant.parse("2026-09-02T09:05:00Z"))
+        .securitiesDetail(List.of())
+        .build();
+  }
+}

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/nav/NavRevisionServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/nav/NavRevisionServiceTest.java
@@ -3,8 +3,6 @@ package ee.tuleva.onboarding.savings.fund.nav;
 import static ee.tuleva.onboarding.notification.OperationsNotificationService.Channel.SAVINGS;
 import static ee.tuleva.onboarding.tulevafund.TulevaFund.TUK75;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.contains;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -79,7 +77,12 @@ class NavRevisionServiceTest {
 
     verify(navPublisher, never()).publishRevision(any(), any());
     verify(notificationService)
-        .sendMessage(contains("fund=TUK75, navDate=2026-09-01"), eq(SAVINGS));
+        .sendMessage(
+            """
+            🔴 NAV revision FAILED after the custodian position report changed: fund=TUK75, navDate=2026-09-01, changedRows=4
+            The published NAV for that date may be stale. Recalculate manually:
+            POST /admin/calculate-nav?fundCode=TUK75&date=2026-09-02&publish=false""",
+            SAVINGS);
   }
 
   private static NavCalculationResult revisedResult() {


### PR DESCRIPTION
## Why

When SEB re-issues a positions file for a date whose NAV is already published, the hourly import updates the positions and re-records the ledger, but nothing recalculates the NAV. `nav_report` keeps the stale calculation, which the next day's tracking difference check and the 16:10 reconciliation read. On 2026-09-02 this left TUK75 and TUK00 with a 09-01 NAV overstated by unpaid redemption cash until the rows were corrected by hand.

## What

- `FundPositionImportJob` publishes `NavPositionsUpdated(fund, navDate, changedRows)` for every fund whose rows were added or updated, after the ledger re-record for that fund. Nothing is published when the report is unchanged.
- `NavRevisionService` (savings NAV module) listens. If no NAV is published for that date yet, it logs and lets the regular run use the new data. Otherwise it recalculates the date and calls `NavPublisher.publishRevision`.
- `publishRevision` persists a new calculation, emails it to funds@tuleva.ee for review, posts a Slack alert with the published versus revised NAV and the changed row count, and logs at error. It never sends the trustee email and never writes the append-only fund value API. `publishRevision` throws when the revised rows cannot be persisted. `NavRevisionService` deliberately catches every revision failure, logs at error and posts a Slack alert with the manual recalculation command (fund, next working day, `publish=false`), and returns normally: the listener runs synchronously inside the import loop, so rethrowing would fail the whole provider/date import after the positions were already stored.
- The revision reads the published NAV through `findPublishedNavPerUnit` from #1934, so it lines up with the registrar's view.

The event lives in the savings NAV package: investment already depends on savings through the `NavPositions` port and savings imports nothing from investment, so the module graph stays acyclic (ModuleMetricsTest passes).

## Tests

- Unit tests for the import result, the job's event publication and ordering, the listener's three paths, and the publisher's revision path.
- End-to-end scenario in `NavPipelineIntegrationTest`: publish, re-issue the report with cash reduced by 10,000, run the real import job, assert the revision NAV equals AUM minus 10,000 and that the published lookup returns it once the review email is out.
- Full suite green apart from the known `FirstPaymentReminderRepositoryTest` full-run collision.

## Not in this PR

Pre-existing upsert limitations surfaced in review: rows omitted from a re-issued snapshot are never deleted, and change detection ignores `accountId` and currency.

