### PR TITLE
Rewrite the third pillar recurring nudge and the payment arrived login block

### DIFF
--- a/emails/src/partials/suggest_membership_en.mjml
+++ b/emails/src/partials/suggest_membership_en.mjml
@@ -2,7 +2,7 @@
   <strong>How can you maximize the benefits of saving with Tuleva?</strong>
 </mj-text>
 <mj-text>
-  Tuleva belongs to Estonian people who also save in these funds. As a Tuleva saver, you
+  Tuleva belongs to people in Estonia who also save in these funds. As a Tuleva saver, you
   are not obligated to join the Tuleva association: anyone in Estonia can save with us.
   However, I invite you to consider becoming a member, as you can benefit the most from
   Tuleva by being a co-owner yourself.

--- a/emails/src/partials/suggest_third_pillar_recurring_en.mjml
+++ b/emails/src/partials/suggest_third_pillar_recurring_en.mjml
@@ -1,8 +1,12 @@
 <mj-text>
-  The smartest move is to make saving in the third pillar automatic. Set up a recurring
-  payment and you will not miss out on the tax benefit even in the hustle of daily life.
+  You have already put your third pillar to work for your future. The next step is to make
+  saving even easier for yourself.
 </mj-text>
-<mj-text><strong>Calculate your tax benefit and set up a recurring payment:</strong></mj-text>
+<mj-text>
+  Set up a <strong>recurring payment</strong> and your third pillar saving carries on
+  automatically, even in the months when you have no time to think about it.
+</mj-text>
+<mj-text><strong>Choose a recurring payment amount that suits your budget:</strong></mj-text>
 <mj-button href="https://tuleva.ee/iii-sammas/?utm_content=nudge_third_pillar_recurring">
-  Check out our calculator
+  Show me the calculator
 </mj-button>

--- a/emails/src/partials/suggest_third_pillar_recurring_et.mjml
+++ b/emails/src/partials/suggest_third_pillar_recurring_et.mjml
@@ -1,8 +1,12 @@
 <mj-text>
-  Nutikas on III&nbsp;sambasse kogumine teha automaatseks. Seadista püsimakse ja sa ei jää
-  ka kiires elurütmis maksuvõidust ilma.
+  Oled juba III&nbsp;samba enda tuleviku heaks tööle pannud. Järgmise sammuna saad teha
+  kogumise enda jaoks veel lihtsamaks.
 </mj-text>
-<mj-text><strong>Arvuta oma maksuvõit ja seadista püsimakse:</strong></mj-text>
+<mj-text>
+  Seadista püsimakse ja III&nbsp;sambasse kogumine toimub automaatselt ka siis, kui sul pole
+  mahti sellele iga kuu mõelda.
+</mj-text>
+<mj-text><strong>Vali püsimakse summa, mis sobib sinu võimalustega:</strong></mj-text>
 <mj-button href="https://tuleva.ee/iii-sammas/?utm_content=nudge_third_pillar_recurring">
-  Vaata kalkulaatorist järele
+  Vaatan kalkulaatorist järele
 </mj-button>

--- a/emails/src/third_pillar_payment_arrived_en.mjml
+++ b/emails/src/third_pillar_payment_arrived_en.mjml
@@ -8,7 +8,7 @@
         <mj-text>Hello,&nbsp;*|FNAME|*</mj-text>
         <mj-text>
           Your payment arrived on *|paymentDate|*. This puts you among
-          the 30% of dedicated Estonians who save in the third pillar. The fund units are already
+          the 30% of dedicated people in Estonia who save in the third pillar. The fund units are already
           in your pension account.
         </mj-text>
 
@@ -20,9 +20,11 @@
 
         <mj-raw>*|ELSE:|*</mj-raw>
         <mj-text>
-          See all your savings in one place by logging in to Tuleva:
+          You can see how your third pillar and your other pension savings are doing at Tuleva
+          whenever you like. You do not need to create a separate account with us, you already
+          have one. Just log in:
         </mj-text>
-        <mj-button href="https://pension.tuleva.ee/login">Log in</mj-button>
+        <mj-button href="https://pension.tuleva.ee/login">Log in to your account</mj-button>
         <mj-raw>*|END:IF|*</mj-raw>
       </mj-column>
     </mj-section>

--- a/emails/src/third_pillar_payment_arrived_en.mjml
+++ b/emails/src/third_pillar_payment_arrived_en.mjml
@@ -24,7 +24,7 @@
           whenever you like. You do not need to create a separate account with us, you already
           have one. Just log in:
         </mj-text>
-        <mj-button href="https://pension.tuleva.ee/login">Log in to your account</mj-button>
+        <mj-button href="https://pension.tuleva.ee/login">Log in</mj-button>
         <mj-raw>*|END:IF|*</mj-raw>
       </mj-column>
     </mj-section>

--- a/emails/src/third_pillar_payment_arrived_et.mjml
+++ b/emails/src/third_pillar_payment_arrived_et.mjml
@@ -20,9 +20,10 @@
 
         <mj-raw>*|ELSE:|*</mj-raw>
         <mj-text>
-          Näed kõiki oma kogumisi ühest kohast, kui logid Tulevasse sisse:
+          Oma III&nbsp;samba ja muu pensionivara käekäiku saad igal ajal ise vaadata Tulevast.
+          Sa ei pea Tulevas eraldi kontot looma, see on sul juba olemas. Logi lihtsalt sisse:
         </mj-text>
-        <mj-button href="https://pension.tuleva.ee/login">Logi sisse</mj-button>
+        <mj-button href="https://pension.tuleva.ee/login">Login kontole</mj-button>
         <mj-raw>*|END:IF|*</mj-raw>
       </mj-column>
     </mj-section>

--- a/emails/src/third_pillar_payment_success_mandate_en.mjml
+++ b/emails/src/third_pillar_payment_success_mandate_en.mjml
@@ -7,8 +7,8 @@
       <mj-column>
         <mj-text>Hello,&nbsp;*|FNAME|*</mj-text>
         <mj-text>
-          Your contribution is complete. This puts you among the 30% of dedicated Estonians who
-          save in the third pillar. Your new units will appear in your pension account by the
+          Your contribution is complete. This puts you among the 30% of dedicated people in
+          Estonia who save in the third pillar. Your new units will appear in your pension account by the
           end of the next working day. If you made the transfer over the weekend, you’ll see the
           new units in your pension account by Tuesday evening.
         </mj-text>


### PR DESCRIPTION
Copy changes to the automated emails, written by Pirje.

## What changes

**Third pillar recurring nudge** (`suggest_third_pillar_recurring_et` and `_en`, a shared partial, so it reaches nine emails)

Old: opened with "the smartest move is to make saving automatic" and led with the tax benefit.
New: opens by acknowledging the contribution the reader has already made, then asks for the recurring payment and points at the calculator.

**Payment arrived, readers with no Tuleva account** (`third_pillar_payment_arrived_et` and `_en`)

Old: "See all your savings in one place by logging in to Tuleva" with a "Log in" button.
New: says the account already exists, so there is nothing to create, and points at the pension account view.

**English copy: "Estonians" replaced with "people in Estonia"** (`third_pillar_payment_arrived_en`, `third_pillar_payment_success_mandate_en`, `suggest_membership_en`)

The English emails go to people who live here but are not necessarily Estonian; the old wording read them out of their own sentence.

## Checks

- `npm test` in the emails directory: 327 passing
- `npm run preview` rebuilt; all twenty affected variants reviewed in the browser, Estonian and English
- No new conditional branches, so no fixture changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
