### PR TITLE
Sign with the ID card through Web eID instead of hwcrypto

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,9 +267,15 @@ When adding a new migration for H2 <-> Postgres compatibility, the name must be 
 
 #### References
 
-[hwcrypto.js](https://github.com/hwcrypto/hwcrypto.js)
+[Web eID](https://www.id.ee/en/article/web-eid/) (ID card authentication and signing in the browser)
 
-[hwcrypto Sequence Diagram](https://github.com/hwcrypto/hwcrypto.js/wiki/SequenceDiagram)
+[web-eid.js](https://github.com/web-eid/web-eid.js) (frontend library: `authenticate`, `getSigningCertificate`, `sign`)
+
+[web-eid-authtoken-validation-java](https://github.com/web-eid/web-eid-authtoken-validation-java) (backend authentication token validation)
+
+[Web eID system architecture](https://github.com/web-eid/web-eid-system-architecture-doc)
+
+[digidoc4j](https://github.com/open-eid/digidoc4j) (container building and signature finalization)
 
 [Test Authentication Methods](https://www.id.ee/en/article/testing-the-services/)
 

--- a/src/main/java/ee/tuleva/onboarding/auth/ocsp/OCSPUtils.java
+++ b/src/main/java/ee/tuleva/onboarding/auth/ocsp/OCSPUtils.java
@@ -10,8 +10,6 @@ import java.security.cert.*;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import lombok.SneakyThrows;
-import org.apache.commons.codec.binary.Hex;
 import org.bouncycastle.asn1.ASN1InputStream;
 import org.bouncycastle.asn1.ASN1OctetString;
 import org.bouncycastle.asn1.ASN1Primitive;
@@ -100,12 +98,6 @@ public class OCSPUtils {
   public X509Certificate getX509Certificate(String certificate) {
     byte[] certificateBytes = certificate.getBytes(UTF_8);
     return generateX09Certificate(certificateBytes);
-  }
-
-  @SneakyThrows
-  public X509Certificate decodeX09Certificate(String hexCertificate) {
-    byte[] decodedCertificate = Hex.decodeHex(hexCertificate);
-    return generateX09Certificate(decodedCertificate);
   }
 
   private X509Certificate generateX09Certificate(byte[] certificate) {

--- a/src/main/java/ee/tuleva/onboarding/auth/webeid/WebEidAuthService.java
+++ b/src/main/java/ee/tuleva/onboarding/auth/webeid/WebEidAuthService.java
@@ -2,6 +2,7 @@ package ee.tuleva.onboarding.auth.webeid;
 
 import ee.tuleva.onboarding.auth.idcard.IdCardSession;
 import ee.tuleva.onboarding.auth.idcard.IdDocumentTypeExtractor;
+import ee.tuleva.onboarding.personalcode.PersonalCode;
 import eu.webeid.security.authtoken.WebEidAuthToken;
 import eu.webeid.security.certificate.CertificateData;
 import eu.webeid.security.challenge.ChallengeNonceGenerator;
@@ -61,7 +62,7 @@ public class WebEidAuthService {
       var serialNumber =
           CertificateData.getSubjectIdCode(certificate)
               .orElseThrow(() -> new WebEidAuthException("Missing personal code in certificate"));
-      var personalCode = extractPersonalCode(serialNumber);
+      var personalCode = PersonalCode.fromSubjectIdCode(serialNumber);
 
       var documentType = documentTypeExtractor.extract(certificate);
       documentTypeExtractor.checkClientAuthentication(certificate);
@@ -76,12 +77,5 @@ public class WebEidAuthService {
     } catch (CertificateEncodingException e) {
       throw new WebEidAuthException("Failed to read certificate data", e);
     }
-  }
-
-  private String extractPersonalCode(String serialNumber) {
-    if (serialNumber.startsWith("PNOEE-")) {
-      return serialNumber.substring(6);
-    }
-    return serialNumber;
   }
 }

--- a/src/main/java/ee/tuleva/onboarding/capital/transfer/CapitalTransferContract.java
+++ b/src/main/java/ee/tuleva/onboarding/capital/transfer/CapitalTransferContract.java
@@ -140,6 +140,25 @@ public class CapitalTransferContract {
     return this;
   }
 
+  public boolean isSignedBy(User user) {
+    Long memberId = user.getMemberOrThrow().getId();
+    if (memberId.equals(seller.getId())) {
+      return isSignedBySeller();
+    }
+    if (memberId.equals(buyer.getId())) {
+      return isSignedByBuyer();
+    }
+    return false;
+  }
+
+  private boolean isSignedBySeller() {
+    return state != CREATED && state != CANCELLED;
+  }
+
+  private boolean isSignedByBuyer() {
+    return isSignedBySeller() && state != SELLER_SIGNED;
+  }
+
   public boolean canBeAccessedBy(User user) {
     var isSeller = user.getMemberOrThrow().getId().equals(seller.getId());
     var isBuyer = user.getMemberOrThrow().getId().equals(buyer.getId());

--- a/src/main/java/ee/tuleva/onboarding/capital/transfer/CapitalTransferContractController.java
+++ b/src/main/java/ee/tuleva/onboarding/capital/transfer/CapitalTransferContractController.java
@@ -105,7 +105,7 @@ public class CapitalTransferContractController implements SignatureController<Lo
   }
 
   @Override
-  @Operation(summary = "Get ID card signing status for a capital transfer contract")
+  @Operation(summary = "Get the ID card signing status of the capital transfer contract")
   public IdCardSignatureStatusResponse getIdCardSignatureStatus(
       @PathVariable Long id, @AuthenticationPrincipal AuthenticatedPerson authenticatedPerson) {
     return signatureService.getIdCardSignatureStatus(id, authenticatedPerson);

--- a/src/main/java/ee/tuleva/onboarding/capital/transfer/CapitalTransferContractController.java
+++ b/src/main/java/ee/tuleva/onboarding/capital/transfer/CapitalTransferContractController.java
@@ -96,15 +96,19 @@ public class CapitalTransferContractController implements SignatureController<Lo
   }
 
   @Override
-  @Operation(
-      summary =
-          "Persist ID Card signed hash and get signing status for a capital transfer contract")
-  public IdCardSignatureStatusResponse persistIdCardSignedHashOrGetSignatureStatus(
+  @Operation(summary = "Persist the ID card signature of a capital transfer contract")
+  public IdCardSignatureStatusResponse persistIdCardSignature(
       @PathVariable Long id,
       @Valid @RequestBody FinishIdCardSignCommand signCommand,
       @AuthenticationPrincipal AuthenticatedPerson authenticatedPerson) {
-    return signatureService.persistIdCardSignedHashAndGetProcessingStatus(
-        id, signCommand, authenticatedPerson);
+    return signatureService.persistIdCardSignature(id, signCommand, authenticatedPerson);
+  }
+
+  @Override
+  @Operation(summary = "Get ID card signing status for a capital transfer contract")
+  public IdCardSignatureStatusResponse getIdCardSignatureStatus(
+      @PathVariable Long id, @AuthenticationPrincipal AuthenticatedPerson authenticatedPerson) {
+    return signatureService.getIdCardSignatureStatus(id, authenticatedPerson);
   }
 
   @Override

--- a/src/main/java/ee/tuleva/onboarding/capital/transfer/CapitalTransferSignatureService.java
+++ b/src/main/java/ee/tuleva/onboarding/capital/transfer/CapitalTransferSignatureService.java
@@ -15,6 +15,7 @@ import ee.tuleva.onboarding.signature.MobileSignatureResponse;
 import ee.tuleva.onboarding.signature.MobileSignatureStatusResponse;
 import ee.tuleva.onboarding.signature.SignatureFile;
 import ee.tuleva.onboarding.signature.SignatureService;
+import ee.tuleva.onboarding.signature.SignatureStateException;
 import ee.tuleva.onboarding.signature.SignatureStatus;
 import ee.tuleva.onboarding.signature.SmartIdSignatureSession;
 import ee.tuleva.onboarding.signature.StartIdCardSignCommand;
@@ -114,8 +115,7 @@ public class CapitalTransferSignatureService {
     CapitalTransferContract contract = contractService.getContract(contractId, user);
 
     if (!contract.isSignedBy(user)) {
-      throw new IllegalStateException(
-          "Capital transfer contract is not signed: contractId=" + contractId);
+      throw SignatureStateException.notSigned("Capital transfer contract", contractId);
     }
     return new IdCardSignatureStatusResponse(SignatureStatus.SIGNATURE);
   }

--- a/src/main/java/ee/tuleva/onboarding/capital/transfer/CapitalTransferSignatureService.java
+++ b/src/main/java/ee/tuleva/onboarding/capital/transfer/CapitalTransferSignatureService.java
@@ -102,6 +102,10 @@ public class CapitalTransferSignatureService {
     User user = userService.getByIdOrThrow(authenticatedPerson.getUserIdOrThrow());
     CapitalTransferContract contract = contractService.getContract(contractId, user);
 
+    if (contract.isSignedBy(user)) {
+      throw SignatureStateException.alreadySigned("Capital transfer contract", contractId);
+    }
+
     byte[] signedFile = signService.getSignedFile(session, signCommand.signature());
     finalizeSignature(contract, user, signedFile);
 

--- a/src/main/java/ee/tuleva/onboarding/capital/transfer/CapitalTransferSignatureService.java
+++ b/src/main/java/ee/tuleva/onboarding/capital/transfer/CapitalTransferSignatureService.java
@@ -81,34 +81,42 @@ public class CapitalTransferSignatureService {
     List<SignatureFile> files = contractService.getSignatureFiles(contractId, user);
 
     IdCardSignatureSession signatureSession =
-        signService.startIdCardSign(files, signCommand.clientCertificate());
+        signService.startIdCardSign(files, signCommand.certificate());
 
     sessionStore.save(signatureSession);
 
-    return new IdCardSignatureResponse(signatureSession.getHashToSignInHex());
+    return IdCardSignatureResponse.from(signatureSession);
   }
 
-  public IdCardSignatureStatusResponse persistIdCardSignedHashAndGetProcessingStatus(
+  public IdCardSignatureStatusResponse persistIdCardSignature(
       Long contractId,
       FinishIdCardSignCommand signCommand,
       AuthenticatedPerson authenticatedPerson) {
 
-    Optional<IdCardSignatureSession> signatureSession =
-        sessionStore.get(IdCardSignatureSession.class);
     IdCardSignatureSession session =
-        signatureSession.orElseThrow(IdSessionException::cardSignatureSessionNotFound);
+        sessionStore
+            .get(IdCardSignatureSession.class)
+            .orElseThrow(IdSessionException::cardSignatureSessionNotFound);
 
     User user = userService.getByIdOrThrow(authenticatedPerson.getUserIdOrThrow());
     CapitalTransferContract contract = contractService.getContract(contractId, user);
 
-    byte[] signedFile = signService.getSignedFile(session, signCommand.signedHash());
+    byte[] signedFile = signService.getSignedFile(session, signCommand.signature());
+    finalizeSignature(contract, user, signedFile);
 
-    if (signedFile != null) {
-      finalizeSignature(contract, user, signedFile);
-      return new IdCardSignatureStatusResponse(SignatureStatus.SIGNATURE);
-    }
+    return new IdCardSignatureStatusResponse(SignatureStatus.SIGNATURE);
+  }
 
-    return new IdCardSignatureStatusResponse(SignatureStatus.OUTSTANDING_TRANSACTION);
+  public IdCardSignatureStatusResponse getIdCardSignatureStatus(
+      Long contractId, AuthenticatedPerson authenticatedPerson) {
+
+    User user = userService.getByIdOrThrow(authenticatedPerson.getUserIdOrThrow());
+    CapitalTransferContract contract = contractService.getContract(contractId, user);
+
+    return new IdCardSignatureStatusResponse(
+        contract.isSignedBy(user)
+            ? SignatureStatus.SIGNATURE
+            : SignatureStatus.OUTSTANDING_TRANSACTION);
   }
 
   public MobileSignatureResponse startMobileIdSignature(

--- a/src/main/java/ee/tuleva/onboarding/capital/transfer/CapitalTransferSignatureService.java
+++ b/src/main/java/ee/tuleva/onboarding/capital/transfer/CapitalTransferSignatureService.java
@@ -82,7 +82,11 @@ public class CapitalTransferSignatureService {
     List<SignatureFile> files = contractService.getSignatureFiles(contractId, user);
 
     IdCardSignatureSession signatureSession =
-        signService.startIdCardSign(files, signCommand.certificate());
+        signService.startIdCardSign(
+            files,
+            signCommand.certificate(),
+            signCommand.supportedHashFunctions(),
+            user.getPersonalCode());
 
     sessionStore.save(signatureSession);
 

--- a/src/main/java/ee/tuleva/onboarding/capital/transfer/CapitalTransferSignatureService.java
+++ b/src/main/java/ee/tuleva/onboarding/capital/transfer/CapitalTransferSignatureService.java
@@ -113,10 +113,11 @@ public class CapitalTransferSignatureService {
     User user = userService.getByIdOrThrow(authenticatedPerson.getUserIdOrThrow());
     CapitalTransferContract contract = contractService.getContract(contractId, user);
 
-    return new IdCardSignatureStatusResponse(
-        contract.isSignedBy(user)
-            ? SignatureStatus.SIGNATURE
-            : SignatureStatus.OUTSTANDING_TRANSACTION);
+    if (!contract.isSignedBy(user)) {
+      throw new IllegalStateException(
+          "Capital transfer contract is not signed: contractId=" + contractId);
+    }
+    return new IdCardSignatureStatusResponse(SignatureStatus.SIGNATURE);
   }
 
   public MobileSignatureResponse startMobileIdSignature(

--- a/src/main/java/ee/tuleva/onboarding/mandate/MandateController.java
+++ b/src/main/java/ee/tuleva/onboarding/mandate/MandateController.java
@@ -168,7 +168,7 @@ public class MandateController implements SignatureController<Long> {
   }
 
   @Override
-  @Operation(summary = "Is the mandate signed with ID card processed")
+  @Operation(summary = "Get the ID card signing status of the mandate")
   public IdCardSignatureStatusResponse getIdCardSignatureStatus(
       @PathVariable("id") Long mandateId,
       @AuthenticationPrincipal AuthenticatedPerson authenticatedPerson) {

--- a/src/main/java/ee/tuleva/onboarding/mandate/MandateController.java
+++ b/src/main/java/ee/tuleva/onboarding/mandate/MandateController.java
@@ -143,15 +143,15 @@ public class MandateController implements SignatureController<Long> {
       @Valid @RequestBody StartIdCardSignCommand signCommand) {
     IdCardSignatureSession signatureSession =
         mandateService.idCardSign(
-            mandateId, authenticatedPerson.getUserIdOrThrow(), signCommand.clientCertificate());
+            mandateId, authenticatedPerson.getUserIdOrThrow(), signCommand.certificate());
     sessionStore.save(signatureSession);
 
-    return new IdCardSignatureResponse(signatureSession.getHashToSignInHex());
+    return IdCardSignatureResponse.from(signatureSession);
   }
 
   @Override
-  @Operation(summary = "Persist ID-card signed mandate, and check if mandate is processed")
-  public IdCardSignatureStatusResponse persistIdCardSignedHashOrGetSignatureStatus(
+  @Operation(summary = "Persist the ID card signature of the mandate and start processing it")
+  public IdCardSignatureStatusResponse persistIdCardSignature(
       @PathVariable("id") Long mandateId,
       @Valid @RequestBody FinishIdCardSignCommand signCommand,
       @AuthenticationPrincipal AuthenticatedPerson authenticatedPerson) {
@@ -161,12 +161,20 @@ public class MandateController implements SignatureController<Long> {
             .orElseThrow(IdSessionException::cardSignatureSessionNotFound);
 
     SignatureStatus statusCode =
-        mandateService.finalizeIdCardSignature(
-            authenticatedPerson.getUserIdOrThrow(),
-            mandateId,
-            session,
-            signCommand.signedHash(),
-            localeService.getCurrentLocale());
+        mandateService.persistIdCardSignature(
+            authenticatedPerson.getUserIdOrThrow(), mandateId, session, signCommand.signature());
+
+    return new IdCardSignatureStatusResponse(statusCode);
+  }
+
+  @Override
+  @Operation(summary = "Is the mandate signed with ID card processed")
+  public IdCardSignatureStatusResponse getIdCardSignatureStatus(
+      @PathVariable("id") Long mandateId,
+      @AuthenticationPrincipal AuthenticatedPerson authenticatedPerson) {
+    SignatureStatus statusCode =
+        mandateService.getIdCardSignatureStatus(
+            authenticatedPerson.getUserIdOrThrow(), mandateId, localeService.getCurrentLocale());
 
     return new IdCardSignatureStatusResponse(statusCode);
   }

--- a/src/main/java/ee/tuleva/onboarding/mandate/MandateController.java
+++ b/src/main/java/ee/tuleva/onboarding/mandate/MandateController.java
@@ -9,6 +9,7 @@ import ee.tuleva.onboarding.auth.principal.AuthenticatedPerson;
 import ee.tuleva.onboarding.auth.session.GenericSessionStore;
 import ee.tuleva.onboarding.error.NotFoundException;
 import ee.tuleva.onboarding.error.ValidationErrorsException;
+import ee.tuleva.onboarding.locale.LocaleService;
 import ee.tuleva.onboarding.mandate.command.CreateMandateCommand;
 import ee.tuleva.onboarding.mandate.generic.GenericMandateService;
 import ee.tuleva.onboarding.signature.*;
@@ -21,27 +22,23 @@ import ee.tuleva.onboarding.signature.SmartIdSignatureSession;
 import ee.tuleva.onboarding.signature.StartIdCardSignCommand;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.List;
-import java.util.Locale;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.tomcat.util.http.fileupload.IOUtils;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.Errors;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.servlet.LocaleResolver;
 
 @Slf4j
 @RestController
 @RequestMapping("/v1" + MANDATES_URI)
 @RequiredArgsConstructor
-public class MandateController {
+public class MandateController implements SignatureController<Long> {
 
   public static final String MANDATES_URI = "/mandates";
 
@@ -51,7 +48,7 @@ public class MandateController {
   private final GenericSessionStore sessionStore;
   private final SignatureFileArchiver signatureFileArchiver;
   private final MandateFileService mandateFileService;
-  private final LocaleResolver localeResolver;
+  private final LocaleService localeService;
 
   @Operation(summary = "Create a mandate")
   @PostMapping
@@ -69,18 +66,11 @@ public class MandateController {
     return mandateService.save(authenticatedPerson, createMandateCommand);
   }
 
+  @Override
   @Operation(summary = "Start signing mandate with mobile ID")
-  @PutMapping("/{id}/signature/mobileId")
   public MobileSignatureResponse startMobileIdSignature(
       @PathVariable("id") Long mandateId,
-      @AuthenticationPrincipal AuthenticatedPerson authenticatedPerson,
-      HttpServletRequest request) {
-
-    log.info(
-        "Mobile-ID signing started: mandateId={}, userId={}, sessionId={}",
-        mandateId,
-        authenticatedPerson.getUserId(),
-        request.getSession(false) != null ? request.getSession(false).getId() : "none");
+      @AuthenticationPrincipal AuthenticatedPerson authenticatedPerson) {
     MobileIdSignatureSession signatureSession =
         mandateService.mobileIdSign(
             mandateId,
@@ -93,133 +83,82 @@ public class MandateController {
     return new MobileSignatureResponse(signatureSession.getVerificationCode());
   }
 
+  @Override
   @Operation(summary = "Is mandate successfully signed with mobile ID")
-  @GetMapping("/{id}/signature/mobileId/status")
   public MobileSignatureStatusResponse getMobileIdSignatureStatus(
       @PathVariable("id") Long mandateId,
-      @AuthenticationPrincipal AuthenticatedPerson authenticatedPerson,
-      @Parameter(hidden = true) HttpServletRequest request) {
-
-    Optional<MobileIdSignatureSession> signatureSession =
-        sessionStore.get(MobileIdSignatureSession.class);
-    log.info(
-        "Mobile-ID signing status check: mandateId={}, userId={}, sessionId={}, sessionExists={}",
-        mandateId,
-        authenticatedPerson.getUserId(),
-        request.getSession(false) != null ? request.getSession(false).getId() : "none",
-        signatureSession.isPresent());
+      @AuthenticationPrincipal AuthenticatedPerson authenticatedPerson) {
     MobileIdSignatureSession session =
-        signatureSession.orElseThrow(IdSessionException::mobileSignatureSessionNotFound);
-
-    Locale locale = localeResolver.resolveLocale(request);
+        sessionStore
+            .get(MobileIdSignatureSession.class)
+            .orElseThrow(IdSessionException::mobileSignatureSessionNotFound);
 
     SignatureStatus statusCode =
         mandateService.finalizeMobileIdSignature(
-            authenticatedPerson.getUserIdOrThrow(), mandateId, session, locale);
+            authenticatedPerson.getUserIdOrThrow(),
+            mandateId,
+            session,
+            localeService.getCurrentLocale());
 
     return new MobileSignatureStatusResponse(statusCode, session.getVerificationCode());
   }
 
+  @Override
   @Operation(summary = "Start signing mandate with Smart ID")
-  @PutMapping("/{id}/signature/smartId")
   public MobileSignatureResponse startSmartIdSignature(
       @PathVariable("id") Long mandateId,
-      @AuthenticationPrincipal AuthenticatedPerson authenticatedPerson,
-      HttpServletRequest request) {
-    log.info(
-        "Smart-ID signing started: mandateId={}, userId={}, sessionId={}",
-        mandateId,
-        authenticatedPerson.getUserId(),
-        request.getSession(false) != null ? request.getSession(false).getId() : "none");
+      @AuthenticationPrincipal AuthenticatedPerson authenticatedPerson) {
     SmartIdSignatureSession signatureSession =
         mandateService.smartIdSign(mandateId, authenticatedPerson.getUserIdOrThrow());
     sessionStore.save(signatureSession);
-    log.info(
-        "Smart-ID signing session saved: mandateId={}, userId={}, sessionId={}",
-        mandateId,
-        authenticatedPerson.getUserId(),
-        request.getSession(false) != null ? request.getSession(false).getId() : "none");
 
-    return new MobileSignatureResponse(null); // verificationCode is null in this instance
+    return new MobileSignatureResponse(signatureSession.getVerificationCode());
   }
 
+  @Override
   @Operation(summary = "Is mandate successfully signed with Smart ID")
-  @GetMapping("/{id}/signature/smartId/status")
   public MobileSignatureStatusResponse getSmartIdSignatureStatus(
       @PathVariable("id") Long mandateId,
-      @AuthenticationPrincipal AuthenticatedPerson authenticatedPerson,
-      HttpServletRequest request) {
-
-    Optional<SmartIdSignatureSession> signatureSession =
-        sessionStore.get(SmartIdSignatureSession.class);
-    log.info(
-        "Smart-ID signing status check: mandateId={}, userId={}, sessionId={}, sessionExists={}",
-        mandateId,
-        authenticatedPerson.getUserId(),
-        request.getSession(false) != null ? request.getSession(false).getId() : "none",
-        signatureSession.isPresent());
+      @AuthenticationPrincipal AuthenticatedPerson authenticatedPerson) {
     SmartIdSignatureSession session =
-        signatureSession.orElseThrow(IdSessionException::smartIdSignatureSessionNotFound);
-
-    Locale locale = localeResolver.resolveLocale(request);
+        sessionStore
+            .get(SmartIdSignatureSession.class)
+            .orElseThrow(IdSessionException::smartIdSignatureSessionNotFound);
 
     SignatureStatus statusCode =
         mandateService.finalizeSmartIdSignature(
-            authenticatedPerson.getUserIdOrThrow(), mandateId, session, locale);
+            authenticatedPerson.getUserIdOrThrow(),
+            mandateId,
+            session,
+            localeService.getCurrentLocale());
 
     return new MobileSignatureStatusResponse(statusCode, session.getVerificationCode());
   }
 
+  @Override
   @Operation(summary = "Start signing mandate with ID card")
-  @PutMapping("/{id}/signature/idCard")
-  public IdCardSignatureResponse startIdCardSign(
+  public IdCardSignatureResponse startIdCardSignature(
       @PathVariable("id") Long mandateId,
       @AuthenticationPrincipal AuthenticatedPerson authenticatedPerson,
-      @Valid @RequestBody StartIdCardSignCommand signCommand,
-      HttpServletRequest request) {
-
-    log.info(
-        "ID card signing started: mandateId={}, userId={}, sessionId={}",
-        mandateId,
-        authenticatedPerson.getUserId(),
-        request.getSession(false) != null ? request.getSession(false).getId() : "none");
+      @Valid @RequestBody StartIdCardSignCommand signCommand) {
     IdCardSignatureSession signatureSession =
         mandateService.idCardSign(
             mandateId, authenticatedPerson.getUserIdOrThrow(), signCommand.clientCertificate());
-
     sessionStore.save(signatureSession);
-    log.info(
-        "ID card signing session saved: mandateId={}, userId={}, sessionId={}",
-        mandateId,
-        authenticatedPerson.getUserId(),
-        request.getSession(false) != null ? request.getSession(false).getId() : "none");
 
     return new IdCardSignatureResponse(signatureSession.getHashToSignInHex());
   }
 
-  // TODO: split this into PUT and GET endpoints or migrate all logic to MandateBatch
-  // Currently first call persists signed hex, and later polling calls just check if mandates have
-  // been processsed
-  @Operation(summary = "Is mandate successfully signed with ID card")
-  @PutMapping("/{id}/signature/idCard/status")
-  public IdCardSignatureStatusResponse getIdCardSignatureStatus(
+  @Override
+  @Operation(summary = "Persist ID-card signed mandate, and check if mandate is processed")
+  public IdCardSignatureStatusResponse persistIdCardSignedHashOrGetSignatureStatus(
       @PathVariable("id") Long mandateId,
       @Valid @RequestBody FinishIdCardSignCommand signCommand,
-      @AuthenticationPrincipal AuthenticatedPerson authenticatedPerson,
-      HttpServletRequest request) {
-
-    Optional<IdCardSignatureSession> signatureSession =
-        sessionStore.get(IdCardSignatureSession.class);
-    log.info(
-        "ID card signing status check: mandateId={}, userId={}, sessionId={}, sessionExists={}",
-        mandateId,
-        authenticatedPerson.getUserId(),
-        request.getSession(false) != null ? request.getSession(false).getId() : "none",
-        signatureSession.isPresent());
+      @AuthenticationPrincipal AuthenticatedPerson authenticatedPerson) {
     IdCardSignatureSession session =
-        signatureSession.orElseThrow(IdSessionException::cardSignatureSessionNotFound);
-
-    Locale locale = localeResolver.resolveLocale(request);
+        sessionStore
+            .get(IdCardSignatureSession.class)
+            .orElseThrow(IdSessionException::cardSignatureSessionNotFound);
 
     SignatureStatus statusCode =
         mandateService.finalizeIdCardSignature(
@@ -227,7 +166,7 @@ public class MandateController {
             mandateId,
             session,
             signCommand.signedHash(),
-            locale);
+            localeService.getCurrentLocale());
 
     return new IdCardSignatureStatusResponse(statusCode);
   }

--- a/src/main/java/ee/tuleva/onboarding/mandate/MandateController.java
+++ b/src/main/java/ee/tuleva/onboarding/mandate/MandateController.java
@@ -142,8 +142,7 @@ public class MandateController implements SignatureController<Long> {
       @AuthenticationPrincipal AuthenticatedPerson authenticatedPerson,
       @Valid @RequestBody StartIdCardSignCommand signCommand) {
     IdCardSignatureSession signatureSession =
-        mandateService.idCardSign(
-            mandateId, authenticatedPerson.getUserIdOrThrow(), signCommand.certificate());
+        mandateService.idCardSign(mandateId, authenticatedPerson.getUserIdOrThrow(), signCommand);
     sessionStore.save(signatureSession);
 
     return IdCardSignatureResponse.from(signatureSession);

--- a/src/main/java/ee/tuleva/onboarding/mandate/MandateService.java
+++ b/src/main/java/ee/tuleva/onboarding/mandate/MandateService.java
@@ -24,6 +24,7 @@ import ee.tuleva.onboarding.signature.IdCardSignatureSession;
 import ee.tuleva.onboarding.signature.MobileIdSignatureSession;
 import ee.tuleva.onboarding.signature.SignatureFile;
 import ee.tuleva.onboarding.signature.SignatureService;
+import ee.tuleva.onboarding.signature.SignatureStateException;
 import ee.tuleva.onboarding.signature.SignatureStatus;
 import ee.tuleva.onboarding.signature.SmartIdSignatureSession;
 import ee.tuleva.onboarding.user.User;
@@ -154,7 +155,7 @@ public class MandateService {
     Mandate mandate = mandateRepository.findByIdAndUserId(mandateId, userId);
 
     if (mandate.isSigned()) {
-      throw new IllegalStateException("Mandate is already signed: mandateId=" + mandateId);
+      throw SignatureStateException.alreadySigned("Mandate", mandateId);
     }
     return getStatus(user, mandate, signService.getSignedFile(session, signature));
   }
@@ -164,7 +165,7 @@ public class MandateService {
     Mandate mandate = mandateRepository.findByIdAndUserId(mandateId, userId);
 
     if (!mandate.isSigned()) {
-      throw new IllegalStateException("Mandate is not signed: mandateId=" + mandateId);
+      throw SignatureStateException.notSigned("Mandate", mandateId);
     }
     return handleSignedMandate(user, mandate, locale);
   }

--- a/src/main/java/ee/tuleva/onboarding/mandate/MandateService.java
+++ b/src/main/java/ee/tuleva/onboarding/mandate/MandateService.java
@@ -148,20 +148,25 @@ public class MandateService {
     return getStatus(user, mandate, signService.getSignedFile(session));
   }
 
-  public SignatureStatus finalizeIdCardSignature(
-      Long userId,
-      Long mandateId,
-      IdCardSignatureSession session,
-      String signedHashInHex,
-      Locale locale) {
+  public SignatureStatus persistIdCardSignature(
+      Long userId, Long mandateId, IdCardSignatureSession session, String signature) {
     User user = userService.getById(userId).orElseThrow();
     Mandate mandate = mandateRepository.findByIdAndUserId(mandateId, userId);
 
     if (mandate.isSigned()) {
-      return handleSignedMandate(user, mandate, locale);
-    } else {
-      return handleUnsignedMandateIdCard(user, mandate, session, signedHashInHex);
+      throw new IllegalStateException("Mandate is already signed: mandateId=" + mandateId);
     }
+    return getStatus(user, mandate, signService.getSignedFile(session, signature));
+  }
+
+  public SignatureStatus getIdCardSignatureStatus(Long userId, Long mandateId, Locale locale) {
+    User user = userService.getById(userId).orElseThrow();
+    Mandate mandate = mandateRepository.findByIdAndUserId(mandateId, userId);
+
+    if (!mandate.isSigned()) {
+      throw new IllegalStateException("Mandate is not signed: mandateId=" + mandateId);
+    }
+    return handleSignedMandate(user, mandate, locale);
   }
 
   public Mandate get(Long id) {
@@ -185,18 +190,6 @@ public class MandateService {
     log.info("Mandate processing errors {}", errorsResponse);
     if (errorsResponse.hasErrors()) {
       throw new MandateProcessingException(errorsResponse);
-    }
-  }
-
-  private SignatureStatus handleUnsignedMandateIdCard(
-      User user, Mandate mandate, IdCardSignatureSession session, String signedHashInHex) {
-    byte[] signedFile = signService.getSignedFile(session, signedHashInHex);
-    if (signedFile != null) { // TODO: use Optional
-      persistSignedFile(mandate, signedFile);
-      mandateProcessor.start(user, mandate);
-      return OUTSTANDING_TRANSACTION;
-    } else {
-      throw new IllegalStateException("There is no signed file to persist");
     }
   }
 

--- a/src/main/java/ee/tuleva/onboarding/mandate/MandateService.java
+++ b/src/main/java/ee/tuleva/onboarding/mandate/MandateService.java
@@ -27,6 +27,7 @@ import ee.tuleva.onboarding.signature.SignatureService;
 import ee.tuleva.onboarding.signature.SignatureStateException;
 import ee.tuleva.onboarding.signature.SignatureStatus;
 import ee.tuleva.onboarding.signature.SmartIdSignatureSession;
+import ee.tuleva.onboarding.signature.StartIdCardSignCommand;
 import ee.tuleva.onboarding.user.User;
 import ee.tuleva.onboarding.user.UserService;
 import java.util.List;
@@ -127,9 +128,15 @@ public class MandateService {
     return OUTSTANDING_TRANSACTION;
   }
 
-  public IdCardSignatureSession idCardSign(Long mandateId, Long userId, String signingCertificate) {
+  public IdCardSignatureSession idCardSign(
+      Long mandateId, Long userId, StartIdCardSignCommand signCommand) {
+    User user = userService.getById(userId).orElseThrow();
     List<SignatureFile> files = mandateFileService.getMandateFiles(mandateId, userId);
-    return signService.startIdCardSign(files, signingCertificate);
+    return signService.startIdCardSign(
+        files,
+        signCommand.certificate(),
+        signCommand.supportedHashFunctions(),
+        user.getPersonalCode());
   }
 
   public SignatureStatus finalizeMobileIdSignature(

--- a/src/main/java/ee/tuleva/onboarding/mandate/batch/MandateBatchController.java
+++ b/src/main/java/ee/tuleva/onboarding/mandate/batch/MandateBatchController.java
@@ -75,7 +75,7 @@ public class MandateBatchController implements SignatureController<Long> {
   }
 
   @Override
-  @Operation(summary = "Is the mandate batch signed with ID card processed")
+  @Operation(summary = "Get the ID card signing status of the mandate batch")
   public IdCardSignatureStatusResponse getIdCardSignatureStatus(
       @PathVariable("id") Long mandateBatchId,
       @AuthenticationPrincipal AuthenticatedPerson authenticatedPerson) {

--- a/src/main/java/ee/tuleva/onboarding/mandate/batch/MandateBatchController.java
+++ b/src/main/java/ee/tuleva/onboarding/mandate/batch/MandateBatchController.java
@@ -64,18 +64,23 @@ public class MandateBatchController implements SignatureController<Long> {
         mandateBatchId, authenticatedPerson, signCommand);
   }
 
-  // TODO: split this into PUT and GET endpoints
-  // Currently first call persists signed hex, and later polling calls just check if mandates have
-  // been processsed
   @Override
-  @Operation(
-      summary = "Persist ID-card signed mandate batch, and check if mandate batch is processed")
-  public IdCardSignatureStatusResponse persistIdCardSignedHashOrGetSignatureStatus(
+  @Operation(summary = "Persist the ID card signature of the mandate batch and start processing it")
+  public IdCardSignatureStatusResponse persistIdCardSignature(
       @PathVariable("id") Long mandateBatchId,
       @Valid @RequestBody FinishIdCardSignCommand signCommand,
       @AuthenticationPrincipal AuthenticatedPerson authenticatedPerson) {
-    return mandateBatchSignatureService.persistIdCardSignedHashAndGetProcessingStatus(
+    return mandateBatchSignatureService.persistIdCardSignature(
         mandateBatchId, signCommand, authenticatedPerson);
+  }
+
+  @Override
+  @Operation(summary = "Is the mandate batch signed with ID card processed")
+  public IdCardSignatureStatusResponse getIdCardSignatureStatus(
+      @PathVariable("id") Long mandateBatchId,
+      @AuthenticationPrincipal AuthenticatedPerson authenticatedPerson) {
+    return mandateBatchSignatureService.getIdCardSignatureStatus(
+        mandateBatchId, authenticatedPerson);
   }
 
   @Override

--- a/src/main/java/ee/tuleva/onboarding/mandate/batch/MandateBatchService.java
+++ b/src/main/java/ee/tuleva/onboarding/mandate/batch/MandateBatchService.java
@@ -24,6 +24,7 @@ import ee.tuleva.onboarding.signature.IdCardSignatureSession;
 import ee.tuleva.onboarding.signature.MobileIdSignatureSession;
 import ee.tuleva.onboarding.signature.SignatureFile;
 import ee.tuleva.onboarding.signature.SignatureService;
+import ee.tuleva.onboarding.signature.SignatureStateException;
 import ee.tuleva.onboarding.signature.SignatureStatus;
 import ee.tuleva.onboarding.signature.SmartIdSignatureSession;
 import ee.tuleva.onboarding.user.User;
@@ -175,8 +176,7 @@ public class MandateBatchService {
     MandateBatch mandateBatch = getByIdAndUser(mandateBatchId, user).orElseThrow();
 
     if (mandateBatch.isSigned()) {
-      throw new IllegalStateException(
-          "Mandate batch is already signed: mandateBatchId=" + mandateBatchId);
+      throw SignatureStateException.alreadySigned("Mandate batch", mandateBatchId);
     }
     byte[] signedFile = signService.getSignedFile(session, signature);
     return persistSignedFileIfPresentAndStartProcessing(
@@ -188,8 +188,7 @@ public class MandateBatchService {
     MandateBatch mandateBatch = getByIdAndUser(mandateBatchId, user).orElseThrow();
 
     if (!mandateBatch.isSigned()) {
-      throw new IllegalStateException(
-          "Mandate batch is not signed: mandateBatchId=" + mandateBatchId);
+      throw SignatureStateException.notSigned("Mandate batch", mandateBatchId);
     }
     return getBatchProcessingStatusAndHandleIfProcessed(user, mandateBatch, locale);
   }

--- a/src/main/java/ee/tuleva/onboarding/mandate/batch/MandateBatchService.java
+++ b/src/main/java/ee/tuleva/onboarding/mandate/batch/MandateBatchService.java
@@ -165,35 +165,32 @@ public class MandateBatchService {
     return persistSignedFileIfPresentAndStartProcessing(user, mandateBatch, signedFile, locale);
   }
 
-  private SignatureStatus persistFileSignedWithIdCard(
-      User user,
-      MandateBatch mandateBatch,
-      IdCardSignatureSession session,
-      String signedHashInHex,
-      Locale locale) {
-    byte[] signedFile = signService.getSignedFile(session, signedHashInHex);
-
-    if (signedFile == null) { // TODO: use Optional
-      throw new IllegalStateException("There is no signed file to persist");
-    }
-
-    return persistSignedFileIfPresentAndStartProcessing(
-        user, mandateBatch, Optional.of(signedFile), locale);
-  }
-
-  public SignatureStatus persistIdCardSignedFileOrGetBatchProcessingStatus(
+  public SignatureStatus persistIdCardSignature(
       Long userId,
       Long mandateBatchId,
       IdCardSignatureSession session,
-      String signedHashInHex,
+      String signature,
       Locale locale) {
     User user = userService.getById(userId).orElseThrow();
     MandateBatch mandateBatch = getByIdAndUser(mandateBatchId, user).orElseThrow();
 
-    if (!mandateBatch.isSigned()) {
-      return persistFileSignedWithIdCard(user, mandateBatch, session, signedHashInHex, locale);
+    if (mandateBatch.isSigned()) {
+      throw new IllegalStateException(
+          "Mandate batch is already signed: mandateBatchId=" + mandateBatchId);
     }
+    byte[] signedFile = signService.getSignedFile(session, signature);
+    return persistSignedFileIfPresentAndStartProcessing(
+        user, mandateBatch, Optional.of(signedFile), locale);
+  }
 
+  public SignatureStatus getIdCardSignatureStatus(Long userId, Long mandateBatchId, Locale locale) {
+    User user = userService.getById(userId).orElseThrow();
+    MandateBatch mandateBatch = getByIdAndUser(mandateBatchId, user).orElseThrow();
+
+    if (!mandateBatch.isSigned()) {
+      throw new IllegalStateException(
+          "Mandate batch is not signed: mandateBatchId=" + mandateBatchId);
+    }
     return getBatchProcessingStatusAndHandleIfProcessed(user, mandateBatch, locale);
   }
 

--- a/src/main/java/ee/tuleva/onboarding/mandate/batch/MandateBatchService.java
+++ b/src/main/java/ee/tuleva/onboarding/mandate/batch/MandateBatchService.java
@@ -179,8 +179,7 @@ public class MandateBatchService {
       throw SignatureStateException.alreadySigned("Mandate batch", mandateBatchId);
     }
     byte[] signedFile = signService.getSignedFile(session, signature);
-    return persistSignedFileIfPresentAndStartProcessing(
-        user, mandateBatch, Optional.of(signedFile), locale);
+    return persistSignedFileAndStartProcessing(user, mandateBatch, signedFile, locale);
   }
 
   public SignatureStatus getIdCardSignatureStatus(Long userId, Long mandateBatchId, Locale locale) {
@@ -233,12 +232,16 @@ public class MandateBatchService {
 
   private SignatureStatus persistSignedFileIfPresentAndStartProcessing(
       User user, MandateBatch mandateBatch, Optional<byte[]> signedFile, Locale locale) {
-    signedFile.ifPresent(
-        it -> {
-          persistSignedFile(mandateBatch, it);
-          startProcessingBatch(user, mandateBatch);
-          mandateBatchProcessingPoller.startPollingForBatchProcessingFinished(mandateBatch, locale);
-        });
+    signedFile.ifPresent(it -> persistSignedFileAndStartProcessing(user, mandateBatch, it, locale));
+
+    return OUTSTANDING_TRANSACTION;
+  }
+
+  private SignatureStatus persistSignedFileAndStartProcessing(
+      User user, MandateBatch mandateBatch, byte[] signedFile, Locale locale) {
+    persistSignedFile(mandateBatch, signedFile);
+    startProcessingBatch(user, mandateBatch);
+    mandateBatchProcessingPoller.startPollingForBatchProcessingFinished(mandateBatch, locale);
 
     return OUTSTANDING_TRANSACTION;
   }

--- a/src/main/java/ee/tuleva/onboarding/mandate/batch/MandateBatchSignatureService.java
+++ b/src/main/java/ee/tuleva/onboarding/mandate/batch/MandateBatchSignatureService.java
@@ -73,7 +73,11 @@ public class MandateBatchSignatureService {
         mandateBatchService.getMandateBatchContentFiles(mandateBatchId, user);
 
     IdCardSignatureSession signatureSession =
-        signService.startIdCardSign(files, signCommand.certificate());
+        signService.startIdCardSign(
+            files,
+            signCommand.certificate(),
+            signCommand.supportedHashFunctions(),
+            user.getPersonalCode());
 
     sessionStore.save(signatureSession);
 

--- a/src/main/java/ee/tuleva/onboarding/mandate/batch/MandateBatchSignatureService.java
+++ b/src/main/java/ee/tuleva/onboarding/mandate/batch/MandateBatchSignatureService.java
@@ -17,13 +17,11 @@ import ee.tuleva.onboarding.signature.SmartIdSignatureSession;
 import ee.tuleva.onboarding.signature.StartIdCardSignCommand;
 import ee.tuleva.onboarding.user.User;
 import ee.tuleva.onboarding.user.UserService;
-import jakarta.validation.Valid;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.web.bind.annotation.RequestBody;
 
 @Service
 @RequiredArgsConstructor
@@ -68,39 +66,49 @@ public class MandateBatchSignatureService {
   public IdCardSignatureResponse startIdCardSign(
       Long mandateBatchId,
       AuthenticatedPerson authenticatedPerson,
-      @Valid @RequestBody StartIdCardSignCommand signCommand) {
+      StartIdCardSignCommand signCommand) {
 
     User user = userService.getById(authenticatedPerson.getUserIdOrThrow()).orElseThrow();
     List<SignatureFile> files =
         mandateBatchService.getMandateBatchContentFiles(mandateBatchId, user);
 
     IdCardSignatureSession signatureSession =
-        signService.startIdCardSign(files, signCommand.clientCertificate());
+        signService.startIdCardSign(files, signCommand.certificate());
 
     sessionStore.save(signatureSession);
 
-    return new IdCardSignatureResponse(signatureSession.getHashToSignInHex());
+    return IdCardSignatureResponse.from(signatureSession);
   }
 
-  public IdCardSignatureStatusResponse persistIdCardSignedHashAndGetProcessingStatus(
+  public IdCardSignatureStatusResponse persistIdCardSignature(
       Long mandateBatchId,
-      @Valid @RequestBody FinishIdCardSignCommand signCommand,
+      FinishIdCardSignCommand signCommand,
       AuthenticatedPerson authenticatedPerson) {
 
-    Optional<IdCardSignatureSession> signatureSession =
-        sessionStore.get(IdCardSignatureSession.class);
     IdCardSignatureSession session =
-        signatureSession.orElseThrow(IdSessionException::cardSignatureSessionNotFound);
-
-    Locale locale = localeService.getCurrentLocale();
+        sessionStore
+            .get(IdCardSignatureSession.class)
+            .orElseThrow(IdSessionException::cardSignatureSessionNotFound);
 
     SignatureStatus statusCode =
-        mandateBatchService.persistIdCardSignedFileOrGetBatchProcessingStatus(
+        mandateBatchService.persistIdCardSignature(
             authenticatedPerson.getUserIdOrThrow(),
             mandateBatchId,
             session,
-            signCommand.signedHash(),
-            locale);
+            signCommand.signature(),
+            localeService.getCurrentLocale());
+
+    return new IdCardSignatureStatusResponse(statusCode);
+  }
+
+  public IdCardSignatureStatusResponse getIdCardSignatureStatus(
+      Long mandateBatchId, AuthenticatedPerson authenticatedPerson) {
+
+    SignatureStatus statusCode =
+        mandateBatchService.getIdCardSignatureStatus(
+            authenticatedPerson.getUserIdOrThrow(),
+            mandateBatchId,
+            localeService.getCurrentLocale());
 
     return new IdCardSignatureStatusResponse(statusCode);
   }

--- a/src/main/java/ee/tuleva/onboarding/personalcode/PersonalCode.java
+++ b/src/main/java/ee/tuleva/onboarding/personalcode/PersonalCode.java
@@ -19,6 +19,8 @@ import org.jspecify.annotations.NullMarked;
 @NullMarked
 public class PersonalCode {
 
+  private static final String ESTONIAN_SUBJECT_ID_CODE_PREFIX = "PNOEE-";
+
   private static final NavigableMap<Integer, Period> ESTABLISHED_RETIREMENT_AGE_BY_YEAR =
       new TreeMap<>(
           Map.of(
@@ -26,6 +28,12 @@ public class PersonalCode {
               2028, Period.of(65, 3, 0)));
 
   private static final Period BASE_RETIREMENT_AGE = Period.ofYears(65);
+
+  public static String fromSubjectIdCode(String subjectIdCode) {
+    return subjectIdCode.startsWith(ESTONIAN_SUBJECT_ID_CODE_PREFIX)
+        ? subjectIdCode.substring(ESTONIAN_SUBJECT_ID_CODE_PREFIX.length())
+        : subjectIdCode;
+  }
 
   public static int getAge(String personalCode) {
     LocalDate today = clock().instant().atZone(ZoneId.systemDefault()).toLocalDate();

--- a/src/main/java/ee/tuleva/onboarding/signature/DigiDocFacade.java
+++ b/src/main/java/ee/tuleva/onboarding/signature/DigiDocFacade.java
@@ -48,10 +48,12 @@ public class DigiDocFacade {
     return files.getFirst().isContainer();
   }
 
-  public DataToSign dataToSign(Container container, X509Certificate certificate) {
+  public DataToSign dataToSign(
+      Container container, X509Certificate certificate, DigestAlgorithm digestAlgorithm) {
     return SignatureBuilder.aSignature(container)
         .withSigningCertificate(certificate)
-        .withSignatureDigestAlgorithm(DigestAlgorithm.SHA256)
+        .withSignatureDigestAlgorithm(digestAlgorithm)
+        .withSignatureProfile(SignatureProfile.LT)
         .buildDataToSign();
   }
 

--- a/src/main/java/ee/tuleva/onboarding/signature/DigiDocFacade.java
+++ b/src/main/java/ee/tuleva/onboarding/signature/DigiDocFacade.java
@@ -57,8 +57,12 @@ public class DigiDocFacade {
 
   @SneakyThrows
   public byte[] digestToSign(DataToSign dataToSign) {
-    MessageDigest digest = MessageDigest.getInstance("SHA-256");
+    MessageDigest digest = MessageDigest.getInstance(hashFunction(dataToSign));
     return digest.digest(dataToSign.getDataToSign());
+  }
+
+  public String hashFunction(DataToSign dataToSign) {
+    return dataToSign.getDigestAlgorithm().getDssDigestAlgorithm().getJavaName();
   }
 
   @SneakyThrows

--- a/src/main/java/ee/tuleva/onboarding/signature/FinishIdCardSignCommand.java
+++ b/src/main/java/ee/tuleva/onboarding/signature/FinishIdCardSignCommand.java
@@ -2,4 +2,4 @@ package ee.tuleva.onboarding.signature;
 
 import jakarta.validation.constraints.NotBlank;
 
-public record FinishIdCardSignCommand(@NotBlank String signedHash) {}
+public record FinishIdCardSignCommand(@NotBlank String signature) {}

--- a/src/main/java/ee/tuleva/onboarding/signature/IdCardSignatureResponse.java
+++ b/src/main/java/ee/tuleva/onboarding/signature/IdCardSignatureResponse.java
@@ -1,13 +1,8 @@
 package ee.tuleva.onboarding.signature;
 
-import lombok.Builder;
-import lombok.Data;
-import lombok.RequiredArgsConstructor;
+public record IdCardSignatureResponse(String hash, String hashFunction) {
 
-@Data
-@Builder
-@RequiredArgsConstructor
-public class IdCardSignatureResponse {
-
-  private final String hash;
+  public static IdCardSignatureResponse from(IdCardSignatureSession session) {
+    return new IdCardSignatureResponse(session.getHashToSign(), session.getHashFunction());
+  }
 }

--- a/src/main/java/ee/tuleva/onboarding/signature/IdCardSignatureSession.java
+++ b/src/main/java/ee/tuleva/onboarding/signature/IdCardSignatureSession.java
@@ -16,7 +16,8 @@ public class IdCardSignatureSession implements Serializable {
 
   private static final long serialVersionUID = 8149193185518071327L;
 
-  private final String hashToSignInHex;
+  private final String hashToSign;
+  private final String hashFunction;
   private final DataToSign dataToSign;
   private final Container container;
 }

--- a/src/main/java/ee/tuleva/onboarding/signature/SignatureController.java
+++ b/src/main/java/ee/tuleva/onboarding/signature/SignatureController.java
@@ -35,7 +35,7 @@ public interface SignatureController<TEntityId> {
       @Valid @RequestBody FinishIdCardSignCommand signCommand,
       @AuthenticationPrincipal AuthenticatedPerson authenticatedPerson);
 
-  @Operation(summary = "Is the entity signed with ID card processed")
+  @Operation(summary = "Get the ID card signing status of the entity")
   @GetMapping("/{id}/signature/id-card/status")
   IdCardSignatureStatusResponse getIdCardSignatureStatus(
       @PathVariable("id") TEntityId entityId,

--- a/src/main/java/ee/tuleva/onboarding/signature/SignatureController.java
+++ b/src/main/java/ee/tuleva/onboarding/signature/SignatureController.java
@@ -28,14 +28,17 @@ public interface SignatureController<TEntityId> {
       @AuthenticationPrincipal AuthenticatedPerson authenticatedPerson,
       @Valid @RequestBody StartIdCardSignCommand signCommand);
 
-  // TODO: split this into PUT and GET endpoints
-  // Currently first call persists signed hex, and later polling calls just check if mandates have
-  // been processsed
-  @Operation(summary = "Persist ID-card signed entity, and check if entity is processed")
-  @PutMapping("/{id}/signature/id-card/status")
-  IdCardSignatureStatusResponse persistIdCardSignedHashOrGetSignatureStatus(
+  @Operation(summary = "Persist the ID card signature of the entity and start processing it")
+  @PutMapping("/{id}/signature/id-card/signature")
+  IdCardSignatureStatusResponse persistIdCardSignature(
       @PathVariable("id") TEntityId entityId,
       @Valid @RequestBody FinishIdCardSignCommand signCommand,
+      @AuthenticationPrincipal AuthenticatedPerson authenticatedPerson);
+
+  @Operation(summary = "Is the entity signed with ID card processed")
+  @GetMapping("/{id}/signature/id-card/status")
+  IdCardSignatureStatusResponse getIdCardSignatureStatus(
+      @PathVariable("id") TEntityId entityId,
       @AuthenticationPrincipal AuthenticatedPerson authenticatedPerson);
 
   @Operation(summary = "Start signing entity with mobile ID")

--- a/src/main/java/ee/tuleva/onboarding/signature/SignatureService.java
+++ b/src/main/java/ee/tuleva/onboarding/signature/SignatureService.java
@@ -34,8 +34,11 @@ public class SignatureService {
   }
 
   public IdCardSignatureSession startIdCardSign(
-      List<SignatureFile> files, String signingCertificate) {
-    return idCardSigner.startSign(files, signingCertificate);
+      List<SignatureFile> files,
+      String signingCertificate,
+      List<String> supportedHashFunctions,
+      String personalCode) {
+    return idCardSigner.startSign(files, signingCertificate, supportedHashFunctions, personalCode);
   }
 
   public byte[] getSignedFile(IdCardSignatureSession session, String signature) {

--- a/src/main/java/ee/tuleva/onboarding/signature/SignatureService.java
+++ b/src/main/java/ee/tuleva/onboarding/signature/SignatureService.java
@@ -38,7 +38,7 @@ public class SignatureService {
     return idCardSigner.startSign(files, signingCertificate);
   }
 
-  public byte[] getSignedFile(IdCardSignatureSession session, String signedHashInHex) {
-    return idCardSigner.getSignedFile(session, signedHashInHex);
+  public byte[] getSignedFile(IdCardSignatureSession session, String signature) {
+    return idCardSigner.getSignedFile(session, signature);
   }
 }

--- a/src/main/java/ee/tuleva/onboarding/signature/SignatureStateException.java
+++ b/src/main/java/ee/tuleva/onboarding/signature/SignatureStateException.java
@@ -1,0 +1,21 @@
+package ee.tuleva.onboarding.signature;
+
+import ee.tuleva.onboarding.error.ErrorsResponseException;
+import ee.tuleva.onboarding.error.response.ErrorsResponse;
+
+public class SignatureStateException extends ErrorsResponseException {
+
+  private SignatureStateException(String code, String message) {
+    super(ErrorsResponse.ofSingleError(code, message));
+  }
+
+  public static SignatureStateException alreadySigned(String entity, Object entityId) {
+    return new SignatureStateException(
+        "signature.already.signed", entity + " is already signed: id=" + entityId);
+  }
+
+  public static SignatureStateException notSigned(String entity, Object entityId) {
+    return new SignatureStateException(
+        "signature.not.signed", entity + " is not signed: id=" + entityId);
+  }
+}

--- a/src/main/java/ee/tuleva/onboarding/signature/StartIdCardSignCommand.java
+++ b/src/main/java/ee/tuleva/onboarding/signature/StartIdCardSignCommand.java
@@ -1,5 +1,8 @@
 package ee.tuleva.onboarding.signature;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import java.util.List;
 
-public record StartIdCardSignCommand(@NotBlank String certificate) {}
+public record StartIdCardSignCommand(
+    @NotBlank String certificate, @NotEmpty List<String> supportedHashFunctions) {}

--- a/src/main/java/ee/tuleva/onboarding/signature/StartIdCardSignCommand.java
+++ b/src/main/java/ee/tuleva/onboarding/signature/StartIdCardSignCommand.java
@@ -2,4 +2,4 @@ package ee.tuleva.onboarding.signature;
 
 import jakarta.validation.constraints.NotBlank;
 
-public record StartIdCardSignCommand(@NotBlank String clientCertificate) {}
+public record StartIdCardSignCommand(@NotBlank String certificate) {}

--- a/src/main/java/ee/tuleva/onboarding/signature/idcard/IdCardSigner.java
+++ b/src/main/java/ee/tuleva/onboarding/signature/idcard/IdCardSigner.java
@@ -34,7 +34,15 @@ public class IdCardSigner {
 
   public byte[] getSignedFile(IdCardSignatureSession session, String signature) {
     return digiDocFacade.addSignatureToContainer(
-        getDecoder().decode(signature), session.getDataToSign(), session.getContainer());
+        decodeSignature(signature), session.getDataToSign(), session.getContainer());
+  }
+
+  private static byte[] decodeSignature(String signature) {
+    try {
+      return getDecoder().decode(signature);
+    } catch (IllegalArgumentException e) {
+      throw new InvalidSignatureException(e);
+    }
   }
 
   private static X509Certificate decodeCertificate(String certificate) {

--- a/src/main/java/ee/tuleva/onboarding/signature/idcard/IdCardSigner.java
+++ b/src/main/java/ee/tuleva/onboarding/signature/idcard/IdCardSigner.java
@@ -1,14 +1,17 @@
 package ee.tuleva.onboarding.signature.idcard;
 
-import ee.tuleva.onboarding.auth.ocsp.OCSPUtils;
+import static java.util.Base64.getDecoder;
+import static java.util.Base64.getEncoder;
+
 import ee.tuleva.onboarding.signature.DigiDocFacade;
 import ee.tuleva.onboarding.signature.IdCardSignatureSession;
 import ee.tuleva.onboarding.signature.SignatureFile;
+import java.io.ByteArrayInputStream;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import lombok.SneakyThrows;
-import org.apache.commons.codec.binary.Hex;
 import org.digidoc4j.Container;
 import org.digidoc4j.DataToSign;
 import org.springframework.stereotype.Service;
@@ -17,24 +20,30 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class IdCardSigner {
 
-  private final OCSPUtils ocspUtils;
   private final DigiDocFacade digiDocFacade;
 
-  public IdCardSignatureSession startSign(List<SignatureFile> files, String signingCertificate) {
-    X509Certificate certificate = ocspUtils.decodeX09Certificate(signingCertificate);
+  public IdCardSignatureSession startSign(List<SignatureFile> files, String certificate) {
+    X509Certificate signingCertificate = decodeCertificate(certificate);
     Container container = digiDocFacade.buildContainer(files);
+    DataToSign dataToSign = digiDocFacade.dataToSign(container, signingCertificate);
+    String hashToSign = getEncoder().encodeToString(digiDocFacade.digestToSign(dataToSign));
 
-    DataToSign dataToSign = digiDocFacade.dataToSign(container, certificate);
-    byte[] digestToSign = digiDocFacade.digestToSign(dataToSign);
-    String hashToSignInHex = Hex.encodeHexString(digestToSign);
-
-    return new IdCardSignatureSession(hashToSignInHex, dataToSign, container);
+    return new IdCardSignatureSession(
+        hashToSign, digiDocFacade.hashFunction(dataToSign), dataToSign, container);
   }
 
-  @SneakyThrows
-  public byte[] getSignedFile(IdCardSignatureSession session, String signedHashInHex) {
-    byte[] signature = Hex.decodeHex(signedHashInHex);
+  public byte[] getSignedFile(IdCardSignatureSession session, String signature) {
     return digiDocFacade.addSignatureToContainer(
-        signature, session.getDataToSign(), session.getContainer());
+        getDecoder().decode(signature), session.getDataToSign(), session.getContainer());
+  }
+
+  private static X509Certificate decodeCertificate(String certificate) {
+    try {
+      return (X509Certificate)
+          CertificateFactory.getInstance("X.509")
+              .generateCertificate(new ByteArrayInputStream(getDecoder().decode(certificate)));
+    } catch (CertificateException | IllegalArgumentException e) {
+      throw new InvalidSigningCertificateException(e);
+    }
   }
 }

--- a/src/main/java/ee/tuleva/onboarding/signature/idcard/IdCardSigner.java
+++ b/src/main/java/ee/tuleva/onboarding/signature/idcard/IdCardSigner.java
@@ -3,10 +3,13 @@ package ee.tuleva.onboarding.signature.idcard;
 import static java.util.Base64.getDecoder;
 import static java.util.Base64.getEncoder;
 
+import ee.tuleva.onboarding.personalcode.PersonalCode;
 import ee.tuleva.onboarding.signature.DigiDocFacade;
 import ee.tuleva.onboarding.signature.IdCardSignatureSession;
 import ee.tuleva.onboarding.signature.SignatureFile;
+import eu.webeid.security.certificate.CertificateData;
 import java.io.ByteArrayInputStream;
+import java.security.cert.CertificateEncodingException;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
@@ -14,6 +17,8 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.digidoc4j.Container;
 import org.digidoc4j.DataToSign;
+import org.digidoc4j.DigestAlgorithm;
+import org.digidoc4j.utils.TokenAlgorithmSupport;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -22,10 +27,21 @@ public class IdCardSigner {
 
   private final DigiDocFacade digiDocFacade;
 
-  public IdCardSignatureSession startSign(List<SignatureFile> files, String certificate) {
+  public IdCardSignatureSession startSign(
+      List<SignatureFile> files,
+      String certificate,
+      List<String> supportedHashFunctions,
+      String personalCode) {
     X509Certificate signingCertificate = decodeCertificate(certificate);
+    requireBelongsToSigner(signingCertificate, personalCode);
+    DigestAlgorithm digestAlgorithm =
+        requireSupported(
+            TokenAlgorithmSupport.determineSignatureDigestAlgorithm(signingCertificate),
+            supportedHashFunctions);
+
     Container container = digiDocFacade.buildContainer(files);
-    DataToSign dataToSign = digiDocFacade.dataToSign(container, signingCertificate);
+    DataToSign dataToSign =
+        digiDocFacade.dataToSign(container, signingCertificate, digestAlgorithm);
     String hashToSign = getEncoder().encodeToString(digiDocFacade.digestToSign(dataToSign));
 
     return new IdCardSignatureSession(
@@ -35,6 +51,31 @@ public class IdCardSigner {
   public byte[] getSignedFile(IdCardSignatureSession session, String signature) {
     return digiDocFacade.addSignatureToContainer(
         decodeSignature(signature), session.getDataToSign(), session.getContainer());
+  }
+
+  private static void requireBelongsToSigner(X509Certificate certificate, String personalCode) {
+    if (!subjectIdCode(certificate).equals(personalCode)) {
+      throw new SigningCertificateMismatchException();
+    }
+  }
+
+  private static String subjectIdCode(X509Certificate certificate) {
+    try {
+      return PersonalCode.fromSubjectIdCode(
+          CertificateData.getSubjectIdCode(certificate)
+              .orElseThrow(SigningCertificateMismatchException::new));
+    } catch (CertificateEncodingException e) {
+      throw new InvalidSigningCertificateException(e);
+    }
+  }
+
+  private static DigestAlgorithm requireSupported(
+      DigestAlgorithm digestAlgorithm, List<String> supportedHashFunctions) {
+    String hashFunction = digestAlgorithm.getDssDigestAlgorithm().getJavaName();
+    if (!supportedHashFunctions.contains(hashFunction)) {
+      throw new UnsupportedHashFunctionException(hashFunction, supportedHashFunctions);
+    }
+    return digestAlgorithm;
   }
 
   private static byte[] decodeSignature(String signature) {

--- a/src/main/java/ee/tuleva/onboarding/signature/idcard/InvalidSignatureException.java
+++ b/src/main/java/ee/tuleva/onboarding/signature/idcard/InvalidSignatureException.java
@@ -1,0 +1,14 @@
+package ee.tuleva.onboarding.signature.idcard;
+
+import ee.tuleva.onboarding.error.ErrorsResponseException;
+import ee.tuleva.onboarding.error.response.ErrorsResponse;
+
+public class InvalidSignatureException extends ErrorsResponseException {
+
+  public InvalidSignatureException(Exception cause) {
+    super(
+        ErrorsResponse.ofSingleError(
+            "id.card.signature.invalid", "Signature is not base64 encoded"));
+    initCause(cause);
+  }
+}

--- a/src/main/java/ee/tuleva/onboarding/signature/idcard/InvalidSigningCertificateException.java
+++ b/src/main/java/ee/tuleva/onboarding/signature/idcard/InvalidSigningCertificateException.java
@@ -1,0 +1,15 @@
+package ee.tuleva.onboarding.signature.idcard;
+
+import ee.tuleva.onboarding.error.ErrorsResponseException;
+import ee.tuleva.onboarding.error.response.ErrorsResponse;
+
+public class InvalidSigningCertificateException extends ErrorsResponseException {
+
+  public InvalidSigningCertificateException(Exception cause) {
+    super(
+        ErrorsResponse.ofSingleError(
+            "id.card.signing.certificate.invalid",
+            "Signing certificate is not a base64 encoded DER certificate"));
+    initCause(cause);
+  }
+}

--- a/src/main/java/ee/tuleva/onboarding/signature/idcard/SigningCertificateMismatchException.java
+++ b/src/main/java/ee/tuleva/onboarding/signature/idcard/SigningCertificateMismatchException.java
@@ -1,0 +1,14 @@
+package ee.tuleva.onboarding.signature.idcard;
+
+import ee.tuleva.onboarding.error.ErrorsResponseException;
+import ee.tuleva.onboarding.error.response.ErrorsResponse;
+
+public class SigningCertificateMismatchException extends ErrorsResponseException {
+
+  public SigningCertificateMismatchException() {
+    super(
+        ErrorsResponse.ofSingleError(
+            "id.card.signing.certificate.mismatch",
+            "Signing certificate belongs to someone other than the signer"));
+  }
+}

--- a/src/main/java/ee/tuleva/onboarding/signature/idcard/UnsupportedHashFunctionException.java
+++ b/src/main/java/ee/tuleva/onboarding/signature/idcard/UnsupportedHashFunctionException.java
@@ -1,0 +1,18 @@
+package ee.tuleva.onboarding.signature.idcard;
+
+import ee.tuleva.onboarding.error.ErrorsResponseException;
+import ee.tuleva.onboarding.error.response.ErrorsResponse;
+import java.util.List;
+
+public class UnsupportedHashFunctionException extends ErrorsResponseException {
+
+  public UnsupportedHashFunctionException(String hashFunction, List<String> supported) {
+    super(
+        ErrorsResponse.ofSingleError(
+            "id.card.signing.hash.function.unsupported",
+            "Signing certificate requires "
+                + hashFunction
+                + ", but the card supports "
+                + String.join(", ", supported)));
+  }
+}

--- a/src/main/java/ee/tuleva/onboarding/signature/mobileid/MobileIdSigner.java
+++ b/src/main/java/ee/tuleva/onboarding/signature/mobileid/MobileIdSigner.java
@@ -24,6 +24,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import org.digidoc4j.Container;
 import org.digidoc4j.DataToSign;
+import org.digidoc4j.DigestAlgorithm;
 import org.jetbrains.annotations.Nullable;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -44,7 +45,8 @@ public class MobileIdSigner {
     X509Certificate certificate = getCertificate(phoneNumber, personalCode);
     Container container = digiDocFacade.buildContainer(files);
 
-    DataToSign dataToSign = digiDocFacade.dataToSign(container, certificate);
+    DataToSign dataToSign =
+        digiDocFacade.dataToSign(container, certificate, DigestAlgorithm.SHA256);
     byte[] dataToHash = dataToSign.getDataToSign();
 
     MidHashToSign hashToSign = hashToSign(dataToHash);

--- a/src/main/java/ee/tuleva/onboarding/signature/smartid/SmartIdSigner.java
+++ b/src/main/java/ee/tuleva/onboarding/signature/smartid/SmartIdSigner.java
@@ -27,6 +27,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import org.digidoc4j.Container;
 import org.digidoc4j.DataToSign;
+import org.digidoc4j.DigestAlgorithm;
 import org.jetbrains.annotations.NotNull;
 import org.jspecify.annotations.Nullable;
 import org.springframework.stereotype.Service;
@@ -91,7 +92,8 @@ public class SmartIdSigner {
 
     Container container = digiDocFacade.buildContainer(files);
 
-    DataToSign dataToSign = digiDocFacade.dataToSign(container, certificate);
+    DataToSign dataToSign =
+        digiDocFacade.dataToSign(container, certificate, DigestAlgorithm.SHA256);
     byte[] digestToSign = digiDocFacade.digestToSign(dataToSign);
 
     SignableHash signableHash = signableHash(digestToSign);

--- a/src/test/groovy/ee/tuleva/onboarding/auth/ocsp/OCSPUtilsSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/auth/ocsp/OCSPUtilsSpec.groovy
@@ -1,6 +1,5 @@
 package ee.tuleva.onboarding.auth.ocsp
 
-import org.apache.commons.codec.binary.Hex
 import spock.lang.Specification
 
 import java.nio.charset.StandardCharsets
@@ -86,19 +85,6 @@ class OCSPUtilsSpec extends Specification {
 
         when:
         def response = ocspUtils.getX509Certificate(certString)
-
-        then:
-        response == originalCert
-    }
-
-    def "Test if X509Certificate is properly decoded from hex"() {
-        given:
-        def originalCert = OCSPFixture.generateCertificate("Tiit,Lepp,37801145819", -1, "SHA1WITHRSA", "http://issuer.ee/ca.crl", "http://issuer.ee/ocsp")
-        def certString = OCSPFixture.certToString(originalCert)
-        def certificateInHex = Hex.encodeHexString(certString.bytes)
-
-        when:
-        def response = ocspUtils.decodeX09Certificate(certificateInHex)
 
         then:
         response == originalCert

--- a/src/test/groovy/ee/tuleva/onboarding/auth/webeid/WebEidAuthServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/auth/webeid/WebEidAuthServiceTest.java
@@ -34,7 +34,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 class WebEidAuthServiceTest {
@@ -199,16 +198,6 @@ class WebEidAuthServiceTest {
 
     assertThatThrownBy(() -> service.authenticate(new WebEidAuthToken()))
         .isInstanceOf(WebEidAuthException.class);
-  }
-
-  @Test
-  void extractPersonalCode_returnsSerialNumberUnchangedWhenNotEstonian() {
-    var foreignSerialNumber = "PASJP-123456789";
-
-    String personalCode =
-        ReflectionTestUtils.invokeMethod(service, "extractPersonalCode", foreignSerialNumber);
-
-    assertThat(personalCode).isEqualTo(foreignSerialNumber);
   }
 
   private void setupNonceStore() throws AuthTokenException {

--- a/src/test/groovy/ee/tuleva/onboarding/capital/transfer/CapitalTransferContractControllerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/capital/transfer/CapitalTransferContractControllerTest.java
@@ -353,7 +353,8 @@ class CapitalTransferContractControllerTest {
     Authentication authentication =
         new UsernamePasswordAuthenticationToken(authenticatedPerson, null, Collections.emptyList());
 
-    StartIdCardSignCommand command = new StartIdCardSignCommand("test-certificate");
+    StartIdCardSignCommand command =
+        new StartIdCardSignCommand("test-certificate", List.of("SHA-256"));
 
     IdCardSignatureResponse response = new IdCardSignatureResponse("hash-to-sign", "SHA-256");
 

--- a/src/test/groovy/ee/tuleva/onboarding/capital/transfer/CapitalTransferContractControllerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/capital/transfer/CapitalTransferContractControllerTest.java
@@ -100,7 +100,7 @@ class CapitalTransferContractControllerTest {
                         new BigDecimal("1.0"))))
             .build();
 
-    User sellerUser = sampleUser().id(1L).personalCode("37605030299").build();
+    User sellerUser = sampleUser().id(1L).personalCode("30303039816").build();
     Member sellerMember = memberFixture().id(1L).user(sellerUser).memberNumber(1001).build();
     User buyerUser = sampleUser().id(2L).personalCode("60001019906").build();
     Member buyerMember = memberFixture().id(2L).user(buyerUser).memberNumber(1002).build();
@@ -145,7 +145,7 @@ class CapitalTransferContractControllerTest {
   void getContract_returns_contract_by_id() throws Exception {
     // given
     Long contractId = 1L;
-    User sellerUser = sampleUser().id(1L).personalCode("37605030299").build();
+    User sellerUser = sampleUser().id(1L).personalCode("30303039816").build();
     Member sellerMember = memberFixture().id(1L).user(sellerUser).memberNumber(1001).build();
     User buyerUser = sampleUser().id(2L).personalCode("60001019906").build();
     Member buyerMember = memberFixture().id(2L).user(buyerUser).memberNumber(1002).build();
@@ -177,7 +177,7 @@ class CapitalTransferContractControllerTest {
   void getContracts_returns_my_contracts() throws Exception {
     // given
     Long contractId = 1L;
-    User sellerUser = sampleUser().id(1L).personalCode("37605030299").build();
+    User sellerUser = sampleUser().id(1L).personalCode("30303039816").build();
     Member sellerMember = memberFixture().id(1L).user(sellerUser).memberNumber(1001).build();
     User buyerUser = sampleUser().id(2L).personalCode("60001019906").build();
     Member buyerMember = memberFixture().id(2L).user(buyerUser).memberNumber(1002).build();
@@ -211,7 +211,7 @@ class CapitalTransferContractControllerTest {
         new UpdateCapitalTransferContractStateCommand();
     command.setState(PAYMENT_CONFIRMED_BY_BUYER);
 
-    User sellerUser = sampleUser().id(1L).personalCode("37605030299").build();
+    User sellerUser = sampleUser().id(1L).personalCode("30303039816").build();
     Member sellerMember = memberFixture().id(1L).user(sellerUser).memberNumber(1001).build();
     User buyerUser = sampleUser().id(2L).personalCode("60001019906").build();
     Member buyerMember = memberFixture().id(2L).user(buyerUser).memberNumber(1002).build();
@@ -251,7 +251,7 @@ class CapitalTransferContractControllerTest {
         new UpdateCapitalTransferContractStateCommand();
     command.setState(CapitalTransferContractState.PAYMENT_CONFIRMED_BY_SELLER);
 
-    User sellerUser = sampleUser().id(1L).personalCode("37605030299").build();
+    User sellerUser = sampleUser().id(1L).personalCode("30303039816").build();
     Member sellerMember = memberFixture().id(1L).user(sellerUser).memberNumber(1001).build();
     User buyerUser = sampleUser().id(2L).personalCode("60001019906").build();
     Member buyerMember = memberFixture().id(2L).user(buyerUser).memberNumber(1002).build();
@@ -288,7 +288,7 @@ class CapitalTransferContractControllerTest {
     // given
     Long contractId = 1L;
 
-    User user = sampleUser().id(1L).personalCode("37605030299").build();
+    User user = sampleUser().id(1L).personalCode("30303039816").build();
     AuthenticatedPerson authenticatedPerson = authenticatedPersonFromUser(user).build();
 
     Authentication authentication =
@@ -317,7 +317,7 @@ class CapitalTransferContractControllerTest {
   void getSmartIdSignatureStatus_returns_signature_status() throws Exception {
     // given
     Long contractId = 1L;
-    User user = sampleUser().id(1L).personalCode("37605030299").build();
+    User user = sampleUser().id(1L).personalCode("30303039816").build();
     AuthenticatedPerson authenticatedPerson = authenticatedPersonFromUser(user).build();
 
     Authentication authentication =
@@ -347,7 +347,7 @@ class CapitalTransferContractControllerTest {
   void startIdCardSignature_initiates_id_card_signature_process() throws Exception {
     // given
     Long contractId = 1L;
-    User user = sampleUser().id(1L).personalCode("37605030299").build();
+    User user = sampleUser().id(1L).personalCode("30303039816").build();
     AuthenticatedPerson authenticatedPerson = authenticatedPersonFromUser(user).build();
 
     Authentication authentication =
@@ -355,7 +355,7 @@ class CapitalTransferContractControllerTest {
 
     StartIdCardSignCommand command = new StartIdCardSignCommand("test-certificate");
 
-    IdCardSignatureResponse response = new IdCardSignatureResponse("hash-to-sign");
+    IdCardSignatureResponse response = new IdCardSignatureResponse("hash-to-sign", "SHA-256");
 
     given(
             signatureService.startIdCardSignature(
@@ -372,7 +372,8 @@ class CapitalTransferContractControllerTest {
                 .with(csrf())
                 .with(authentication(authentication)))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$.hash", is("hash-to-sign")));
+        .andExpect(jsonPath("$.hash", is("hash-to-sign")))
+        .andExpect(jsonPath("$.hashFunction", is("SHA-256")));
 
     verify(signatureService)
         .startIdCardSignature(
@@ -382,49 +383,56 @@ class CapitalTransferContractControllerTest {
   }
 
   @Test
-  void persistIdCardSignedHashOrGetSignatureStatus_returns_signature_status() throws Exception {
-    // given
+  void persistIdCardSignature_returns_signature_status() throws Exception {
     Long contractId = 1L;
-    User user = sampleUser().id(1L).personalCode("37605030299").build();
+    User user = sampleUser().id(1L).personalCode("30303039816").build();
     AuthenticatedPerson authenticatedPerson = authenticatedPersonFromUser(user).build();
-
     Authentication authentication =
         new UsernamePasswordAuthenticationToken(authenticatedPerson, null, Collections.emptyList());
-
-    FinishIdCardSignCommand command = new FinishIdCardSignCommand("signed-hash");
-
-    IdCardSignatureStatusResponse response =
-        new IdCardSignatureStatusResponse(SignatureStatus.SIGNATURE);
+    FinishIdCardSignCommand command = new FinishIdCardSignCommand("signature");
 
     given(
-            signatureService.persistIdCardSignedHashAndGetProcessingStatus(
+            signatureService.persistIdCardSignature(
                 Mockito.eq(contractId),
-                Mockito.any(FinishIdCardSignCommand.class),
+                Mockito.eq(command),
                 Mockito.any(AuthenticatedPerson.class)))
-        .willReturn(response);
+        .willReturn(new IdCardSignatureStatusResponse(SignatureStatus.SIGNATURE));
 
-    // when, then
     mvc.perform(
-            put("/v1/capital-transfer-contracts/{id}/signature/id-card/status", contractId)
+            put("/v1/capital-transfer-contracts/{id}/signature/id-card/signature", contractId)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(command))
                 .with(csrf())
                 .with(authentication(authentication)))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.statusCode", is("SIGNATURE")));
+  }
 
-    verify(signatureService)
-        .persistIdCardSignedHashAndGetProcessingStatus(
-            Mockito.eq(contractId),
-            Mockito.any(FinishIdCardSignCommand.class),
-            Mockito.any(AuthenticatedPerson.class));
+  @Test
+  void getIdCardSignatureStatus_returns_signature_status() throws Exception {
+    Long contractId = 1L;
+    User user = sampleUser().id(1L).personalCode("30303039816").build();
+    AuthenticatedPerson authenticatedPerson = authenticatedPersonFromUser(user).build();
+    Authentication authentication =
+        new UsernamePasswordAuthenticationToken(authenticatedPerson, null, Collections.emptyList());
+
+    given(
+            signatureService.getIdCardSignatureStatus(
+                Mockito.eq(contractId), Mockito.any(AuthenticatedPerson.class)))
+        .willReturn(new IdCardSignatureStatusResponse(SignatureStatus.OUTSTANDING_TRANSACTION));
+
+    mvc.perform(
+            get("/v1/capital-transfer-contracts/{id}/signature/id-card/status", contractId)
+                .with(authentication(authentication)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.statusCode", is("OUTSTANDING_TRANSACTION")));
   }
 
   @Test
   void startMobileIdSignature_initiates_mobile_id_signature_process() throws Exception {
     // given
     Long contractId = 1L;
-    User user = sampleUser().id(1L).personalCode("37605030299").build();
+    User user = sampleUser().id(1L).personalCode("30303039816").build();
     AuthenticatedPerson authenticatedPerson = authenticatedPersonFromUser(user).build();
 
     Authentication authentication =
@@ -453,7 +461,7 @@ class CapitalTransferContractControllerTest {
   void getMobileIdSignatureStatus_returns_mobile_id_signature_status() throws Exception {
     // given
     Long contractId = 1L;
-    User user = sampleUser().id(1L).personalCode("37605030299").build();
+    User user = sampleUser().id(1L).personalCode("30303039816").build();
     AuthenticatedPerson authenticatedPerson = authenticatedPersonFromUser(user).build();
 
     Authentication authentication =

--- a/src/test/groovy/ee/tuleva/onboarding/capital/transfer/CapitalTransferContractTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/capital/transfer/CapitalTransferContractTest.java
@@ -1,5 +1,6 @@
 package ee.tuleva.onboarding.capital.transfer;
 
+import static ee.tuleva.onboarding.auth.UserFixture.sampleUser;
 import static ee.tuleva.onboarding.capital.event.member.MemberCapitalEventType.CAPITAL_PAYMENT;
 import static ee.tuleva.onboarding.capital.transfer.CapitalTransferContractFixture.sampleCapitalTransferContract;
 import static ee.tuleva.onboarding.user.MemberFixture.memberFixture;
@@ -7,6 +8,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import ee.tuleva.onboarding.time.ClockHolder;
+import ee.tuleva.onboarding.user.User;
 import ee.tuleva.onboarding.user.member.Member;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validation;
@@ -379,6 +381,65 @@ class CapitalTransferContractTest {
       assertThat(contract.getBuyerFirstName()).isEqualTo(buyer.getFirstName());
       assertThat(contract.getBuyerLastName()).isEqualTo(buyer.getLastName());
       assertThat(contract.getBuyerFullName()).isEqualTo(buyer.getFullName());
+    }
+  }
+
+  @Nested
+  class IsSignedBy {
+
+    private User sellerUser;
+    private User buyerUser;
+
+    @BeforeEach
+    void setUpUsers() {
+      sellerUser = sampleUser().id(11L).member(seller).build();
+      buyerUser = sampleUser().id(12L).member(buyer).build();
+    }
+
+    @Test
+    void nobodyHasSignedACreatedContract() {
+      CapitalTransferContract contract =
+          contractBuilder.state(CapitalTransferContractState.CREATED).build();
+
+      assertThat(contract.isSignedBy(sellerUser)).isFalse();
+      assertThat(contract.isSignedBy(buyerUser)).isFalse();
+    }
+
+    @Test
+    void onlyTheSellerHasSignedASellerSignedContract() {
+      CapitalTransferContract contract =
+          contractBuilder.state(CapitalTransferContractState.SELLER_SIGNED).build();
+
+      assertThat(contract.isSignedBy(sellerUser)).isTrue();
+      assertThat(contract.isSignedBy(buyerUser)).isFalse();
+    }
+
+    @Test
+    void bothPartiesHaveSignedFromBuyerSignedOnwards() {
+      CapitalTransferContract contract =
+          contractBuilder.state(CapitalTransferContractState.BUYER_SIGNED).build();
+
+      assertThat(contract.isSignedBy(sellerUser)).isTrue();
+      assertThat(contract.isSignedBy(buyerUser)).isTrue();
+    }
+
+    @Test
+    void nobodyHasSignedACancelledContract() {
+      CapitalTransferContract contract =
+          contractBuilder.state(CapitalTransferContractState.CANCELLED).build();
+
+      assertThat(contract.isSignedBy(sellerUser)).isFalse();
+      assertThat(contract.isSignedBy(buyerUser)).isFalse();
+    }
+
+    @Test
+    void aThirdPartyHasNeverSigned() {
+      User stranger =
+          sampleUser().id(13L).member(memberFixture().id(3L).memberNumber(103).build()).build();
+      CapitalTransferContract contract =
+          contractBuilder.state(CapitalTransferContractState.BUYER_SIGNED).build();
+
+      assertThat(contract.isSignedBy(stranger)).isFalse();
     }
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/capital/transfer/CapitalTransferSignatureServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/capital/transfer/CapitalTransferSignatureServiceTest.java
@@ -325,7 +325,7 @@ class CapitalTransferSignatureServiceTest {
   }
 
   @Test
-  void getIdCardSignatureStatus_isOutstandingWhileTheUserHasNotSigned() {
+  void getIdCardSignatureStatus_rejectsAContractTheUserHasNotSignedYet() {
     Long contractId = 1L;
     User user = sampleUser().build();
     AuthenticatedPerson authenticatedPerson = authenticatedPersonFromUser(user).build();
@@ -339,10 +339,9 @@ class CapitalTransferSignatureServiceTest {
     when(userService.getByIdOrThrow(user.getId())).thenReturn(user);
     when(contractService.getContract(contractId, user)).thenReturn(contract);
 
-    IdCardSignatureStatusResponse response =
-        signatureService.getIdCardSignatureStatus(contractId, authenticatedPerson);
-
-    assertThat(response.getStatusCode()).isEqualTo(SignatureStatus.OUTSTANDING_TRANSACTION);
+    assertThatThrownBy(
+            () -> signatureService.getIdCardSignatureStatus(contractId, authenticatedPerson))
+        .isInstanceOf(IllegalStateException.class);
   }
 
   @Test

--- a/src/test/groovy/ee/tuleva/onboarding/capital/transfer/CapitalTransferSignatureServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/capital/transfer/CapitalTransferSignatureServiceTest.java
@@ -243,7 +243,8 @@ class CapitalTransferSignatureServiceTest {
     User user = sampleUser().build();
     AuthenticatedPerson authenticatedPerson = authenticatedPersonFromUser(user).build();
 
-    StartIdCardSignCommand command = new StartIdCardSignCommand("test-certificate");
+    StartIdCardSignCommand command =
+        new StartIdCardSignCommand("test-certificate", List.of("SHA-256"));
 
     SignatureFile signatureFile =
         new SignatureFile("test.pdf", "application/pdf", "test content".getBytes());
@@ -254,7 +255,9 @@ class CapitalTransferSignatureServiceTest {
 
     when(userService.getByIdOrThrow(user.getId())).thenReturn(user);
     when(contractService.getSignatureFiles(contractId, user)).thenReturn(files);
-    when(signService.startIdCardSign(files, "test-certificate")).thenReturn(signatureSession);
+    when(signService.startIdCardSign(
+            files, "test-certificate", List.of("SHA-256"), user.getPersonalCode()))
+        .thenReturn(signatureSession);
 
     // when
     IdCardSignatureResponse response =

--- a/src/test/groovy/ee/tuleva/onboarding/capital/transfer/CapitalTransferSignatureServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/capital/transfer/CapitalTransferSignatureServiceTest.java
@@ -23,6 +23,7 @@ import ee.tuleva.onboarding.signature.MobileSignatureResponse;
 import ee.tuleva.onboarding.signature.MobileSignatureStatusResponse;
 import ee.tuleva.onboarding.signature.SignatureFile;
 import ee.tuleva.onboarding.signature.SignatureService;
+import ee.tuleva.onboarding.signature.SignatureStateException;
 import ee.tuleva.onboarding.signature.SignatureStatus;
 import ee.tuleva.onboarding.signature.SmartIdSignatureSession;
 import ee.tuleva.onboarding.signature.StartIdCardSignCommand;
@@ -51,7 +52,7 @@ class CapitalTransferSignatureServiceTest {
   @Test
   void startSmartIdSignature_startsSignatureSession() {
     // given
-    Long contractId = 1L;
+    long contractId = 1L;
     User user = sampleUser().build();
     AuthenticatedPerson authenticatedPerson = authenticatedPersonFromUser(user).build();
 
@@ -79,7 +80,7 @@ class CapitalTransferSignatureServiceTest {
   @Test
   void getSmartIdSignatureStatus_returnsSignatureWhenFileIsSigned() {
     // given
-    Long contractId = 1L;
+    long contractId = 1L;
     User user = sampleUser().build();
     AuthenticatedPerson authenticatedPerson = authenticatedPersonFromUser(user).build();
 
@@ -113,7 +114,7 @@ class CapitalTransferSignatureServiceTest {
   @Test
   void getSmartIdSignatureStatus_returnsOutstandingTransactionWhenFileNotSigned() {
     // given
-    Long contractId = 1L;
+    long contractId = 1L;
     User user = sampleUser().build();
     AuthenticatedPerson authenticatedPerson = authenticatedPersonFromUser(user).build();
 
@@ -145,7 +146,7 @@ class CapitalTransferSignatureServiceTest {
   @Test
   void getSmartIdSignatureStatus_throwsExceptionWhenSessionNotFound() {
     // given
-    Long contractId = 1L;
+    long contractId = 1L;
     User user = sampleUser().build();
     AuthenticatedPerson authenticatedPerson = authenticatedPersonFromUser(user).build();
 
@@ -160,7 +161,7 @@ class CapitalTransferSignatureServiceTest {
   @Test
   void getSmartIdSignatureStatus_signsByBuyerWhenSellerAlreadySigned() {
     // given
-    Long contractId = 1L;
+    long contractId = 1L;
     User user = sampleUser().build();
     AuthenticatedPerson authenticatedPerson = authenticatedPersonFromUser(user).build();
 
@@ -205,7 +206,7 @@ class CapitalTransferSignatureServiceTest {
   @Test
   void getSmartIdSignatureStatus_throwsExceptionWhenCannotSignInCurrentState() {
     // given
-    Long contractId = 1L;
+    long contractId = 1L;
     User user = sampleUser().build();
     AuthenticatedPerson authenticatedPerson = authenticatedPersonFromUser(user).build();
 
@@ -236,7 +237,7 @@ class CapitalTransferSignatureServiceTest {
   @Test
   void startIdCardSignature_startsIdCardSignatureSession() {
     // given
-    Long contractId = 1L;
+    long contractId = 1L;
     User user = sampleUser().build();
     AuthenticatedPerson authenticatedPerson = authenticatedPersonFromUser(user).build();
 
@@ -264,7 +265,7 @@ class CapitalTransferSignatureServiceTest {
 
   @Test
   void persistIdCardSignature_signsTheContractAndReturnsSignature() {
-    Long contractId = 1L;
+    long contractId = 1L;
     User user = sampleUser().build();
     AuthenticatedPerson authenticatedPerson = authenticatedPersonFromUser(user).build();
     FinishIdCardSignCommand command = new FinishIdCardSignCommand("signature");
@@ -305,7 +306,7 @@ class CapitalTransferSignatureServiceTest {
 
   @Test
   void getIdCardSignatureStatus_isSignatureOnceTheUserHasSigned() {
-    Long contractId = 1L;
+    long contractId = 1L;
     User user = sampleUser().build();
     AuthenticatedPerson authenticatedPerson = authenticatedPersonFromUser(user).build();
     Member seller = memberFixture().user(user).build();
@@ -326,7 +327,7 @@ class CapitalTransferSignatureServiceTest {
 
   @Test
   void getIdCardSignatureStatus_rejectsAContractTheUserHasNotSignedYet() {
-    Long contractId = 1L;
+    long contractId = 1L;
     User user = sampleUser().build();
     AuthenticatedPerson authenticatedPerson = authenticatedPersonFromUser(user).build();
     Member seller = memberFixture().user(user).build();
@@ -341,13 +342,13 @@ class CapitalTransferSignatureServiceTest {
 
     assertThatThrownBy(
             () -> signatureService.getIdCardSignatureStatus(contractId, authenticatedPerson))
-        .isInstanceOf(IllegalStateException.class);
+        .isInstanceOf(SignatureStateException.class);
   }
 
   @Test
   void startMobileIdSignature_startsMobileIdSignatureSession() {
     // given
-    Long contractId = 1L;
+    long contractId = 1L;
     String phoneNumber = "+37255555555";
     User user = sampleUser().build();
     AuthenticatedPerson authenticatedPerson =
@@ -377,7 +378,7 @@ class CapitalTransferSignatureServiceTest {
   @Test
   void getMobileIdSignatureStatus_returnsSignatureWhenFileIsSigned() {
     // given
-    Long contractId = 1L;
+    long contractId = 1L;
     User user = sampleUser().build();
     AuthenticatedPerson authenticatedPerson = authenticatedPersonFromUser(user).build();
 
@@ -411,7 +412,7 @@ class CapitalTransferSignatureServiceTest {
   @Test
   void getMobileIdSignatureStatus_returnsOutstandingTransactionWhenFileNotSigned() {
     // given
-    Long contractId = 1L;
+    long contractId = 1L;
     User user = sampleUser().build();
     AuthenticatedPerson authenticatedPerson = authenticatedPersonFromUser(user).build();
 

--- a/src/test/groovy/ee/tuleva/onboarding/capital/transfer/CapitalTransferSignatureServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/capital/transfer/CapitalTransferSignatureServiceTest.java
@@ -8,6 +8,8 @@ import static ee.tuleva.onboarding.capital.transfer.CapitalTransferContractFixtu
 import static ee.tuleva.onboarding.user.MemberFixture.memberFixture;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -289,6 +291,31 @@ class CapitalTransferSignatureServiceTest {
 
     assertThat(response.getStatusCode()).isEqualTo(SignatureStatus.SIGNATURE);
     verify(contractService).signBySeller(contractId, signedFile, user);
+  }
+
+  @Test
+  void persistIdCardSignature_rejectsAContractTheUserHasAlreadySigned() {
+    long contractId = 1L;
+    User user = sampleUser().build();
+    AuthenticatedPerson authenticatedPerson = authenticatedPersonFromUser(user).build();
+    FinishIdCardSignCommand command = new FinishIdCardSignCommand("signature");
+    Member seller = memberFixture().user(user).build();
+    CapitalTransferContract contract =
+        sampleCapitalTransferContractWithSeller(seller)
+            .id(contractId)
+            .state(CapitalTransferContractState.SELLER_SIGNED)
+            .build();
+    IdCardSignatureSession signatureSession =
+        IdCardSignatureSession.builder().hashToSign("hash-to-sign").build();
+
+    when(sessionStore.get(IdCardSignatureSession.class)).thenReturn(Optional.of(signatureSession));
+    when(userService.getByIdOrThrow(user.getId())).thenReturn(user);
+    when(contractService.getContract(contractId, user)).thenReturn(contract);
+
+    assertThatThrownBy(
+            () -> signatureService.persistIdCardSignature(contractId, command, authenticatedPerson))
+        .isInstanceOf(SignatureStateException.class);
+    verify(signService, never()).getSignedFile(any(IdCardSignatureSession.class), any());
   }
 
   @Test

--- a/src/test/groovy/ee/tuleva/onboarding/capital/transfer/CapitalTransferSignatureServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/capital/transfer/CapitalTransferSignatureServiceTest.java
@@ -247,7 +247,7 @@ class CapitalTransferSignatureServiceTest {
     List<SignatureFile> files = List.of(signatureFile);
 
     IdCardSignatureSession signatureSession =
-        IdCardSignatureSession.builder().hashToSignInHex("hash-to-sign").build();
+        IdCardSignatureSession.builder().hashToSign("hash-to-sign").hashFunction("SHA-256").build();
 
     when(userService.getByIdOrThrow(user.getId())).thenReturn(user);
     when(contractService.getSignatureFiles(contractId, user)).thenReturn(files);
@@ -258,55 +258,77 @@ class CapitalTransferSignatureServiceTest {
         signatureService.startIdCardSignature(contractId, authenticatedPerson, command);
 
     // then
-    assertThat(response.getHash()).isEqualTo("hash-to-sign");
+    assertThat(response).isEqualTo(new IdCardSignatureResponse("hash-to-sign", "SHA-256"));
     verify(sessionStore).save(signatureSession);
   }
 
   @Test
-  void persistIdCardSignedHashAndGetProcessingStatus_returnsSignatureWhenFileIsSigned() {
-    // given
+  void persistIdCardSignature_signsTheContractAndReturnsSignature() {
     Long contractId = 1L;
     User user = sampleUser().build();
     AuthenticatedPerson authenticatedPerson = authenticatedPersonFromUser(user).build();
-
-    FinishIdCardSignCommand command = new FinishIdCardSignCommand("signed-hash");
-
+    FinishIdCardSignCommand command = new FinishIdCardSignCommand("signature");
     Member seller = memberFixture().user(user).build();
     CapitalTransferContract contract =
         sampleCapitalTransferContractWithSeller(seller)
             .id(contractId)
             .state(CapitalTransferContractState.CREATED)
             .build();
-
     IdCardSignatureSession signatureSession =
-        IdCardSignatureSession.builder().hashToSignInHex("hash-to-sign").build();
+        IdCardSignatureSession.builder().hashToSign("hash-to-sign").build();
     byte[] signedFile = "signed content".getBytes();
 
     when(sessionStore.get(IdCardSignatureSession.class)).thenReturn(Optional.of(signatureSession));
     when(userService.getByIdOrThrow(user.getId())).thenReturn(user);
     when(contractService.getContract(contractId, user)).thenReturn(contract);
-    when(signService.getSignedFile(signatureSession, "signed-hash")).thenReturn(signedFile);
+    when(signService.getSignedFile(signatureSession, "signature")).thenReturn(signedFile);
 
-    // when
     IdCardSignatureStatusResponse response =
-        signatureService.persistIdCardSignedHashAndGetProcessingStatus(
-            contractId, command, authenticatedPerson);
+        signatureService.persistIdCardSignature(contractId, command, authenticatedPerson);
 
-    // then
     assertThat(response.getStatusCode()).isEqualTo(SignatureStatus.SIGNATURE);
     verify(contractService).signBySeller(contractId, signedFile, user);
   }
 
   @Test
-  void
-      persistIdCardSignedHashAndGetProcessingStatus_returnsOutstandingTransactionWhenFileNotSigned() {
-    // given
+  void persistIdCardSignature_requiresAnIdCardSignatureSession() {
+    User user = sampleUser().build();
+    AuthenticatedPerson authenticatedPerson = authenticatedPersonFromUser(user).build();
+    FinishIdCardSignCommand command = new FinishIdCardSignCommand("signature");
+
+    when(sessionStore.get(IdCardSignatureSession.class)).thenReturn(Optional.empty());
+
+    assertThatThrownBy(
+            () -> signatureService.persistIdCardSignature(1L, command, authenticatedPerson))
+        .isInstanceOf(IdSessionException.class);
+  }
+
+  @Test
+  void getIdCardSignatureStatus_isSignatureOnceTheUserHasSigned() {
     Long contractId = 1L;
     User user = sampleUser().build();
     AuthenticatedPerson authenticatedPerson = authenticatedPersonFromUser(user).build();
+    Member seller = memberFixture().user(user).build();
+    CapitalTransferContract contract =
+        sampleCapitalTransferContractWithSeller(seller)
+            .id(contractId)
+            .state(CapitalTransferContractState.SELLER_SIGNED)
+            .build();
 
-    FinishIdCardSignCommand command = new FinishIdCardSignCommand("signed-hash");
+    when(userService.getByIdOrThrow(user.getId())).thenReturn(user);
+    when(contractService.getContract(contractId, user)).thenReturn(contract);
 
+    IdCardSignatureStatusResponse response =
+        signatureService.getIdCardSignatureStatus(contractId, authenticatedPerson);
+
+    assertThat(response.getStatusCode()).isEqualTo(SignatureStatus.SIGNATURE);
+  }
+
+  @Test
+  void getIdCardSignatureStatus_isOutstandingWhileTheUserHasNotSigned() {
+    Long contractId = 1L;
+    User user = sampleUser().build();
+    AuthenticatedPerson authenticatedPerson = authenticatedPersonFromUser(user).build();
     Member seller = memberFixture().user(user).build();
     CapitalTransferContract contract =
         sampleCapitalTransferContractWithSeller(seller)
@@ -314,20 +336,12 @@ class CapitalTransferSignatureServiceTest {
             .state(CapitalTransferContractState.CREATED)
             .build();
 
-    IdCardSignatureSession signatureSession =
-        IdCardSignatureSession.builder().hashToSignInHex("hash-to-sign").build();
-
-    when(sessionStore.get(IdCardSignatureSession.class)).thenReturn(Optional.of(signatureSession));
     when(userService.getByIdOrThrow(user.getId())).thenReturn(user);
     when(contractService.getContract(contractId, user)).thenReturn(contract);
-    when(signService.getSignedFile(signatureSession, "signed-hash")).thenReturn(null);
 
-    // when
     IdCardSignatureStatusResponse response =
-        signatureService.persistIdCardSignedHashAndGetProcessingStatus(
-            contractId, command, authenticatedPerson);
+        signatureService.getIdCardSignatureStatus(contractId, authenticatedPerson);
 
-    // then
     assertThat(response.getStatusCode()).isEqualTo(SignatureStatus.OUTSTANDING_TRANSACTION);
   }
 

--- a/src/test/groovy/ee/tuleva/onboarding/error/ErrorHandlingControllerAdviceSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/error/ErrorHandlingControllerAdviceSpec.groovy
@@ -2,12 +2,12 @@ package ee.tuleva.onboarding.error
 
 import ee.tuleva.onboarding.BaseControllerSpec
 import ee.tuleva.onboarding.auth.session.GenericSessionStore
+import ee.tuleva.onboarding.locale.LocaleService
 import ee.tuleva.onboarding.mandate.*
 import ee.tuleva.onboarding.mandate.command.CreateMandateCommand
 import ee.tuleva.onboarding.mandate.generic.GenericMandateService
 import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.MockMvc
-import org.springframework.web.servlet.LocaleResolver
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
@@ -21,10 +21,10 @@ class ErrorHandlingControllerAdviceSpec extends BaseControllerSpec {
   GenericSessionStore sessionStore = Mock()
   SignatureFileArchiver signatureFileArchiver = Mock()
   MandateFileService mandateFileService = Mock()
-  LocaleResolver localeResolver = Mock()
+  LocaleService localeService = Mock()
 
   MandateController controller =
-      new MandateController(mandateRepository, mandateService, genericMandateService, sessionStore, signatureFileArchiver, mandateFileService, localeResolver)
+      new MandateController(mandateRepository, mandateService, genericMandateService, sessionStore, signatureFileArchiver, mandateFileService, localeService)
 
   MockMvc mvc = mockMvc(controller)
 

--- a/src/test/groovy/ee/tuleva/onboarding/mandate/MandateControllerSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/mandate/MandateControllerSpec.groovy
@@ -131,7 +131,7 @@ class MandateControllerSpec extends BaseControllerSpec {
   def "id card signature start returns the hash to sign and its hash function"() {
     when:
     def session = IdCardSignatureSession.builder().hashToSign("asdfg").hashFunction("SHA-256").build()
-    mandateService.idCardSign(1L, _, "certificate") >> session
+    mandateService.idCardSign(1L, _, sampleStartIdCardSignCommand("certificate")) >> session
     1 * sessionStore.save(session)
 
     then:

--- a/src/test/groovy/ee/tuleva/onboarding/mandate/MandateControllerSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/mandate/MandateControllerSpec.groovy
@@ -4,6 +4,7 @@ import ee.tuleva.onboarding.BaseControllerSpec
 import ee.tuleva.onboarding.auth.AuthenticatedPersonFixture
 import ee.tuleva.onboarding.auth.principal.AuthenticatedPerson
 import ee.tuleva.onboarding.auth.session.GenericSessionStore
+import ee.tuleva.onboarding.locale.LocaleService
 import ee.tuleva.onboarding.mandate.command.CreateMandateCommand
 import ee.tuleva.onboarding.mandate.generic.GenericMandateService
 import ee.tuleva.onboarding.signature.SignatureFile
@@ -13,7 +14,6 @@ import ee.tuleva.onboarding.signature.SmartIdSignatureSession
 import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.MvcResult
-import org.springframework.web.servlet.LocaleResolver
 
 import static ee.tuleva.onboarding.auth.mobileid.MobileIDSession.PHONE_NUMBER
 import static ee.tuleva.onboarding.mandate.MandateFixture.*
@@ -29,12 +29,12 @@ class MandateControllerSpec extends BaseControllerSpec {
   GenericSessionStore sessionStore = Mock(GenericSessionStore)
   SignatureFileArchiver signatureFileArchiver = Mock(SignatureFileArchiver)
   MandateFileService mandateFileService = Mock(MandateFileService)
-  LocaleResolver localeResolver = Mock(LocaleResolver)
+  LocaleService localeService = Mock(LocaleService)
   GenericMandateService genericMandateService = Mock(GenericMandateService)
 
   MandateController controller =
       new MandateController(mandateRepository, mandateService, genericMandateService, sessionStore, signatureFileArchiver, mandateFileService,
-          localeResolver)
+          localeService)
   AuthenticatedPerson authenticatedPerson = AuthenticatedPersonFixture.sampleAuthenticatedPersonNonMember()
       .attributes(Map.of(PHONE_NUMBER, "5555555"))
       .build()
@@ -71,7 +71,7 @@ class MandateControllerSpec extends BaseControllerSpec {
 
     then:
     mvc
-        .perform(put("/v1/mandates/1/signature/mobileId")
+        .perform(put("/v1/mandates/1/signature/mobile-id")
             .contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -82,12 +82,12 @@ class MandateControllerSpec extends BaseControllerSpec {
     when:
     def session = MobileIdSignatureSession.builder().verificationCode("1234").build()
     sessionStore.get(MobileIdSignatureSession) >> Optional.of(session)
-    localeResolver.resolveLocale(_) >> ENGLISH
+    localeService.getCurrentLocale() >> ENGLISH
     mandateService.finalizeMobileIdSignature(_ as Long, 1L, session, ENGLISH) >> "SIGNATURE"
 
     then:
     mvc
-        .perform(get("/v1/mandates/1/signature/mobileId/status"))
+        .perform(get("/v1/mandates/1/signature/mobile-id/status"))
         .andExpect(status().isOk())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath('$.statusCode', is("SIGNATURE")))
@@ -102,7 +102,7 @@ class MandateControllerSpec extends BaseControllerSpec {
 
     then:
     mvc
-        .perform(put("/v1/mandates/1/signature/smartId")
+        .perform(put("/v1/mandates/1/signature/smart-id")
             .contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -114,12 +114,12 @@ class MandateControllerSpec extends BaseControllerSpec {
     def session = new SmartIdSignatureSession("certSessionId", "personalCode", [])
     session.verificationCode = "1234"
     1 * sessionStore.get(SmartIdSignatureSession) >> Optional.of(session)
-    1 * localeResolver.resolveLocale(_) >> ENGLISH
+    1 * localeService.getCurrentLocale() >> ENGLISH
     1 * mandateService.finalizeSmartIdSignature(_, 1L, session, ENGLISH) >> "SIGNATURE"
 
     then:
     mvc
-        .perform(get("/v1/mandates/1/signature/smartId/status"))
+        .perform(get("/v1/mandates/1/signature/smart-id/status"))
         .andExpect(status().isOk())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath('$.statusCode', is("SIGNATURE")))
@@ -134,7 +134,7 @@ class MandateControllerSpec extends BaseControllerSpec {
 
     then:
     mvc
-        .perform(put("/v1/mandates/1/signature/idCard")
+        .perform(put("/v1/mandates/1/signature/id-card")
             .content(mapper.writeValueAsString(sampleStartIdCardSignCommand("clientCertificate")))
             .contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
@@ -146,12 +146,12 @@ class MandateControllerSpec extends BaseControllerSpec {
     when:
     def session = IdCardSignatureSession.builder().build()
     sessionStore.get(IdCardSignatureSession) >> Optional.of(session)
-    localeResolver.resolveLocale(_) >> ENGLISH
+    localeService.getCurrentLocale() >> ENGLISH
     mandateService.finalizeIdCardSignature(_ as Long, 1L, session, "signedHash", ENGLISH) >> "SIGNATURE"
 
     then:
     mvc
-        .perform(put("/v1/mandates/1/signature/idCard/status")
+        .perform(put("/v1/mandates/1/signature/id-card/status")
             .content(mapper.writeValueAsString(sampleFinishIdCardSignCommand("signedHash")))
             .contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())

--- a/src/test/groovy/ee/tuleva/onboarding/mandate/MandateControllerSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/mandate/MandateControllerSpec.groovy
@@ -17,6 +17,8 @@ import org.springframework.test.web.servlet.MvcResult
 
 import static ee.tuleva.onboarding.auth.mobileid.MobileIDSession.PHONE_NUMBER
 import static ee.tuleva.onboarding.mandate.MandateFixture.*
+import static ee.tuleva.onboarding.signature.SignatureStatus.OUTSTANDING_TRANSACTION
+import static ee.tuleva.onboarding.signature.SignatureStatus.SIGNATURE
 import static java.util.Locale.ENGLISH
 import static org.hamcrest.Matchers.is
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
@@ -126,34 +128,47 @@ class MandateControllerSpec extends BaseControllerSpec {
         .andExpect(jsonPath('$.challengeCode', is("1234")))
   }
 
-  def "id card signature start returns the hash to be signed by the client"() {
+  def "id card signature start returns the hash to sign and its hash function"() {
     when:
-    def session = IdCardSignatureSession.builder().hashToSignInHex("asdfg").build()
-    mandateService.idCardSign(1L, _, "clientCertificate") >> session
+    def session = IdCardSignatureSession.builder().hashToSign("asdfg").hashFunction("SHA-256").build()
+    mandateService.idCardSign(1L, _, "certificate") >> session
     1 * sessionStore.save(session)
 
     then:
     mvc
         .perform(put("/v1/mandates/1/signature/id-card")
-            .content(mapper.writeValueAsString(sampleStartIdCardSignCommand("clientCertificate")))
+            .content(mapper.writeValueAsString(sampleStartIdCardSignCommand("certificate")))
             .contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath('$.hash', is("asdfg")))
+        .andExpect(jsonPath('$.hashFunction', is("SHA-256")))
   }
 
-  def "put ID card signature status returns the status code"() {
+  def "persisting the id card signature returns the processing status"() {
     when:
     def session = IdCardSignatureSession.builder().build()
     sessionStore.get(IdCardSignatureSession) >> Optional.of(session)
-    localeService.getCurrentLocale() >> ENGLISH
-    mandateService.finalizeIdCardSignature(_ as Long, 1L, session, "signedHash", ENGLISH) >> "SIGNATURE"
+    mandateService.persistIdCardSignature(_ as Long, 1L, session, "signature") >> OUTSTANDING_TRANSACTION
 
     then:
     mvc
-        .perform(put("/v1/mandates/1/signature/id-card/status")
-            .content(mapper.writeValueAsString(sampleFinishIdCardSignCommand("signedHash")))
+        .perform(put("/v1/mandates/1/signature/id-card/signature")
+            .content(mapper.writeValueAsString(sampleFinishIdCardSignCommand("signature")))
             .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath('$.statusCode', is("OUTSTANDING_TRANSACTION")))
+  }
+
+  def "id card signature status returns the processing status"() {
+    when:
+    localeService.getCurrentLocale() >> ENGLISH
+    mandateService.getIdCardSignatureStatus(_ as Long, 1L, ENGLISH) >> SIGNATURE
+
+    then:
+    mvc
+        .perform(get("/v1/mandates/1/signature/id-card/status"))
         .andExpect(status().isOk())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath('$.statusCode', is("SIGNATURE")))

--- a/src/test/groovy/ee/tuleva/onboarding/mandate/MandateFixture.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/mandate/MandateFixture.groovy
@@ -69,12 +69,12 @@ class MandateFixture {
     return MandateDto.builder().details(details).build()
   }
 
-  static StartIdCardSignCommand sampleStartIdCardSignCommand(String clientCertificate) {
-    return new StartIdCardSignCommand(clientCertificate)
+  static StartIdCardSignCommand sampleStartIdCardSignCommand(String certificate) {
+    return new StartIdCardSignCommand(certificate)
   }
 
-  static FinishIdCardSignCommand sampleFinishIdCardSignCommand(String signedHash) {
-    return new FinishIdCardSignCommand(signedHash)
+  static FinishIdCardSignCommand sampleFinishIdCardSignCommand(String signature) {
+    return new FinishIdCardSignCommand(signature)
   }
 
   static CreateMandateCommand invalidCreateMandateCommand() {

--- a/src/test/groovy/ee/tuleva/onboarding/mandate/MandateFixture.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/mandate/MandateFixture.groovy
@@ -70,7 +70,7 @@ class MandateFixture {
   }
 
   static StartIdCardSignCommand sampleStartIdCardSignCommand(String certificate) {
-    return new StartIdCardSignCommand(certificate)
+    return new StartIdCardSignCommand(certificate, ["SHA-256"])
   }
 
   static FinishIdCardSignCommand sampleFinishIdCardSignCommand(String signature) {

--- a/src/test/groovy/ee/tuleva/onboarding/mandate/MandateServiceSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/mandate/MandateServiceSpec.groovy
@@ -358,68 +358,76 @@ class MandateServiceSpec extends Specification {
     session == signatureSession
   }
 
-  def "finalizeIdCardSignature: throws exception when no signed file exist"() {
-    given:
-    Mandate sampleMandate = sampleUnsignedMandate()
-    def signatureSession = IdCardSignatureSession.builder().build()
-
-    1 * mandateRepository.findByIdAndUserId(sampleMandate.id, sampleUser.id) >> sampleMandate
-    1 * signService.getSignedFile(signatureSession, "signedHash") >> null
-    0 * eventPublisher.publishEvent(_)
-
-    when:
-    service.finalizeIdCardSignature(sampleUser.id, sampleMandate.id, signatureSession, "signedHash", ENGLISH)
-
-    then:
-    thrown(IllegalStateException)
-  }
-
-  def "finalizeIdCardSignature: get correct status if currently signed a mandate and start processing"() {
+  def "persistIdCardSignature: persists the signed file and starts processing"() {
     given:
     Mandate sampleMandate = sampleUnsignedMandate()
     def signatureSession = IdCardSignatureSession.builder().build()
     byte[] sampleFile = "file".getBytes()
-    1 * signService.getSignedFile(signatureSession, "signedHash") >> sampleFile
+    1 * signService.getSignedFile(signatureSession, "signature") >> sampleFile
     1 * mandateRepository.findByIdAndUserId(sampleMandate.id, sampleUser.id) >> sampleMandate
     1 * mandateRepository.save({ Mandate it -> it.mandate.get() == sampleFile }) >> sampleMandate
     0 * eventPublisher.publishEvent(_)
 
     when:
-    def status = service.finalizeIdCardSignature(sampleUser.id, sampleMandate.id, signatureSession, "signedHash", ENGLISH)
+    def status = service.persistIdCardSignature(sampleUser.id, sampleMandate.id, signatureSession, "signature")
 
     then:
     1 * mandateProcessor.start(sampleUser, sampleMandate)
     status == OUTSTANDING_TRANSACTION
   }
 
-  def "finalizeIdCardSignature: get correct status if mandate is signed and being processed"() {
+  def "persistIdCardSignature: rejects a mandate that is already signed"() {
     given:
     Mandate sampleMandate = sampleMandate()
     def signatureSession = IdCardSignatureSession.builder().build()
+    1 * mandateRepository.findByIdAndUserId(sampleMandate.id, sampleUser.id) >> sampleMandate
+    0 * signService.getSignedFile(_, _)
+    0 * mandateProcessor.start(_, _)
 
+    when:
+    service.persistIdCardSignature(sampleUser.id, sampleMandate.id, signatureSession, "signature")
+
+    then:
+    thrown(IllegalStateException)
+  }
+
+  def "getIdCardSignatureStatus: rejects a mandate that is not signed"() {
+    given:
+    Mandate sampleMandate = sampleUnsignedMandate()
+    1 * mandateRepository.findByIdAndUserId(sampleMandate.id, sampleUser.id) >> sampleMandate
+    0 * eventPublisher.publishEvent(_)
+
+    when:
+    service.getIdCardSignatureStatus(sampleUser.id, sampleMandate.id, ENGLISH)
+
+    then:
+    thrown(IllegalStateException)
+  }
+
+  def "getIdCardSignatureStatus: outstanding while the signed mandate is being processed"() {
+    given:
+    Mandate sampleMandate = sampleMandate()
     1 * mandateRepository.findByIdAndUserId(sampleMandate.id, sampleUser.id) >> sampleMandate
     1 * mandateProcessor.isFinished(sampleMandate) >> false
     0 * eventPublisher.publishEvent(_)
 
     when:
-    def status = service.finalizeIdCardSignature(sampleUser.id, sampleMandate.id, signatureSession, "signedHash", ENGLISH)
+    def status = service.getIdCardSignatureStatus(sampleUser.id, sampleMandate.id, ENGLISH)
 
     then:
     status == OUTSTANDING_TRANSACTION
   }
 
-  def "finalizeIdCardSignature: get correct status and notify and invalidate EPIS cache if mandate is signed and processed"() {
+  def "getIdCardSignatureStatus: signature once processed, notifying and invalidating the EPIS cache"() {
     given:
     Mandate sampleMandate = sampleMandate()
-    def signatureSession = IdCardSignatureSession.builder().build()
-
     1 * mandateRepository.findByIdAndUserId(sampleMandate.id, sampleUser.id) >> sampleMandate
     1 * mandateProcessor.isFinished(sampleMandate) >> true
     1 * mandateProcessor.getErrors(sampleMandate) >> sampleEmptyErrorsResponse
     1 * mandateContacts.clearCache(sampleUser)
 
     when:
-    def status = service.finalizeIdCardSignature(sampleUser.id, sampleMandate.id, signatureSession, "signedHash", ENGLISH)
+    def status = service.getIdCardSignatureStatus(sampleUser.id, sampleMandate.id, ENGLISH)
 
     then:
     status == SIGNATURE
@@ -429,18 +437,16 @@ class MandateServiceSpec extends Specification {
     })
   }
 
-  def "finalizeIdCardSignature: throw exception if mandate is signed and processed and has errors"() {
+  def "getIdCardSignatureStatus: throws when the mandate was processed with errors"() {
     given:
     Mandate sampleMandate = sampleMandate()
-    def signatureSession = IdCardSignatureSession.builder().build()
-
     1 * mandateRepository.findByIdAndUserId(sampleMandate.id, sampleUser.id) >> sampleMandate
     1 * mandateProcessor.isFinished(sampleMandate) >> true
     1 * mandateProcessor.getErrors(sampleMandate) >> sampleErrorsResponse
     0 * eventPublisher.publishEvent(_)
 
     when:
-    service.finalizeIdCardSignature(sampleUser.id, sampleMandate.id, signatureSession, "signedHash", ENGLISH)
+    service.getIdCardSignatureStatus(sampleUser.id, sampleMandate.id, ENGLISH)
 
     then:
     thrown MandateProcessingException

--- a/src/test/groovy/ee/tuleva/onboarding/mandate/MandateServiceSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/mandate/MandateServiceSpec.groovy
@@ -346,14 +346,14 @@ class MandateServiceSpec extends Specification {
 
   def "id card signing works"() {
     given:
-    def user = sampleUser()
     def signatureSession = IdCardSignatureSession.builder().build()
 
-    1 * mandateFileService.getMandateFiles(sampleMandateId, user.id) >> sampleFiles()
-    1 * signService.startIdCardSign(_ as List<SignatureFile>, "signingCertificate") >> signatureSession
+    1 * mandateFileService.getMandateFiles(sampleMandateId, sampleUser.id) >> sampleFiles()
+    1 * signService.startIdCardSign(
+        _ as List<SignatureFile>, "signingCertificate", ["SHA-256"], sampleUser.personalCode) >> signatureSession
 
     when:
-    def session = service.idCardSign(sampleMandateId, user.id, "signingCertificate")
+    def session = service.idCardSign(sampleMandateId, sampleUser.id, sampleStartIdCardSignCommand("signingCertificate"))
 
     then:
     session == signatureSession

--- a/src/test/groovy/ee/tuleva/onboarding/mandate/MandateServiceSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/mandate/MandateServiceSpec.groovy
@@ -22,6 +22,7 @@ import ee.tuleva.onboarding.mandate.exception.MandateProcessingException
 import ee.tuleva.onboarding.mandate.processor.MandateProcessorService
 import ee.tuleva.onboarding.signature.SignatureFile
 import ee.tuleva.onboarding.signature.SignatureService
+import ee.tuleva.onboarding.signature.SignatureStateException
 import ee.tuleva.onboarding.signature.IdCardSignatureSession
 import ee.tuleva.onboarding.signature.MobileIdSignatureSession
 import ee.tuleva.onboarding.signature.SmartIdSignatureSession
@@ -388,7 +389,7 @@ class MandateServiceSpec extends Specification {
     service.persistIdCardSignature(sampleUser.id, sampleMandate.id, signatureSession, "signature")
 
     then:
-    thrown(IllegalStateException)
+    thrown(SignatureStateException)
   }
 
   def "getIdCardSignatureStatus: rejects a mandate that is not signed"() {
@@ -401,7 +402,7 @@ class MandateServiceSpec extends Specification {
     service.getIdCardSignatureStatus(sampleUser.id, sampleMandate.id, ENGLISH)
 
     then:
-    thrown(IllegalStateException)
+    thrown(SignatureStateException)
   }
 
   def "getIdCardSignatureStatus: outstanding while the signed mandate is being processed"() {

--- a/src/test/groovy/ee/tuleva/onboarding/mandate/batch/MandateBatchServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/mandate/batch/MandateBatchServiceTest.java
@@ -760,33 +760,26 @@ public class MandateBatchServiceTest {
   class IdCardTests {
 
     @Test
-    @DisplayName(
-        "persistIdCardSignedFileOrGetBatchProcessingStatus handles signed mandate and all mandates processed successfully")
-    void finalizeIdCardSignatureHandlesSignedMandateAndAllMandatesProcessedSuccessfully() {
+    void getIdCardSignatureStatusReturnsSignatureOnceAllMandatesAreProcessed() {
       Mandate mandate1 = sampleFundPensionOpeningMandate();
       Mandate mandate2 = samplePartialWithdrawalMandate();
-
       MandateBatch mandateBatch =
           MandateBatchFixture.aSavedMandateBatch(List.of(mandate1, mandate2));
       mandateBatch.setStatus(SIGNED);
-
       var user = mockUser();
-      IdCardSignatureSession session = mock(IdCardSignatureSession.class);
 
       when(mandateBatchRepository.findById(mandateBatch.getId()))
           .thenReturn(Optional.of(mandateBatch));
-
       when(mandateProcessor.isFinished(mandate1)).thenReturn(true);
       when(mandateProcessor.isFinished(mandate2)).thenReturn(true);
-
       when(mandateProcessor.getErrors(mandate1)).thenReturn(new ErrorsResponse(List.of()));
       when(mandateProcessor.getErrors(mandate2)).thenReturn(new ErrorsResponse(List.of()));
 
       SignatureStatus status =
-          mandateBatchService.persistIdCardSignedFileOrGetBatchProcessingStatus(
-              user.getId(), mandateBatch.getId(), session, "hash", Locale.ENGLISH);
+          mandateBatchService.getIdCardSignatureStatus(
+              user.getId(), mandateBatch.getId(), Locale.ENGLISH);
 
-      assertThat(SIGNATURE).isEqualTo(status);
+      assertThat(status).isEqualTo(SIGNATURE);
       verify(mandateContacts, times(1)).clearCache(user);
       verify(applicationEventPublisher, times(2)).publishEvent(any(AfterMandateSignedEvent.class));
       verify(applicationEventPublisher, times(1))
@@ -794,25 +787,18 @@ public class MandateBatchServiceTest {
     }
 
     @Test
-    @DisplayName(
-        "persistIdCardSignedFileOrGetBatchProcessingStatus handles signed mandate with processing errors")
-    void finalizeIdCardSignatureHandlesSignedMandateWithProcessingErrors() {
+    void getIdCardSignatureStatusThrowsWhenMandatesWereProcessedWithErrors() {
       Mandate mandate1 = sampleFundPensionOpeningMandate();
       Mandate mandate2 = samplePartialWithdrawalMandate();
-
       MandateBatch mandateBatch =
           MandateBatchFixture.aSavedMandateBatch(List.of(mandate1, mandate2));
       mandateBatch.setStatus(SIGNED);
-
       var user = mockUser();
-      IdCardSignatureSession session = mock(IdCardSignatureSession.class);
 
       when(mandateBatchRepository.findById(mandateBatch.getId()))
           .thenReturn(Optional.of(mandateBatch));
-
       when(mandateProcessor.isFinished(mandate1)).thenReturn(true);
       when(mandateProcessor.isFinished(mandate2)).thenReturn(true);
-
       List<ErrorResponse> errors =
           List.of(
               new ErrorResponse("ERROR_CODE_1", "Error message 1", null, List.of()),
@@ -820,80 +806,83 @@ public class MandateBatchServiceTest {
       when(mandateProcessor.getErrors(mandate1)).thenReturn(new ErrorsResponse(List.of()));
       when(mandateProcessor.getErrors(mandate2)).thenReturn(new ErrorsResponse(errors));
 
-      MandateProcessingException exception =
-          assertThrows(
-              MandateProcessingException.class,
-              () ->
-                  mandateBatchService.persistIdCardSignedFileOrGetBatchProcessingStatus(
-                      user.getId(), mandateBatch.getId(), session, "hash", Locale.ENGLISH));
-
-      assertThat(exception).isNotNull();
-      assertThat(errors.size()).isEqualTo(2);
+      assertThrows(
+          MandateProcessingException.class,
+          () ->
+              mandateBatchService.getIdCardSignatureStatus(
+                  user.getId(), mandateBatch.getId(), Locale.ENGLISH));
 
       verify(mandateContacts, times(1)).clearCache(user);
       verify(applicationEventPublisher, never()).publishEvent(any());
     }
 
     @Test
-    @DisplayName(
-        "persistIdCardSignedFileOrGetBatchProcessingStatus handles signed mandate when mandates are still processing")
-    void finalizeIdCardSignatureHandlesSignedMandateButMandateIsProcessing() {
+    void getIdCardSignatureStatusIsOutstandingWhileMandatesAreStillProcessing() {
       Mandate mandate1 = sampleFundPensionOpeningMandate();
       Mandate mandate2 = samplePartialWithdrawalMandate();
-
       MandateBatch mandateBatch =
           MandateBatchFixture.aSavedMandateBatch(List.of(mandate1, mandate2));
       mandateBatch.setStatus(SIGNED);
-
       var user = mockUser();
-      IdCardSignatureSession session = mock(IdCardSignatureSession.class);
 
       when(mandateBatchRepository.findById(mandateBatch.getId()))
           .thenReturn(Optional.of(mandateBatch));
-
       when(mandateProcessor.isFinished(mandate1)).thenReturn(true);
       when(mandateProcessor.isFinished(mandate2)).thenReturn(false);
 
       SignatureStatus status =
-          mandateBatchService.persistIdCardSignedFileOrGetBatchProcessingStatus(
-              user.getId(), mandateBatch.getId(), session, "hash", Locale.ENGLISH);
+          mandateBatchService.getIdCardSignatureStatus(
+              user.getId(), mandateBatch.getId(), Locale.ENGLISH);
 
-      assertThat(OUTSTANDING_TRANSACTION).isEqualTo(status);
+      assertThat(status).isEqualTo(OUTSTANDING_TRANSACTION);
       verify(mandateContacts, never()).clearCache(any());
       verify(applicationEventPublisher, never()).publishEvent(any());
     }
 
     @Test
-    @DisplayName(
-        "persistIdCardSignedFileOrGetBatchProcessingStatus handles signed file and starts processing mandates")
-    void finalizeIdCardSignatureHandlesUnsignedMandateWithSignedFile() {
+    void getIdCardSignatureStatusRejectsAnUnsignedBatch() {
+      MandateBatch mandateBatch =
+          MandateBatchFixture.aSavedMandateBatch(
+              List.of(sampleFundPensionOpeningMandate(), samplePartialWithdrawalMandate()));
+      mandateBatch.setStatus(INITIALIZED);
+      var user = mockUser();
+
+      when(mandateBatchRepository.findById(mandateBatch.getId()))
+          .thenReturn(Optional.of(mandateBatch));
+
+      assertThrows(
+          IllegalStateException.class,
+          () ->
+              mandateBatchService.getIdCardSignatureStatus(
+                  user.getId(), mandateBatch.getId(), Locale.ENGLISH));
+
+      verify(mandateProcessor, never()).isFinished(any());
+      verify(applicationEventPublisher, never()).publishEvent(any());
+    }
+
+    @Test
+    void persistIdCardSignaturePersistsTheSignedFileAndStartsProcessing() {
       Mandate mandate1 = sampleFundPensionOpeningMandate();
       Mandate mandate2 = samplePartialWithdrawalMandate();
-
       byte[] signedFile = "signedFileBytes".getBytes();
-
       MandateBatch mandateBatch =
           MandateBatchFixture.aSavedMandateBatch(List.of(mandate1, mandate2));
       mandateBatch.setStatus(INITIALIZED);
-
       var user = mockUser();
       IdCardSignatureSession session = mock(IdCardSignatureSession.class);
 
       when(mandateBatchRepository.findById(mandateBatch.getId()))
           .thenReturn(Optional.of(mandateBatch));
-      when(signService.getSignedFile(eq(session), any())).thenReturn(signedFile);
-
-      ArgumentCaptor<MandateBatch> mandateBatchCaptor = ArgumentCaptor.forClass(MandateBatch.class);
+      when(signService.getSignedFile(session, "signature")).thenReturn(signedFile);
 
       SignatureStatus status =
-          mandateBatchService.persistIdCardSignedFileOrGetBatchProcessingStatus(
-              user.getId(), mandateBatch.getId(), session, "hash", Locale.ENGLISH);
+          mandateBatchService.persistIdCardSignature(
+              user.getId(), mandateBatch.getId(), session, "signature", Locale.ENGLISH);
 
-      assertThat(OUTSTANDING_TRANSACTION).isEqualTo(status);
-      verify(mandateBatchRepository, times(1)).save(mandateBatchCaptor.capture());
-      MandateBatch savedBatch = mandateBatchCaptor.getValue();
-      assertThat(signedFile).isEqualTo(savedBatch.getFile());
-      assertThat(SIGNED).isEqualTo(savedBatch.getStatus());
+      assertThat(status).isEqualTo(OUTSTANDING_TRANSACTION);
+      verify(mandateBatchRepository, times(1)).save(mandateBatch);
+      assertThat(mandateBatch.getFile()).isEqualTo(signedFile);
+      assertThat(mandateBatch.getStatus()).isEqualTo(SIGNED);
       verify(mandateProcessor, times(1)).start(user, mandate1);
       verify(mandateProcessor, times(1)).start(user, mandate2);
       verify(mandateBatchProcessingPoller, times(1))
@@ -902,30 +891,24 @@ public class MandateBatchServiceTest {
     }
 
     @Test
-    @DisplayName(
-        "persistIdCardSignedFileOrGetBatchProcessingStatus throws when signed file is missing")
-    void finalizeIdCardSignatureHandlesUnsignedMandateWithoutSignedFile() {
-      Mandate mandate1 = sampleFundPensionOpeningMandate();
-      Mandate mandate2 = samplePartialWithdrawalMandate();
-
+    void persistIdCardSignatureRejectsAnAlreadySignedBatch() {
       MandateBatch mandateBatch =
-          MandateBatchFixture.aSavedMandateBatch(List.of(mandate1, mandate2));
-      mandateBatch.setStatus(INITIALIZED);
-
+          MandateBatchFixture.aSavedMandateBatch(
+              List.of(sampleFundPensionOpeningMandate(), samplePartialWithdrawalMandate()));
+      mandateBatch.setStatus(SIGNED);
       var user = mockUser();
       IdCardSignatureSession session = mock(IdCardSignatureSession.class);
 
       when(mandateBatchRepository.findById(mandateBatch.getId()))
           .thenReturn(Optional.of(mandateBatch));
-      when(signService.getSignedFile(eq(session), any())).thenReturn(null);
 
       assertThrows(
           IllegalStateException.class,
           () ->
-              mandateBatchService.persistIdCardSignedFileOrGetBatchProcessingStatus(
-                  user.getId(), mandateBatch.getId(), session, "hash", Locale.ENGLISH));
+              mandateBatchService.persistIdCardSignature(
+                  user.getId(), mandateBatch.getId(), session, "signature", Locale.ENGLISH));
 
-      verify(signService, times(1)).getSignedFile(eq(session), any());
+      verify(signService, never()).getSignedFile(any(IdCardSignatureSession.class), any());
       verify(mandateBatchRepository, never()).save(any());
       verify(mandateProcessor, never()).start(any(), any());
       verify(applicationEventPublisher, never()).publishEvent(any());

--- a/src/test/groovy/ee/tuleva/onboarding/mandate/batch/MandateBatchServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/mandate/batch/MandateBatchServiceTest.java
@@ -31,6 +31,7 @@ import ee.tuleva.onboarding.signature.IdCardSignatureSession;
 import ee.tuleva.onboarding.signature.MobileIdSignatureSession;
 import ee.tuleva.onboarding.signature.SignatureFile;
 import ee.tuleva.onboarding.signature.SignatureService;
+import ee.tuleva.onboarding.signature.SignatureStateException;
 import ee.tuleva.onboarding.signature.SignatureStatus;
 import ee.tuleva.onboarding.signature.SmartIdSignatureSession;
 import ee.tuleva.onboarding.user.User;
@@ -851,7 +852,7 @@ public class MandateBatchServiceTest {
           .thenReturn(Optional.of(mandateBatch));
 
       assertThrows(
-          IllegalStateException.class,
+          SignatureStateException.class,
           () ->
               mandateBatchService.getIdCardSignatureStatus(
                   user.getId(), mandateBatch.getId(), Locale.ENGLISH));
@@ -903,7 +904,7 @@ public class MandateBatchServiceTest {
           .thenReturn(Optional.of(mandateBatch));
 
       assertThrows(
-          IllegalStateException.class,
+          SignatureStateException.class,
           () ->
               mandateBatchService.persistIdCardSignature(
                   user.getId(), mandateBatch.getId(), session, "signature", Locale.ENGLISH));

--- a/src/test/groovy/ee/tuleva/onboarding/mandate/batch/MandateBatchSignatureServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/mandate/batch/MandateBatchSignatureServiceTest.java
@@ -178,7 +178,9 @@ class MandateBatchSignatureServiceTest {
       when(userService.getById(eq(authenticatedPerson.getUserId()))).thenReturn(Optional.of(user));
       when(mandateBatchService.getMandateBatchContentFiles(eq(mandateBatchId), eq(user)))
           .thenReturn(List.of());
-      when(signService.startIdCardSign(any(), eq(certificate))).thenReturn(mockSession);
+      when(signService.startIdCardSign(
+              any(), eq(certificate), eq(List.of("SHA-256")), eq(user.getPersonalCode())))
+          .thenReturn(mockSession);
 
       var result =
           mandateBatchSignatureService.startIdCardSign(

--- a/src/test/groovy/ee/tuleva/onboarding/mandate/batch/MandateBatchSignatureServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/mandate/batch/MandateBatchSignatureServiceTest.java
@@ -6,7 +6,8 @@ import static ee.tuleva.onboarding.auth.UserFixture.sampleUser;
 import static ee.tuleva.onboarding.auth.mobileid.MobileIDSession.PHONE_NUMBER;
 import static ee.tuleva.onboarding.signature.SignatureStatus.OUTSTANDING_TRANSACTION;
 import static ee.tuleva.onboarding.signature.SignatureStatus.SIGNATURE;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
@@ -15,7 +16,9 @@ import static org.mockito.Mockito.when;
 import ee.tuleva.onboarding.auth.session.GenericSessionStore;
 import ee.tuleva.onboarding.locale.LocaleService;
 import ee.tuleva.onboarding.mandate.MandateFixture;
+import ee.tuleva.onboarding.signature.IdCardSignatureResponse;
 import ee.tuleva.onboarding.signature.IdCardSignatureSession;
+import ee.tuleva.onboarding.signature.IdSessionException;
 import ee.tuleva.onboarding.signature.MobileIdSignatureSession;
 import ee.tuleva.onboarding.signature.SignatureService;
 import ee.tuleva.onboarding.signature.SmartIdSignatureSession;
@@ -163,47 +166,72 @@ class MandateBatchSignatureServiceTest {
   class IdCardTests {
 
     @Test
-    @DisplayName("start id card signature returns the hash to be signed by the client")
-    void startIdCardSignatureReturnsHash() {
+    void startIdCardSignatureReturnsTheHashToSignAndItsHashFunction() {
       var mandateBatchId = 1L;
-      var clientCertificate = "clientCertificate";
-      var startCommand = MandateFixture.sampleStartIdCardSignCommand(clientCertificate);
-      var mockSession = IdCardSignatureSession.builder().hashToSignInHex("asdfg").build();
-
+      var certificate = "certificate";
+      var startCommand = MandateFixture.sampleStartIdCardSignCommand(certificate);
+      var mockSession =
+          IdCardSignatureSession.builder().hashToSign("asdfg").hashFunction("SHA-256").build();
       var user = sampleUser().build();
       var authenticatedPerson = authenticatedPersonFromUser(user).build();
 
       when(userService.getById(eq(authenticatedPerson.getUserId()))).thenReturn(Optional.of(user));
       when(mandateBatchService.getMandateBatchContentFiles(eq(mandateBatchId), eq(user)))
           .thenReturn(List.of());
-      when(signService.startIdCardSign(any(), eq(clientCertificate))).thenReturn(mockSession);
+      when(signService.startIdCardSign(any(), eq(certificate))).thenReturn(mockSession);
 
       var result =
           mandateBatchSignatureService.startIdCardSign(
               mandateBatchId, authenticatedPerson, startCommand);
 
-      assertThat(result.getHash()).isEqualTo("asdfg");
+      assertThat(result).isEqualTo(new IdCardSignatureResponse("asdfg", "SHA-256"));
       verify(sessionStore, times(1)).save(mockSession);
     }
 
     @Test
-    @DisplayName("persistIdCardAndGetProcessingStatus returns finished status code")
-    void finishIdCardSignatureReturnsStatusCode() {
+    void persistIdCardSignatureReturnsTheProcessingStatus() {
       var mandateBatchId = 1L;
-      var signedHash = "signedHash";
-      var finishCommand = MandateFixture.sampleFinishIdCardSignCommand(signedHash);
+      var finishCommand = MandateFixture.sampleFinishIdCardSignCommand("signature");
       var mockSession = IdCardSignatureSession.builder().build();
+      var user = sampleAuthenticatedPersonAndMember().build();
 
       when(sessionStore.get(IdCardSignatureSession.class)).thenReturn(Optional.of(mockSession));
       when(localeService.getCurrentLocale()).thenReturn(Locale.ENGLISH);
-      when(mandateBatchService.persistIdCardSignedFileOrGetBatchProcessingStatus(
-              any(), eq(mandateBatchId), eq(mockSession), eq(signedHash), eq(Locale.ENGLISH)))
+      when(mandateBatchService.persistIdCardSignature(
+              any(), eq(mandateBatchId), eq(mockSession), eq("signature"), eq(Locale.ENGLISH)))
+          .thenReturn(OUTSTANDING_TRANSACTION);
+
+      var result =
+          mandateBatchSignatureService.persistIdCardSignature(mandateBatchId, finishCommand, user);
+
+      assertThat(result.getStatusCode()).isEqualTo(OUTSTANDING_TRANSACTION);
+    }
+
+    @Test
+    void persistIdCardSignatureRequiresAnIdCardSignatureSession() {
+      var finishCommand = MandateFixture.sampleFinishIdCardSignCommand("signature");
+      var user = sampleAuthenticatedPersonAndMember().build();
+
+      when(sessionStore.get(IdCardSignatureSession.class)).thenReturn(Optional.empty());
+
+      assertThatThrownBy(
+              () -> mandateBatchSignatureService.persistIdCardSignature(1L, finishCommand, user))
+          .isInstanceOf(IdSessionException.class);
+      verify(mandateBatchService, never())
+          .persistIdCardSignature(any(), any(), any(), any(), any());
+    }
+
+    @Test
+    void getIdCardSignatureStatusReturnsTheProcessingStatus() {
+      var mandateBatchId = 1L;
+      var user = sampleAuthenticatedPersonAndMember().build();
+
+      when(localeService.getCurrentLocale()).thenReturn(Locale.ENGLISH);
+      when(mandateBatchService.getIdCardSignatureStatus(
+              any(), eq(mandateBatchId), eq(Locale.ENGLISH)))
           .thenReturn(SIGNATURE);
 
-      var user = sampleAuthenticatedPersonAndMember().build();
-      var result =
-          mandateBatchSignatureService.persistIdCardSignedHashAndGetProcessingStatus(
-              mandateBatchId, finishCommand, user);
+      var result = mandateBatchSignatureService.getIdCardSignatureStatus(mandateBatchId, user);
 
       assertThat(result.getStatusCode()).isEqualTo(SIGNATURE);
     }

--- a/src/test/groovy/ee/tuleva/onboarding/mandate/batch/MandateBatchSigningControllerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/mandate/batch/MandateBatchSigningControllerTest.java
@@ -1,6 +1,7 @@
 package ee.tuleva.onboarding.mandate.batch;
 
 import static ee.tuleva.onboarding.auth.JwtTokenGenerator.getHeaders;
+import static ee.tuleva.onboarding.signature.SignatureStatus.OUTSTANDING_TRANSACTION;
 import static ee.tuleva.onboarding.signature.SignatureStatus.SIGNATURE;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.*;
@@ -11,7 +12,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import ee.tuleva.onboarding.mandate.MandateFixture;
 import ee.tuleva.onboarding.signature.IdCardSignatureResponse;
-import ee.tuleva.onboarding.signature.IdCardSignatureSession;
 import ee.tuleva.onboarding.signature.IdCardSignatureStatusResponse;
 import ee.tuleva.onboarding.signature.MobileIdSignatureSession;
 import ee.tuleva.onboarding.signature.MobileSignatureResponse;
@@ -139,14 +139,10 @@ public class MandateBatchSigningControllerTest {
   class IdCardTests {
 
     @Test
-    @DisplayName("start id card signature returns the hash to be signed by the client")
-    void startIdCardSignatureReturnsHash() throws Exception {
+    void startIdCardSignatureReturnsTheHashToSignAndItsHashFunction() throws Exception {
       var mandateBatchId = 1L;
-      var clientCertificate = "clientCertificate";
-      var startCommand = MandateFixture.sampleStartIdCardSignCommand(clientCertificate);
-      var mockSession = IdCardSignatureSession.builder().hashToSignInHex("asdfg").build();
-      var mockResponse =
-          IdCardSignatureResponse.builder().hash(mockSession.getHashToSignInHex()).build();
+      var startCommand = MandateFixture.sampleStartIdCardSignCommand("certificate");
+      var mockResponse = new IdCardSignatureResponse("asdfg", "SHA-256");
 
       when(mandateBatchSignatureService.startIdCardSign(
               eq(mandateBatchId), any(), eq(startCommand)))
@@ -159,27 +155,40 @@ public class MandateBatchSigningControllerTest {
                   .headers(getHeaders()))
           .andExpect(status().isOk())
           .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-          .andExpect(jsonPath("$.hash", is("asdfg")));
+          .andExpect(jsonPath("$.hash", is("asdfg")))
+          .andExpect(jsonPath("$.hashFunction", is("SHA-256")));
     }
 
     @Test
-    @DisplayName(
-        "id card signature status endpoint returns finalized status when processing is finished")
-    void finishIdCardSignatureReturnsStatusCode() throws Exception {
+    void persistIdCardSignatureReturnsTheProcessingStatus() throws Exception {
       var mandateBatchId = 1L;
-      var signedHash = "signedHash";
-      var finishCommand = MandateFixture.sampleFinishIdCardSignCommand(signedHash);
+      var finishCommand = MandateFixture.sampleFinishIdCardSignCommand("signature");
+      var mockResponse = new IdCardSignatureStatusResponse(OUTSTANDING_TRANSACTION);
 
-      var mockResponse = IdCardSignatureStatusResponse.builder().statusCode(SIGNATURE).build();
-
-      when(mandateBatchSignatureService.persistIdCardSignedHashAndGetProcessingStatus(
+      when(mandateBatchSignatureService.persistIdCardSignature(
               eq(mandateBatchId), eq(finishCommand), any()))
           .thenReturn(mockResponse);
 
       mvc.perform(
-              put("/v1/mandate-batches/{id}/signature/id-card/status", mandateBatchId)
+              put("/v1/mandate-batches/{id}/signature/id-card/signature", mandateBatchId)
                   .content(mapper.writeValueAsString(finishCommand))
                   .contentType(MediaType.APPLICATION_JSON)
+                  .headers(getHeaders()))
+          .andExpect(status().isOk())
+          .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+          .andExpect(jsonPath("$.statusCode", is(OUTSTANDING_TRANSACTION.toString())));
+    }
+
+    @Test
+    void getIdCardSignatureStatusReturnsTheProcessingStatus() throws Exception {
+      var mandateBatchId = 1L;
+      var mockResponse = new IdCardSignatureStatusResponse(SIGNATURE);
+
+      when(mandateBatchSignatureService.getIdCardSignatureStatus(eq(mandateBatchId), any()))
+          .thenReturn(mockResponse);
+
+      mvc.perform(
+              get("/v1/mandate-batches/{id}/signature/id-card/status", mandateBatchId)
                   .headers(getHeaders()))
           .andExpect(status().isOk())
           .andExpect(content().contentType(MediaType.APPLICATION_JSON))

--- a/src/test/groovy/ee/tuleva/onboarding/personalcode/PersonalCodeTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/personalcode/PersonalCodeTest.java
@@ -187,4 +187,14 @@ class PersonalCodeTest {
     assertThat(PersonalCode.getRetirementAge("36203105216")).isEqualTo(65); // 65y1m
     assertThat(PersonalCode.getRetirementAge("39912310015")).isEqualTo(65); // 65y3m
   }
+
+  @Test
+  void fromSubjectIdCodeStripsTheEstonianPrefix() {
+    assertThat(PersonalCode.fromSubjectIdCode("PNOEE-38888888888")).isEqualTo("38888888888");
+  }
+
+  @Test
+  void fromSubjectIdCodeLeavesANonEstonianSubjectIdCodeAlone() {
+    assertThat(PersonalCode.fromSubjectIdCode("PASJP-123456789")).isEqualTo("PASJP-123456789");
+  }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/signature/DigiDocFacadeSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/signature/DigiDocFacadeSpec.groovy
@@ -87,16 +87,26 @@ class DigiDocFacadeSpec extends Specification {
     dataToSign.dataToSign.length > 0
   }
 
-  def "hashes the bytes to be signed with SHA-256"() {
+  def "hashes the bytes to be signed with the digest algorithm of the data to sign"() {
     given:
     def dataToSign = Mock(DataToSign)
     1 * dataToSign.dataToSign >> "some data".bytes
+    dataToSign.digestAlgorithm >> DigestAlgorithm.SHA256
 
     when:
     def digest = digiDocFacade.digestToSign(dataToSign)
 
     then:
     digest == MessageDigest.getInstance("SHA-256").digest("some data".bytes)
+  }
+
+  def "names the hash function of the data to sign the way Web eID expects it"() {
+    given:
+    def dataToSign = Mock(DataToSign)
+    dataToSign.digestAlgorithm >> DigestAlgorithm.SHA256
+
+    expect:
+    digiDocFacade.hashFunction(dataToSign) == "SHA-256"
   }
 
   def "adds the finalized signature to the container and returns its bytes"() {

--- a/src/test/groovy/ee/tuleva/onboarding/signature/DigiDocFacadeSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/signature/DigiDocFacadeSpec.groovy
@@ -8,6 +8,7 @@ import org.digidoc4j.ContainerBuilder
 import org.digidoc4j.DataToSign
 import org.digidoc4j.DigestAlgorithm
 import org.digidoc4j.Signature
+import org.digidoc4j.SignatureProfile
 import spock.lang.Specification
 
 import java.security.MessageDigest
@@ -80,10 +81,11 @@ class DigiDocFacadeSpec extends Specification {
         "TEST", "USER", "38888888888", IdDocumentType.ESTONIAN_CITIZEN_ID_CARD)
 
     when:
-    def dataToSign = digiDocFacade.dataToSign(container, certificate)
+    def dataToSign = digiDocFacade.dataToSign(container, certificate, DigestAlgorithm.SHA256)
 
     then:
     dataToSign.digestAlgorithm == DigestAlgorithm.SHA256
+    dataToSign.signatureParameters.signatureProfile == SignatureProfile.LT
     dataToSign.dataToSign.length > 0
   }
 

--- a/src/test/groovy/ee/tuleva/onboarding/signature/SignatureServiceSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/signature/SignatureServiceSpec.groovy
@@ -70,10 +70,10 @@ class SignatureServiceSpec extends Specification {
         given:
         def signingCertificate = "signingCertificate"
         def signatureSession = Mock(IdCardSignatureSession)
-        1 * idCardSigner.startSign(files, signingCertificate) >> signatureSession
+        1 * idCardSigner.startSign(files, signingCertificate, ["SHA-256"], personalCode) >> signatureSession
 
         when:
-        def session = service.startIdCardSign(files, signingCertificate)
+        def session = service.startIdCardSign(files, signingCertificate, ["SHA-256"], personalCode)
 
         then:
         session == signatureSession

--- a/src/test/groovy/ee/tuleva/onboarding/signature/idcard/IdCardSignerSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/signature/idcard/IdCardSignerSpec.groovy
@@ -53,6 +53,18 @@ class IdCardSignerSpec extends Specification {
     invalidCertificate << ["not base64!", getEncoder().encodeToString("not a certificate".bytes)]
   }
 
+  def "rejects a signature that is not base64"() {
+    given:
+    def session = new IdCardSignatureSession("aGFzaA==", "SHA-256", Mock(DataToSign), Mock(Container))
+
+    when:
+    idCardSigner.getSignedFile(session, "not base64!")
+
+    then:
+    thrown(InvalidSignatureException)
+    0 * digiDocFacade.addSignatureToContainer(_, _, _)
+  }
+
   def "adds the base64 signature to the container of the session"() {
     given:
     def dataToSign = Mock(DataToSign)

--- a/src/test/groovy/ee/tuleva/onboarding/signature/idcard/IdCardSignerSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/signature/idcard/IdCardSignerSpec.groovy
@@ -1,67 +1,72 @@
 package ee.tuleva.onboarding.signature.idcard
 
-import ee.tuleva.onboarding.auth.ocsp.OCSPUtils
+import ee.tuleva.onboarding.auth.webeid.WebEidCertificateFixture
 import ee.tuleva.onboarding.signature.DigiDocFacade
 import ee.tuleva.onboarding.signature.IdCardSignatureSession
 import ee.tuleva.onboarding.signature.SignatureFile
-import org.bouncycastle.util.encoders.Hex
 import org.digidoc4j.Container
 import org.digidoc4j.DataToSign
 import spock.lang.Specification
 
-import java.security.cert.X509Certificate
+import static ee.tuleva.onboarding.auth.idcard.IdDocumentType.ESTONIAN_CITIZEN_ID_CARD
+import static java.util.Base64.getDecoder
+import static java.util.Base64.getEncoder
 
 class IdCardSignerSpec extends Specification {
 
-    OCSPUtils ocspUtils
-    DigiDocFacade digiDocFacade
-    IdCardSigner idCardSigner
+  DigiDocFacade digiDocFacade = Mock()
+  IdCardSigner idCardSigner = new IdCardSigner(digiDocFacade)
 
-    def setup() {
-        ocspUtils = Mock(OCSPUtils)
-        digiDocFacade = Mock(DigiDocFacade)
-        idCardSigner = new IdCardSigner(ocspUtils, digiDocFacade)
-    }
+  def files = [new SignatureFile("fileName", "mimeType", "content".bytes)]
+  def certificate = WebEidCertificateFixture.certificate("TEST", "USER", "38888888888", ESTONIAN_CITIZEN_ID_CARD)
+  def certificateInBase64 = getEncoder().encodeToString(certificate.encoded)
 
-    def "can start id card signature"() {
-        given:
-        def files = [new SignatureFile("fileName", "mimeType", "content".bytes)]
-        def signingCertificate = "cert"
-        def certificate = Mock(X509Certificate)
-        def container = Mock(Container)
-        def dataToSign = Mock(DataToSign)
-        def hashToSign = "hello"
-        def digestToSign = hashToSign.bytes
+  def "starts an id card signature from a base64 DER certificate and returns the base64 hash to sign"() {
+    given:
+    def container = Mock(Container)
+    def dataToSign = Mock(DataToSign)
+    def digestToSign = "digest".bytes
 
-        1 * ocspUtils.decodeX09Certificate(signingCertificate) >> certificate
-        1 * digiDocFacade.buildContainer(files) >> container
-        1 * digiDocFacade.dataToSign(container, certificate) >> dataToSign
-        1 * digiDocFacade.digestToSign(dataToSign) >> digestToSign
+    1 * digiDocFacade.buildContainer(files) >> container
+    1 * digiDocFacade.dataToSign(container, certificate) >> dataToSign
+    1 * digiDocFacade.digestToSign(dataToSign) >> digestToSign
+    1 * digiDocFacade.hashFunction(dataToSign) >> "SHA-256"
 
-        when:
-        def signatureSession = idCardSigner.startSign(files, signingCertificate)
+    when:
+    def session = idCardSigner.startSign(files, certificateInBase64)
 
-        then:
-        new String(Hex.decode(signatureSession.hashToSignInHex)) == hashToSign
-        signatureSession.container == container
-        signatureSession.dataToSign == dataToSign
-    }
+    then:
+    getDecoder().decode(session.hashToSign) == digestToSign
+    session.hashFunction == "SHA-256"
+    session.container == container
+    session.dataToSign == dataToSign
+  }
 
-    def "can get signed file"() {
-        given:
-        def dataToSign = Mock(DataToSign)
-        def container = Mock(Container)
-        def session = new IdCardSignatureSession("68656c6c6f", dataToSign, container)
-        def signedHash = "68656c6c6f"
-        def signature = Hex.decode(signedHash)
-        def signedContainer = "signed".bytes
+  def "rejects a signing certificate that is not a base64 DER certificate"() {
+    when:
+    idCardSigner.startSign(files, invalidCertificate)
 
-        1 * digiDocFacade.addSignatureToContainer(signature, dataToSign, container) >> signedContainer
+    then:
+    thrown(InvalidSigningCertificateException)
 
-        when:
-        def signedFile = idCardSigner.getSignedFile(session, signedHash)
+    where:
+    invalidCertificate << ["not base64!", getEncoder().encodeToString("not a certificate".bytes)]
+  }
 
-        then:
-        signedFile == signedContainer
-    }
+  def "adds the base64 signature to the container of the session"() {
+    given:
+    def dataToSign = Mock(DataToSign)
+    def container = Mock(Container)
+    def session = new IdCardSignatureSession("aGFzaA==", "SHA-256", dataToSign, container)
+    def signature = "signature".bytes
+    def signedContainer = "signed".bytes
+
+    1 * digiDocFacade.addSignatureToContainer(signature, dataToSign, container) >> signedContainer
+
+    when:
+    def signedFile = idCardSigner.getSignedFile(session, getEncoder().encodeToString(signature))
+
+    then:
+    signedFile == signedContainer
+  }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/signature/idcard/IdCardSignerSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/signature/idcard/IdCardSignerSpec.groovy
@@ -6,6 +6,7 @@ import ee.tuleva.onboarding.signature.IdCardSignatureSession
 import ee.tuleva.onboarding.signature.SignatureFile
 import org.digidoc4j.Container
 import org.digidoc4j.DataToSign
+import org.digidoc4j.DigestAlgorithm
 import spock.lang.Specification
 
 import static ee.tuleva.onboarding.auth.idcard.IdDocumentType.ESTONIAN_CITIZEN_ID_CARD
@@ -17,9 +18,11 @@ class IdCardSignerSpec extends Specification {
   DigiDocFacade digiDocFacade = Mock()
   IdCardSigner idCardSigner = new IdCardSigner(digiDocFacade)
 
+  def personalCode = "38888888888"
   def files = [new SignatureFile("fileName", "mimeType", "content".bytes)]
-  def certificate = WebEidCertificateFixture.certificate("TEST", "USER", "38888888888", ESTONIAN_CITIZEN_ID_CARD)
+  def certificate = WebEidCertificateFixture.certificate("TEST", "USER", personalCode, ESTONIAN_CITIZEN_ID_CARD)
   def certificateInBase64 = getEncoder().encodeToString(certificate.encoded)
+  def supportedHashFunctions = ["SHA-224", "SHA-256", "SHA-384", "SHA-512"]
 
   def "starts an id card signature from a base64 DER certificate and returns the base64 hash to sign"() {
     given:
@@ -28,12 +31,12 @@ class IdCardSignerSpec extends Specification {
     def digestToSign = "digest".bytes
 
     1 * digiDocFacade.buildContainer(files) >> container
-    1 * digiDocFacade.dataToSign(container, certificate) >> dataToSign
+    1 * digiDocFacade.dataToSign(container, certificate, _ as DigestAlgorithm) >> dataToSign
     1 * digiDocFacade.digestToSign(dataToSign) >> digestToSign
     1 * digiDocFacade.hashFunction(dataToSign) >> "SHA-256"
 
     when:
-    def session = idCardSigner.startSign(files, certificateInBase64)
+    def session = idCardSigner.startSign(files, certificateInBase64, supportedHashFunctions, personalCode)
 
     then:
     getDecoder().decode(session.hashToSign) == digestToSign
@@ -42,9 +45,42 @@ class IdCardSignerSpec extends Specification {
     session.dataToSign == dataToSign
   }
 
+  def "signs with the digest algorithm the signing certificate calls for"() {
+    given:
+    def container = Mock(Container)
+    def dataToSign = Mock(DataToSign)
+    digiDocFacade.buildContainer(files) >> container
+    digiDocFacade.digestToSign(dataToSign) >> "digest".bytes
+    digiDocFacade.hashFunction(dataToSign) >> "SHA-256"
+
+    when:
+    idCardSigner.startSign(files, certificateInBase64, supportedHashFunctions, personalCode)
+
+    then:
+    1 * digiDocFacade.dataToSign(container, certificate, DigestAlgorithm.SHA256) >> dataToSign
+  }
+
+  def "rejects a certificate that belongs to someone other than the signer"() {
+    when:
+    idCardSigner.startSign(files, certificateInBase64, supportedHashFunctions, "38812121215")
+
+    then:
+    thrown(SigningCertificateMismatchException)
+    0 * digiDocFacade.buildContainer(_)
+  }
+
+  def "rejects a certificate whose digest algorithm the card cannot sign with"() {
+    when:
+    idCardSigner.startSign(files, certificateInBase64, ["SHA-512"], personalCode)
+
+    then:
+    thrown(UnsupportedHashFunctionException)
+    0 * digiDocFacade.buildContainer(_)
+  }
+
   def "rejects a signing certificate that is not a base64 DER certificate"() {
     when:
-    idCardSigner.startSign(files, invalidCertificate)
+    idCardSigner.startSign(files, invalidCertificate, supportedHashFunctions, personalCode)
 
     then:
     thrown(InvalidSigningCertificateException)

--- a/src/test/groovy/ee/tuleva/onboarding/signature/mobileid/MobileIdSignerSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/signature/mobileid/MobileIdSignerSpec.groovy
@@ -12,6 +12,7 @@ import ee.tuleva.onboarding.signature.DigiDocFacade
 import ee.tuleva.onboarding.signature.MobileIdSignatureSession
 import ee.tuleva.onboarding.signature.SignatureFile
 import org.digidoc4j.Container
+import org.digidoc4j.DigestAlgorithm
 import org.digidoc4j.DataToSign
 import spock.lang.Specification
 
@@ -48,7 +49,7 @@ class MobileIdSignerSpec extends Specification {
         }) >> certificateResponse
         1 * mobileIdClient.createMobileIdCertificate(certificateResponse) >> certificate
         1 * digiDocFacade.buildContainer(files) >> container
-        1 * digiDocFacade.dataToSign(container, certificate) >> dataToSign
+        1 * digiDocFacade.dataToSign(container, certificate, DigestAlgorithm.SHA256) >> dataToSign
         1 * dataToSign.getDataToSign() >> "dataToSign".bytes
         1 * mobileIdConnector.sign({ it.phoneNumber == phoneNumber && it.nationalIdentityNumber == personalCode }) >> new MidSignatureResponse(sessionId)
 


### PR DESCRIPTION
## Why

`hwcrypto.js` is superseded by Web eID, and Web eID's backward compatibility for it is being removed at the end of 2026:

- [Web eID](https://www.id.ee/en/article/web-eid/)
- [Backward compatibility will be removed from the Web eID solution by the end of 2026](https://www.id.ee/en/article/backward-compatibility-will-be-removed-from-the-web-eid-solution-by-the-end-of-2026/)

ID-card **login** already moved to Web eID. This does the same for ID-card **signing**, which was the last hwcrypto user.

## The contract

Web eID hands the browser a base64 DER signing certificate, expects a base64 hash plus the name of the hash function to sign, and returns a base64 signature. The ID-card endpoints now speak that contract, and mirror the Smart-ID / Mobile-ID shape on every signable entity (mandate, mandate batch, capital transfer contract):

```
PUT /{id}/signature/id-card            {certificate, supportedHashFunctions} -> {hash, hashFunction}
PUT /{id}/signature/id-card/signature  {signature}                           -> {statusCode}
GET /{id}/signature/id-card/status                                           -> {statusCode}
```

The old single `PUT /id-card/status`, which persisted on the first call and polled on every later one, is gone along with its `TODO: split this into PUT and GET endpoints`. Persisting rejects an entity that is already signed, and the status poll rejects one with no signature yet, so calling out of order is reported rather than silently absorbed.

## Please look here first

**The signing certificate is now checked against the person signing.** It never was: a mandate belonging to one person could be signed with someone else's card, and the container would carry the wrong signature. `IdCardSigner` now requires the certificate's subject ID code to match the authenticated signer.

This is a behaviour change with its own deploy consequence: after this ships, any ID-card signing request whose certificate does not match the authenticated user is refused. Role switching is unaffected, because `PrincipalService.withRole` keeps the authenticated human's user id and personal code (already asserted in `PrincipalServiceSpec`), so acting for a company or a child still compares against the card in the reader. I found no path that relied on signing with a different card, but it touches every signable entity and deserves a second pair of eyes.

## Comparison against the Web eID reference

Checked against [web-eid-authtoken-validation-java/example](https://github.com/web-eid/web-eid-authtoken-validation-java/tree/main/example). Besides the certificate check above, it does two things we did not:

- **The digest algorithm comes from the certificate** (`TokenAlgorithmSupport`) instead of being hardcoded to SHA-256. Narrow in practice: digidoc4j only diverges for pre-2011 Estonian cards, which expired years ago, so we were right by luck rather than by construction.
- **The hash function is checked against what the card reported.** The client now sends `supportedHashFunctions`, so we refuse an algorithm the card cannot sign with instead of letting the card fail the request obscurely.

`SignatureProfile.LT` turned out to be digidoc4j's default already, so our signatures were always LT; it is now explicit and covered by a test, since AIA OCSP depends on it.

The wire shapes otherwise matched the reference exactly.

## Other details

- Refactor first: `MandateController` implements the shared `SignatureController`, so mandate paths become kebab-case like the other entities and the frontend loses its per-entity path branch. Locale comes from `LocaleService`; the April session-id debug logs go with the request handle.
- Malformed input answers `400`, not `500`: an undecodable certificate or signature, and every out-of-order rejection, raise `ErrorsResponseException` with a code the frontend can act on.
- `OCSPUtils`' hex certificate decoder had no callers left and is removed, dropping the `signature.idcard` → `auth.ocsp` dependency.
- Capital transfer contracts answer the status poll through a new `CapitalTransferContract.isSignedBy(user)` domain rule.
- The `PNOEE-` prefix strip moved to `PersonalCode.fromSubjectIdCode` instead of a private copy in the authentication service.
- README references now point at Web eID, `web-eid.js`, the auth-token validation library and digidoc4j.

## Deploy order

**Deploy this before the frontend change.** The old frontend sends a hex certificate under the old field name and polls with a `PUT`.

Frontend PR: TulevaEE/onboarding-client#1636

## Testing

TDD throughout: failing test first, then the minimal production change, per class. `IdCardSignerSpec` covers the certificate/signer match, the derived digest algorithm, the unsupported hash function, and both decoding failures; `DigiDocFacadeSpec` pins the digest and the LT profile; the mandate, batch and capital transfer service and controller tests cover the split endpoints and every rejection path.

Full suite green apart from `FirstPaymentReminderRepositoryTest`, which is a known full-run collision that also fails on master and passes in isolation. Reviewed with `codex review`.
