### PR TITLE
Block the position import per fund, not per file

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/investment/check/health/CompletenessChecker.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/check/health/CompletenessChecker.java
@@ -1,5 +1,6 @@
 package ee.tuleva.onboarding.investment.check.health;
 
+import static ee.tuleva.onboarding.investment.check.health.HealthCheckSeverity.FAIL;
 import static ee.tuleva.onboarding.investment.check.health.HealthCheckSeverity.WARNING;
 import static ee.tuleva.onboarding.investment.check.health.HealthCheckType.COMPLETENESS;
 import static ee.tuleva.onboarding.investment.position.AccountType.CASH;
@@ -38,6 +39,8 @@ class CompletenessChecker {
               "%s: no CASH position found for navDate=%s".formatted(fund, navDate)));
     }
 
+    // A holding you cannot own must not reach the NAV input. This FAILs, and since the import gate
+    // blocks per fund, it takes down only this fund's positions for the day.
     positions.stream()
         .filter(position -> position.getAccountType() == SECURITY)
         .filter(position -> position.getQuantity() != null && position.getQuantity().signum() < 0)
@@ -47,7 +50,7 @@ class CompletenessChecker {
                     new HealthCheckFinding(
                         fund,
                         COMPLETENESS,
-                        WARNING,
+                        FAIL,
                         "%s: negative SECURITY quantity %s for %s"
                             .formatted(
                                 fund,

--- a/src/main/java/ee/tuleva/onboarding/investment/check/tracking/NavTrackingDifferenceGate.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/check/tracking/NavTrackingDifferenceGate.java
@@ -68,6 +68,7 @@ public class NavTrackingDifferenceGate {
       log.warn("TD gate incomplete price data, proceeding: fund={}, date={}", fund, navDate);
       return Optional.empty();
     } catch (Exception e) {
+      trackingDifferenceNotifier.notifyCheckCouldNotRun(fund, navDate);
       pipelineTracker.stepFailed(TRACKING_DIFFERENCE, e.getMessage());
       log.warn("TD gate error, proceeding: fund={}, date={}", fund, navDate, e);
       return Optional.empty();

--- a/src/main/java/ee/tuleva/onboarding/investment/position/FundPositionImportJob.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/position/FundPositionImportJob.java
@@ -5,6 +5,7 @@ import static ee.tuleva.onboarding.investment.event.PipelineStep.POSITION_IMPORT
 import static ee.tuleva.onboarding.investment.report.ReportProvider.SEB;
 import static ee.tuleva.onboarding.investment.report.ReportProvider.SWEDBANK;
 import static ee.tuleva.onboarding.investment.report.ReportType.POSITIONS;
+import static java.util.stream.Collectors.toCollection;
 
 import ee.tuleva.onboarding.fund.TulevaFund;
 import ee.tuleva.onboarding.investment.check.health.HealthCheckNotifier;
@@ -23,9 +24,11 @@ import ee.tuleva.onboarding.investment.report.InvestmentReportService;
 import ee.tuleva.onboarding.investment.report.ReportProvider;
 import java.time.Clock;
 import java.time.LocalDate;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.IntStream;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
@@ -160,15 +163,33 @@ public class FundPositionImportJob {
         "Parsed fund positions: provider={}, date={}, count={}", provider, date, positions.size());
 
     var healthResults = healthCheckService.check(positions);
-    if (healthResults.stream().anyMatch(HealthCheckResult::hasFails)) {
+    // Blocking per fund, not per file: one fund's unusable figures must not stop the other three
+    // from being imported, and the checks themselves are already scoped to a single fund.
+    Set<TulevaFund> blockedFunds =
+        healthResults.stream()
+            .filter(HealthCheckResult::hasFails)
+            .map(HealthCheckResult::fund)
+            .collect(toCollection(() -> EnumSet.noneOf(TulevaFund.class)));
+
+    if (!blockedFunds.isEmpty()) {
       healthCheckFailed = true;
-      healthCheckFailureDetail = "Import blocked: provider=%s, date=%s".formatted(provider, date);
+      healthCheckFailureDetail =
+          "Import blocked: provider=%s, date=%s, funds=%s".formatted(provider, date, blockedFunds);
+      log.error(
+          "Health check failed, import blocked for these funds: provider={}, date={}, funds={}",
+          provider,
+          date,
+          blockedFunds);
+    }
+
+    List<FundPosition> importablePositions =
+        positions.stream().filter(position -> !blockedFunds.contains(position.getFund())).toList();
+    if (importablePositions.isEmpty()) {
       notifyHealth(provider, date, healthResults);
-      log.error("Health check failed, import blocked: provider={}, date={}", provider, date);
       return new ImportResult(0, 0);
     }
 
-    ImportResult result = importService.upsertPositions(positions);
+    ImportResult result = importService.upsertPositions(importablePositions);
 
     notifyHealth(provider, date, healthResults);
     if (result.imported() > 0 || result.updated() > 0) {
@@ -183,7 +204,7 @@ public class FundPositionImportJob {
         investmentReport.getRawData().size());
 
     List<TulevaFund> navFunds =
-        positions.stream()
+        importablePositions.stream()
             .map(FundPosition::getFund)
             .filter(TulevaFund::hasNavCalculation)
             .distinct()

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/CalculationWarningType.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/CalculationWarningType.java
@@ -2,5 +2,6 @@ package ee.tuleva.onboarding.investment.transaction;
 
 public enum CalculationWarningType {
   REBALANCE_NET_CASH_MISMATCH,
-  REBALANCE_NET_NOT_ACHIEVED
+  REBALANCE_NET_NOT_ACHIEVED,
+  FEE_POLICY_UNRESOLVED
 }

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/FundTransactionInput.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/FundTransactionInput.java
@@ -31,9 +31,11 @@ public record FundTransactionInput(
     @Nullable BigDecimal appliedCash,
     @Nullable BigDecimal ledgerCash,
     @Nullable LocalDate positionDate,
-    @Nullable LocalDate modelEffectiveDate) {
+    @Nullable LocalDate modelEffectiveDate,
+    List<CalculationWarning> inputWarnings) {
 
   public static class FundTransactionInputBuilder {
+    private List<CalculationWarning> inputWarnings = List.of();
     private BigDecimal receivables = ZERO;
     private Map<String, InstrumentType> instrumentTypes = Map.of();
     private Map<String, OrderVenue> orderVenues = Map.of();

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionInputService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/TransactionInputService.java
@@ -9,6 +9,7 @@ import static ee.tuleva.onboarding.investment.config.InvestmentParameter.R16_ROU
 import static ee.tuleva.onboarding.investment.epis.PevaRavaPhase.DONE;
 import static ee.tuleva.onboarding.investment.position.AccountType.CASH;
 import static ee.tuleva.onboarding.investment.position.AccountType.SECURITY;
+import static ee.tuleva.onboarding.investment.transaction.CalculationWarningType.FEE_POLICY_UNRESOLVED;
 import static java.math.BigDecimal.ONE;
 import static java.math.BigDecimal.ZERO;
 import static java.math.RoundingMode.CEILING;
@@ -114,8 +115,9 @@ public class TransactionInputService {
         applyUnreportedPositions(getPositions(fund, positionDate), pendingOrders);
     BigDecimal reportCash = getCashBalance(fund, positionDate);
     BigDecimal appliedCash = cashOverride == null ? reportCash : cashOverride;
-    BigDecimal managementFee = getAccruedFees(fund, asOfDate, FeeType.MANAGEMENT);
-    BigDecimal depotFee = getAccruedFees(fund, asOfDate, FeeType.DEPOT);
+    List<CalculationWarning> inputWarnings = new ArrayList<>();
+    BigDecimal managementFee = getAccruedFees(fund, asOfDate, FeeType.MANAGEMENT, inputWarnings);
+    BigDecimal depotFee = getAccruedFees(fund, asOfDate, FeeType.DEPOT, inputWarnings);
     List<ModelPortfolioAllocation> allocations = getModelAllocations(fund, asOfDate);
     List<ModelPortfolioAllocation> previousAllocations =
         modelPortfolioAllocationRepository.findPreviousByFundAsOf(fund, asOfDate).stream()
@@ -215,6 +217,7 @@ public class TransactionInputService {
         .ledgerCash(ledgerCash)
         .positionDate(positionDate)
         .modelEffectiveDate(modelEffectiveDate)
+        .inputWarnings(List.copyOf(inputWarnings))
         .build();
   }
 
@@ -311,12 +314,37 @@ public class TransactionInputService {
         .reduce(ZERO, BigDecimal::add);
   }
 
-  private BigDecimal getAccruedFees(TulevaFund fund, LocalDate asOfDate, FeeType feeType) {
-    if (!feeChargedToFundPolicy.chargedToFund(fund, feeType, asOfDate)) {
+  private BigDecimal getAccruedFees(
+      TulevaFund fund,
+      LocalDate asOfDate,
+      FeeType feeType,
+      List<CalculationWarning> inputWarnings) {
+    if (!isChargedToFund(fund, feeType, asOfDate, inputWarnings)) {
       return ZERO;
     }
     LocalDate feeMonth = asOfDate.withDayOfMonth(1);
     return feeAccrualRepository.getAccruedFeesForMonth(fund, feeMonth, List.of(feeType), asOfDate);
+  }
+
+  // An unconfigured, gapped or overlapping fee policy must not stop an order from being created:
+  // the accrual is small next to the portfolio, so the calculation reserves it — the conservative
+  // direction — and the operator sees why on the draft.
+  private boolean isChargedToFund(
+      TulevaFund fund,
+      FeeType feeType,
+      LocalDate asOfDate,
+      List<CalculationWarning> inputWarnings) {
+    try {
+      return feeChargedToFundPolicy.chargedToFund(fund, feeType, asOfDate);
+    } catch (IllegalStateException e) {
+      String message =
+          ("Fee policy does not resolve, reserving the accrual as if it were charged to the fund:"
+                  + " fund=%s, feeType=%s, asOfDate=%s, reason=%s")
+              .formatted(fund.name(), feeType, asOfDate, e.getMessage());
+      log.warn(message);
+      inputWarnings.add(new CalculationWarning(FEE_POLICY_UNRESOLVED, message));
+      return true;
+    }
   }
 
   private List<ModelPortfolioAllocation> getModelAllocations(TulevaFund fund, LocalDate asOfDate) {

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/calculation/TradeCalculationEngine.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/calculation/TradeCalculationEngine.java
@@ -91,10 +91,12 @@ public class TradeCalculationEngine {
 
   private List<CalculationWarning> warnings(
       FundTransactionInput input, TransactionMode mode, List<TradeCalculation> trades) {
-    if (mode != TransactionMode.REBALANCE || input.positions().isEmpty()) {
-      return List.of();
+    // Warnings raised while gathering the input travel in every mode, not just REBALANCE.
+    List<CalculationWarning> warnings = new ArrayList<>(input.inputWarnings());
+    if (mode == TransactionMode.REBALANCE && !input.positions().isEmpty()) {
+      warnings.addAll(rebalanceWarnings(input, trades));
     }
-    return rebalanceWarnings(input, trades);
+    return List.copyOf(warnings);
   }
 
   private List<CalculationWarning> rebalanceWarnings(

--- a/src/test/groovy/ee/tuleva/onboarding/investment/check/health/CompletenessCheckerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/check/health/CompletenessCheckerTest.java
@@ -1,6 +1,7 @@
 package ee.tuleva.onboarding.investment.check.health;
 
 import static ee.tuleva.onboarding.fund.TulevaFund.TUK75;
+import static ee.tuleva.onboarding.investment.check.health.HealthCheckSeverity.FAIL;
 import static ee.tuleva.onboarding.investment.check.health.HealthCheckSeverity.WARNING;
 import static ee.tuleva.onboarding.investment.check.health.HealthCheckType.COMPLETENESS;
 import static ee.tuleva.onboarding.investment.position.AccountType.*;
@@ -30,7 +31,7 @@ class CompletenessCheckerTest {
   }
 
   @Test
-  void warnsOnNegativeSecurityQuantityWithoutBlockingTheImport() {
+  void failsOnNegativeSecurityQuantitySoItCannotReachTheNavInput() {
     var positions =
         List.of(
             securityPosition("IE00BFG1TM61", new BigDecimal("-50")),
@@ -43,13 +44,13 @@ class CompletenessCheckerTest {
         .satisfies(
             finding -> {
               assertThat(finding.checkType()).isEqualTo(COMPLETENESS);
-              assertThat(finding.severity()).isEqualTo(WARNING);
+              assertThat(finding.severity()).isEqualTo(FAIL);
               assertThat(finding.message()).contains("IE00BFG1TM61", "-50");
             });
   }
 
   @Test
-  void warnsOnNegativeSecurityQuantityWithoutIsinAndNamesTheAccount() {
+  void failsOnNegativeSecurityQuantityWithoutIsinAndNamesTheAccount() {
     var positions =
         List.of(
             FundPosition.builder()
@@ -67,7 +68,7 @@ class CompletenessCheckerTest {
         .singleElement()
         .satisfies(
             finding -> {
-              assertThat(finding.severity()).isEqualTo(WARNING);
+              assertThat(finding.severity()).isEqualTo(FAIL);
               assertThat(finding.message()).contains("Unmapped custody line", "-3");
             });
   }

--- a/src/test/groovy/ee/tuleva/onboarding/investment/check/health/QuantityChangeCheckerTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/check/health/QuantityChangeCheckerTest.java
@@ -136,7 +136,7 @@ class QuantityChangeCheckerTest {
   }
 
   @Test
-  void warnsWhenTheChangeIgnoresASettledSaleAndOnlyMatchesTheBuys() {
+  void warnsWhenTheChangeIgnoresAReportedSaleAndOnlyMatchesTheBuys() {
     var today = List.of(security("IE0009FT4LX4", new BigDecimal("2000")));
     var previous = List.of(security("IE0009FT4LX4", new BigDecimal("1000")));
     var traded =
@@ -154,7 +154,7 @@ class QuantityChangeCheckerTest {
   }
 
   @Test
-  void warnsWhenLessSettledThanWeTraded() {
+  void warnsWhenThePositionMovedLessThanTheReportedTradesSay() {
     var today = List.of(security("IE0009FT4LX4", new BigDecimal("1200")));
     var previous = List.of(security("IE0009FT4LX4", new BigDecimal("1000")));
     var traded = Map.of("IE0009FT4LX4", new TradedQuantity(new BigDecimal("500"), ZERO));

--- a/src/test/groovy/ee/tuleva/onboarding/investment/check/tracking/NavTrackingDifferenceGateTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/check/tracking/NavTrackingDifferenceGateTest.java
@@ -208,10 +208,12 @@ class NavTrackingDifferenceGateTest {
   }
 
   @Test
-  void passes_whenUnexpectedException() {
+  void passes_andSaysTheCheckCouldNotRun_whenUnexpectedException() {
     given(trackingDifferenceService.checkFund(TUK75, NAV_DATE))
         .willThrow(new RuntimeException("unexpected"));
 
     assertThat(gate.check(TUK75, NAV_DATE)).isEmpty();
+
+    then(trackingDifferenceNotifier).should().notifyCheckCouldNotRun(TUK75, NAV_DATE);
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/investment/position/FundPositionImportJobTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/position/FundPositionImportJobTest.java
@@ -2,6 +2,10 @@ package ee.tuleva.onboarding.investment.position;
 
 import static ee.tuleva.onboarding.fund.TulevaFund.TUK75;
 import static ee.tuleva.onboarding.fund.TulevaFund.TUV100;
+import static ee.tuleva.onboarding.investment.check.health.HealthCheckSeverity.FAIL;
+import static ee.tuleva.onboarding.investment.check.health.HealthCheckSeverity.WARNING;
+import static ee.tuleva.onboarding.investment.check.health.HealthCheckType.COMPLETENESS;
+import static ee.tuleva.onboarding.investment.check.health.HealthCheckType.ISIN_MATCH;
 import static ee.tuleva.onboarding.investment.position.AccountType.CASH;
 import static ee.tuleva.onboarding.investment.position.AccountType.SECURITY;
 import static ee.tuleva.onboarding.investment.report.ReportProvider.SEB;
@@ -13,9 +17,12 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import ee.tuleva.onboarding.fund.TulevaFund;
+import ee.tuleva.onboarding.investment.check.health.HealthCheckFinding;
 import ee.tuleva.onboarding.investment.check.health.HealthCheckNotifier;
 import ee.tuleva.onboarding.investment.check.health.HealthCheckResult;
 import ee.tuleva.onboarding.investment.check.health.HealthCheckService;
+import ee.tuleva.onboarding.investment.check.health.HealthCheckSeverity;
+import ee.tuleva.onboarding.investment.check.health.HealthCheckType;
 import ee.tuleva.onboarding.investment.event.PipelineTracker;
 import ee.tuleva.onboarding.investment.position.parser.SebFundPositionParser;
 import ee.tuleva.onboarding.investment.position.parser.SwedbankFundPositionParser;
@@ -223,22 +230,36 @@ class FundPositionImportJobTest {
         .recordPositionsToLedger(any(TulevaFund.class), any());
   }
 
+  // The report carries two TUK75 rows and one TUV100 row: a FAIL on one fund must not cost the
+  // other
+  // its positions for the day.
   @Test
-  void importForProviderAndDate_blocksImportOnHealthCheckFail() {
+  void importForProviderAndDate_blocksOnlyTheFundThatFailedItsHealthCheck() {
     LocalDate date = LocalDate.of(2026, 1, 5);
     when(reportService.getReport(SWEDBANK, POSITIONS, date))
         .thenReturn(Optional.of(createSwedbankReport(date)));
-    var failResult =
-        new HealthCheckResult(
-            TUK75,
-            date,
+    when(repository.findByNavDateAndFundAndAccountTypeAndAccountName(any(), any(), any(), any()))
+        .thenReturn(Optional.empty());
+    when(healthCheckService.check(anyList()))
+        .thenReturn(List.of(healthCheckResult(TUK75, date, FAIL, ISIN_MATCH, "unknown ISIN")));
+
+    var result = job.importForProviderAndDate(SWEDBANK, date);
+
+    assertThat(result.imported()).isEqualTo(1);
+    verify(repository, times(1)).save(any(FundPosition.class));
+    verify(healthCheckNotifier).notify(eq(SWEDBANK), eq(date), anyList());
+  }
+
+  @Test
+  void importForProviderAndDate_importsNothingWhenEveryFundInTheReportFailed() {
+    LocalDate date = LocalDate.of(2026, 1, 5);
+    when(reportService.getReport(SWEDBANK, POSITIONS, date))
+        .thenReturn(Optional.of(createSwedbankReport(date)));
+    when(healthCheckService.check(anyList()))
+        .thenReturn(
             List.of(
-                new ee.tuleva.onboarding.investment.check.health.HealthCheckFinding(
-                    TUK75,
-                    ee.tuleva.onboarding.investment.check.health.HealthCheckType.ISIN_MATCH,
-                    ee.tuleva.onboarding.investment.check.health.HealthCheckSeverity.FAIL,
-                    "unknown ISIN")));
-    when(healthCheckService.check(anyList())).thenReturn(List.of(failResult));
+                healthCheckResult(TUK75, date, FAIL, ISIN_MATCH, "unknown ISIN"),
+                healthCheckResult(TUV100, date, FAIL, COMPLETENESS, "negative quantity")));
 
     var result = job.importForProviderAndDate(SWEDBANK, date);
 
@@ -249,27 +270,43 @@ class FundPositionImportJobTest {
   }
 
   @Test
+  void importForProviderAndDate_doesNotRecordToLedgerForABlockedFund() {
+    LocalDate date = LocalDate.of(2026, 1, 5);
+    when(reportService.getReport(SWEDBANK, POSITIONS, date))
+        .thenReturn(Optional.of(createSwedbankReport(date)));
+    when(repository.findByNavDateAndFundAndAccountTypeAndAccountName(any(), any(), any(), any()))
+        .thenReturn(Optional.empty());
+    when(healthCheckService.check(anyList()))
+        .thenReturn(List.of(healthCheckResult(TUK75, date, FAIL, ISIN_MATCH, "unknown ISIN")));
+
+    job.importForProviderAndDate(SWEDBANK, date);
+
+    verify(fundPositionLedgerService, never()).recordPositionsToLedger(eq(TUK75), any());
+  }
+
+  @Test
   void importForProviderAndDate_proceedsAndNotifiesOnWarning() {
     LocalDate date = LocalDate.of(2026, 1, 5);
     when(reportService.getReport(SWEDBANK, POSITIONS, date))
         .thenReturn(Optional.of(createSwedbankReport(date)));
     when(repository.findByNavDateAndFundAndAccountTypeAndAccountName(any(), any(), any(), any()))
         .thenReturn(Optional.empty());
-    var warningResult =
-        new HealthCheckResult(
-            TUK75,
-            date,
-            List.of(
-                new ee.tuleva.onboarding.investment.check.health.HealthCheckFinding(
-                    TUK75,
-                    ee.tuleva.onboarding.investment.check.health.HealthCheckType.COMPLETENESS,
-                    ee.tuleva.onboarding.investment.check.health.HealthCheckSeverity.WARNING,
-                    "no CASH")));
-    when(healthCheckService.check(anyList())).thenReturn(List.of(warningResult));
+    when(healthCheckService.check(anyList()))
+        .thenReturn(List.of(healthCheckResult(TUK75, date, WARNING, COMPLETENESS, "no CASH")));
 
     job.importForProviderAndDate(SWEDBANK, date);
 
     verify(repository, times(3)).save(any(FundPosition.class));
     verify(healthCheckNotifier).notify(eq(SWEDBANK), eq(date), anyList());
+  }
+
+  private HealthCheckResult healthCheckResult(
+      TulevaFund fund,
+      LocalDate date,
+      HealthCheckSeverity severity,
+      HealthCheckType checkType,
+      String message) {
+    return new HealthCheckResult(
+        fund, date, List.of(new HealthCheckFinding(fund, checkType, severity, message)));
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionInputServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/TransactionInputServiceTest.java
@@ -163,6 +163,47 @@ class TransactionInputServiceTest {
     assertThat(result.liabilities()).isEqualByComparingTo(new BigDecimal("5000"));
   }
 
+  // A hand-maintained reference row must not be able to stop an order from being created.
+  @Test
+  void gatherInput_reservesTheAccrualAndWarnsWhenTheFeePolicyDoesNotResolve() {
+    var positionDate = AS_OF_DATE;
+    given(feeChargedToFundPolicy.chargedToFund(TUV100, FeeType.DEPOT, AS_OF_DATE))
+        .willThrow(new IllegalStateException("Gap in the fee policy"));
+    given(feeChargedToFundPolicy.chargedToFund(TUV100, FeeType.MANAGEMENT, AS_OF_DATE))
+        .willReturn(true);
+    given(fundPositionRepository.findLatestNavDateByFundAndAsOfDate(TUV100, AS_OF_DATE))
+        .willReturn(Optional.of(positionDate));
+    given(fundPositionRepository.findByNavDateAndFundAndAccountType(positionDate, TUV100, SECURITY))
+        .willReturn(List.of());
+    given(fundPositionRepository.findByNavDateAndFundAndAccountType(positionDate, TUV100, CASH))
+        .willReturn(List.of());
+    given(
+            feeAccrualRepository.getAccruedFeesForMonth(
+                eq(TUV100), any(), eq(List.of(FeeType.DEPOT)), any()))
+        .willReturn(new BigDecimal("120"));
+    given(
+            feeAccrualRepository.getAccruedFeesForMonth(
+                eq(TUV100), any(), eq(List.of(FeeType.MANAGEMENT)), any()))
+        .willReturn(new BigDecimal("3000"));
+    given(modelPortfolioAllocationRepository.findLatestByFundAsOf(TUV100, AS_OF_DATE))
+        .willReturn(List.of());
+    given(fundLimitRepository.findLatestByFundAsOf(TUV100, AS_OF_DATE))
+        .willReturn(Optional.of(zeroFundLimit(TUV100)));
+    given(positionLimitRepository.findLatestByFundAsOf(TUV100, AS_OF_DATE)).willReturn(List.of());
+    given(r45ReportService.getLatestFlows()).willReturn(Map.of());
+
+    var result = service.gatherInput(TUV100, AS_OF_DATE, Map.of());
+
+    assertThat(result.liabilityBreakdown().depotFee()).isEqualByComparingTo("120");
+    assertThat(result.inputWarnings())
+        .singleElement()
+        .satisfies(
+            warning -> {
+              assertThat(warning.type()).isEqualTo(CalculationWarningType.FEE_POLICY_UNRESOLVED);
+              assertThat(warning.message()).contains("TUV100", "DEPOT");
+            });
+  }
+
   @Test
   void gatherInput_leavesOutADepotFeeThatIsExcludedFromNav() {
     var positionDate = AS_OF_DATE;


### PR DESCRIPTION
> ⚠️ **Draft, parked for a future session — do not merge as-is.** The branch is ~400 commits behind `master` and conflicts. It needs a **fresh port**, not a rebase: the packages moved (`ee.tuleva.onboarding.tulevafund.TulevaFund`, `ee.tuleva.onboarding.pipeline.PipelineTracker`) and `TransactionInputService.getAccruedFees` was refactored to `resolverFor(...).sumChargedDays(...)`, so the fee-policy patch below no longer applies as written. Opened to store the work and its reasoning where it can be found.

Three unrelated fixes found reviewing #1827 / #1839 / #1847. **They should be split into three PRs when this is picked up** — they are together only because they came out of one review.

## 1. A negative SECURITY quantity goes back to `FAIL`, because the gate now blocks per fund

#1827 raised it as a `FAIL`, then downgraded it to `WARNING` for a sound reason: `FundPositionImportJob` abandoned the **whole file** for **every fund** the moment any check failed, and the SEB parser maps anything it cannot classify as cash, a receivable, a payable or a register line to `SECURITY` — so a securities borrow or an unmapped custody line would have gated the NAV pipeline on a heuristic.

The fix is the gate, not the severity. `importForProviderAndDate` now drops the positions of every fund whose `HealthCheckResult` has fails and imports the rest normally; the ledger recording and NAV trigger follow the same set. The checks were already scoped to one fund — only the gate was not. With the blast radius down to one fund for one day, a holding you cannot own stops at the gate instead of reaching the NAV input with a Slack line.

⚠️ **#1944 rewrites this same method** and keeps the whole-file blocking, while introducing `changedRowsByFund()`. This sits naturally on top of it and will conflict textually.

## 2. The TD gate says when the check could not run

`NavTrackingDifferenceGate`'s generic `catch (Exception)` only marked the step failed and logged, while its `IncompletePriceDataException` sibling calls `notifyCheckCouldNotRun`. So an error inside the check — a fee-policy gap, for instance — switched the tracking check off for the day in silence.

## 3. An unresolved fee policy warns instead of blocking order creation

`FeeChargedToFundPolicy` throws on a missing, gapped or overlapping `investment_fee_policy` row, and `TransactionInputService.gatherInput` had no catch — so a hand-maintained reference row could stop an operator creating orders for that fund.

It now reserves the accrual as if it were charged (the conservative direction, and small next to the portfolio) and raises `CalculationWarningType.FEE_POLICY_UNRESOLVED`, which reaches the operator on the DRAFT snapshot. `TradeCalculationEngine.warnings()` returned `List.of()` for every non-`REBALANCE` mode and would have swallowed it, so it now carries input-stage warnings in all modes.

## Also

Two test names in `QuantityChangeCheckerTest` lose their settlement wording — the behaviour they pin is right, but the names said the position moves at settlement, which is the premise #1851 corrected.

## Withdrawn from this branch

An earlier version had the quantity control skip an ISIN whose executions carried no unit count, on the claim that *"SEB leaves Quantity empty on a FUND BUY"*. **That claim is false** — 27 transaction rows across the real 2026-02 reports all carry a Quantity, the mutual-fund buy `IE00BFG1TM61` included. What is true is that we **order** a fund buy in amount, so `orderQuantity` is null until the dealing NAV is struck; the execution still carries units. The code was removed: it opened a real blind spot to solve a problem that does not exist.

## Testing

Targeted tests green after the withdrawal (`QuantityChangeChecker`, `TradedQuantitySource`, `CompletenessChecker`, `FundPositionImportJob`, `TransactionInputService`, `NavTrackingDifferenceGate`). The full suite was green on the pre-withdrawal state, against the old base.

Context: tuleva PR #473 §4.15. Related: #1850, #1944.

🤖 Generated with [Claude Code](https://claude.com/claude-code)