### PR TITLE
Report any definition change as one, not just the holding period

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/investment/risk/IndicatorDiagnosticsFormatter.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/risk/IndicatorDiagnosticsFormatter.java
@@ -62,10 +62,20 @@ class IndicatorDiagnosticsFormatter {
                     redefinitions.size(),
                     first.date(),
                     redefinitions.getLast().date())
-            + " hoidmisperioodi kauplemispäevi %s → %s. Alusandmed ei muutunud."
-                .formatted(
-                    text(first.previousHoldingPeriodTradingDays()),
-                    first.holdingPeriodTradingDays()));
+            + whatChanged(first)
+            + " Alusandmed ei muutunud.");
+  }
+
+  private String whatChanged(Redefinition redefinition) {
+    return switch (redefinition) {
+      case Redefinition.HoldingPeriod holdingPeriod ->
+          " hoidmisperioodi kauplemispäevi %s → %s."
+              .formatted(text(holdingPeriod.previousTradingDays()), holdingPeriod.tradingDays());
+      case Redefinition.PublicationRule publicationRule ->
+          " avaldamisreegel muutus, klass %s → %s."
+              .formatted(
+                  text(publicationRule.previousRiskClass()), text(publicationRule.riskClass()));
+    };
   }
 
   private Optional<String> skippedLine(RiskIndicatorOutcome outcome) {

--- a/src/main/java/ee/tuleva/onboarding/investment/risk/Redefinition.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/risk/Redefinition.java
@@ -3,7 +3,14 @@ package ee.tuleva.onboarding.investment.risk;
 import java.time.LocalDate;
 import org.jspecify.annotations.Nullable;
 
-record Redefinition(
-    LocalDate date,
-    @Nullable String previousHoldingPeriodTradingDays,
-    String holdingPeriodTradingDays) {}
+sealed interface Redefinition {
+
+  LocalDate date();
+
+  record HoldingPeriod(LocalDate date, @Nullable String previousTradingDays, String tradingDays)
+      implements Redefinition {}
+
+  record PublicationRule(
+      LocalDate date, @Nullable Integer previousRiskClass, @Nullable Integer riskClass)
+      implements Redefinition {}
+}

--- a/src/main/java/ee/tuleva/onboarding/investment/risk/RiskIndicatorSeriesService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/risk/RiskIndicatorSeriesService.java
@@ -142,7 +142,11 @@ class RiskIndicatorSeriesService {
       } else if (!hasDrifted(stored, point)) {
         continue;
       } else if (holdingPeriodChanged(stored, point)) {
-        var redefinition = redefinition(stored, point);
+        var redefinition = holdingPeriodRedefinition(stored, point);
+        toSave.add(applyRedefinition(stored, point, redefinition));
+        redefined.add(redefinition);
+      } else if (publishedClassChangedWhileTheMeasurementsDidNot(stored, point)) {
+        var redefinition = publicationRuleRedefinition(stored, point);
         toSave.add(applyRedefinition(stored, point, redefinition));
         redefined.add(redefinition);
       } else {
@@ -161,11 +165,26 @@ class RiskIndicatorSeriesService {
     return current != null && !current.equals(storedHoldingPeriod(stored));
   }
 
-  private Redefinition redefinition(RiskIndicatorPoint stored, ReferencePoint recomputed) {
-    return new Redefinition(
+  private Redefinition holdingPeriodRedefinition(
+      RiskIndicatorPoint stored, ReferencePoint recomputed) {
+    return new Redefinition.HoldingPeriod(
         stored.getAsOfDate(),
         storedHoldingPeriod(stored),
         Objects.requireNonNull(recomputedHoldingPeriod(recomputed)));
+  }
+
+  private boolean publishedClassChangedWhileTheMeasurementsDidNot(
+      RiskIndicatorPoint stored, ReferencePoint recomputed) {
+    var storedVolatility = stored.getVolatility();
+    return storedVolatility != null
+        && storedVolatility.compareTo(recomputed.volatility()) == 0
+        && Objects.equals(stored.getObservationCount(), recomputed.observationCount());
+  }
+
+  private Redefinition publicationRuleRedefinition(
+      RiskIndicatorPoint stored, ReferencePoint recomputed) {
+    return new Redefinition.PublicationRule(
+        stored.getAsOfDate(), stored.getRiskClass(), recomputed.riskClass());
   }
 
   private @Nullable String storedHoldingPeriod(RiskIndicatorPoint stored) {
@@ -183,7 +202,7 @@ class RiskIndicatorSeriesService {
     log.info(
         "Risk indicator point recomputed under a new definition: fund={}, type={}, date={},"
             + " storedClass={}, recomputedClass={}, storedVolatility={}, recomputedVolatility={},"
-            + " previousHoldingPeriodTradingDays={}, holdingPeriodTradingDays={}",
+            + " redefinition={}",
         stored.getFund(),
         stored.getIndicatorType(),
         stored.getAsOfDate(),
@@ -191,8 +210,7 @@ class RiskIndicatorSeriesService {
         recomputed.riskClass(),
         stored.getVolatility(),
         recomputed.volatility(),
-        redefinition.previousHoldingPeriodTradingDays(),
-        redefinition.holdingPeriodTradingDays());
+        redefinition);
 
     var metrics = new HashMap<String, Object>(stringKeyed(recomputed.metrics()));
     var history = driftHistory(stored);

--- a/src/test/groovy/ee/tuleva/onboarding/investment/risk/IndicatorDetailFormatterTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/risk/IndicatorDetailFormatterTest.java
@@ -200,8 +200,8 @@ class IndicatorDetailFormatterTest {
             RiskIndicatorPublication.builder().build(),
             List.of(),
             List.of(
-                new Redefinition(LocalDate.of(2026, 6, 1), "1300", "1280"),
-                new Redefinition(LocalDate.of(2026, 6, 30), "1300", "1280")),
+                new Redefinition.HoldingPeriod(LocalDate.of(2026, 6, 1), "1300", "1280"),
+                new Redefinition.HoldingPeriod(LocalDate.of(2026, 6, 30), "1300", "1280")),
             List.of());
 
     assertThat(detailFormatter.detailBlock(outcome))

--- a/src/test/groovy/ee/tuleva/onboarding/investment/risk/IndicatorDiagnosticsFormatterTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/risk/IndicatorDiagnosticsFormatterTest.java
@@ -116,8 +116,8 @@ class IndicatorDiagnosticsFormatterTest {
             RiskIndicatorPublication.builder().build(),
             List.of(),
             List.of(
-                new Redefinition(LocalDate.of(2026, 6, 1), "1300", "1280"),
-                new Redefinition(LocalDate.of(2026, 6, 30), "1300", "1280")),
+                new Redefinition.HoldingPeriod(LocalDate.of(2026, 6, 1), "1300", "1280"),
+                new Redefinition.HoldingPeriod(LocalDate.of(2026, 6, 30), "1300", "1280")),
             List.of());
 
     var lines = diagnosticsFormatter.withDiagnostics(new ArrayList<>(), outcome);
@@ -127,6 +127,27 @@ class IndicatorDiagnosticsFormatterTest {
             "ℹ️ TKF100 SRI: 2 varasemat referentspunkti arvutati ümber (vanim 2026-06-01, viimane"
                 + " 2026-06-30) — hoidmisperioodi kauplemispäevi 1300 → 1280. Alusandmed ei"
                 + " muutunud.");
+  }
+
+  @Test
+  void aClassWithheldByAChangedRuleIsReportedAsARedefinitionRatherThanSourceDataDrift() {
+    var outcome =
+        new RiskIndicatorService.RiskIndicatorOutcome(
+            stableSri(),
+            null,
+            RiskIndicatorPublication.builder().build(),
+            List.of(),
+            List.of(
+                new Redefinition.PublicationRule(LocalDate.of(2026, 6, 1), 4, null),
+                new Redefinition.PublicationRule(LocalDate.of(2026, 6, 30), 4, null)),
+            List.of());
+
+    var lines = diagnosticsFormatter.withDiagnostics(new ArrayList<>(), outcome);
+
+    assertThat(lines)
+        .containsExactly(
+            "ℹ️ TKF100 SRI: 2 varasemat referentspunkti arvutati ümber (vanim 2026-06-01, viimane"
+                + " 2026-06-30) — avaldamisreegel muutus, klass 4 → —. Alusandmed ei muutunud.");
   }
 
   @Test

--- a/src/test/groovy/ee/tuleva/onboarding/investment/risk/RiskIndicatorSeriesServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/risk/RiskIndicatorSeriesServiceTest.java
@@ -146,7 +146,7 @@ class RiskIndicatorSeriesServiceTest {
 
     assertThat(refresh.driftedDates()).isEmpty();
     assertThat(refresh.redefinitions())
-        .containsExactly(new Redefinition(ANCHOR, null, CURRENT_HOLDING_PERIOD));
+        .containsExactly(new Redefinition.HoldingPeriod(ANCHOR, null, CURRENT_HOLDING_PERIOD));
     assertThat(stored.getRiskClass()).isNotEqualTo(1);
     assertThat(stored.getMetrics())
         .doesNotContainKey("driftHistory")
@@ -154,6 +154,37 @@ class RiskIndicatorSeriesServiceTest {
     var saved = ArgumentCaptor.forClass(List.class);
     verify(pointRepository).saveAll(saved.capture());
     assertThat((List<RiskIndicatorPoint>) saved.getValue()).contains(stored);
+  }
+
+  // Restoring the SRRI coverage gate withdraws the class from points whose window does not reach
+  // back five years. Nothing upstream moved - the volatility and the observation count are the
+  // ones already stored - so reporting it as drift would tell the reader the source data changed
+  // retroactively, which is the one thing that did not happen.
+  @Test
+  void aClassThatChangedWhileTheInputsDidNotIsRedefinedRatherThanReportedAsDrift() {
+    givenPrices(dailyPrices(ACWI, ANCHOR.minusYears(7), ANCHOR));
+    var stored = new ArrayList<RiskIndicatorPoint>();
+    given(pointRepository.findByIndicatorTypeAndFundOrderByAsOfDateAsc(SRI, TKF100))
+        .willAnswer(invocation -> List.copyOf(stored));
+    given(pointRepository.saveAll(any()))
+        .willAnswer(
+            invocation -> {
+              stored.addAll(invocation.getArgument(0));
+              return invocation.getArgument(0);
+            });
+    service.refreshSeries(TKF100, SRI, 1);
+
+    var withheld = stored.getFirst();
+    var previouslyPublished = withheld.getRiskClass();
+    withheld.setRiskClass(null);
+
+    var refresh = service.refreshSeries(TKF100, SRI, 1);
+
+    assertThat(refresh.driftedDates()).isEmpty();
+    assertThat(refresh.redefinitions())
+        .containsExactly(
+            new Redefinition.PublicationRule(withheld.getAsOfDate(), null, previouslyPublished));
+    assertThat(withheld.getMetrics()).doesNotContainKey("driftHistory");
   }
 
   @Test
@@ -168,7 +199,7 @@ class RiskIndicatorSeriesServiceTest {
 
     assertThat(refresh.driftedDates()).isEmpty();
     assertThat(refresh.redefinitions())
-        .containsExactly(new Redefinition(ANCHOR, "1300", CURRENT_HOLDING_PERIOD));
+        .containsExactly(new Redefinition.HoldingPeriod(ANCHOR, "1300", CURRENT_HOLDING_PERIOD));
     assertThat(stored.getMetrics())
         .doesNotContainKey("driftHistory")
         .containsEntry("holdingPeriodTradingDays", CURRENT_HOLDING_PERIOD);


### PR DESCRIPTION
`RiskIndicatorSeriesService` sorts a recomputed reference point into one of two buckets,
and the reader sees a different sentence for each:

- `Redefinition` → ℹ️ … `Alusandmed ei muutunud.`
- drift → ⚠️ … `allikaandmed muutusid tagantjärele.`

The test for the first bucket was `holdingPeriodChanged`, which is one specific way an
SRI definition moves. Every *other* way our own definition can move therefore reported
as the source data changing retroactively — a claim about upstream data, made in the one
channel people read to decide whether to go and investigate upstream data.

## The distinction that actually matters

Volatility and observation count are what the source data says. If those are untouched
and only the published class differs, nothing drifted under us — the rule deciding what
may be published moved. If a measurement moved, it is drift.

So the classifier now asks that question directly, and `Redefinition` becomes a sealed
pair — `HoldingPeriod` and `PublicationRule` — rather than growing nullable fields used
as a discriminator. The formatter switches exhaustively, so the compiler will catch the
next variant rather than letting it fall through to the ⚠️ wording.

## Red before green

Removing just the new classification branch fails
`aClassThatChangedWhileTheInputsDidNotIsRedefinedRatherThanReportedAsDrift` and nothing
else, so the test pins the new path rather than riding on the holding-period one. The
existing holding-period tests are unchanged apart from the type name.

## Why now

Restoring the SRRI coverage gate (#1889) is what exposed this: it withdraws the class
from points whose window falls short of five years, over inputs that never moved. That
PR is deliberately kept to the gate alone, so this ships first and #1889 rebases onto
it — otherwise #1889's own first run would emit the ⚠️ line for all three SRRI funds
saying the exact thing that did not happen.

This change stands on its own regardless of #1889: it is the reporting that was too
narrow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
