### PR TITLE
Only nudge the second pillar at people who have one, and speak as the reader

### DIFF
--- a/emails/manifest.json
+++ b/emails/manifest.json
@@ -301,12 +301,12 @@
       "from_name": "Tuleva"
     },
     "third_pillar_suggest_second_en": {
-      "subject": "Check where your second pillar is invested",
+      "subject": "Check your second pillar",
       "from_email": "tuleva@tuleva.ee",
       "from_name": "Tuleva"
     },
     "third_pillar_suggest_second_et": {
-      "subject": "Vaata oma teine sammas üle",
+      "subject": "Vaata oma II sammas üle",
       "from_email": "tuleva@tuleva.ee",
       "from_name": "Tuleva"
     },

--- a/emails/src/partials/suggest_membership_et.mjml
+++ b/emails/src/partials/suggest_membership_et.mjml
@@ -6,5 +6,5 @@
   kasu, olles ise kaasomanik.
 </mj-text>
 <mj-button href="https://tuleva.ee/liikmetele/31-marts-korduma-kippuvad-kusimused/?utm_content=nudge_membership">
-  Uuri lähemalt
+  Uurin lähemalt
 </mj-button>

--- a/emails/src/partials/suggest_payment_rate_et.mjml
+++ b/emails/src/partials/suggest_payment_rate_et.mjml
@@ -5,4 +5,4 @@
   aastas.
 </mj-text>
 <mj-text><strong>Vaata järele, kui suureks kujuneks sinu maksuvõit sissemakset tõstes:</strong></mj-text>
-<mj-button href="https://pension.tuleva.ee/2nd-pillar-tax-win?utm_content=nudge_payment_rate">Vaata järele</mj-button>
+<mj-button href="https://pension.tuleva.ee/2nd-pillar-tax-win?utm_content=nudge_payment_rate">Vaatan järele</mj-button>

--- a/emails/src/partials/suggest_savings_fund_et.mjml
+++ b/emails/src/partials/suggest_savings_fund_et.mjml
@@ -4,4 +4,4 @@
   Täiendav Kogumisfond on madala tasuga indeksfond, mis investeerib ligi 2500 maailma suurima
   börsiettevõtte aktsiatesse. Tasu on *|savingsFundFee|*% aastas ja alustada saad kasvõi 1&nbsp;eurost.
 </mj-text>
-<mj-button href="https://tuleva.ee/taiendav-kogumisfond/?utm_content=nudge_savings_fund">Uuri lähemalt</mj-button>
+<mj-button href="https://tuleva.ee/taiendav-kogumisfond/?utm_content=nudge_savings_fund">Uurin lähemalt</mj-button>

--- a/emails/src/partials/suggest_second_pillar_et.mjml
+++ b/emails/src/partials/suggest_second_pillar_et.mjml
@@ -6,4 +6,4 @@
 <mj-text>
   <strong>Vaata järele, kui palju maksad täna aastas oma II&nbsp;samba tasudeks:</strong>
 </mj-text>
-<mj-button href="https://pension.tuleva.ee/login?utm_content=nudge_second_pillar">Vaata oma tasud üle</mj-button>
+<mj-button href="https://pension.tuleva.ee/login?utm_content=nudge_second_pillar">Vaatan oma tasud üle</mj-button>

--- a/emails/src/partials/suggest_third_pillar_et.mjml
+++ b/emails/src/partials/suggest_third_pillar_et.mjml
@@ -6,7 +6,7 @@
 </mj-text>
 <mj-text><strong>Vaata järele, kui palju maksad täna aastas oma III&nbsp;samba tasudeks:</strong></mj-text>
 <mj-button href="https://pension.tuleva.ee/login?utm_content=nudge_third_pillar">
-  Vaata oma tasud üle
+  Vaatan oma tasud üle
 </mj-button>
 <mj-raw>*|ELSE:|*</mj-raw>
 <mj-text>
@@ -14,5 +14,5 @@
   100‑eurose sissemakse, annab riik sulle kevadel 264 eurot tulumaksu tagasi.
 </mj-text>
 <mj-text><strong>Vaata järele, kui palju sina võidaksid maksudelt:</strong></mj-text>
-<mj-button href="https://tuleva.ee/iii-sammas/?utm_content=nudge_third_pillar">Arvuta&nbsp;oma&nbsp;maksuvõit</mj-button>
+<mj-button href="https://tuleva.ee/iii-sammas/?utm_content=nudge_third_pillar">Arvutan&nbsp;oma&nbsp;maksuvõidu</mj-button>
 <mj-raw>*|END:IF|*</mj-raw>

--- a/emails/src/partials/suggest_third_pillar_raise_et.mjml
+++ b/emails/src/partials/suggest_third_pillar_raise_et.mjml
@@ -6,5 +6,5 @@
 </mj-text>
 <mj-text><strong>Vaata kohe, kas saaksid püsimakset suurendada:</strong></mj-text>
 <mj-button href="https://tuleva.ee/iii-sammas/?utm_content=nudge_third_pillar_raise">
-  Arvuta oma võit
+  Arvutan oma võidu
 </mj-button>

--- a/emails/src/third_pillar_payment_arrived_en.mjml
+++ b/emails/src/third_pillar_payment_arrived_en.mjml
@@ -7,9 +7,11 @@
       <mj-column>
         <mj-text>Hello,&nbsp;*|FNAME|*</mj-text>
         <mj-text>
-          Your payment arrived on *|paymentDate|*. This puts you among
-          the 30% of dedicated people in Estonia who save in the third pillar. The fund units are already
-          in your pension account.
+          Your payment arrived on *|paymentDate|* and the fund units are in your pension account.
+        </mj-text>
+        <mj-text>
+          Only 30% of people in Estonia save in the third pillar. You are one of them, and you
+          are deliberately putting money aside for your future.
         </mj-text>
 
         <mj-raw>*|IF:hasTulevaUser|*</mj-raw>

--- a/emails/src/third_pillar_payment_arrived_et.mjml
+++ b/emails/src/third_pillar_payment_arrived_et.mjml
@@ -7,9 +7,12 @@
       <mj-column>
         <mj-text>Tere,&nbsp;*|FNAME|*</mj-text>
         <mj-text>
-          Sinu sissemakse jõudis pärale *|paymentDate|*. Sellega oled 30%
-          tublimate Eesti inimeste seas, kes III&nbsp;sambas koguvad. Fondiosakud on sinu
-          pensionikontol olemas.
+          Sinu sissemakse jõudis pärale *|paymentDate|* ja fondiosakud on sinu pensionikontol
+          olemas.
+        </mj-text>
+        <mj-text>
+          III&nbsp;sambas kogub vaid 30% Eesti inimestest. Sina kuulud nende hulka ja panustad
+          teadlikult oma tuleviku heaks.
         </mj-text>
 
         <mj-raw>*|IF:hasTulevaUser|*</mj-raw>

--- a/emails/src/third_pillar_payment_reminder_mandate_et.mjml
+++ b/emails/src/third_pillar_payment_reminder_mandate_et.mjml
@@ -27,7 +27,7 @@
             Vaata, kui palju saad maksimaalselt&nbsp;III&nbsp;sambaga maksudelt võita:
           </strong>
         </mj-text>
-        <mj-button href="https://tuleva.ee/iii-sammas/">Arvuta oma võit</mj-button>
+        <mj-button href="https://tuleva.ee/iii-sammas/">Arvutan oma võidu</mj-button>
         <mj-text>
           Manuses on koopia sinu tehtud avaldustest, mille edastasime Pensionikeskusele.
         </mj-text>

--- a/emails/src/third_pillar_suggest_second_en.mjml
+++ b/emails/src/third_pillar_suggest_second_en.mjml
@@ -7,13 +7,13 @@
       <mj-column>
         <mj-text>Hello,&nbsp;*|FNAME|*</mj-text>
         <mj-text>
-          You have started to save in Tuleva’s third pillar fund with low fees and a
-          fact-based investment strategy. I noticed that you are not yet saving your
-          second pillar with us.
+          You have started saving in Tuleva’s third pillar fund, with low fees and a fact-based
+          investment strategy. Your second pillar is currently invested elsewhere.
         </mj-text>
         <mj-text>
-          If you're currently saving in a bank's second pillar fund, it's worth checking
-          whether you're really investing in a low-fee, well-diversified index fund.
+          For your third pillar you have already chosen a low-fee index fund. It is worth
+          checking whether your second pillar fund follows the same principles: low fees and
+          broad diversification.
         </mj-text>
         <mj-text>
           <strong>
@@ -22,7 +22,7 @@
           </strong>
         </mj-text>
         <mj-button href="https://pension.tuleva.ee/login?language=en">
-          Calculate your savings
+          Check your second pillar
         </mj-button>
       </mj-column>
     </mj-section>

--- a/emails/src/third_pillar_suggest_second_et.mjml
+++ b/emails/src/third_pillar_suggest_second_et.mjml
@@ -7,12 +7,12 @@
       <mj-column>
         <mj-text>Tere,&nbsp;*|FNAME|*</mj-text>
         <mj-text>
-          Alustasid kogumist Tuleva madalate tasudega III&nbsp;samba fondis. Märkasin, et
-          II&nbsp;sambasse sa veel koos meiega ei kogu.
+          Alustasid kogumist Tuleva madalate tasudega III&nbsp;samba fondis. II&nbsp;sambasse
+          kogud praegu mujal.
         </mj-text>
         <mj-text>
-          Kui kogud täna oma II&nbsp;sammast pangafondis, siis tasub vaadata üle, kas kogud ikka
-          madalate tasudega ja hästi hajutatud indeksfondis.
+          Oled III&nbsp;samba puhul juba valinud madala tasuga indeksfondi. Tasub vaadata, kas
+          sinu II&nbsp;samba fond järgib samu põhimõtteid: madalad tasud ja lai hajutatus.
         </mj-text>
         <mj-text>
           <strong>
@@ -20,7 +20,7 @@
             indeksfondis:
           </strong>
         </mj-text>
-        <mj-button href="https://pension.tuleva.ee/login">Arvuta oma võit</mj-button>
+        <mj-button href="https://pension.tuleva.ee/login">Vaatan järele</mj-button>
       </mj-column>
     </mj-section>
 

--- a/src/main/java/ee/tuleva/onboarding/analytics/transaction/thirdpillar/FirstThirdPillarPaymentRepository.java
+++ b/src/main/java/ee/tuleva/onboarding/analytics/transaction/thirdpillar/FirstThirdPillarPaymentRepository.java
@@ -64,10 +64,10 @@ public class FirstThirdPillarPaymentRepository {
                fa.first_payment_date,
                (u.id IS NOT NULL) AS has_tuleva_user,
                (COALESCE(uo.p2_rava_status, '') <> 'R'
-                 AND (uo.personal_id IS NULL
-                   OR uo.p2_choice IS NULL
-                   OR uo.p2_choice NOT IN ('TUK75', 'TUK00'))) AS suggest_second_pillar,
+                 AND uo.p2_choice IS NOT NULL
+                 AND uo.p2_choice NOT IN ('TUK75', 'TUK00')) AS suggest_second_pillar,
                (COALESCE(uo.p2_rava_status, '') <> 'R'
+                 AND uo.p2_choice IS NOT NULL
                  AND COALESCE(uo.p2_next_rate, uo.p2_rate, 2) < 6) AS suggest_payment_rate,
                (m.id IS NULL) AS suggest_membership,
                (COALESCE(uo.p2_rava_status, '') = 'R') AS left_second_pillar,

--- a/src/main/java/ee/tuleva/onboarding/mandate/PillarSuggestion.java
+++ b/src/main/java/ee/tuleva/onboarding/mandate/PillarSuggestion.java
@@ -161,8 +161,8 @@ public class PillarSuggestion {
             && !user.hasReachedRetirementAge()
             && !leftSecondPillar
             && !mandatePillars.contains(2)
-            && (!secondPillarActive
-                || !conversion.isSecondPillarPartiallyConverted()
+            && secondPillarActive
+            && (!conversion.isSecondPillarPartiallyConverted()
                 || (!conversion.isSecondPillarFullyConverted()
                     && conversion.getSecondPillarWeightedAverageFee() != null
                     && conversion

--- a/src/test/groovy/ee/tuleva/onboarding/mandate/PillarSuggestionSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/mandate/PillarSuggestionSpec.groovy
@@ -25,9 +25,9 @@ class PillarSuggestionSpec extends Specification {
 
     where:
     secondPillarActive | secondPillarPartiallyConverted | secondPillarWeightedAverageFee | suggestSecondPillar
-    false              | false                          | null                           | true
+    false              | false                          | null                           | false
     true               | false                          | null                           | true
-    false              | true                           | null                           | true
+    false              | true                           | null                           | false
     true               | true                           | 0.003                          | false
     true               | true                           | 0.006                          | true
   }
@@ -170,7 +170,7 @@ class PillarSuggestionSpec extends Specification {
     pillarSuggestion.isSuggestPaymentRate()
   }
 
-  def "does not suggest a payment rate increase without an active second pillar"() {
+  def "never suggests second pillar steps without an active second pillar"() {
     when:
     user.getAge() >> 40
     conversion.isSecondPillarPartiallyConverted() >> false
@@ -178,7 +178,7 @@ class PillarSuggestionSpec extends Specification {
     def pillarSuggestion = new PillarSuggestion(user, false, false, conversion, paymentRates)
 
     then:
-    pillarSuggestion.isSuggestSecondPillar()
+    !pillarSuggestion.isSuggestSecondPillar()
     !pillarSuggestion.isSuggestPaymentRate()
   }
 
@@ -296,24 +296,24 @@ class PillarSuggestionSpec extends Specification {
     when:
     user.getAge() >> 40
     user.isMember() >> member
-    conversion.isSecondPillarPartiallyConverted() >> secondPillarActive
+    conversion.isSecondPillarPartiallyConverted() >> secondPillarConverted
     conversion.isThirdPillarPartiallyConverted() >> true
     conversion.getSecondPillarWeightedAverageFee() >> 0.003
     conversion.getThirdPillarWeightedAverageFee() >> 0.003
     paymentRates.canIncrease() >> canIncrease
     def pillarSuggestion =
         new PillarSuggestion(
-            user, secondPillarActive, true, conversion, paymentRates, [] as Set, false, savesInSavingsFund)
+            user, true, true, conversion, paymentRates, [] as Set, false, savesInSavingsFund)
 
     then:
     pillarSuggestion.renderedNudgeTag() == Optional.ofNullable(tag)
 
     where:
-    secondPillarActive | canIncrease | savesInSavingsFund | member | tag
-    false              | false       | true               | false  | "nudge_second_pillar"
-    true               | true        | true               | false  | "nudge_payment_rate"
-    true               | false       | false              | false  | "nudge_savings_fund"
-    true               | false       | true               | false  | "nudge_membership"
-    true               | false       | true               | true   | "nudge_none"
+    secondPillarConverted | canIncrease | savesInSavingsFund | member | tag
+    false                 | false       | true               | false  | "nudge_second_pillar"
+    true                  | true        | true               | false  | "nudge_payment_rate"
+    true                  | false       | false              | false  | "nudge_savings_fund"
+    true                  | false       | true               | false  | "nudge_membership"
+    true                  | false       | true               | true   | "nudge_none"
   }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/notification/email/firstpayment/ThirdPillarPaymentArrivedEmailIntegrationTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/notification/email/firstpayment/ThirdPillarPaymentArrivedEmailIntegrationTest.java
@@ -61,6 +61,7 @@ class ThirdPillarPaymentArrivedEmailIntegrationTest {
   private static final String SECOND_PILLAR_LEAVER =
       TestPersonalCodes.withValidChecksum("3830101000");
   private static final String MAXED_OUT = TestPersonalCodes.withValidChecksum("3820101000");
+  private static final String NO_SECOND_PILLAR = TestPersonalCodes.withValidChecksum("3810101000");
 
   @Autowired private ThirdPillarPaymentArrivedJob job;
   @Autowired private AnalyticsThirdPillarTransactionRepository transactionRepository;
@@ -97,6 +98,7 @@ class ThirdPillarPaymentArrivedEmailIntegrationTest {
   @Test
   void sendsTheEmailOnceToAFirstTimePayerWithAnAccount() {
     saveUser(ACCOUNT_HOLDER, "account.holder@example.com");
+    saveUnitOwner(ACCOUNT_HOLDER, builder -> builder.p2choice("LXK75"));
     saveOwnPayment(ACCOUNT_HOLDER, LocalDate.now().minusDays(1), new BigDecimal("300.00"));
 
     job.run();
@@ -122,6 +124,24 @@ class ThirdPillarPaymentArrivedEmailIntegrationTest {
             eq("third_pillar_payment_arrived_et"));
     assertThat(sentEmailCount()).isEqualTo(1);
     assertThat(claimCount()).isEqualTo(1);
+  }
+
+  @Test
+  void neverSuggestsSecondPillarStepsWhenTheFundChoiceIsUnknown() {
+    saveUnitOwner(NO_SECOND_PILLAR, builder -> builder.email("no.second.pillar@example.com"));
+    saveOwnPayment(NO_SECOND_PILLAR, LocalDate.now().minusDays(1), new BigDecimal("100.00"));
+
+    job.run();
+
+    verify(emailService)
+        .newMandrillMessage(
+            eq("no.second.pillar@example.com"),
+            eq("third_pillar_payment_arrived_et"),
+            argThat(
+                mergeVars ->
+                    Boolean.FALSE.equals(mergeVars.get("suggestSecondPillar"))
+                        && Boolean.FALSE.equals(mergeVars.get("suggestPaymentRate"))),
+            any());
   }
 
   @Test


### PR DESCRIPTION
Copy by Pirje, behaviour change to match it.

## Behaviour: only nudge the second pillar at people who have one

`suggest_second_pillar` was true whenever the registry did not name a fund, which meant a first-time third pillar payer with no second pillar at all was told to check its fees. It now requires the registry to name a fund and that fund not to be ours. In doubt we say nothing, and the reader falls through to the next nudge that does apply.

The same hole sat one slot down in `suggest_payment_rate`: a missing rate defaulted to 2, so the same person was told to raise a contribution rate they do not have. Same guard.

The two paths asked the question with different rules. `PillarSuggestion` (in-app) treated "no active second pillar" as a reason to nudge; the registry query (bank transfer) treated "fund unknown" the same way. Both now require an actual second pillar. This matters now because the follow-up letter is about to reach bank payers too, and its new copy states the fact rather than hedging it.

## Copy

**Payment arrived** leads with the confirmation, then the recognition, instead of running both into one sentence that had lost its grammar and its point.

**Second pillar follow-up** now says the reader's second pillar is elsewhere, and pairs it with what they already did right in the third pillar. The tightened rule above is what makes that sentence safe to write.

**Every Estonian nudge button speaks as the reader** ("Vaatan järele", "Arvutan oma võidu", "Uurin lähemalt"), so the button reads as the reader's own decision rather than an instruction. Two were already in that form. English keeps the imperative.

Subject line of the follow-up letter shortened to match.

## Checks

- `npm test` in the emails directory: 327 passing
- `ThirdPillarPaymentArrivedEmailIntegrationTest`, `PillarSuggestionSpec`, `MandateEmailServiceSpec`, `MandateEmailSenderSpec`: passing
- A new integration test covers a payer whose fund choice is unknown: neither the second pillar nor the payment rate nudge fires
- Four existing tests encoded the old behaviour and were rewritten
- `npm run preview` rebuilt; both languages reviewed in the browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)
