### PR TITLE
Publish NAV history at each fund's own scale

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/fund/FundService.java
+++ b/src/main/java/ee/tuleva/onboarding/fund/FundService.java
@@ -1,6 +1,5 @@
 package ee.tuleva.onboarding.fund;
 
-import static ee.tuleva.onboarding.tulevafund.TulevaFund.TKF100;
 import static java.math.RoundingMode.HALF_UP;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.stream.StreamSupport.stream;
@@ -9,6 +8,7 @@ import static org.springframework.http.HttpStatus.NOT_FOUND;
 import ee.tuleva.onboarding.fund.statistics.PensionFundStatistics;
 import ee.tuleva.onboarding.fund.statistics.PensionFundStatisticsService;
 import ee.tuleva.onboarding.locale.LocaleService;
+import ee.tuleva.onboarding.tulevafund.TulevaFund;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
@@ -83,7 +83,7 @@ class FundService {
     boolean issuanceCompleted = currentBalance.compareTo(balanceAtCutoff) != 0;
 
     if (issuanceCompleted) {
-      var nav = toNavScale(latestFundValue.value());
+      var nav = toNavScale(fund.getIsin(), latestFundValue.value());
       return PensionFundStatistics.builder()
           .nav(nav)
           .volume(currentBalance.multiply(nav).setScale(2, HALF_UP))
@@ -93,6 +93,7 @@ class FundService {
 
     var previousNav =
         toNavScale(
+            fund.getIsin(),
             fundNavValues
                 .latestValueOnOrBefore(fund.getIsin(), latestFundValue.date().minusDays(1))
                 .map(FundNavValues.NavPoint::value)
@@ -104,8 +105,10 @@ class FundService {
         .build();
   }
 
-  private BigDecimal toNavScale(BigDecimal nav) {
-    return nav.setScale(TKF100.getNavScale());
+  private BigDecimal toNavScale(String isin, BigDecimal nav) {
+    return TulevaFund.findByIsin(isin)
+        .map(tulevaFund -> nav.setScale(tulevaFund.getNavScale(), HALF_UP))
+        .orElse(nav);
   }
 
   private static final DateTimeFormatter ESTONIAN_DATE = DateTimeFormatter.ofPattern("dd.MM.yyyy");
@@ -141,7 +144,9 @@ class FundService {
       return List.of();
     }
     return fundNavValues.valuesBetween(fund.getIsin(), start, end).stream()
-        .map(navPoint -> new NavValueResponse(navPoint.date(), navPoint.value()))
+        .map(
+            navPoint ->
+                new NavValueResponse(navPoint.date(), toNavScale(fund.getIsin(), navPoint.value())))
         .toList();
   }
 

--- a/src/test/groovy/ee/tuleva/onboarding/fund/FundServiceNavHistoryTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/fund/FundServiceNavHistoryTest.java
@@ -53,7 +53,7 @@ class FundServiceNavHistoryTest {
     given(savingsFundNav.isSavingsFund(anyString()))
         .willAnswer(i -> TKF_ISIN.equals(i.getArgument(0)));
     given(fundNavValues.valuesBetween(stockFund.getIsin(), start, LocalDate.of(9999, 12, 31)))
-        .willReturn(List.of(new NavPoint(LocalDate.of(2026, 2, 3), new BigDecimal("1.0000"))));
+        .willReturn(List.of(new NavPoint(LocalDate.of(2026, 2, 3), new BigDecimal("1.59583"))));
     given(fundNavValues.valuesBetween(bondFund.getIsin(), start, LocalDate.of(9999, 12, 31)))
         .willReturn(List.of());
 
@@ -63,7 +63,7 @@ class FundServiceNavHistoryTest {
         .containsExactly(
             new FundNavHistoryResponse(
                 stockFund.getIsin(),
-                List.of(new NavValueResponse(LocalDate.of(2026, 2, 3), new BigDecimal("1.0000")))),
+                List.of(new NavValueResponse(LocalDate.of(2026, 2, 3), new BigDecimal("1.59583")))),
             new FundNavHistoryResponse(bondFund.getIsin(), List.of()));
   }
 
@@ -215,6 +215,87 @@ class FundServiceNavHistoryTest {
     String csv = new String(bytes, StandardCharsets.UTF_8);
     assertThat(csv)
         .isEqualTo("\uFEFFKuupäev;NAV (EUR)\r\n03.02.2026;1.0000\r\n04.02.2026;1.0012\r\n");
+  }
+
+  @Test
+  void getNavHistoryCsv_printsNavAtTheFundsOwnScale() {
+    LocalDate start = LocalDate.of(2026, 2, 2);
+    LocalDate end = LocalDate.of(2026, 4, 14);
+    given(savingsFundNav.isSavingsFund(anyString()))
+        .willAnswer(i -> TKF_ISIN.equals(i.getArgument(0)));
+    given(fundRepository.findByIsin(TKF_ISIN)).willReturn(additionalSavingsFund());
+    given(savingsFundNav.safeMaxNavDate()).willReturn(LocalDate.of(2099, 1, 1));
+    given(fundNavValues.valuesBetween(TKF_ISIN, start, end))
+        .willReturn(
+            List.of(
+                new NavPoint(LocalDate.of(2026, 2, 3), new BigDecimal("1.11500")),
+                new NavPoint(LocalDate.of(2026, 2, 4), new BigDecimal("1.12000"))));
+
+    byte[] bytes = fundService.getNavHistoryCsv(TKF_ISIN, start, end);
+
+    String csv = new String(bytes, StandardCharsets.UTF_8);
+    assertThat(csv)
+        .isEqualTo("\uFEFFKuupäev;NAV (EUR)\r\n03.02.2026;1.1150\r\n04.02.2026;1.1200\r\n");
+  }
+
+  @Test
+  void getNavHistory_returnsNavAtTheFundsOwnScale() {
+    LocalDate start = LocalDate.of(2026, 2, 2);
+    LocalDate end = LocalDate.of(2026, 4, 14);
+    given(savingsFundNav.isSavingsFund(anyString()))
+        .willAnswer(i -> TKF_ISIN.equals(i.getArgument(0)));
+    given(fundRepository.findByIsin(TKF_ISIN)).willReturn(additionalSavingsFund());
+    given(savingsFundNav.safeMaxNavDate()).willReturn(LocalDate.of(2099, 1, 1));
+    given(fundNavValues.valuesBetween(TKF_ISIN, start, end))
+        .willReturn(List.of(new NavPoint(LocalDate.of(2026, 2, 3), new BigDecimal("1.11500"))));
+
+    List<NavValueResponse> result = fundService.getNavHistory(TKF_ISIN, start, end);
+
+    assertThat(result)
+        .containsExactly(new NavValueResponse(LocalDate.of(2026, 2, 3), new BigDecimal("1.1150")));
+  }
+
+  @Test
+  void getNavHistory_keepsPensionFundNavAtItsOwnScale() {
+    LocalDate start = LocalDate.of(2026, 2, 2);
+    LocalDate end = LocalDate.of(2026, 4, 14);
+    Fund stockFund = tuleva2ndPillarStockFund();
+    given(savingsFundNav.isSavingsFund(anyString()))
+        .willAnswer(i -> TKF_ISIN.equals(i.getArgument(0)));
+    given(fundRepository.findByIsin(stockFund.getIsin())).willReturn(stockFund);
+    given(fundNavValues.valuesBetween(stockFund.getIsin(), start, end))
+        .willReturn(List.of(new NavPoint(LocalDate.of(2026, 2, 3), new BigDecimal("1.59583"))));
+
+    List<NavValueResponse> result = fundService.getNavHistory(stockFund.getIsin(), start, end);
+
+    assertThat(result)
+        .containsExactly(new NavValueResponse(LocalDate.of(2026, 2, 3), new BigDecimal("1.59583")));
+  }
+
+  @Test
+  void getNavHistory_leavesNonTulevaFundNavUnscaled() {
+    LocalDate start = LocalDate.of(2026, 2, 2);
+    LocalDate end = LocalDate.of(2026, 4, 14);
+    Fund otherFund = firstNonTulevaFund();
+    String isin = otherFund.getIsin();
+    given(savingsFundNav.isSavingsFund(anyString()))
+        .willAnswer(i -> TKF_ISIN.equals(i.getArgument(0)));
+    given(fundRepository.findByIsin(isin)).willReturn(otherFund);
+    given(fundNavValues.valuesBetween(isin, start, end))
+        .willReturn(List.of(new NavPoint(LocalDate.of(2026, 2, 3), new BigDecimal("1.234567"))));
+
+    List<NavValueResponse> result = fundService.getNavHistory(isin, start, end);
+
+    assertThat(result)
+        .containsExactly(
+            new NavValueResponse(LocalDate.of(2026, 2, 3), new BigDecimal("1.234567")));
+  }
+
+  private Fund firstNonTulevaFund() {
+    return sampleFunds().stream()
+        .filter(f -> !f.getFundManager().getName().equals("Tuleva"))
+        .findFirst()
+        .get();
   }
 
   private Fund firstTulevaNonSavingsFund() {

--- a/src/test/groovy/ee/tuleva/onboarding/fund/FundServiceNavHistoryTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/fund/FundServiceNavHistoryTest.java
@@ -272,6 +272,26 @@ class FundServiceNavHistoryTest {
         .containsExactly(new NavValueResponse(LocalDate.of(2026, 2, 3), new BigDecimal("1.59583")));
   }
 
+  // Every other fixture here is already at its fund's scale or only loses a trailing zero, which
+  // rescales exactly and would pass without a RoundingMode at all. A value that genuinely rounds
+  // is what pins HALF_UP, and it is the legacy row the endpoint must not 500 over.
+  @Test
+  void getNavHistory_roundsALegacyValueCarryingMoreDecimalsThanTheFundPublishes() {
+    LocalDate start = LocalDate.of(2026, 2, 2);
+    LocalDate end = LocalDate.of(2026, 4, 14);
+    given(savingsFundNav.isSavingsFund(anyString()))
+        .willAnswer(i -> TKF_ISIN.equals(i.getArgument(0)));
+    given(fundRepository.findByIsin(TKF_ISIN)).willReturn(additionalSavingsFund());
+    given(savingsFundNav.safeMaxNavDate()).willReturn(LocalDate.of(2099, 1, 1));
+    given(fundNavValues.valuesBetween(TKF_ISIN, start, end))
+        .willReturn(List.of(new NavPoint(LocalDate.of(2026, 2, 3), new BigDecimal("1.12195"))));
+
+    List<NavValueResponse> result = fundService.getNavHistory(TKF_ISIN, start, end);
+
+    assertThat(result)
+        .containsExactly(new NavValueResponse(LocalDate.of(2026, 2, 3), new BigDecimal("1.1220")));
+  }
+
   @Test
   void getNavHistory_leavesNonTulevaFundNavUnscaled() {
     LocalDate start = LocalDate.of(2026, 2, 2);


### PR DESCRIPTION
## Problem

The NAV history we link from the fund page (`/v1/funds/{isin}/nav?format=csv`) prints TKF100 NAV with five decimals — `1.12190` — while the official NAV has four. The JSON form of the same endpoint does the same (`"value":1.12190`).

Nothing is wrong with the stored number: `index_values.value` is `NUMERIC(16,5)` (V1_92), so a NAV already rounded to four decimals comes back from JDBC at scale 5 and `toPlainString()` faithfully prints the trailing zero. Every TKF100 row in prod ends in `0`. This is a printing bug only.

## Fix

Scale each NAV point to its own fund's `TulevaFund.navScale` in `FundService.navHistoryFor`, so both the CSV and the JSON carry the published precision:

- TKF100 and TUV100 → 4 decimals
- TUK75 and TUK00 → 5 decimals, which is what they genuinely publish (`1.59583`, `0.60643`) — so this is per fund, not a blanket 4
- funds we do not manage → untouched

This also removes a hardcode: `toNavScale` applied `TKF100.getNavScale()` to every fund's statistics.

Rounding is `HALF_UP` rather than `UNNECESSARY`: no stored value needs rounding today, and a public read endpoint should not 500 over one legacy row.

## Not changed

The publication cutoff is untouched. `navHistoryFor` still caps a savings fund's end date at `SavingsFundNav.safeMaxNavDate()`, i.e. `FundNavProvider.safeMaxNavDate()` — today's NAV only appears from 16:00 Estonian time on a working day. The existing tests for that capping still pass unchanged.

## Tests

Added to `FundServiceNavHistoryTest`: CSV at fund scale, JSON at fund scale, pension fund keeps 5 decimals, non-Tuleva fund untouched. One existing test stubbed TUK75 with a 4-decimal `1.0000` and expected it back verbatim; it now uses a realistic 5-decimal value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)