### PR TITLE
Fail the build when two migrations claim one version

### DIFF
--- a/src/test/groovy/ee/tuleva/onboarding/FlywayMigrationVersionTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/FlywayMigrationVersionTest.java
@@ -1,0 +1,100 @@
+package ee.tuleva.onboarding;
+
+import static java.util.stream.Collectors.counting;
+import static java.util.stream.Collectors.groupingBy;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+
+class FlywayMigrationVersionTest {
+
+  private static final List<Path> FLYWAY_LOCATIONS =
+      List.of(
+          Path.of("src/main/resources/db/migration"),
+          Path.of("src/main/resources/db/dev"),
+          Path.of("src/main/java/db/migration"),
+          Path.of("src/test/resources/db/h2"));
+
+  @Test
+  void everyMigrationVersionIsClaimedByExactlyOneFile() throws IOException {
+    assertThat(duplicateVersions(versionedMigrationFileNames()))
+        .as("Two migrations claiming one version stop Flyway from starting any schema")
+        .isEmpty();
+  }
+
+  @Test
+  void aVersionClaimedTwiceIsFoundEvenWhenTheFileNamesDiffer() {
+    var fileNames =
+        List.of(
+            "V1_251__create_investment_account.sql",
+            "V1_251__drop_legacy_benchmark_proxy_columns.sql",
+            "V1_252__savings_fund_onboarding_updated_at.sql");
+
+    assertThat(duplicateVersions(fileNames)).containsExactly("1.251");
+  }
+
+  @Test
+  void underscoreAndDotSeparatorsNameTheSameVersion() {
+    var fileNames = List.of("V1_249_1__h2_shim.sql", "V1_249.1__dev_seed.sql");
+
+    assertThat(duplicateVersions(fileNames)).containsExactly("1.249.1");
+  }
+
+  @Test
+  void javaAndSqlMigrationsShareOneVersionNamespace() {
+    var fileNames =
+        List.of("V1_250__reference_data_history_trigger.java", "V1_250__reference_data.sql");
+
+    assertThat(duplicateVersions(fileNames)).containsExactly("1.250");
+  }
+
+  @Test
+  void repeatableMigrationsCarryNoVersionAndAreLeftAlone() {
+    var fileNames = List.of("R__refresh_views.sql", "R__rebuild_indexes.sql");
+
+    assertThat(duplicateVersions(fileNames)).isEmpty();
+  }
+
+  private static List<String> duplicateVersions(List<String> fileNames) {
+    return fileNames.stream()
+        .filter(FlywayMigrationVersionTest::isVersioned)
+        .collect(groupingBy(FlywayMigrationVersionTest::version, counting()))
+        .entrySet()
+        .stream()
+        .filter(entry -> entry.getValue() > 1)
+        .map(Map.Entry::getKey)
+        .sorted()
+        .toList();
+  }
+
+  private static boolean isVersioned(String fileName) {
+    return fileName.startsWith("V") && fileName.contains("__");
+  }
+
+  private static String version(String fileName) {
+    return fileName.substring(1, fileName.indexOf("__")).replace('_', '.');
+  }
+
+  private static List<String> versionedMigrationFileNames() throws IOException {
+    var fileNames = new ArrayList<String>();
+    for (Path location : FLYWAY_LOCATIONS) {
+      if (!Files.isDirectory(location)) {
+        continue;
+      }
+      try (Stream<Path> files = Files.list(location)) {
+        files
+            .filter(Files::isRegularFile)
+            .map(file -> file.getFileName().toString())
+            .forEach(fileNames::add);
+      }
+    }
+    return List.copyOf(fileNames);
+  }
+}


### PR DESCRIPTION
## Why

Twice this week a branch reached CI carrying a migration numbered against a version master had since given to something else — #1936 (`V1_252`) and #1899 (`V1_251`). Both times the symptom was ~1500 unrelated tests failing to bring a Spring context up, with the real cause one buried line:

```
FlywayException: Found more than one migration with version 1.252
```

**Git cannot catch this class of bug.** The colliding files have different *names*, so `git merge-tree` reports the merge CLEAN and `git diff master...branch -- src/main/resources/db/migration` shows no change at all. Only Flyway compares the version that each name encodes. CLAUDE.md already warns to re-check migration numbers after every merge to master; this makes the check automatic instead of remembered.

## What

A plain JUnit guard test — no Spring context, runs in under a second — that reads every configured Flyway location and fails if any version is claimed twice.

It normalises versions the way Flyway does, which is where the subtle cases live:

- **Underscores and dots are the same separator**, so `V1_249_1__x.sql` and `V1_249.1__x.sql` are both version `1.249.1`. The repo mixes both notations today: `db/dev` uses `V1_168.1__`, the H2 shims use `V1_249_1__`.
- **`.java` and `.sql` migrations share one namespace**, so `V1_250__x.java` collides with `V1_250__x.sql`.
- **Repeatable (`R__`) migrations carry no version** and are left alone.

Locations covered: `db/migration` (sql + java) and `db/dev` from `application.yml`, plus the `db/h2` shims the test profile adds.

## Verified

Planting PR #1899's actual collision fails the build with:

```
FlywayMigrationVersionTest > everyMigrationVersionIsClaimedByExactlyOneFile() FAILED
    Expecting empty but was: ["1.251"]
```

Removing it goes green. All 5 tests pass on master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019TtQgzUMVzAwjagQQvbjQC