### PR TITLE
Refuse a SEB report that carries no As of date

### DIFF
--- a/src/main/java/ee/tuleva/onboarding/investment/position/FundPositionImportJob.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/position/FundPositionImportJob.java
@@ -20,6 +20,8 @@ import ee.tuleva.onboarding.investment.position.parser.SebFundPositionParser;
 import ee.tuleva.onboarding.investment.position.parser.SwedbankFundPositionParser;
 import ee.tuleva.onboarding.investment.report.InvestmentReport;
 import ee.tuleva.onboarding.investment.report.InvestmentReportService;
+import ee.tuleva.onboarding.investment.report.MissingReportAsOfDateEvent;
+import ee.tuleva.onboarding.investment.report.MissingReportAsOfDateException;
 import ee.tuleva.onboarding.investment.report.ReportProvider;
 import java.time.Clock;
 import java.time.LocalDate;
@@ -151,11 +153,20 @@ public class FundPositionImportJob {
     }
 
     InvestmentReport investmentReport = report.get();
-    List<FundPosition> positions =
-        parser.parse(
-            investmentReport.getRawData(),
-            investmentReport.getReportDate(),
-            investmentReport.getMetadata());
+    List<FundPosition> positions;
+    try {
+      positions =
+          parser.parse(
+              investmentReport.getRawData(),
+              investmentReport.getReportDate(),
+              investmentReport.getMetadata());
+    } catch (MissingReportAsOfDateException e) {
+      // runImport swallows every exception into a log line, so this has to alert here or the
+      // report is silently skipped day after day.
+      log.error("Positions report refused: provider={}, date={}", provider, date, e);
+      eventPublisher.publishEvent(new MissingReportAsOfDateEvent(provider, POSITIONS, date));
+      return new ImportResult(0, 0);
+    }
     log.info(
         "Parsed fund positions: provider={}, date={}, count={}", provider, date, positions.size());
 

--- a/src/main/java/ee/tuleva/onboarding/investment/position/parser/SebFundPositionParser.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/position/parser/SebFundPositionParser.java
@@ -1,11 +1,14 @@
 package ee.tuleva.onboarding.investment.position.parser;
 
+import static ee.tuleva.onboarding.investment.report.ReportProvider.SEB;
+import static ee.tuleva.onboarding.investment.report.ReportType.POSITIONS;
 import static java.math.BigDecimal.ONE;
 import static java.math.BigDecimal.ZERO;
 
 import ee.tuleva.onboarding.fund.TulevaFund;
 import ee.tuleva.onboarding.investment.position.AccountType;
 import ee.tuleva.onboarding.investment.position.FundPosition;
+import ee.tuleva.onboarding.investment.report.MissingReportAsOfDateException;
 import ee.tuleva.onboarding.investment.report.SebReportHeaders;
 import java.math.BigDecimal;
 import java.time.Clock;
@@ -42,12 +45,15 @@ public class SebFundPositionParser implements FundPositionParser {
   @Override
   public List<FundPosition> parse(
       List<Map<String, Object>> rawData, LocalDate reportDate, Map<String, Object> metadata) {
+    if (rawData.isEmpty()) {
+      return List.of();
+    }
+
     LocalDate navDate = SebReportHeaders.asOfDate(metadata, rawData);
     LocalDate sentDate = SebReportHeaders.sentDate(metadata, rawData);
 
     if (navDate == null) {
-      log.warn("No 'As of' date found in SEB data, falling back to report date");
-      navDate = reportDate;
+      throw new MissingReportAsOfDateException(SEB, POSITIONS);
     }
     if (sentDate == null) {
       log.warn("No 'Sent' date found in SEB data, falling back to report date");

--- a/src/main/java/ee/tuleva/onboarding/investment/report/MissingReportAsOfDateAlertListener.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/report/MissingReportAsOfDateAlertListener.java
@@ -1,0 +1,42 @@
+package ee.tuleva.onboarding.investment.report;
+
+import static ee.tuleva.onboarding.notification.OperationsNotificationService.Channel.INVESTMENT;
+
+import ee.tuleva.onboarding.notification.OperationsNotificationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+class MissingReportAsOfDateAlertListener {
+
+  private final OperationsNotificationService notificationService;
+
+  @EventListener
+  public void onMissingReportAsOfDate(MissingReportAsOfDateEvent event) {
+    try {
+      notificationService.sendMessage(buildSlackMessage(event), INVESTMENT);
+    } catch (RuntimeException e) {
+      log.error(
+          "Failed to send missing report As-of date alert: provider={}, reportType={},"
+              + " reportDate={}",
+          event.provider(),
+          event.reportType(),
+          event.reportDate(),
+          e);
+    }
+  }
+
+  private static String buildSlackMessage(MissingReportAsOfDateEvent event) {
+    return """
+        ⚠️ %s %s raportis puudub „As of" kuupäev – %s
+        Raportit ei kasutatud: ilma selle kuupäevata ei saa ridu ajas paigutada ja faili enda \
+        kuupäev on saatmispäev, mis on ühe pangapäeva hiljem.
+        Palu SEB-lt uus raport ja lase neil see enne saatmist üle vaadata – kui päis on puudu, \
+        võib ka ülejäänud sisu olla vigane. Uus fail imporditakse automaatselt."""
+        .formatted(event.provider(), event.reportType(), event.reportDate());
+  }
+}

--- a/src/main/java/ee/tuleva/onboarding/investment/report/MissingReportAsOfDateEvent.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/report/MissingReportAsOfDateEvent.java
@@ -1,0 +1,6 @@
+package ee.tuleva.onboarding.investment.report;
+
+import java.time.LocalDate;
+
+public record MissingReportAsOfDateEvent(
+    ReportProvider provider, ReportType reportType, LocalDate reportDate) {}

--- a/src/main/java/ee/tuleva/onboarding/investment/report/MissingReportAsOfDateException.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/report/MissingReportAsOfDateException.java
@@ -1,0 +1,12 @@
+package ee.tuleva.onboarding.investment.report;
+
+// The "As of" preamble marker dates every row in a SEB report. Without it the rows cannot be placed
+// in time, and the file's own date is the day it was sent — a different clock, one business day
+// later. Substituting it silently shifts positions onto the wrong NAV date and stamps executions as
+// unreported when the custodian has already reported them, so the report is refused instead.
+public class MissingReportAsOfDateException extends RuntimeException {
+
+  public MissingReportAsOfDateException(ReportProvider provider, ReportType reportType) {
+    super("No 'As of' date in report: provider=%s, reportType=%s".formatted(provider, reportType));
+  }
+}

--- a/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/SebPendingTransactionReconciliationService.java
+++ b/src/main/java/ee/tuleva/onboarding/investment/transaction/ingest/SebPendingTransactionReconciliationService.java
@@ -10,6 +10,7 @@ import static ee.tuleva.onboarding.investment.transaction.ingest.ReconciliationA
 import ee.tuleva.onboarding.fund.TulevaFund;
 import ee.tuleva.onboarding.investment.report.InvestmentReport;
 import ee.tuleva.onboarding.investment.report.InvestmentReportService;
+import ee.tuleva.onboarding.investment.report.MissingReportAsOfDateEvent;
 import ee.tuleva.onboarding.investment.report.SebReportHeaders;
 import ee.tuleva.onboarding.investment.transaction.OrderStatus;
 import ee.tuleva.onboarding.investment.transaction.OrderVenue;
@@ -65,11 +66,21 @@ public class SebPendingTransactionReconciliationService {
 
   @Transactional
   public void reconcile(InvestmentReport report) {
+    LocalDate reportDate = report.getReportDate();
+    LocalDate asOfDate = SebReportHeaders.asOfDate(report);
+    if (asOfDate == null) {
+      log.error(
+          "No 'As of' date in SEB pending transactions report, refusing to reconcile it:"
+              + " reportDate={}",
+          reportDate);
+      eventPublisher.publishEvent(
+          new MissingReportAsOfDateEvent(SEB, PENDING_TRANSACTIONS, reportDate));
+      return;
+    }
+
     SebPendingTransactionExtractor.ExtractionResult extraction =
         extractor.extractWithDiagnostics(report);
     List<SebPendingTransactionRow> rows = extraction.rows();
-    LocalDate reportDate = report.getReportDate();
-    LocalDate asOfDate = asOfDate(report);
     TransactionMatchingProperties matchingProperties = matchingPolicy.current();
     log.info(
         "Reconciling SEB pending transactions: reportDate={}, rowCount={}, malformedCount={}",
@@ -438,18 +449,6 @@ public class SebPendingTransactionReconciliationService {
           .ifPresent(orderIds::add);
     }
     return orderIds;
-  }
-
-  private LocalDate asOfDate(InvestmentReport report) {
-    LocalDate asOfDate = SebReportHeaders.asOfDate(report);
-    if (asOfDate == null) {
-      log.warn(
-          "No 'As of' date in SEB pending transactions report, falling back to report date:"
-              + " reportDate={}",
-          report.getReportDate());
-      return report.getReportDate();
-    }
-    return asOfDate;
   }
 
   private boolean wouldOrphanExistingExecution(

--- a/src/test/groovy/ee/tuleva/onboarding/investment/position/FundPositionImportJobTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/position/FundPositionImportJobTest.java
@@ -21,6 +21,7 @@ import ee.tuleva.onboarding.investment.position.parser.SebFundPositionParser;
 import ee.tuleva.onboarding.investment.position.parser.SwedbankFundPositionParser;
 import ee.tuleva.onboarding.investment.report.InvestmentReport;
 import ee.tuleva.onboarding.investment.report.InvestmentReportService;
+import ee.tuleva.onboarding.investment.report.MissingReportAsOfDateEvent;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -158,6 +159,29 @@ class FundPositionImportJobTest {
     job.importForProviderAndDate(SWEDBANK, date);
 
     verify(repository, times(2)).save(any(FundPosition.class));
+  }
+
+  // runImport swallows exceptions into a log line, so a refused report has to alert from here or it
+  // is silently skipped every day the file stays broken.
+  @Test
+  void importForProviderAndDate_alertsAndImportsNothingWhenTheReportCarriesNoAsOfDate() {
+    LocalDate date = LocalDate.of(2026, 1, 5);
+    var report =
+        InvestmentReport.builder()
+            .provider(SEB)
+            .reportType(POSITIONS)
+            .reportDate(date)
+            .rawData(List.of(Map.of("Client name", "TKF100", "Market Value (EUR)", "1000")))
+            .metadata(Map.of())
+            .createdAt(Instant.now())
+            .build();
+    when(reportService.getReport(SEB, POSITIONS, date)).thenReturn(Optional.of(report));
+
+    var result = job.importForProviderAndDate(SEB, date);
+
+    assertThat(result.imported()).isEqualTo(0);
+    verify(repository, never()).save(any(FundPosition.class));
+    verify(eventPublisher).publishEvent(new MissingReportAsOfDateEvent(SEB, POSITIONS, date));
   }
 
   @Test

--- a/src/test/groovy/ee/tuleva/onboarding/investment/position/parser/SebFundPositionParserTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/position/parser/SebFundPositionParserTest.java
@@ -4,14 +4,17 @@ import static ee.tuleva.onboarding.fund.TulevaFund.*;
 import static ee.tuleva.onboarding.investment.position.AccountType.*;
 import static java.math.BigDecimal.ONE;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import ee.tuleva.onboarding.investment.position.FundPosition;
 import ee.tuleva.onboarding.investment.report.CsvToJsonConverter;
+import ee.tuleva.onboarding.investment.report.MissingReportAsOfDateException;
 import java.io.ByteArrayInputStream;
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.time.Clock;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -37,12 +40,12 @@ class SebFundPositionParserTest {
                 "Currency", "EUR",
                 "Market Value (EUR)", new BigDecimal("5302814.90")));
 
-    List<FundPosition> positions = parser.parse(rawData, REPORT_DATE);
+    List<FundPosition> positions = parseWithPreamble(rawData);
 
     assertThat(positions).hasSize(1);
 
     FundPosition position = positions.getFirst();
-    assertThat(position.getNavDate()).isEqualTo(REPORT_DATE);
+    assertThat(position.getNavDate()).isEqualTo(NAV_DATE);
     assertThat(position.getReportDate()).isEqualTo(REPORT_DATE);
     assertThat(position.getFund()).isEqualTo(TKF100);
     assertThat(position.getAccountType()).isEqualTo(CASH);
@@ -99,7 +102,7 @@ class SebFundPositionParserTest {
                 "Currency", "EUR",
                 "Market Value (EUR)", new BigDecimal("528888.44")));
 
-    List<FundPosition> positions = parser.parse(rawData, REPORT_DATE);
+    List<FundPosition> positions = parseWithPreamble(rawData);
 
     assertThat(positions).hasSize(1);
     FundPosition position = positions.getFirst();
@@ -124,7 +127,7 @@ class SebFundPositionParserTest {
                 "Name", "Receivables of outstanding units",
                 "Market Value (EUR)", new BigDecimal("0.00")));
 
-    List<FundPosition> positions = parser.parse(rawData, REPORT_DATE);
+    List<FundPosition> positions = parseWithPreamble(rawData);
 
     assertThat(positions).hasSize(1);
     FundPosition position = positions.getFirst();
@@ -145,7 +148,7 @@ class SebFundPositionParserTest {
                 "Name", "Payables of redeemed units",
                 "Market Value (EUR)", new BigDecimal("0.00")));
 
-    List<FundPosition> positions = parser.parse(rawData, REPORT_DATE);
+    List<FundPosition> positions = parseWithPreamble(rawData);
 
     assertThat(positions).hasSize(1);
     FundPosition position = positions.getFirst();
@@ -164,7 +167,7 @@ class SebFundPositionParserTest {
                 "Name", "Total outstanding units:",
                 "Quantity", new BigDecimal("219655461.600")));
 
-    List<FundPosition> positions = parser.parse(rawData, REPORT_DATE);
+    List<FundPosition> positions = parseWithPreamble(rawData);
 
     assertThat(positions).hasSize(1);
     FundPosition position = positions.getFirst();
@@ -183,7 +186,7 @@ class SebFundPositionParserTest {
                 "Account", "Total",
                 "Market Value (EUR)", new BigDecimal("59801848.29")));
 
-    List<FundPosition> positions = parser.parse(rawData, REPORT_DATE);
+    List<FundPosition> positions = parseWithPreamble(rawData);
 
     assertThat(positions).hasSize(1);
     FundPosition position = positions.getFirst();
@@ -202,7 +205,7 @@ class SebFundPositionParserTest {
             createDataRow("TUK75", "Cash account in SEB Pank", "3000.00"),
             createDataRow("TUK00", "Cash account in SEB Pank", "4000.00"));
 
-    List<FundPosition> positions = parser.parse(rawData, REPORT_DATE);
+    List<FundPosition> positions = parseWithPreamble(rawData);
 
     assertThat(positions).hasSize(4);
     assertThat(positions.get(0).getFund()).isEqualTo(TKF100);
@@ -277,11 +280,11 @@ class SebFundPositionParserTest {
                 "Currency", "EUR",
                 "Market Value (EUR)", new BigDecimal("1000")));
 
-    List<FundPosition> positions = parser.parse(rawData, REPORT_DATE);
+    List<FundPosition> positions = parseWithPreamble(rawData);
 
     assertThat(positions).hasSize(1);
     FundPosition position = positions.getFirst();
-    assertThat(position.getNavDate()).isEqualTo(REPORT_DATE);
+    assertThat(position.getNavDate()).isEqualTo(NAV_DATE);
     assertThat(position.getReportDate()).isEqualTo(REPORT_DATE);
   }
 
@@ -302,7 +305,7 @@ class SebFundPositionParserTest {
                 "Quantity", new BigDecimal("1000"),
                 "Currency", "EUR"));
 
-    List<FundPosition> positions = parser.parse(rawData, REPORT_DATE);
+    List<FundPosition> positions = parseWithPreamble(rawData);
 
     assertThat(positions).isEmpty();
   }
@@ -314,7 +317,7 @@ class SebFundPositionParserTest {
             + "TKF100;EE861010220306591229;;Cash account in SEB Pank;24826773,530;1,000;EUR;24826773,53\n"
             + "TKF100;VP68168;IE00BMDBMY19;Invesco MSCI ETF;15000,523;35,258;EUR;528888,44";
 
-    List<FundPosition> positions = parser.parse(toJson(csv), REPORT_DATE);
+    List<FundPosition> positions = parseWithPreamble(toJson(csv));
 
     assertThat(positions).hasSize(2);
     assertThat(positions.get(0).getFund()).isEqualTo(TKF100);
@@ -335,7 +338,7 @@ class SebFundPositionParserTest {
     row.put("Currency", "EUR");
     row.put("Market Value (EUR)", 528888.44);
 
-    List<FundPosition> positions = parser.parse(List.of(row), REPORT_DATE);
+    List<FundPosition> positions = parseWithPreamble(List.of(row));
 
     assertThat(positions).hasSize(1);
     assertThat(positions.getFirst().getQuantity()).isEqualByComparingTo(new BigDecimal("15000.5"));
@@ -355,7 +358,7 @@ class SebFundPositionParserTest {
     row.put("Currency", "EUR");
     row.put("Market Value (EUR)", "528 888.44");
 
-    List<FundPosition> positions = parser.parse(List.of(row), REPORT_DATE);
+    List<FundPosition> positions = parseWithPreamble(List.of(row));
 
     assertThat(positions).hasSize(1);
     assertThat(positions.getFirst().getQuantity())
@@ -377,7 +380,7 @@ class SebFundPositionParserTest {
     row.put("Currency", "EUR");
     row.put("Market Value (EUR)", "-");
 
-    List<FundPosition> positions = parser.parse(List.of(row), REPORT_DATE);
+    List<FundPosition> positions = parseWithPreamble(List.of(row));
 
     assertThat(positions).hasSize(1);
     assertThat(positions.getFirst().getQuantity()).isNull();
@@ -402,10 +405,35 @@ class SebFundPositionParserTest {
     List<Map<String, Object>> rawData =
         List.of(unreadable, createDataRow("TKF100", "Cash account in SEB Pank", "1000"));
 
-    List<FundPosition> positions = parser.parse(rawData, REPORT_DATE);
+    List<FundPosition> positions = parseWithPreamble(rawData);
 
     assertThat(positions).hasSize(1);
     assertThat(positions.getFirst().getAccountName()).isEqualTo("Cash account in SEB Pank");
+  }
+
+  // A real SEB positions CSV carries the 'As of' preamble row; the parser refuses one without it,
+  // so fixtures have to carry it too.
+  @Test
+  void parse_refusesAReportWithNoAsOfDate() {
+    List<Map<String, Object>> rawData =
+        List.of(createDataRow("TKF100", "Cash account in SEB Pank", "1000"));
+
+    assertThatThrownBy(() -> parser.parse(rawData, REPORT_DATE))
+        .isInstanceOf(MissingReportAsOfDateException.class);
+  }
+
+  private List<FundPosition> parseWithPreamble(List<Map<String, Object>> rawData) {
+    List<Map<String, Object>> withPreamble = new ArrayList<>();
+    withPreamble.add(preambleRow("As of:", NAV_DATE.toString()));
+    withPreamble.addAll(rawData);
+    return parser.parse(withPreamble, REPORT_DATE);
+  }
+
+  private static Map<String, Object> preambleRow(String label, String value) {
+    Map<String, Object> row = new HashMap<>();
+    row.put("Fund Management Company:", label);
+    row.put("Tuleva Fondid AS", value);
+    return row;
   }
 
   private Map<String, Object> createDataRow(String fundCode, String name, String marketValue) {

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/SebPendingTransactionComplexMatchIT.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/SebPendingTransactionComplexMatchIT.java
@@ -74,8 +74,8 @@ class SebPendingTransactionComplexMatchIT {
                 .provider(SEB)
                 .reportType(PENDING_TRANSACTIONS)
                 .reportDate(LocalDate.of(2026, 5, 13))
+                .metadata(Map.of("source", "fixture", "asOfDate", "2026-05-12"))
                 .rawData(List.of(rawRowWithoutClientRef()))
-                .metadata(Map.of("source", "fixture"))
                 .createdAt(Instant.now())
                 .build());
   }
@@ -114,8 +114,8 @@ class SebPendingTransactionComplexMatchIT {
                 .provider(SEB)
                 .reportType(PENDING_TRANSACTIONS)
                 .reportDate(LocalDate.of(2026, 5, 14))
+                .metadata(Map.of("source", "fixture", "asOfDate", "2026-05-13"))
                 .rawData(List.of(rawRowWithoutClientRef("DLA0002222", "3288")))
-                .metadata(Map.of("source", "fixture"))
                 .createdAt(Instant.now())
                 .build());
 

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/SebPendingTransactionReconciliationIT.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/SebPendingTransactionReconciliationIT.java
@@ -93,7 +93,7 @@ class SebPendingTransactionReconciliationIT {
                 .reportType(PENDING_TRANSACTIONS)
                 .reportDate(LocalDate.of(2026, 2, 13))
                 .rawData(rawData)
-                .metadata(Map.of("source", "fixture"))
+                .metadata(Map.of("source", "fixture", "asOfDate", "2026-02-12"))
                 .createdAt(Instant.now())
                 .build());
   }
@@ -307,7 +307,7 @@ class SebPendingTransactionReconciliationIT {
                         splitRow(splitClientRef, "DLA0935620", "34985"),
                         splitRow(splitClientRef, "DLA0936075", "377403"),
                         splitRow(splitClientRef, "DLA0927877", "64611")))
-                .metadata(Map.of("source", "fixture"))
+                .metadata(Map.of("source", "fixture", "asOfDate", "2026-06-23"))
                 .createdAt(Instant.now())
                 .build());
 
@@ -368,7 +368,7 @@ class SebPendingTransactionReconciliationIT {
                     List.of(
                         splitRowAtPrice(clientRef, "DLA1000001", "100000", "9.99"),
                         splitRowAtPrice(clientRef, "DLA1000002", "100000", "10.40")))
-                .metadata(Map.of("source", "fixture"))
+                .metadata(Map.of("source", "fixture", "asOfDate", "2026-06-23"))
                 .createdAt(Instant.now())
                 .build());
 

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/SebPendingTransactionReconciliationIdempotencyIT.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/SebPendingTransactionReconciliationIdempotencyIT.java
@@ -75,7 +75,7 @@ class SebPendingTransactionReconciliationIdempotencyIT {
                 .reportType(PENDING_TRANSACTIONS)
                 .reportDate(LocalDate.of(2026, 5, 13))
                 .rawData(List.of(rawRow()))
-                .metadata(Map.of("source", "fixture"))
+                .metadata(Map.of("source", "fixture", "asOfDate", "2026-05-12"))
                 .createdAt(Instant.now())
                 .build());
   }

--- a/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/SebPendingTransactionReconciliationServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/investment/transaction/ingest/SebPendingTransactionReconciliationServiceTest.java
@@ -14,11 +14,13 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import ee.tuleva.onboarding.investment.report.InvestmentReport;
 import ee.tuleva.onboarding.investment.report.InvestmentReportService;
+import ee.tuleva.onboarding.investment.report.MissingReportAsOfDateEvent;
 import ee.tuleva.onboarding.investment.transaction.InstrumentType;
 import ee.tuleva.onboarding.investment.transaction.OrderVenue;
 import ee.tuleva.onboarding.investment.transaction.TransactionAuditEvent;
@@ -67,8 +69,10 @@ class SebPendingTransactionReconciliationServiceTest {
   private SebPendingTransactionReconciliationService service;
 
   private SebPendingTransactionReconciliationService newService() {
-    given(matchingPolicy.current())
-        .willReturn(new TransactionMatchingProperties(null, null, null, null, null));
+    // lenient: a report refused before matching never reads the policy
+    lenient()
+        .when(matchingPolicy.current())
+        .thenReturn(new TransactionMatchingProperties(null, null, null, null, null));
     SebClientNameToFundResolver resolver = new SebClientNameToFundResolver();
     QuantityAmountValidator validator = new QuantityAmountValidator();
     return new SebPendingTransactionReconciliationService(
@@ -149,7 +153,7 @@ class SebPendingTransactionReconciliationServiceTest {
     service.reconcile(reportWithSingleRow(clientRef));
 
     verify(eventPublisher, org.mockito.Mockito.never()).publishEvent(any(Object.class));
-    verify(executionRepository, org.mockito.Mockito.never()).save(any());
+    verify(executionRepository, never()).save(any());
   }
 
   @Test
@@ -282,7 +286,7 @@ class SebPendingTransactionReconciliationServiceTest {
                         && qe.reportDate().equals(report.getReportDate())
                         && qe.order().getId().equals(123L)
                         && qe.kind() == QuantityAmountMismatchEvent.MismatchKind.ETF_QUANTITY));
-    verify(executionRepository, org.mockito.Mockito.never()).save(any());
+    verify(executionRepository, never()).save(any());
   }
 
   @Test
@@ -461,7 +465,7 @@ class SebPendingTransactionReconciliationServiceTest {
     service.reconcile(reportWithSingleRow(clientRef));
 
     verify(eventPublisher, org.mockito.Mockito.never()).publishEvent(any(Object.class));
-    verify(executionRepository, org.mockito.Mockito.never()).save(any());
+    verify(executionRepository, never()).save(any());
   }
 
   @Test
@@ -485,6 +489,7 @@ class SebPendingTransactionReconciliationServiceTest {
             .provider(SEB)
             .reportType(PENDING_TRANSACTIONS)
             .reportDate(LocalDate.of(2026, 5, 13))
+            .metadata(Map.of("asOfDate", "2026-05-12"))
             .rawData(List.of(malformed, validRow))
             .build();
 
@@ -515,7 +520,7 @@ class SebPendingTransactionReconciliationServiceTest {
     service.reconcile(reportWithSingleRow(clientRef));
 
     // Defensive: do not silently re-link — refuse to write a second execution that conflicts.
-    verify(executionRepository, org.mockito.Mockito.never()).save(any());
+    verify(executionRepository, never()).save(any());
   }
 
   @Test
@@ -704,6 +709,7 @@ class SebPendingTransactionReconciliationServiceTest {
             .provider(SEB)
             .reportType(PENDING_TRANSACTIONS)
             .reportDate(LocalDate.of(2026, 5, 13))
+            .metadata(Map.of("asOfDate", "2026-05-12"))
             .rawData(List.of(validRawRow(clientRefA), rowB))
             .build();
 
@@ -850,6 +856,7 @@ class SebPendingTransactionReconciliationServiceTest {
             .provider(SEB)
             .reportType(PENDING_TRANSACTIONS)
             .reportDate(LocalDate.of(2026, 5, 13))
+            .metadata(Map.of("asOfDate", "2026-05-12"))
             .rawData(List.of())
             .build();
 
@@ -967,6 +974,7 @@ class SebPendingTransactionReconciliationServiceTest {
             .provider(SEB)
             .reportType(PENDING_TRANSACTIONS)
             .reportDate(LocalDate.of(2026, 5, 13))
+            .metadata(Map.of("asOfDate", "2026-05-12"))
             .rawData(List.of(validRawRow(clientRef), secondRow))
             .build();
 
@@ -1085,6 +1093,7 @@ class SebPendingTransactionReconciliationServiceTest {
                     .provider(SEB)
                     .reportType(PENDING_TRANSACTIONS)
                     .reportDate(LocalDate.of(2026, 5, 14))
+                    .metadata(Map.of("asOfDate", "2026-05-13"))
                     .rawData(List.of())
                     .build()));
 
@@ -1114,6 +1123,7 @@ class SebPendingTransactionReconciliationServiceTest {
             .provider(SEB)
             .reportType(PENDING_TRANSACTIONS)
             .reportDate(LocalDate.of(2026, 5, 13))
+            .metadata(Map.of("asOfDate", "2026-05-12"))
             .rawData(List.of(validRawRow(clientRef), malformed))
             .build();
 
@@ -1297,6 +1307,7 @@ class SebPendingTransactionReconciliationServiceTest {
         .provider(SEB)
         .reportType(PENDING_TRANSACTIONS)
         .reportDate(LocalDate.of(2026, 5, 13))
+        .metadata(Map.of("asOfDate", "2026-05-12"))
         .rawData(List.of(raw))
         .build();
   }
@@ -1319,20 +1330,19 @@ class SebPendingTransactionReconciliationServiceTest {
   }
 
   @Test
-  void reconcile_fallsBackToTheReportDateWhenTheReportCarriesNoAsOfDate() {
+  // The file's own date is the day SEB sent it, one business day after the rows it carries, so it
+  // cannot stand in for a missing 'As of'. A report that has no usable date is refused whole.
+  void reconcile_refusesAndAlertsWhenTheReportCarriesNoAsOfDate() {
     service = newService();
     UUID clientRef = UUID.fromString("bd83f551-8c79-4193-b92b-18e1dfd0bd29");
-    TransactionOrder order = sampleOrder(clientRef);
-    given(orderRepository.findByOrderUuid(clientRef)).willReturn(Optional.of(order));
-    given(executionRepository.findAllByOrderId(123L)).willReturn(List.of());
-    List<TransactionExecution> saved = recordSavedExecutions();
 
     service.reconcile(reportOf(validRawRow(clientRef), Map.of()));
 
-    assertThat(saved)
-        .singleElement()
-        .extracting(TransactionExecution::getReportedDate)
-        .isEqualTo(LocalDate.of(2026, 5, 13));
+    verify(executionRepository, never()).save(any());
+    verify(orderRepository, never()).findByOrderUuid(any());
+    verify(eventPublisher)
+        .publishEvent(
+            new MissingReportAsOfDateEvent(SEB, PENDING_TRANSACTIONS, LocalDate.of(2026, 5, 13)));
   }
 
   @Test
@@ -1425,6 +1435,7 @@ class SebPendingTransactionReconciliationServiceTest {
         .provider(SEB)
         .reportType(PENDING_TRANSACTIONS)
         .reportDate(reportDate)
+        .metadata(Map.of("asOfDate", reportDate.minusDays(1).toString()))
         .rawData(rows)
         .build();
   }

--- a/src/test/groovy/ee/tuleva/onboarding/savings/fund/nav/NavPipelineIntegrationTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/savings/fund/nav/NavPipelineIntegrationTest.java
@@ -27,6 +27,7 @@ import ee.tuleva.onboarding.investment.position.FundPositionLedgerService;
 import ee.tuleva.onboarding.investment.position.FundPositionRepository;
 import ee.tuleva.onboarding.investment.position.parser.SebFundPositionParser;
 import ee.tuleva.onboarding.investment.report.InvestmentReportService;
+import ee.tuleva.onboarding.investment.report.SebReportSource;
 import ee.tuleva.onboarding.ledger.*;
 import ee.tuleva.onboarding.time.ClockHolder;
 import ee.tuleva.onboarding.user.User;
@@ -63,6 +64,7 @@ class NavPipelineIntegrationTest {
 
   @Autowired InvestmentReportService investmentReportService;
   @Autowired SebFundPositionParser sebFundPositionParser;
+  @Autowired SebReportSource sebReportSource;
   @Autowired FundPositionImportService fundPositionImportService;
   @Autowired FundPositionRepository fundPositionRepository;
   @Autowired NavPositionLedger navPositionLedger;
@@ -613,9 +615,17 @@ class NavPipelineIntegrationTest {
   @SneakyThrows
   private void importPositionReport(Path positionReportFile, LocalDate reportDate) {
     byte[] csvBytes = Files.readAllBytes(positionReportFile);
+    // Go through the real preamble extraction: the importer strips the first five rows into
+    // metadata, so that is where the 'As of' date comes from in production.
     var report =
         investmentReportService.saveReport(
-            SEB, POSITIONS, reportDate, new ByteArrayInputStream(csvBytes), ';', 5, Map.of());
+            SEB,
+            POSITIONS,
+            reportDate,
+            new ByteArrayInputStream(csvBytes),
+            ';',
+            5,
+            sebReportSource.extractCsvMetadata(csvBytes));
     var positions =
         sebFundPositionParser.parse(report.getRawData(), reportDate, report.getMetadata());
     fundPositionImportService.importNewPositions(positions);


### PR DESCRIPTION
> ⚠️ **Draft, parked for a future session — do not merge as-is.** The branch is ~400 commits behind `master` and conflicts; it needs a **fresh port**, not a rebase (packages moved, and `FundPositionImportJob` is rewritten by #1944). It also overlaps #1958, which touches the same method. Opened to store the work and its reasoning.

## The bug

Both SEB parsers fell back to `report_date` when the `As of:` preamble was missing:

- `SebPendingTransactionReconciliationService.asOfDate()` → stamps `investment_transaction_execution.reported_date`
- `SebFundPositionParser` → sets `fund_position.nav_date`, the NAV date itself

`report_date` is the **S3 filename date**, i.e. the day SEB *sent* the file — one business day after the rows it carries. `SebReportHeadersTest` pins the gap: `reportDate(SENT)` = 26 Jan while `AS_OF` = 25 Jan.

The two reports run on **one clock**: a trade appears in the pending-transactions report *and* in the position report's quantity on execution, with the cash held as a liability (buy) or receivable (sale) until settlement. Settlement moves the cash and clears that leg; it never moves the quantity again. So the substitution is not conservative — it double counts. `reported_date` lands a day ahead of `positionDate`, `PendingOrderImpactService.isMissingFromPositionReport` returns true for a fill the position report already carries, and the position is synthesized on top of itself while its cash is reserved once.

**The invariant does not catch it.** Gross and `securityValue` both move by the fill amount, so `netInvestable − securityValue == freeCash` still holds and W1 stays silent. What breaks is the **denominator** — on a €1.9m fill against a €12m fund the bought instrument reads ~9pp overweight and everything else ~7pp underweight, so a REBALANCE proposes selling back what was just bought, and a position limit can read as breached when the true weight is inside it. The sell side mirrors it: `adjustPosition(... .max(ZERO))` can take a sold position to zero and the next rebalance buys it back.

## The fix

A report with no `As of` marker has no honest date, and the filename is a different clock — so it is refused, not dated. The reconciliation returns before matching anything; the position parser throws `MissingReportAsOfDateException`; both publish `MissingReportAsOfDateEvent` → one Slack line on `Channel.INVESTMENT` saying the report was **not used** and that a new report must be requested from SEB and **reviewed on their side**, since a missing preamble means the rest of the file may be wrong too. The 7-day reconciliation lookback and 14-day position lookback pick up the corrected file automatically. An empty report still returns empty — no rows, nothing to misdate.

`FundPositionImportJob` catches the exception itself because `runImport` swallows every exception into a log line; without that catch the report would be skipped silently every day the file stayed broken.

Accepted consequence: while the report is refused the order stays `SENT` with no fill, so the unfilled remainder is still synthesized. Unavoidable with no fill recorded, and it errs toward not re-buying.

## What the fix flushed out is worth more than the fix

Removing the fallback broke 18 tests. The importer strips the **first five rows** of every SEB CSV into `metadata` via `SebReportSource.extractCsvMetadata`, so the preamble is never in `raw_data` — every fixture handing a parser raw rows with `metadata = Map.of()` had **no date at all** and was silently riding the fallback.

Including `NavPipelineIntegrationTest`, which loads a **real** SEB CSV carrying `As of:;2026-02-13` and then called `saveReport(…, Map.of())`, throwing the preamble away. It now goes through `extractCsvMetadata`, i.e. through the production path. That check also confirms the change is safe in production, where the As-of comes from metadata.

Context: tuleva PR #473 §4.16 and Formats Reference §B2.1. Related: #1827, #1851, #1896, #1944.

🤖 Generated with [Claude Code](https://claude.com/claude-code)