### PR TITLE
Delete the user the mandate batch test signs in as

### DIFF
--- a/src/test/groovy/ee/tuleva/onboarding/mandate/batch/MandateBatchIntegrationTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/mandate/batch/MandateBatchIntegrationTest.java
@@ -1,6 +1,7 @@
 package ee.tuleva.onboarding.mandate.batch;
 
 import static ee.tuleva.onboarding.auth.JwtTokenGenerator.getHeaders;
+import static ee.tuleva.onboarding.auth.PersonFixture.samplePerson;
 import static ee.tuleva.onboarding.epis.ContactDetailsFixture.contactDetailsFixture;
 import static ee.tuleva.onboarding.mandate.MandateType.FUND_PENSION_OPENING;
 import static ee.tuleva.onboarding.mandate.MandateType.PARTIAL_WITHDRAWAL;
@@ -22,6 +23,7 @@ import ee.tuleva.onboarding.mandate.MandateFixture;
 import ee.tuleva.onboarding.mandate.MandateRepository;
 import ee.tuleva.onboarding.mandate.generic.MandateDto;
 import ee.tuleva.onboarding.notification.OperationsNotificationService;
+import ee.tuleva.onboarding.user.UserRepository;
 import ee.tuleva.onboarding.withdrawals.WithdrawalEligibilityDto;
 import ee.tuleva.onboarding.withdrawals.WithdrawalEligibilityService;
 import java.util.List;
@@ -45,16 +47,23 @@ class MandateBatchIntegrationTest {
 
   @Autowired private MandateBatchRepository mandateBatchRepository;
   @Autowired private MandateRepository mandateRepository;
+  @Autowired private UserRepository userRepository;
 
   @MockitoBean private EpisService episService;
   @MockitoBean private AmlAutoChecker amlAutoChecker;
   @MockitoBean private WithdrawalEligibilityService withdrawalEligibilityService;
   @MockitoBean private OperationsNotificationService notificationService;
 
+  // The JWT authenticates samplePerson, and the auth filter creates that user on the server
+  // thread, which no test-side transaction can roll back. It outlives the test in the shared
+  // database and collides with every later test that inserts the same personal code.
   @AfterEach
   void cleanup() {
     mandateRepository.deleteAll();
     mandateBatchRepository.deleteAll();
+    userRepository
+        .findByPersonalCode(samplePerson().getPersonalCode())
+        .ifPresent(userRepository::delete);
   }
 
   void assertCorrectResponse(byte[] responseBody) throws Exception {

--- a/src/test/groovy/ee/tuleva/onboarding/zzz/UserPollutionProbeTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/zzz/UserPollutionProbeTest.java
@@ -3,19 +3,13 @@ package ee.tuleva.onboarding.zzz;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import ee.tuleva.onboarding.user.UserRepository;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
-// Disabled until the suite is clean under -DmaxParallelForks=1. The whole suite currently leaks
-// committed rows across many tables (ledger/nav/fund-position/analytics/...) from non-transactional
-// specs, so this global cleanliness canary is red in single-fork mode and fork-distribution-flaky
-// in CI. Re-enable once the single-fork cleanup is complete (see tracked todo: "Make full test
-// suite green under -DmaxParallelForks=1"). It stays here as the regression guard for the
-// personal_code auth-user leak class (Withdrawals + MandateBatchSigningControllerTest).
-@Disabled(
-    "Re-enable once the suite is green under -DmaxParallelForks=1; see single-fork cleanup todo")
+// The shared H2/Postgres test database outlives every test class, so a non-transactional test
+// that authenticates as samplePerson and never removes the user it caused to be created poisons
+// every later test inserting that personal code. This runs last (package zzz) and is the guard.
 @SpringBootTest
 class UserPollutionProbeTest {
 


### PR DESCRIPTION
A full local `./gradlew test` on master fails 12 tests in
`FirstPaymentReminderRepositoryTest` with a unique-index violation on
`users.personal_code` for the shared fixture code. The class passes alone, so it is
suite pollution — and CI is green only because its fork count happens to separate the
two classes. This is the third instance of the auth-user leak class that
`UserPollutionProbeTest` was written to guard.

## Who leaks

`MandateBatchIntegrationTest`. It sends a real JWT for `samplePerson`, and
`PrincipalUsersAdapter.findOrCreate` commits a `users` row for that personal code.

Attribution was measured, not guessed: a temporary `TestExecutionListener` that
queried the shared database after every test class named this one on three
independent runs.

## Why `@Transactional` is the wrong fix here

The two earlier leaks — Withdrawals and `MandateBatchSigningControllerTest` (1bd306f10,
0ee6134b8) — were fixed with `@Transactional`, which works because MockMvc runs the
request on the test thread.

This class is `@SpringBootTest(webEnvironment = RANDOM_PORT)` driving a real
`RestTestClient` over HTTP, so the auth filter runs on a **server** thread. No test-side
transaction reaches it, and `@Transactional` would have looked like a fix while
changing nothing.

The class already deletes the mandates and batches it creates in `@AfterEach`. The user
is simply one more row it causes to exist, so it now deletes that too — by personal
code, not `deleteAll()`.

## Red before green

Reverting just the cleanup and running the three classes single-fork:

```
FirstPaymentReminderRepositoryTest: tests=14 failures=12
UserPollutionProbeTest:             tests=1  failures=1
```

With the cleanup, the **whole suite is green under `-DmaxParallelForks=1`** — 8344
tests, 0 failures — plus two runs at the default fork count.

## The canary goes back on

`UserPollutionProbeTest` was disabled in 0ee6134b8 pending a single-fork-clean suite.
That condition now holds, so it is re-enabled; the red-before-green above shows it is a
real guard rather than a vacuous one. It cannot produce false positives under parallel
forks — a probe that runs before the polluter, or in another fork, simply passes.

No fixture personal codes were changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
