### PR TITLE
Bridge into the pillar nudge with a question, not a fear of missing out

### DIFF
--- a/emails/fixtures/savings_fund_payment_success_child_en.json
+++ b/emails/fixtures/savings_fund_payment_success_child_en.json
@@ -5,21 +5,24 @@
       "RECIPIENTNAME": "Mari Maasikas",
       "recipientIsChild": true,
       "suggestSecondPillar": true,
-      "recipientAccountId": "0f6f9d1e-4c1a-4b2a-9c3d-8e7f6a5b4c3d"
+      "recipientAccountId": "0f6f9d1e-4c1a-4b2a-9c3d-8e7f6a5b4c3d",
+      "anyPillarSuggestion": true
     },
     "payment rate increase suggestion": {
       "FNAME": "Mari",
       "RECIPIENTNAME": "Mari Maasikas",
       "recipientIsChild": true,
       "suggestPaymentRate": true,
-      "recipientAccountId": "0f6f9d1e-4c1a-4b2a-9c3d-8e7f6a5b4c3d"
+      "recipientAccountId": "0f6f9d1e-4c1a-4b2a-9c3d-8e7f6a5b4c3d",
+      "anyPillarSuggestion": true
     },
     "third pillar suggestion": {
       "FNAME": "Mari",
       "RECIPIENTNAME": "Mari Maasikas",
       "recipientIsChild": true,
       "suggestThirdPillar": true,
-      "recipientAccountId": "0f6f9d1e-4c1a-4b2a-9c3d-8e7f6a5b4c3d"
+      "recipientAccountId": "0f6f9d1e-4c1a-4b2a-9c3d-8e7f6a5b4c3d",
+      "anyPillarSuggestion": true
     },
     "third pillar fees suggestion": {
       "FNAME": "Mari",
@@ -27,21 +30,24 @@
       "recipientIsChild": true,
       "suggestThirdPillar": true,
       "thirdPillarActive": true,
-      "recipientAccountId": "0f6f9d1e-4c1a-4b2a-9c3d-8e7f6a5b4c3d"
+      "recipientAccountId": "0f6f9d1e-4c1a-4b2a-9c3d-8e7f6a5b4c3d",
+      "anyPillarSuggestion": true
     },
     "third pillar recurring suggestion": {
       "FNAME": "Mari",
       "RECIPIENTNAME": "Mari Maasikas",
       "recipientIsChild": true,
       "suggestThirdPillarRecurringPayment": true,
-      "recipientAccountId": "0f6f9d1e-4c1a-4b2a-9c3d-8e7f6a5b4c3d"
+      "recipientAccountId": "0f6f9d1e-4c1a-4b2a-9c3d-8e7f6a5b4c3d",
+      "anyPillarSuggestion": true
     },
     "third pillar raise suggestion": {
       "FNAME": "Mari",
       "RECIPIENTNAME": "Mari Maasikas",
       "recipientIsChild": true,
       "suggestThirdPillarRaise": true,
-      "recipientAccountId": "0f6f9d1e-4c1a-4b2a-9c3d-8e7f6a5b4c3d"
+      "recipientAccountId": "0f6f9d1e-4c1a-4b2a-9c3d-8e7f6a5b4c3d",
+      "anyPillarSuggestion": true
     },
     "savings fund suggestion (cannot occur)": {
       "FNAME": "Mari",
@@ -64,7 +70,8 @@
       "recipientIsChild": true,
       "suggestSecondPillar": true,
       "suggestSavingsFundRecurringPayment": true,
-      "recipientAccountId": "0f6f9d1e-4c1a-4b2a-9c3d-8e7f6a5b4c3d"
+      "recipientAccountId": "0f6f9d1e-4c1a-4b2a-9c3d-8e7f6a5b4c3d",
+      "anyPillarSuggestion": true
     },
     "membership suggestion": {
       "FNAME": "Mari",

--- a/emails/fixtures/savings_fund_payment_success_child_et.json
+++ b/emails/fixtures/savings_fund_payment_success_child_et.json
@@ -5,21 +5,24 @@
       "RECIPIENTNAME": "Jaan Tamm",
       "recipientIsChild": true,
       "suggestSecondPillar": true,
-      "recipientAccountId": "0f6f9d1e-4c1a-4b2a-9c3d-8e7f6a5b4c3d"
+      "recipientAccountId": "0f6f9d1e-4c1a-4b2a-9c3d-8e7f6a5b4c3d",
+      "anyPillarSuggestion": true
     },
     "II samba määra tõstmise soovitus": {
       "FNAME": "Mari",
       "RECIPIENTNAME": "Jaan Tamm",
       "recipientIsChild": true,
       "suggestPaymentRate": true,
-      "recipientAccountId": "0f6f9d1e-4c1a-4b2a-9c3d-8e7f6a5b4c3d"
+      "recipientAccountId": "0f6f9d1e-4c1a-4b2a-9c3d-8e7f6a5b4c3d",
+      "anyPillarSuggestion": true
     },
     "III samba soovitus": {
       "FNAME": "Mari",
       "RECIPIENTNAME": "Jaan Tamm",
       "recipientIsChild": true,
       "suggestThirdPillar": true,
-      "recipientAccountId": "0f6f9d1e-4c1a-4b2a-9c3d-8e7f6a5b4c3d"
+      "recipientAccountId": "0f6f9d1e-4c1a-4b2a-9c3d-8e7f6a5b4c3d",
+      "anyPillarSuggestion": true
     },
     "III samba tasude soovitus": {
       "FNAME": "Mari",
@@ -27,21 +30,24 @@
       "recipientIsChild": true,
       "suggestThirdPillar": true,
       "thirdPillarActive": true,
-      "recipientAccountId": "0f6f9d1e-4c1a-4b2a-9c3d-8e7f6a5b4c3d"
+      "recipientAccountId": "0f6f9d1e-4c1a-4b2a-9c3d-8e7f6a5b4c3d",
+      "anyPillarSuggestion": true
     },
     "III samba püsimakse soovitus": {
       "FNAME": "Mari",
       "RECIPIENTNAME": "Jaan Tamm",
       "recipientIsChild": true,
       "suggestThirdPillarRecurringPayment": true,
-      "recipientAccountId": "0f6f9d1e-4c1a-4b2a-9c3d-8e7f6a5b4c3d"
+      "recipientAccountId": "0f6f9d1e-4c1a-4b2a-9c3d-8e7f6a5b4c3d",
+      "anyPillarSuggestion": true
     },
     "III samba sissemakse tõstmise soovitus": {
       "FNAME": "Mari",
       "RECIPIENTNAME": "Jaan Tamm",
       "recipientIsChild": true,
       "suggestThirdPillarRaise": true,
-      "recipientAccountId": "0f6f9d1e-4c1a-4b2a-9c3d-8e7f6a5b4c3d"
+      "recipientAccountId": "0f6f9d1e-4c1a-4b2a-9c3d-8e7f6a5b4c3d",
+      "anyPillarSuggestion": true
     },
     "kogumisfondi soovitus (ei esine)": {
       "FNAME": "Mari",
@@ -64,7 +70,8 @@
       "recipientIsChild": true,
       "suggestSecondPillar": true,
       "suggestSavingsFundRecurringPayment": true,
-      "recipientAccountId": "0f6f9d1e-4c1a-4b2a-9c3d-8e7f6a5b4c3d"
+      "recipientAccountId": "0f6f9d1e-4c1a-4b2a-9c3d-8e7f6a5b4c3d",
+      "anyPillarSuggestion": true
     },
     "liikmesuse soovitus": {
       "FNAME": "Mari",

--- a/emails/fixtures/savings_fund_payment_success_company_en.json
+++ b/emails/fixtures/savings_fund_payment_success_company_en.json
@@ -5,21 +5,24 @@
       "RECIPIENTNAME": "Mesila OÜ",
       "recipientIsCompany": true,
       "suggestSecondPillar": true,
-      "recipientAccountId": "0f6f9d1e-4c1a-4b2a-9c3d-8e7f6a5b4c3d"
+      "recipientAccountId": "0f6f9d1e-4c1a-4b2a-9c3d-8e7f6a5b4c3d",
+      "anyPillarSuggestion": true
     },
     "payment rate increase suggestion": {
       "FNAME": "Mari",
       "RECIPIENTNAME": "Mesila OÜ",
       "recipientIsCompany": true,
       "suggestPaymentRate": true,
-      "recipientAccountId": "0f6f9d1e-4c1a-4b2a-9c3d-8e7f6a5b4c3d"
+      "recipientAccountId": "0f6f9d1e-4c1a-4b2a-9c3d-8e7f6a5b4c3d",
+      "anyPillarSuggestion": true
     },
     "third pillar suggestion": {
       "FNAME": "Mari",
       "RECIPIENTNAME": "Mesila OÜ",
       "recipientIsCompany": true,
       "suggestThirdPillar": true,
-      "recipientAccountId": "0f6f9d1e-4c1a-4b2a-9c3d-8e7f6a5b4c3d"
+      "recipientAccountId": "0f6f9d1e-4c1a-4b2a-9c3d-8e7f6a5b4c3d",
+      "anyPillarSuggestion": true
     },
     "third pillar fees suggestion": {
       "FNAME": "Mari",
@@ -27,21 +30,24 @@
       "recipientIsCompany": true,
       "suggestThirdPillar": true,
       "thirdPillarActive": true,
-      "recipientAccountId": "0f6f9d1e-4c1a-4b2a-9c3d-8e7f6a5b4c3d"
+      "recipientAccountId": "0f6f9d1e-4c1a-4b2a-9c3d-8e7f6a5b4c3d",
+      "anyPillarSuggestion": true
     },
     "third pillar recurring suggestion": {
       "FNAME": "Mari",
       "RECIPIENTNAME": "Mesila OÜ",
       "recipientIsCompany": true,
       "suggestThirdPillarRecurringPayment": true,
-      "recipientAccountId": "0f6f9d1e-4c1a-4b2a-9c3d-8e7f6a5b4c3d"
+      "recipientAccountId": "0f6f9d1e-4c1a-4b2a-9c3d-8e7f6a5b4c3d",
+      "anyPillarSuggestion": true
     },
     "third pillar raise suggestion": {
       "FNAME": "Mari",
       "RECIPIENTNAME": "Mesila OÜ",
       "recipientIsCompany": true,
       "suggestThirdPillarRaise": true,
-      "recipientAccountId": "0f6f9d1e-4c1a-4b2a-9c3d-8e7f6a5b4c3d"
+      "recipientAccountId": "0f6f9d1e-4c1a-4b2a-9c3d-8e7f6a5b4c3d",
+      "anyPillarSuggestion": true
     },
     "savings fund suggestion (cannot occur)": {
       "FNAME": "Mari",
@@ -64,7 +70,8 @@
       "recipientIsCompany": true,
       "suggestSecondPillar": true,
       "suggestSavingsFundRecurringPayment": true,
-      "recipientAccountId": "0f6f9d1e-4c1a-4b2a-9c3d-8e7f6a5b4c3d"
+      "recipientAccountId": "0f6f9d1e-4c1a-4b2a-9c3d-8e7f6a5b4c3d",
+      "anyPillarSuggestion": true
     },
     "membership suggestion": {
       "FNAME": "Mari",

--- a/emails/fixtures/savings_fund_payment_success_company_et.json
+++ b/emails/fixtures/savings_fund_payment_success_company_et.json
@@ -5,21 +5,24 @@
       "RECIPIENTNAME": "Mesila OÜ",
       "recipientIsCompany": true,
       "suggestSecondPillar": true,
-      "recipientAccountId": "0f6f9d1e-4c1a-4b2a-9c3d-8e7f6a5b4c3d"
+      "recipientAccountId": "0f6f9d1e-4c1a-4b2a-9c3d-8e7f6a5b4c3d",
+      "anyPillarSuggestion": true
     },
     "II samba määra tõstmise soovitus": {
       "FNAME": "Mari",
       "RECIPIENTNAME": "Mesila OÜ",
       "recipientIsCompany": true,
       "suggestPaymentRate": true,
-      "recipientAccountId": "0f6f9d1e-4c1a-4b2a-9c3d-8e7f6a5b4c3d"
+      "recipientAccountId": "0f6f9d1e-4c1a-4b2a-9c3d-8e7f6a5b4c3d",
+      "anyPillarSuggestion": true
     },
     "III samba soovitus": {
       "FNAME": "Mari",
       "RECIPIENTNAME": "Mesila OÜ",
       "recipientIsCompany": true,
       "suggestThirdPillar": true,
-      "recipientAccountId": "0f6f9d1e-4c1a-4b2a-9c3d-8e7f6a5b4c3d"
+      "recipientAccountId": "0f6f9d1e-4c1a-4b2a-9c3d-8e7f6a5b4c3d",
+      "anyPillarSuggestion": true
     },
     "III samba tasude soovitus": {
       "FNAME": "Mari",
@@ -27,21 +30,24 @@
       "recipientIsCompany": true,
       "suggestThirdPillar": true,
       "thirdPillarActive": true,
-      "recipientAccountId": "0f6f9d1e-4c1a-4b2a-9c3d-8e7f6a5b4c3d"
+      "recipientAccountId": "0f6f9d1e-4c1a-4b2a-9c3d-8e7f6a5b4c3d",
+      "anyPillarSuggestion": true
     },
     "III samba püsimakse soovitus": {
       "FNAME": "Mari",
       "RECIPIENTNAME": "Mesila OÜ",
       "recipientIsCompany": true,
       "suggestThirdPillarRecurringPayment": true,
-      "recipientAccountId": "0f6f9d1e-4c1a-4b2a-9c3d-8e7f6a5b4c3d"
+      "recipientAccountId": "0f6f9d1e-4c1a-4b2a-9c3d-8e7f6a5b4c3d",
+      "anyPillarSuggestion": true
     },
     "III samba sissemakse tõstmise soovitus": {
       "FNAME": "Mari",
       "RECIPIENTNAME": "Mesila OÜ",
       "recipientIsCompany": true,
       "suggestThirdPillarRaise": true,
-      "recipientAccountId": "0f6f9d1e-4c1a-4b2a-9c3d-8e7f6a5b4c3d"
+      "recipientAccountId": "0f6f9d1e-4c1a-4b2a-9c3d-8e7f6a5b4c3d",
+      "anyPillarSuggestion": true
     },
     "kogumisfondi soovitus (ei esine)": {
       "FNAME": "Mari",
@@ -64,7 +70,8 @@
       "recipientIsCompany": true,
       "suggestSecondPillar": true,
       "suggestSavingsFundRecurringPayment": true,
-      "recipientAccountId": "0f6f9d1e-4c1a-4b2a-9c3d-8e7f6a5b4c3d"
+      "recipientAccountId": "0f6f9d1e-4c1a-4b2a-9c3d-8e7f6a5b4c3d",
+      "anyPillarSuggestion": true
     },
     "liikmesuse soovitus": {
       "FNAME": "Mari",

--- a/emails/fixtures/savings_fund_payment_success_en.json
+++ b/emails/fixtures/savings_fund_payment_success_en.json
@@ -2,28 +2,34 @@
   "variants": {
     "second pillar suggestion": {
       "FNAME": "Mari",
-      "suggestSecondPillar": true
+      "suggestSecondPillar": true,
+      "anyPillarSuggestion": true
     },
     "payment rate increase suggestion": {
       "FNAME": "Mari",
-      "suggestPaymentRate": true
+      "suggestPaymentRate": true,
+      "anyPillarSuggestion": true
     },
     "third pillar suggestion": {
       "FNAME": "Mari",
-      "suggestThirdPillar": true
+      "suggestThirdPillar": true,
+      "anyPillarSuggestion": true
     },
     "third pillar fees suggestion": {
       "FNAME": "Mari",
       "suggestThirdPillar": true,
-      "thirdPillarActive": true
+      "thirdPillarActive": true,
+      "anyPillarSuggestion": true
     },
     "third pillar recurring suggestion": {
       "FNAME": "Mari",
-      "suggestThirdPillarRecurringPayment": true
+      "suggestThirdPillarRecurringPayment": true,
+      "anyPillarSuggestion": true
     },
     "third pillar raise suggestion": {
       "FNAME": "Mari",
-      "suggestThirdPillarRaise": true
+      "suggestThirdPillarRaise": true,
+      "anyPillarSuggestion": true
     },
     "savings fund suggestion (cannot occur)": {
       "FNAME": "Mari",
@@ -37,7 +43,8 @@
     "second pillar outranks the savings fund recurring suggestion": {
       "FNAME": "Mari",
       "suggestSecondPillar": true,
-      "suggestSavingsFundRecurringPayment": true
+      "suggestSavingsFundRecurringPayment": true,
+      "anyPillarSuggestion": true
     },
     "membership suggestion": {
       "FNAME": "Mari",

--- a/emails/fixtures/savings_fund_payment_success_et.json
+++ b/emails/fixtures/savings_fund_payment_success_et.json
@@ -2,28 +2,34 @@
   "variants": {
     "II samba soovitus": {
       "FNAME": "Mari",
-      "suggestSecondPillar": true
+      "suggestSecondPillar": true,
+      "anyPillarSuggestion": true
     },
     "II samba määra tõstmise soovitus": {
       "FNAME": "Mari",
-      "suggestPaymentRate": true
+      "suggestPaymentRate": true,
+      "anyPillarSuggestion": true
     },
     "III samba soovitus": {
       "FNAME": "Mari",
-      "suggestThirdPillar": true
+      "suggestThirdPillar": true,
+      "anyPillarSuggestion": true
     },
     "III samba tasude soovitus": {
       "FNAME": "Mari",
       "suggestThirdPillar": true,
-      "thirdPillarActive": true
+      "thirdPillarActive": true,
+      "anyPillarSuggestion": true
     },
     "III samba püsimakse soovitus": {
       "FNAME": "Mari",
-      "suggestThirdPillarRecurringPayment": true
+      "suggestThirdPillarRecurringPayment": true,
+      "anyPillarSuggestion": true
     },
     "III samba sissemakse tõstmise soovitus": {
       "FNAME": "Mari",
-      "suggestThirdPillarRaise": true
+      "suggestThirdPillarRaise": true,
+      "anyPillarSuggestion": true
     },
     "kogumisfondi soovitus (ei esine)": {
       "FNAME": "Mari",
@@ -37,7 +43,8 @@
     "II sammas läheb kogumisfondi püsimaksest ette": {
       "FNAME": "Mari",
       "suggestSecondPillar": true,
-      "suggestSavingsFundRecurringPayment": true
+      "suggestSavingsFundRecurringPayment": true,
+      "anyPillarSuggestion": true
     },
     "liikmesuse soovitus": {
       "FNAME": "Mari",

--- a/emails/fixtures/savings_fund_payment_success_person_en.json
+++ b/emails/fixtures/savings_fund_payment_success_person_en.json
@@ -2,28 +2,34 @@
   "variants": {
     "second pillar suggestion": {
       "FNAME": "Mari",
-      "suggestSecondPillar": true
+      "suggestSecondPillar": true,
+      "anyPillarSuggestion": true
     },
     "payment rate increase suggestion": {
       "FNAME": "Mari",
-      "suggestPaymentRate": true
+      "suggestPaymentRate": true,
+      "anyPillarSuggestion": true
     },
     "third pillar suggestion": {
       "FNAME": "Mari",
-      "suggestThirdPillar": true
+      "suggestThirdPillar": true,
+      "anyPillarSuggestion": true
     },
     "third pillar fees suggestion": {
       "FNAME": "Mari",
       "suggestThirdPillar": true,
-      "thirdPillarActive": true
+      "thirdPillarActive": true,
+      "anyPillarSuggestion": true
     },
     "third pillar recurring suggestion": {
       "FNAME": "Mari",
-      "suggestThirdPillarRecurringPayment": true
+      "suggestThirdPillarRecurringPayment": true,
+      "anyPillarSuggestion": true
     },
     "third pillar raise suggestion": {
       "FNAME": "Mari",
-      "suggestThirdPillarRaise": true
+      "suggestThirdPillarRaise": true,
+      "anyPillarSuggestion": true
     },
     "savings fund suggestion (cannot occur)": {
       "FNAME": "Mari",
@@ -37,7 +43,8 @@
     "second pillar outranks the savings fund recurring suggestion": {
       "FNAME": "Mari",
       "suggestSecondPillar": true,
-      "suggestSavingsFundRecurringPayment": true
+      "suggestSavingsFundRecurringPayment": true,
+      "anyPillarSuggestion": true
     },
     "membership suggestion": {
       "FNAME": "Mari",

--- a/emails/fixtures/savings_fund_payment_success_person_et.json
+++ b/emails/fixtures/savings_fund_payment_success_person_et.json
@@ -2,28 +2,34 @@
   "variants": {
     "II samba soovitus": {
       "FNAME": "Mari",
-      "suggestSecondPillar": true
+      "suggestSecondPillar": true,
+      "anyPillarSuggestion": true
     },
     "II samba määra tõstmise soovitus": {
       "FNAME": "Mari",
-      "suggestPaymentRate": true
+      "suggestPaymentRate": true,
+      "anyPillarSuggestion": true
     },
     "III samba soovitus": {
       "FNAME": "Mari",
-      "suggestThirdPillar": true
+      "suggestThirdPillar": true,
+      "anyPillarSuggestion": true
     },
     "III samba tasude soovitus": {
       "FNAME": "Mari",
       "suggestThirdPillar": true,
-      "thirdPillarActive": true
+      "thirdPillarActive": true,
+      "anyPillarSuggestion": true
     },
     "III samba püsimakse soovitus": {
       "FNAME": "Mari",
-      "suggestThirdPillarRecurringPayment": true
+      "suggestThirdPillarRecurringPayment": true,
+      "anyPillarSuggestion": true
     },
     "III samba sissemakse tõstmise soovitus": {
       "FNAME": "Mari",
-      "suggestThirdPillarRaise": true
+      "suggestThirdPillarRaise": true,
+      "anyPillarSuggestion": true
     },
     "kogumisfondi soovitus (ei esine)": {
       "FNAME": "Mari",
@@ -37,7 +43,8 @@
     "II sammas läheb kogumisfondi püsimaksest ette": {
       "FNAME": "Mari",
       "suggestSecondPillar": true,
-      "suggestSavingsFundRecurringPayment": true
+      "suggestSavingsFundRecurringPayment": true,
+      "anyPillarSuggestion": true
     },
     "liikmesuse soovitus": {
       "FNAME": "Mari",

--- a/emails/src/partials/suggest_payment_rate_en.mjml
+++ b/emails/src/partials/suggest_payment_rate_en.mjml
@@ -1,4 +1,3 @@
-<mj-text><strong>Don't miss out on the second pillar tax benefit</strong></mj-text>
 <mj-text>
   Second pillar contributions are exempt from income tax: the bigger the contribution, the
   greater the benefit. For example, with a 2,000 euro gross salary, a 6% contribution gives

--- a/emails/src/partials/suggest_payment_rate_et.mjml
+++ b/emails/src/partials/suggest_payment_rate_et.mjml
@@ -1,4 +1,3 @@
-<mj-text><strong>Ära jää ilma ka II&nbsp;samba maksuvõidust</strong></mj-text>
 <mj-text>
   II&nbsp;samba sissemaksed on tulumaksuvabad: mida suurem sissemakse, seda suurem
   maksuvõit. Näiteks 2000-eurose brutopalga juures annab 6% sissemakse maksuvõitu 316 eurot

--- a/emails/src/partials/suggest_third_pillar_en.mjml
+++ b/emails/src/partials/suggest_third_pillar_en.mjml
@@ -10,7 +10,7 @@
 </mj-button>
 <mj-raw>*|ELSE:|*</mj-raw>
 <mj-text>
-  Next, it's smart to set up the third pillar. For example, if you make a monthly
+  It's smart to set up a third pillar as well. For example, if you make a monthly
   contribution of 100 euros, the state will refund you 264 euros in income tax next
   spring.
 </mj-text>

--- a/emails/src/partials/suggest_third_pillar_et.mjml
+++ b/emails/src/partials/suggest_third_pillar_et.mjml
@@ -10,7 +10,7 @@
 </mj-button>
 <mj-raw>*|ELSE:|*</mj-raw>
 <mj-text>
-  Järgmisena on kaval üles seada III&nbsp;sammas. Näiteks kui teed igal kuul
+  Kaval on üles seada ka III&nbsp;sammas. Näiteks kui teed igal kuul
   100‑eurose sissemakse, annab riik sulle kevadel 264 eurot tulumaksu tagasi.
 </mj-text>
 <mj-text><strong>Vaata järele, kui palju sina võidaksid maksudelt:</strong></mj-text>

--- a/emails/src/partials/suggest_third_pillar_recurring_en.mjml
+++ b/emails/src/partials/suggest_third_pillar_recurring_en.mjml
@@ -1,5 +1,5 @@
 <mj-text>
-  You have already put your third pillar to work for your future. The next step is to make
+  You are already saving for your future in your third pillar. The next step is to make
   saving even easier for yourself.
 </mj-text>
 <mj-text>

--- a/emails/src/partials/suggest_third_pillar_recurring_et.mjml
+++ b/emails/src/partials/suggest_third_pillar_recurring_et.mjml
@@ -1,6 +1,6 @@
 <mj-text>
-  Oled juba III&nbsp;samba enda tuleviku heaks tööle pannud. Järgmise sammuna saad teha
-  kogumise enda jaoks veel lihtsamaks.
+  Kogud juba oma tuleviku heaks III&nbsp;sambas. Järgmise sammuna saad teha kogumise enda
+  jaoks veel lihtsamaks.
 </mj-text>
 <mj-text>
   Seadista püsimakse ja III&nbsp;sambasse kogumine toimub automaatselt ka siis, kui sul pole

--- a/emails/src/savings_fund_payment_success_child_en.mjml
+++ b/emails/src/savings_fund_payment_success_child_en.mjml
@@ -17,6 +17,10 @@
 
     <mj-section padding="0 24px">
       <mj-column>
+        <mj-raw>*|IF:anyPillarSuggestion|*</mj-raw>
+        <mj-text><strong>How can you make your pension pillars work harder?</strong></mj-text>
+        <mj-raw>*|END:IF|*</mj-raw>
+
         <mj-include path="./partials/suggest_chain_open_en.mjml" />
         <mj-raw>*|END:IF|*</mj-raw>
       </mj-column>

--- a/emails/src/savings_fund_payment_success_child_et.mjml
+++ b/emails/src/savings_fund_payment_success_child_et.mjml
@@ -13,6 +13,10 @@
           jooksul.*|END:IF|*
         </mj-text>
 
+        <mj-raw>*|IF:anyPillarSuggestion|*</mj-raw>
+        <mj-text><strong>Kuidas oma sambad paremini tööle panna?</strong></mj-text>
+        <mj-raw>*|END:IF|*</mj-raw>
+
         <mj-include path="./partials/suggest_chain_open_et.mjml" />
         <mj-raw>*|END:IF|*</mj-raw>
       </mj-column>

--- a/emails/src/savings_fund_payment_success_company_en.mjml
+++ b/emails/src/savings_fund_payment_success_company_en.mjml
@@ -17,6 +17,10 @@
 
     <mj-section padding="0 24px">
       <mj-column>
+        <mj-raw>*|IF:anyPillarSuggestion|*</mj-raw>
+        <mj-text><strong>How can you make your pension pillars work harder?</strong></mj-text>
+        <mj-raw>*|END:IF|*</mj-raw>
+
         <mj-include path="./partials/suggest_chain_open_en.mjml" />
         <mj-raw>*|END:IF|*</mj-raw>
       </mj-column>

--- a/emails/src/savings_fund_payment_success_company_et.mjml
+++ b/emails/src/savings_fund_payment_success_company_et.mjml
@@ -17,6 +17,10 @@
 
     <mj-section padding="0 24px">
       <mj-column>
+        <mj-raw>*|IF:anyPillarSuggestion|*</mj-raw>
+        <mj-text><strong>Kuidas oma sambad paremini tööle panna?</strong></mj-text>
+        <mj-raw>*|END:IF|*</mj-raw>
+
         <mj-include path="./partials/suggest_chain_open_et.mjml" />
         <mj-raw>*|END:IF|*</mj-raw>
       </mj-column>

--- a/emails/src/savings_fund_payment_success_en.mjml
+++ b/emails/src/savings_fund_payment_success_en.mjml
@@ -15,6 +15,10 @@
 
     <mj-section padding="0 24px">
       <mj-column>
+        <mj-raw>*|IF:anyPillarSuggestion|*</mj-raw>
+        <mj-text><strong>How can you make your pension pillars work harder?</strong></mj-text>
+        <mj-raw>*|END:IF|*</mj-raw>
+
         <mj-include path="./partials/suggest_chain_open_en.mjml" />
         <mj-raw>*|END:IF|*</mj-raw>
       </mj-column>

--- a/emails/src/savings_fund_payment_success_et.mjml
+++ b/emails/src/savings_fund_payment_success_et.mjml
@@ -11,6 +11,10 @@
           kontole kahe tööpäeva jooksul.
         </mj-text>
 
+        <mj-raw>*|IF:anyPillarSuggestion|*</mj-raw>
+        <mj-text><strong>Kuidas oma sambad paremini tööle panna?</strong></mj-text>
+        <mj-raw>*|END:IF|*</mj-raw>
+
         <mj-include path="./partials/suggest_chain_open_et.mjml" />
         <mj-raw>*|END:IF|*</mj-raw>
       </mj-column>

--- a/emails/src/savings_fund_payment_success_person_en.mjml
+++ b/emails/src/savings_fund_payment_success_person_en.mjml
@@ -15,6 +15,10 @@
 
     <mj-section padding="0 24px">
       <mj-column>
+        <mj-raw>*|IF:anyPillarSuggestion|*</mj-raw>
+        <mj-text><strong>How can you make your pension pillars work harder?</strong></mj-text>
+        <mj-raw>*|END:IF|*</mj-raw>
+
         <mj-include path="./partials/suggest_chain_open_en.mjml" />
         <mj-raw>*|END:IF|*</mj-raw>
       </mj-column>

--- a/emails/src/savings_fund_payment_success_person_et.mjml
+++ b/emails/src/savings_fund_payment_success_person_et.mjml
@@ -11,6 +11,10 @@
           kontole kahe tööpäeva jooksul.
         </mj-text>
 
+        <mj-raw>*|IF:anyPillarSuggestion|*</mj-raw>
+        <mj-text><strong>Kuidas oma sambad paremini tööle panna?</strong></mj-text>
+        <mj-raw>*|END:IF|*</mj-raw>
+
         <mj-include path="./partials/suggest_chain_open_et.mjml" />
         <mj-raw>*|END:IF|*</mj-raw>
       </mj-column>

--- a/src/main/java/ee/tuleva/onboarding/mandate/EmailVariablesAttachments.java
+++ b/src/main/java/ee/tuleva/onboarding/mandate/EmailVariablesAttachments.java
@@ -30,7 +30,8 @@ public class EmailVariablesAttachments {
         Map.entry("suggestThirdPillarRaise", pillarSuggestion.isSuggestThirdPillarRaise()),
         Map.entry(
             "suggestSavingsFundRecurringPayment",
-            pillarSuggestion.isSuggestSavingsFundRecurringPayment()));
+            pillarSuggestion.isSuggestSavingsFundRecurringPayment()),
+        Map.entry("anyPillarSuggestion", pillarSuggestion.isAnyPillarSuggestion()));
   }
 
   public static Map<String, Object> getNameMergeVars(User user) {

--- a/src/main/java/ee/tuleva/onboarding/mandate/PillarSuggestion.java
+++ b/src/main/java/ee/tuleva/onboarding/mandate/PillarSuggestion.java
@@ -25,6 +25,7 @@ public class PillarSuggestion {
   private final boolean suggestThirdPillarRecurringPayment;
   private final boolean suggestThirdPillarRaise;
   private final boolean suggestSavingsFundRecurringPayment;
+  private final boolean anyPillarSuggestion;
 
   public PillarSuggestion(
       User user,
@@ -195,6 +196,12 @@ public class PillarSuggestion {
             && !suggestThirdPillarRaise;
     this.suggestSavingsFundRecurringPayment =
         adult && savesInSavingsFund && !recurringPayments.savingsFund();
+    this.anyPillarSuggestion =
+        suggestSecondPillar
+            || suggestPaymentRate
+            || suggestThirdPillar
+            || suggestThirdPillarRecurringPayment
+            || suggestThirdPillarRaise;
   }
 
   public Optional<String> renderedNudgeTag() {

--- a/src/test/groovy/ee/tuleva/onboarding/mandate/PillarSuggestionSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/mandate/PillarSuggestionSpec.groovy
@@ -316,4 +316,42 @@ class PillarSuggestionSpec extends Specification {
     true               | false       | true               | false  | "nudge_membership"
     true               | false       | true               | true   | "nudge_none"
   }
+
+  def "flags a pillar suggestion only when the rendered nudge is about a pillar"() {
+    when:
+    user.getAge() >> 40
+    user.isMember() >> member
+    conversion.isSecondPillarPartiallyConverted() >> secondPillarActive
+    conversion.isThirdPillarPartiallyConverted() >> true
+    conversion.getSecondPillarWeightedAverageFee() >> 0.003
+    conversion.getThirdPillarWeightedAverageFee() >> 0.003
+    paymentRates.canIncrease() >> canIncrease
+    def pillarSuggestion =
+        new PillarSuggestion(
+            user, secondPillarActive, true, conversion, paymentRates, [] as Set, false, savesInSavingsFund)
+
+    then:
+    pillarSuggestion.isAnyPillarSuggestion() == anyPillarSuggestion
+
+    where:
+    secondPillarActive | canIncrease | savesInSavingsFund | member | anyPillarSuggestion
+    false              | false       | true               | false  | true
+    true               | true        | true               | false  | true
+    true               | false       | false              | false  | false
+    true               | false       | true               | false  | false
+    true               | false       | true               | true   | false
+  }
+
+  def "flags a pillar suggestion when the third pillar step is the open one"() {
+    when:
+    user.getAge() >> 40
+    conversion.isSecondPillarPartiallyConverted() >> true
+    conversion.getSecondPillarWeightedAverageFee() >> 0.003
+    conversion.isThirdPillarPartiallyConverted() >> false
+    def pillarSuggestion =
+        new PillarSuggestion(user, true, false, conversion, paymentRates, [] as Set, false)
+
+    then:
+    pillarSuggestion.isAnyPillarSuggestion()
+  }
 }

--- a/src/test/groovy/ee/tuleva/onboarding/mandate/email/MandateBatchEmailServiceTest.java
+++ b/src/test/groovy/ee/tuleva/onboarding/mandate/email/MandateBatchEmailServiceTest.java
@@ -99,6 +99,7 @@ class MandateBatchEmailServiceTest {
             Map.entry(
                 "suggestSavingsFundRecurringPayment",
                 pillarSuggestion.isSuggestSavingsFundRecurringPayment()),
+            Map.entry("anyPillarSuggestion", pillarSuggestion.isAnyPillarSuggestion()),
             Map.entry("fundPensionSecondPillar", true),
             Map.entry("fundPensionThirdPillar", false),
             Map.entry("partialWithdrawalSecondPillar", true),
@@ -183,6 +184,7 @@ class MandateBatchEmailServiceTest {
             Map.entry(
                 "suggestSavingsFundRecurringPayment",
                 pillarSuggestion.isSuggestSavingsFundRecurringPayment()),
+            Map.entry("anyPillarSuggestion", pillarSuggestion.isAnyPillarSuggestion()),
             Map.entry("fundPensionSecondPillar", true),
             Map.entry("fundPensionThirdPillar", true),
             Map.entry("partialWithdrawalSecondPillar", true),

--- a/src/test/groovy/ee/tuleva/onboarding/mandate/email/MandateEmailServiceSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/mandate/email/MandateEmailServiceSpec.groovy
@@ -91,6 +91,7 @@ class MandateEmailServiceSpec extends Specification {
         suggestThirdPillarRecurringPayment : pillarSuggestion.suggestThirdPillarRecurringPayment,
         suggestThirdPillarRaise : pillarSuggestion.suggestThirdPillarRaise,
         suggestSavingsFundRecurringPayment : pillarSuggestion.suggestSavingsFundRecurringPayment,
+        anyPillarSuggestion : pillarSuggestion.anyPillarSuggestion,
     ]
     def tags = ["mandate", "pillar_2", "suggest_payment_rate", "suggest_3"] + pillarSuggestion.renderedNudgeTag().stream().toList()
     def mandrillResponse = new MandrillMessageStatus().tap {
@@ -344,6 +345,7 @@ class MandateEmailServiceSpec extends Specification {
         suggestThirdPillarRecurringPayment : pillarSuggestion.suggestThirdPillarRecurringPayment,
         suggestThirdPillarRaise : pillarSuggestion.suggestThirdPillarRaise,
         suggestSavingsFundRecurringPayment : pillarSuggestion.suggestSavingsFundRecurringPayment,
+        anyPillarSuggestion : pillarSuggestion.anyPillarSuggestion,
     ]
 
     authenticationHolder.getAuthenticatedPerson() >> authenticatedPerson
@@ -402,6 +404,7 @@ class MandateEmailServiceSpec extends Specification {
         suggestThirdPillarRecurringPayment : pillarSuggestion.suggestThirdPillarRecurringPayment,
         suggestThirdPillarRaise : pillarSuggestion.suggestThirdPillarRaise,
         suggestSavingsFundRecurringPayment : pillarSuggestion.suggestSavingsFundRecurringPayment,
+        anyPillarSuggestion : pillarSuggestion.anyPillarSuggestion,
     ]
 
     authenticationHolder.getAuthenticatedPerson() >> authenticatedPerson

--- a/src/test/groovy/ee/tuleva/onboarding/payment/email/PaymentEmailServiceSpec.groovy
+++ b/src/test/groovy/ee/tuleva/onboarding/payment/email/PaymentEmailServiceSpec.groovy
@@ -62,7 +62,8 @@ class PaymentEmailServiceSpec extends Specification {
         "suggestThirdPillarRecurringPayment" : pillarSuggestion.suggestThirdPillarRecurringPayment,
         "suggestThirdPillarRaise"            : pillarSuggestion.suggestThirdPillarRaise,
         "savingsFundFee"                     : "0.28",
-        "suggestSavingsFundRecurringPayment" : pillarSuggestion.suggestSavingsFundRecurringPayment
+        "suggestSavingsFundRecurringPayment" : pillarSuggestion.suggestSavingsFundRecurringPayment,
+        "anyPillarSuggestion"                : pillarSuggestion.anyPillarSuggestion
     ]
     def tags = ["pillar_3.1", "mandate", "payment", "suggest_payment_rate", "suggest_2"] + pillarSuggestion.renderedNudgeTag().stream().toList()
     def locale = Locale.ENGLISH
@@ -112,7 +113,8 @@ class PaymentEmailServiceSpec extends Specification {
         "suggestThirdPillarRecurringPayment" : pillarSuggestion.suggestThirdPillarRecurringPayment,
         "suggestThirdPillarRaise"            : pillarSuggestion.suggestThirdPillarRaise,
         "savingsFundFee"                     : "0.28",
-        "suggestSavingsFundRecurringPayment" : pillarSuggestion.suggestSavingsFundRecurringPayment
+        "suggestSavingsFundRecurringPayment" : pillarSuggestion.suggestSavingsFundRecurringPayment,
+        "anyPillarSuggestion"                : pillarSuggestion.anyPillarSuggestion
     ]
     def tags = ["savings_fund", "suggest_payment_rate", "suggest_2"] + pillarSuggestion.renderedNudgeTag().stream().toList()
     def locale = Locale.ENGLISH
@@ -188,7 +190,8 @@ class PaymentEmailServiceSpec extends Specification {
         "suggestThirdPillarRecurringPayment" : pillarSuggestion.suggestThirdPillarRecurringPayment,
         "suggestThirdPillarRaise"            : pillarSuggestion.suggestThirdPillarRaise,
         "savingsFundFee"                     : "0.28",
-        "suggestSavingsFundRecurringPayment" : pillarSuggestion.suggestSavingsFundRecurringPayment
+        "suggestSavingsFundRecurringPayment" : pillarSuggestion.suggestSavingsFundRecurringPayment,
+        "anyPillarSuggestion"                : pillarSuggestion.anyPillarSuggestion
     ]
     def tags = ["savings_fund", "suggest_payment_rate", "suggest_2"] + pillarSuggestion.renderedNudgeTag().stream().toList()
     def locale = Locale.ENGLISH


### PR DESCRIPTION
Someone who has just paid into the savings fund reads "your contribution is done" and then, with no bridge at all, "if you are not saving your second pillar with us, make sure your fees are below 0.3%". Pirje spotted the jump.

## What changes

**The savings fund receipt introduces the nudge** (all eight `savings_fund_payment_success*` templates, Estonian and English)

A bold question now sits between the receipt and the nudge: "Kuidas oma sambad paremini tööle panna?"

It appears only when the nudge chain actually lands on a pillar. Above the membership or the savings fund recurring nudge the question would not be true, so a new `anyPillarSuggestion` flag on `PillarSuggestion` decides it, rather than each template restating the chain's conditions.

**The payment rate nudge loses its own heading** (`suggest_payment_rate_et` and `_en`)

"Ära jää ilma ka II samba maksuvõidust" is gone, and the nudge opens with its body text instead.

⚠ This partial is shared by 18 templates, so this one is the change that reaches beyond the savings fund receipt — every email carrying the nudge chain loses that heading. That is deliberate: it was the only pillar nudge with a heading of its own, and the second and third pillar nudges have always opened with body text.

**Two nudge sentences reworded** (`suggest_third_pillar_et` / `_en`, `suggest_third_pillar_recurring_et` / `_en`)

The new question made two existing sentences read oddly directly beneath it:

- "Oled juba III samba enda tuleviku heaks tööle pannud" repeated the question's own idiom and answered it in the negative, two lines after asking → "Kogud juba oma tuleviku heaks III sambas"
- "Järgmisena on kaval üles seada III sammas" performed the transition the question had just performed → "Kaval on üles seada ka III sammas"

## Checks

- `npm test` in the emails directory: 327 passing, including the merge tag structure checks
- New fixture variants cover both sides of the new condition in all eight templates
- `./gradlew test` for `PillarSuggestionSpec`, `PaymentEmailServiceSpec`, `MandateEmailServiceSpec` and `MandateBatchEmailServiceTest`: passing
- `npm run preview` rebuilt, and every branch of every changed template reviewed in the browser, Estonian and English
- Full suite left to CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
