### PR TITLE
Test the NAV flow wiring that a double-count slipped through

### DIFF
--- a/src/test/groovy/ee/tuleva/onboarding/investment/check/health/HealthCheckNotifierTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/check/health/HealthCheckNotifierTest.java
@@ -3,6 +3,7 @@ package ee.tuleva.onboarding.investment.check.health;
 import static ee.tuleva.onboarding.investment.check.health.HealthCheckSeverity.*;
 import static ee.tuleva.onboarding.investment.check.health.HealthCheckType.COMPLETENESS;
 import static ee.tuleva.onboarding.investment.check.health.HealthCheckType.ISIN_MATCH;
+import static ee.tuleva.onboarding.investment.check.health.HealthCheckType.NAV_FLOW_CONSISTENCY;
 import static ee.tuleva.onboarding.investment.report.ReportProvider.SEB;
 import static ee.tuleva.onboarding.notification.OperationsNotificationService.Channel.INVESTMENT;
 import static ee.tuleva.onboarding.tulevafund.TulevaFund.TUK75;
@@ -62,6 +63,22 @@ class HealthCheckNotifierTest {
     assertThat(notified).isTrue();
     verify(notificationService).sendMessage(contains("Import warning"), eq(INVESTMENT));
     verify(notificationService).sendMessage(contains("[WARNING]"), eq(INVESTMENT));
+  }
+
+  // A check that declined to answer is not a clean import and not a warning about the fund, so
+  // it has to read as its own thing rather than borrowing either headline.
+  @Test
+  void sendsCouldNotRunWhenACheckDeclinedToAnswer() {
+    var finding =
+        new HealthCheckFinding(
+            TUK75, NAV_FLOW_CONSISTENCY, NOT_RUN, "TUK75: unpricedHoldings=IE00A");
+    var result = new HealthCheckResult(TUK75, DATE, List.of(finding));
+
+    var notified = notifier.notify(SEB, DATE, List.of(result));
+
+    assertThat(notified).isTrue();
+    verify(notificationService).sendMessage(contains("could not run"), eq(INVESTMENT));
+    verify(notificationService).sendMessage(contains("[NOT_RUN]"), eq(INVESTMENT));
   }
 
   @Test

--- a/src/test/groovy/ee/tuleva/onboarding/investment/check/health/HealthCheckServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/check/health/HealthCheckServiceTest.java
@@ -2,6 +2,8 @@ package ee.tuleva.onboarding.investment.check.health;
 
 import static ee.tuleva.onboarding.investment.check.health.HealthCheckSeverity.*;
 import static ee.tuleva.onboarding.investment.check.health.HealthCheckType.COMPLETENESS;
+import static ee.tuleva.onboarding.investment.check.health.HealthCheckType.NAV_FLOW_CONSISTENCY;
+import static ee.tuleva.onboarding.investment.config.InvestmentParameter.NAV_FLOW_CONSISTENCY_THRESHOLD;
 import static ee.tuleva.onboarding.investment.position.AccountType.*;
 import static ee.tuleva.onboarding.tulevafund.TulevaFund.*;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -78,6 +80,36 @@ class HealthCheckServiceTest {
     assertThat(results.getFirst().fund()).isEqualTo(TUK75);
     assertThat(results.getFirst().checkDate()).isEqualTo(NAV_DATE);
     verify(completenessChecker).check(eq(TUK75), eq(NAV_DATE), eq(positions));
+  }
+
+  // Only @Mock fields were added when this checker was wired in, so an unstubbed mock returned
+  // null and nothing here failed if the wiring were deleted. That is how a double-counted
+  // netAssets reached a green build.
+  @Test
+  void runsTheNavFlowCheckAgainstBothDaysPositionsAndReportsWhatItFinds() {
+    var positions = List.of(securityPosition(TUK75, "IE001", new BigDecimal("1000")));
+    var previousPositions = List.of(securityPosition(TUK75, "IE001", new BigDecimal("900")));
+    var previousNavDate = NAV_DATE.minusDays(1);
+    var threshold = new BigDecimal("0.001");
+
+    given(modelPortfolioAllocationRepository.findLatestByFundAsOf(TUK75, NAV_DATE))
+        .willReturn(List.of());
+    given(fundPositionRepository.findLatestNavDateByFundAndAsOfDate(TUK75, previousNavDate))
+        .willReturn(Optional.of(previousNavDate));
+    given(fundPositionRepository.findByNavDateAndFund(previousNavDate, TUK75))
+        .willReturn(previousPositions);
+    given(investmentParameterRepository.findLatestValue(NAV_FLOW_CONSISTENCY_THRESHOLD, NAV_DATE))
+        .willReturn(threshold);
+
+    var finding =
+        new HealthCheckFinding(TUK75, NAV_FLOW_CONSISTENCY, WARNING, "NAV flow does not reconcile");
+    given(navFlowConsistencyChecker.check(TUK75, positions, previousPositions, threshold))
+        .willReturn(List.of(finding));
+
+    var results = healthCheckService.check(positions);
+
+    assertThat(results.getFirst().findings()).contains(finding);
+    verify(navFlowConsistencyChecker).check(TUK75, positions, previousPositions, threshold);
   }
 
   @Test

--- a/src/test/groovy/ee/tuleva/onboarding/investment/check/health/NavFlowConsistencyCheckerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/check/health/NavFlowConsistencyCheckerTest.java
@@ -104,6 +104,34 @@ class NavFlowConsistencyCheckerTest {
         .contains("quantitiesChanged=true");
   }
 
+  // The gate is a strict "less than", so a fraction sitting exactly on the threshold warns.
+  @Test
+  void aGapExactlyOnTheThresholdWarns() {
+    var previous =
+        positions(security("IE00A", "10000", "100", "1000000"), units("1000000"), total("1000000"));
+    var today =
+        positions(
+            security("IE00A", "10000", "100", "1000000"),
+            cash("1000"),
+            units("1000000"),
+            total("1001000"));
+
+    var findings = checker.check(TUK75, today, previous, new BigDecimal("0.001"));
+
+    assertThat(findings).hasSize(1);
+    assertThat(findings.getFirst().severity()).isEqualTo(WARNING);
+  }
+
+  // Dividing the gap by a fund that was empty yesterday says nothing, so there is nothing to check.
+  @Test
+  void aFundWithNothingInItYesterdayHasNoFractionToReport() {
+    var previous = positions(units("1000000"), total("0"));
+    var today =
+        positions(security("IE00A", "10000", "100", "1000000"), units("1000000"), total("1000000"));
+
+    assertThat(checker.check(TUK75, today, previous, THRESHOLD)).isEmpty();
+  }
+
   @Test
   void aFirstEverImportHasNothingToReconcileAgainst() {
     var today = positions(security("IE00A", "10000", "100", "1000000"), units("800000"));

--- a/src/test/groovy/ee/tuleva/onboarding/investment/check/tracking/BreachMessageFormatterTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/check/tracking/BreachMessageFormatterTest.java
@@ -23,8 +23,6 @@ class BreachMessageFormatterTest {
                 new RedemptionCycleHint(true, new BigDecimal("5928109.00"), BigDecimal.ZERO))
             .format();
 
-    System.out.println(message);
-
     assertThat(message)
         .contains("NAV bridge (EUR)")
         .contains("UNEXPLAINED")
@@ -42,9 +40,6 @@ class BreachMessageFormatterTest {
         new BreachMessageFormatter(
                 tuk75On20260901(), false, RedemptionCycleHint.executionDateWithoutFigures())
             .format();
-
-    System.out.println("\n\n---------- FALLBACK (no R17/R21 ingested) ----------");
-    System.out.println(message);
 
     assertThat(message)
         .contains("PEVA/RAVA execution date")

--- a/src/test/groovy/ee/tuleva/onboarding/investment/check/tracking/RedemptionCycleLookupTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/check/tracking/RedemptionCycleLookupTest.java
@@ -56,8 +56,10 @@ class RedemptionCycleLookupTest {
 
     assertThat(hint.executionDate()).isTrue();
     assertThat(hint.hasFigures()).isTrue();
-    assertThat(hint.ravaEur()).isEqualByComparingTo(new BigDecimal("5928109.00"));
-    assertThat(hint.pikEur()).isEqualByComparingTo(new BigDecimal("120000.00"));
+    assertThat(hint)
+        .isEqualTo(
+            new RedemptionCycleHint(
+                true, new BigDecimal("5928109.00"), new BigDecimal("120000.00")));
   }
 
   @Test

--- a/src/test/groovy/ee/tuleva/onboarding/investment/check/tracking/TrackingDifferenceNotifierTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/check/tracking/TrackingDifferenceNotifierTest.java
@@ -951,6 +951,43 @@ class TrackingDifferenceNotifierTest {
         .contains("TUK75 MODEL_PORTFOLIO: the breach streak could not be counted");
   }
 
+  // Only the @Mock field was added when the lookup was wired in, so resolve() returned null in
+  // every test and the PEVA/RAVA section was never proved to reach a message.
+  @Test
+  void namesThePevaRavaCycleOnAModelPortfolioBreach() {
+    var result = result(true, 1, new BigDecimal("0.0015"));
+    given(redemptionCycleLookup.resolve(TUK75, result.checkDate()))
+        .willReturn(new RedemptionCycleHint(true, new BigDecimal("5928109.00"), null));
+
+    notifier.notify(List.of(result));
+
+    then(notificationService).should().sendMessage(contains("PEVA/RAVA"), eq(INVESTMENT));
+  }
+
+  @Test
+  void doesNotLookUpARedemptionCycleForABenchmarkCheck() {
+    var result =
+        TrackingDifferenceResult.builder()
+            .fund(TUK75)
+            .checkDate(LocalDate.of(2026, 4, 3))
+            .checkType(BENCHMARK)
+            .trackingDifference(new BigDecimal("0.0015"))
+            .fundReturn(new BigDecimal("0.0100"))
+            .benchmarkReturn(new BigDecimal("0.0085"))
+            .breach(true)
+            .consecutiveBreachDays(1)
+            .consecutiveNetTd(new BigDecimal("0.0015"))
+            .securityAttributions(List.of())
+            .cashDrag(ZERO)
+            .feeDrag(ZERO)
+            .residual(ZERO)
+            .build();
+
+    notifier.notify(List.of(result));
+
+    then(redemptionCycleLookup).shouldHaveNoInteractions();
+  }
+
   private TrackingDifferenceResult result(
       boolean breach, int consecutiveBreachDays, BigDecimal consecutiveNetTd) {
     return TrackingDifferenceResult.builder()


### PR DESCRIPTION
Follow-up to #1941. Tests only — no production code changes.

## The gap this closes

Wiring `NavFlowConsistencyChecker` into `HealthCheckService`, and `RedemptionCycleLookup` into
`TrackingDifferenceNotifier`, added only `@Mock` fields to the existing tests. An unstubbed mock
returns `null`/empty, so every test passed whether or not the wiring existed — deleting either
call broke nothing.

That is not hypothetical: it is how `netAssets` counting the report's own `Total` row on top of
the lines that sum to it (fixed in #1941) reached a green build. The unit under test was wrong and
the integration was untested, so nothing anywhere failed.

Both are now pinned the only way worth trusting — by deleting the production call and watching a
named test go red:

```
HealthCheckServiceTest > runsTheNavFlowCheckAgainstBothDaysPositionsAndReportsWhatItFinds FAILED
TrackingDifferenceNotifierTest > namesThePevaRavaCycleOnAModelPortfolioBreach FAILED
```

## Boundaries nothing asserted

- A gap sitting **exactly** on the threshold warns — the gate is a strict `<`, so `<=` would
  silently swallow the boundary case. Verified by mutation: flipping it fails
  `aGapExactlyOnTheThresholdWarns` and nothing else.
- A fund that held nothing the previous day has no fraction to report, rather than dividing by it.
- `NOT_RUN` renders as its own headline instead of borrowing the clean or the warning one.
- `TrackingDifferenceNotifier` does not look up a redemption cycle for a `BENCHMARK` check.

## Tidying

Three `System.out.println` calls left in `BreachMessageFormatterTest`, and a
`RedemptionCycleHint` compared two components at a time where the whole record does.

Full suite green: 8422 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
