### PR TITLE
Tell payment rate raisers what their new rate means for them

### DIFF
--- a/emails/fixtures/second_pillar_payment_rate_en.json
+++ b/emails/fixtures/second_pillar_payment_rate_en.json
@@ -58,6 +58,14 @@
       "newPaymentRate": "4",
       "suggestSavingsFundRecurringPayment": true
     },
+    "rate raised to 6%": {
+      "FNAME": "Mari",
+      "increased": true,
+      "maxPaymentRate": true,
+      "paymentRateFulfillmentDate": "01.01.2027",
+      "newPaymentRate": "6",
+      "suggestThirdPillar": true
+    },
     "membership suggestion": {
       "FNAME": "Mari",
       "increased": true,

--- a/emails/fixtures/second_pillar_payment_rate_et.json
+++ b/emails/fixtures/second_pillar_payment_rate_et.json
@@ -58,6 +58,14 @@
       "newPaymentRate": "4",
       "suggestSavingsFundRecurringPayment": true
     },
+    "määr tõusis 6% peale": {
+      "FNAME": "Mari",
+      "increased": true,
+      "maxPaymentRate": true,
+      "paymentRateFulfillmentDate": "01.01.2027",
+      "newPaymentRate": "6",
+      "suggestThirdPillar": true
+    },
     "liikmesuse soovitus": {
       "FNAME": "Mari",
       "increased": true,

--- a/emails/src/partials/suggest_second_pillar_en.mjml
+++ b/emails/src/partials/suggest_second_pillar_en.mjml
@@ -1,7 +1,7 @@
 <mj-text>
   If you're not saving your second pillar with us at Tuleva, make sure your second pillar
-  fund fees are below 0.3% per year, as low fees provide the best foundation for optimal
-  long-term returns.
+  fund fees are <strong>below 0.3% per year</strong>, as low fees give you the best chance
+  of good long-term returns.
 </mj-text>
 <mj-text>
   <strong>Check how much you're currently paying annually in fees for your second

--- a/emails/src/partials/suggest_second_pillar_et.mjml
+++ b/emails/src/partials/suggest_second_pillar_et.mjml
@@ -1,7 +1,7 @@
 <mj-text>
   Kui sa ei kogu oma II&nbsp;sammast veel koos meiega Tulevas, siis veendu, et sinu
-  II&nbsp;samba fonditasud jääksid alla 0,3% aastas, sest madalad tasud annavad parimad
-  eeldused parimaks pikaajaliseks tootluseks.
+  II&nbsp;samba fonditasud jääksid <strong>alla 0,3% aastas</strong>, sest madalad tasud
+  annavad parimad eeldused heaks pikaajaliseks tootluseks.
 </mj-text>
 <mj-text>
   <strong>Vaata järele, kui palju maksad täna aastas oma II&nbsp;samba tasudeks:</strong>

--- a/emails/src/second_pillar_payment_rate_en.mjml
+++ b/emails/src/second_pillar_payment_rate_en.mjml
@@ -9,7 +9,9 @@
         <mj-text>
           Your second pillar contribution rate has been changed. *|IF:increased|*From
           <strong>*|paymentRateFulfillmentDate|*</strong> you will start saving
-          <strong>*|newPaymentRate|*%</strong> of your monthly gross income into your second pillar.*|ELSE:|*From
+          <strong>*|newPaymentRate|*%</strong> of your monthly gross income into your second pillar.*|IF:maxPaymentRate|*
+          This means you are making full use of the second pillar tax benefit.*|ELSE:|* This puts
+          a little more aside for your future every month.*|END:IF|**|ELSE:|*From
           <strong>*|paymentRateFulfillmentDate|*</strong> your second pillar contribution will
           decrease and you will start contributing <strong>*|newPaymentRate|*%</strong> of your
           gross salary.*|END:IF|*

--- a/emails/src/second_pillar_payment_rate_et.mjml
+++ b/emails/src/second_pillar_payment_rate_et.mjml
@@ -9,7 +9,9 @@
         <mj-text>
           Sinu II&nbsp;samba sissemakse suurus on muudetud. *|IF:increased|*Alates
           <strong>*|paymentRateFulfillmentDate|*</strong> hakkad II&nbsp;sambasse maksma
-          <strong>*|newPaymentRate|*%</strong> oma brutopalgast.*|ELSE:|*Alates
+          <strong>*|newPaymentRate|*%</strong> oma brutopalgast.*|IF:maxPaymentRate|* See
+          tähendab, et kasutad II&nbsp;samba maksuvõitu täies mahus.*|ELSE:|* Nii paned iga
+          kuu oma tuleviku heaks rohkem kõrvale.*|END:IF|**|ELSE:|*Alates
           <strong>*|paymentRateFulfillmentDate|*</strong> langeb sinu II&nbsp;samba sissemakse suurus
           ja hakkad panustama <strong>*|newPaymentRate|*%</strong> oma brutopalgast.*|END:IF|*
         </mj-text>

--- a/src/main/java/ee/tuleva/onboarding/mandate/email/MandateEmailService.java
+++ b/src/main/java/ee/tuleva/onboarding/mandate/email/MandateEmailService.java
@@ -120,6 +120,7 @@ public class MandateEmailService {
       boolean decreased = isPaymentRateDecreased(oldRate, newRate);
       mergeVars.put("decreased", decreased);
       mergeVars.put("increased", !decreased);
+      mergeVars.put("maxPaymentRate", isMaxPaymentRate(newRate));
 
       mergeVars.put(
           "paymentRateFulfillmentDate",
@@ -285,6 +286,10 @@ public class MandateEmailService {
 
   boolean isPaymentRateDecreased(Integer oldRate, Integer newRate) {
     return newRate == 2 || newRate < oldRate;
+  }
+
+  boolean isMaxPaymentRate(Integer newRate) {
+    return newRate == 6;
   }
 
   private boolean hasEmailsToday(Person person, EmailType emailType, Mandate mandate) {

--- a/src/test/groovy/ee/tuleva/onboarding/mandate/email/MandateEmailServiceSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/mandate/email/MandateEmailServiceSpec.groovy
@@ -332,6 +332,7 @@ class MandateEmailServiceSpec extends Specification {
         oldPaymentRate            : samplePaymentRates.current,
         decreased                 : false,  // 6 > 2, so not decreased
         increased                 : true,   // 6 > 2, so increased
+        maxPaymentRate            : true,   // 6 is the highest rate
         suggestPaymentRate        : pillarSuggestion.suggestPaymentRate,
         savingsFundFee            : "0.28",
         suggestSecondPillar       : pillarSuggestion.suggestSecondPillar,
@@ -389,6 +390,7 @@ class MandateEmailServiceSpec extends Specification {
         oldPaymentRate            : samplePaymentRates.current,
         decreased                 : true,   // 2 < 4 and 2 == 2, so decreased
         increased                 : false,  // not increased
+        maxPaymentRate            : false,  // 2 is not the highest rate
         suggestPaymentRate        : pillarSuggestion.suggestPaymentRate,
         savingsFundFee            : "0.28",
         suggestSecondPillar       : pillarSuggestion.suggestSecondPillar,


### PR DESCRIPTION
Copy changes to the automated emails, written by Pirje. Follows up on #1961.

## What changes

**Payment rate confirmation now says what the new rate means** (`second_pillar_payment_rate_et` and `_en`)

The email confirmed the new rate and stopped there. It now adds one line that depends on the rate:

- raised to 6%: the second pillar tax benefit is used in full
- raised to 4%: more is set aside each month
- rate going down: unchanged

A template can only branch on a boolean, so `MandateEmailService` now passes `maxPaymentRate`. Raising can only land on 4 or 6, because 2 always counts as a decrease, so the 4% line is the other branch of that same condition rather than a second flag.

**Second pillar nudge** (`suggest_second_pillar_et` and `_en`, a shared partial, so it reaches nine emails)

Drops a doubled superlative ("the best foundation for optimal long-term returns") and puts the fee threshold in bold, so the number a reader is meant to check stands out.

## Checks

- `npm test` in the emails directory: 327 passing
- `./gradlew test --tests MandateEmailServiceSpec`: passing
- `npm run preview` rebuilt; all three rate branches reviewed in the browser, Estonian and English
- New preview fixture variants cover the 6% branch in both languages

🤖 Generated with [Claude Code](https://claude.com/claude-code)
